### PR TITLE
Update to current FOLIO styles

### DIFF
--- a/src/components/customer-resource-show/customer-resource-show.js
+++ b/src/components/customer-resource-show/customer-resource-show.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '@folio/stripes-components/lib/Icon';
+import IconButton from '@folio/stripes-components/lib/IconButton';
 import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 
@@ -30,7 +31,9 @@ export default function CustomerResourceShow({ model, toggleSelected }, { router
         <PaneHeader
           firstMenu={historyState && historyState.eholdings && (
             <PaneMenu>
-              <button data-test-eholdings-customer-resource-show-back-button onClick={() => router.history.goBack()}><Icon icon="left-arrow" /></button>
+              <div data-test-eholdings-customer-resource-show-back-button>
+                <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
+              </div>
             </PaneMenu>
           )}
         />

--- a/src/components/key-value-label/key-value-label.css
+++ b/src/components/key-value-label/key-value-label.css
@@ -1,10 +1,14 @@
+@import '@folio/stripes-components/lib/variables';
+
 .kv-label {
   display: block;
-  font-size: 0.8em;
-  font-weight: bold;
-  margin-bottom: 0;
-  text-transform: Uppercase;
-  color: #333;
+  font-weight: 600;
+  margin-bottom: 2px;
+  color: var(--secondary, #333);
+}
+
+.kvValue {
+  line-height: 120%;
 }
 
 .kv-value h1 {
@@ -12,5 +16,5 @@
 }
 
 .kv-root {
-  margin-bottom: 1rem;
+  padding: 0 5px 14px 0;
 }

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Icon from '@folio/stripes-components/lib/Icon';
+import IconButton from '@folio/stripes-components/lib/IconButton';
 import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 
@@ -22,7 +23,9 @@ export default function PackageShow({ model, toggleSelected }, { intl, router, q
         <PaneHeader
           firstMenu={historyState && historyState.eholdings && (
             <PaneMenu>
-              <button data-test-eholdings-package-details-back-button onClick={() => router.history.goBack()}><Icon icon="left-arrow" /></button>
+              <div data-test-eholdings-package-details-back-button>
+                <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
+              </div>
             </PaneMenu>
           )}
         />

--- a/src/components/search-paneset/search-paneset.css
+++ b/src/components/search-paneset/search-paneset.css
@@ -5,6 +5,11 @@
   position: relative;
 }
 
+.search-pane-toggle {
+  height: 44px;
+  padding: 0 1em;
+}
+
 @media (--largeUp) {
   .search-paneset {
     align-items: flex-start;

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
-import Icon from '@folio/stripes-components/lib/Icon';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+import Button from '@folio/stripes-components/lib/Button';
 import capitalize from 'lodash/capitalize';
 
 import SearchPane from '../search-pane';
@@ -87,9 +88,9 @@ export default class SearchPaneset extends React.Component {
           <PaneHeader
             lastMenu={resultsView ? (
               <PaneMenu>
-                <button onClick={this.toggleFilters} className={styles['search-pane-toggle']}>
+                <Button buttonStyle="transparent" onClick={this.toggleFilters} className={styles['search-pane-toggle']}>
                   Apply
-                </button>
+                </Button>
               </PaneMenu>
             ) : null}
           />
@@ -100,23 +101,22 @@ export default class SearchPaneset extends React.Component {
 
         {!!resultsView && (
           <ResultsPane>
-            <PaneHeader
-              paneTitle={(
-                <div className={styles['search-heading']}>
-                  <strong>{capitalize(resultsType)}</strong>
-                  <div data-test-eholdings-total-search-results>
-                    <em>{intl.formatNumber(totalResults)} search results</em>
+            <div data-test-eholdings-search-results-header>
+              <PaneHeader
+                paneTitle={capitalize(resultsType)}
+                paneSub={`${intl.formatNumber(totalResults)} search results`}
+                firstMenu={
+                  <div className={styles['results-pane-search-toggle']}>
+                    <PaneMenu>
+                      <IconButton
+                        onClick={this.toggleFilters}
+                        icon="search"
+                      />
+                    </PaneMenu>
                   </div>
-                </div>
-              )}
-              firstMenu={(
-                <PaneMenu>
-                  <button onClick={this.toggleFilters} className={styles['results-pane-search-toggle']}>
-                    &larr; Search
-                  </button>
-                </PaneMenu>
-              )}
-            />
+                }
+              />
+            </div>
             <div className={styles['scrollable-container']}>
               {resultsView}
             </div>
@@ -128,9 +128,10 @@ export default class SearchPaneset extends React.Component {
             <PaneHeader
               firstMenu={(
                 <PaneMenu>
-                  <button onClick={this.closePreview}>
-                    <Icon icon="closeX" />
-                  </button>
+                  <IconButton
+                    onClick={this.closePreview}
+                    icon="closeX"
+                  />
                 </PaneMenu>
               )}
             />

--- a/src/components/title-show/title-show.js
+++ b/src/components/title-show/title-show.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Icon from '@folio/stripes-components/lib/Icon';
+import IconButton from '@folio/stripes-components/lib/IconButton';
 import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 
@@ -21,7 +22,9 @@ export default function TitleShow({ model }, { router, queryParams }) {
         <PaneHeader
           firstMenu={historyState && historyState.eholdings && (
             <PaneMenu>
-              <button data-test-eholdings-title-show-back-button onClick={() => router.history.goBack()}><Icon icon="left-arrow" /></button>
+              <div data-test-eholdings-title-show-back-button>
+                <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
+              </div>
             </PaneMenu>
           )}
         />

--- a/src/components/vendor-show/vendor-show.js
+++ b/src/components/vendor-show/vendor-show.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Icon from '@folio/stripes-components/lib/Icon';
+import IconButton from '@folio/stripes-components/lib/IconButton';
 import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 
@@ -19,7 +20,9 @@ export default function VendorShow({ model }, { router, queryParams }) {
         <PaneHeader
           firstMenu={historyState && historyState.eholdings && (
             <PaneMenu>
-              <button data-test-eholdings-vendor-details-back-button onClick={() => router.history.goBack()}><Icon icon="left-arrow" /></button>
+              <div data-test-eholdings-vendor-details-back-button>
+                <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
+              </div>
             </PaneMenu>
           )}
         />

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -94,6 +94,6 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-customer-resource-show-back-button]');
+    return $('[data-test-eholdings-customer-resource-show-back-button] button');
   }
 };

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -39,7 +39,7 @@ export default {
   },
 
   get totalResults() {
-    return $('[data-test-eholdings-total-search-results]').text();
+    return $('[data-test-eholdings-search-results-header] p').text();
   },
 
   get hasErrors() {

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -59,7 +59,7 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-package-details-back-button]');
+    return $('[data-test-eholdings-package-details-back-button] button');
   },
 
   clickSearchVignette() {
@@ -93,7 +93,7 @@ export default {
   },
 
   clickBackButton() {
-    return $('[data-test-eholdings-customer-resource-show-back-button]').trigger('click');
+    return $('[data-test-eholdings-customer-resource-show-back-button] button').trigger('click');
   },
 
   scrollToOffset(readOffset) {

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -86,6 +86,6 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-package-details-back-button]');
+    return $('[data-test-eholdings-package-details-back-button] button');
   }
 };

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -39,7 +39,7 @@ export default {
   },
 
   get totalResults() {
-    return $('[data-test-eholdings-total-search-results]').text();
+    return $('[data-test-eholdings-search-results-header] p').text();
   },
 
   get hasErrors() {

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -59,7 +59,7 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-title-show-back-button]');
+    return $('[data-test-eholdings-title-show-back-button] button');
   },
 
   clickSearchVignette() {
@@ -93,7 +93,7 @@ export default {
   },
 
   clickBackButton() {
-    return $('[data-test-eholdings-customer-resource-show-back-button]').trigger('click');
+    return $('[data-test-eholdings-customer-resource-show-back-button] button').trigger('click');
   },
 
   scrollToOffset(readOffset) {

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -52,6 +52,6 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-title-show-back-button]');
+    return $('[data-test-eholdings-title-show-back-button] button');
   }
 };

--- a/tests/pages/vendor-search.js
+++ b/tests/pages/vendor-search.js
@@ -35,7 +35,7 @@ export default {
   },
 
   get totalResults() {
-    return $('[data-test-eholdings-total-search-results]').text();
+    return $('[data-test-eholdings-search-results-header] p').text();
   },
 
   get hasErrors() {

--- a/tests/pages/vendor-search.js
+++ b/tests/pages/vendor-search.js
@@ -59,7 +59,7 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-vendor-details-back-button]');
+    return $('[data-test-eholdings-vendor-details-back-button] button');
   },
 
   clickSearchVignette() {
@@ -93,7 +93,7 @@ export default {
   },
 
   clickBackButton() {
-    return $('[data-test-eholdings-package-details-back-button]').trigger('click');
+    return $('[data-test-eholdings-package-details-back-button] button').trigger('click');
   },
 
   scrollToOffset(readOffset) {

--- a/tests/pages/vendor-show.js
+++ b/tests/pages/vendor-show.js
@@ -48,6 +48,6 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-vendor-details-back-button]');
+    return $('[data-test-eholdings-vendor-details-back-button] button');
   }
 };


### PR DESCRIPTION
## Purpose
`stripes-components` has several style updates that were not applied to `ui-eholdings`.

## Approach
- Pane header actions are using the new `IconButton` for consistent padding.
- Our `KeyValueLabel` component now uses the same styles as the `stripes-components` `KeyValue` component (which doesn't accept blocks as the value, only strings).
- We can now use `paneSub` in `PaneHeader`s for the search results count.

## Screenshots
![localhost_3000_eholdings_searchtype titles q baseball ipad pro](https://user-images.githubusercontent.com/230597/34642663-6abc9aa8-f2dc-11e7-9015-ac463c9cc21c.png)
