### PR TITLE
Fix Safari errors in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: node_js
 env:
   - BROWSER=Chrome_travis_ci
   - BROWSER=bs_safari_11
-matrix:
-  allow_failures:
-    - env: BROWSER=bs_safari_11
 addons:
   chrome: stable
 before_install:

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -38,6 +38,10 @@ export default function configure() {
     name: 'kb-ebsco'
   }]);
 
+  this.get('_/proxy/tenants/:id/modules', [{
+    id: 'mod-kb-ebsco'
+  }]);
+
   this.get('/_/proxy/modules/mod-kb-ebsco', {
     id: 'mod-kb-ebsco',
     name: 'kb-ebsco',

--- a/mirage/scenarios/no-backend.js
+++ b/mirage/scenarios/no-backend.js
@@ -2,5 +2,6 @@ export default function noBackendScenario(server) {
   let ns = server.namespace;
   server.namespace = '';
   server.get('/_/proxy/modules', []);
+  server.get('_/proxy/tenants/:id/modules', []);
   server.namespace = ns;
 }

--- a/tests/harness.js
+++ b/tests/harness.js
@@ -32,7 +32,7 @@ export default class TestHarness extends Component {
 
     this.history = createMemoryHistory();
 
-    discoverServices(okapi.url, this.store);
+    discoverServices(this.store);
 
     // While we have disableAuth on, manually tell our app Okapi is ready
     this.store.dispatch(setOkapiReady());

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -59,7 +59,7 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-package-details-back-button');
+    return $('[data-test-eholdings-package-details-back-button]');
   },
 
   clickSearchVignette() {

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -34,11 +34,11 @@ export default {
   },
 
   get numTitles() {
-    return $('[data-test-eholdings-package-details-titles-total').text();
+    return $('[data-test-eholdings-package-details-titles-total]').text();
   },
 
   get numTitlesSelected() {
-    return $('[data-test-eholdings-package-details-titles-selected').text();
+    return $('[data-test-eholdings-package-details-titles-selected]').text();
   },
 
   get isSelected() {

--- a/tests/pages/vendor-search.js
+++ b/tests/pages/vendor-search.js
@@ -59,7 +59,7 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-vendor-details-back-button');
+    return $('[data-test-eholdings-vendor-details-back-button]');
   },
 
   clickSearchVignette() {


### PR DESCRIPTION
The only existing failures were from malformed data attributes selectors (they were missing the closing `]`).