### PR TITLE
Adds secure slack token for Travis/Slack integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 script:
-  - echo "test All tests passed"
+- echo "test All tests passed"
 deploy:
   provider: s3
   acl: public_read
-  cache_control: "max-age=30"
+  cache_control: max-age=30
   access_key_id: AKIAJS2B2FMG7GS4E5MA
   secret_access_key:
     secure: gDvEoQgPvIvNxT37tf8uv2Qu29WLcZdqQG3LNEBJiBhGaWqHtOcnFs9dmibSv992+yPjar4A8Iq8Ws5+9nalzNPRqndSiwLVdSYU2DJs45+t6lbTx96uFOewxCF0oWiihVj9Gje55XfqCnp23PfPMlTHywZUYifRlk/SO6QwDOP0bb9SJCGlZCusuU7msEtJonP1vuD7qv7GE8uPrM2lylOs8BMzGNURsWG53b77GiJNwipbnw6BOKsZQdy8oFN/Cpe+BUAn1iOkg2nwsM/yLzmVQJfny9Mr0u2yZO7IJdncCe3dnSXzIFq4nzcTqKV+ZLg/K6ThaYotF+XGGzmBFodISt1P2YHgpWymbUFv9ZAj5bHF8F1xb/pofy8SsTjwtDw9aJ+4BewtWdpUpSw+bQvvz/Fj1xOSSR1T7Htdx0h4AlTJwOHyMuJezg7J/X6xLqbMtgBiRvhbekzS+mEtTGh1op6QboXxHKg38ZjLyDWdqgjysL5RYaZYdvr9V2SaDs5gffaAgLNuYpK4lWoRzWzbLf1fAbTKhW0ZkZN/sQHWpVfdL1lU8vxJ6hy33fEFMtDfdxpQX0RYlAkpq7xkncUTLUfUrfOMo6ABkgN3C2lcDwwRijYw5chU4UT/3V4AxzPtT7+BEs00bM/zMvjwXhNhNWaUeeDisD5CM4Bg33A=
@@ -12,3 +12,6 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
+notifications:
+  slack:
+    secure: iusPOAEys0QvynLobYSaUnjIrJVJ9Ss/QJslre5h41pr9Hw4w63Sd6HGmIdfjZYU6A2BolgJ2FrCHSIFH78JtzgUgmsOc86zyiMU/Y3ZOEPe0i+qL3Xw152czX6RIexHQ+DQdV8iyKm6XuZ4qwj+FOSG0F9qVMc8ZBOPEQbmxwGxkRCoCZ9WTUWV3mb9e+AQwn2ln+AuC3SnG6CAAe7p2qns8nGhSw/Gt6B50DxHu4nXVFniekZHdPjh2CUGQ75JCQfbDMiD6HIQ4Y1Ezfxn3DagdcSc06ypfpvxxWDch35G+D7G8hTXXaoJHr109+hluhq+wHa+DV1AJzJxLadt4ppc/6QNfbCZ2o/I0kr6ceGkmewzj6saH0fMaSGRoHFH++r5ha1x1t9dqNwP0Nm4xsig6E9sjSvGcfU7O9BZEITbXcoYuisSFqVFsYfMs242kQPDXM44K1HZLIUY8mt8LdYfJmlNvIJUhVsGilEJDbb0rzeyxiPXh67fNnXGyR743ZQNC/+ViJ40lxKd2BtVkGVqdNtbCekqazUZ+IDAFBIwGkB8EnBkimVP1HJIvdhu3MaaWAE6uyGamqY/AoOYUh9p0eWPoPCa/oI+lE3HquBXeCmEhK9DNKqcdWpaA3dHG6mt9svQxvPHgb2STh2jkarUdVzHpE5aWMQhJCF6yas=


### PR DESCRIPTION
This YAML entry was generated with the command
`travis encrypt "<frontside_super_secret_token>" --add notifications.slack`
The raw value of the token is accessible through Slack preferences.

This integration will keep us up-to-date with build status.