### PR TITLE
Interrupt package deselection with confirmation modal

### DIFF
--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,0 +1,1 @@
+export { default } from './modal';

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -1,0 +1,112 @@
+@import '@folio/stripes-components/lib/variables';
+
+.modalRoot {
+  display: flex;
+  justify-content: center;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  align-items: center;
+  position: absolute;
+  z-index: 12;
+}
+
+.modal {
+  position: relative;
+  background-color: #fff;
+  max-height: calc(80vh);
+  width: 100%;
+  overflow: hidden;
+  border-radius: var(--radius, 4px);
+  box-shadow: 0 5px 28px 1px rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  margin: 0 20px;
+  outline: 0;
+}
+
+.modalHeader {
+  position: relative;
+  border-bottom: 1px solid #dedede;
+  padding: 0.5em 1em;
+  line-height: 1.2;
+}
+
+.modalLabel {
+  font-weight: bold;
+  font-size: calc(1.2rem);
+  flex-grow: 1;
+  flex-shrink: 0;
+}
+
+.modalContent {
+  padding: 1rem;
+  flex: 1 2 auto;
+  overflow: auto;
+  width: 100%;
+  max-height: calc(100% - 31px - 2rem);
+  line-height: 1.2;
+}
+
+.modalControls {
+  pointer-events: none;
+}
+
+.closeModal {
+  background-color: transparent;
+  border: 0;
+  padding: 0;
+  pointer-events: all;
+}
+
+.backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.modalFooter {
+  border-top: 1px solid #dcdcdc;
+  margin-top: 1em;
+  padding: 0.5em 0;
+
+  & div {
+    padding: 0 1em;
+  }
+
+  & button {
+    margin: 0.5em 0;
+    width: 100%;
+  }
+}
+
+@media (--mediumUp) {
+  .modal {
+    margin: 0 auto;
+    width: 60%;
+
+    &.small {
+      width: 40%;
+    }
+
+    &.large {
+      width: 90%;
+    }
+  }
+
+  .modalFooter {
+    & div {
+      display: flex;
+      flex-direction: row-reverse;
+      padding: 0 0.5em;
+    }
+
+    & button {
+      margin: 0.5em;
+      width: auto;
+    }
+  }
+}

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1,0 +1,126 @@
+/*
+  Forked from stripes-components due to z-index incompatibility.
+  Should revert back to upstream when fixed.
+*/
+
+import React from 'react';
+import { Modal as OverlayModal } from 'react-overlays';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import Icon from '@folio/stripes-components/lib/Icon';
+import css from './modal.css';
+
+const propTypes = {
+  /** Deciding value for rendering the modal(true) or not(false). */
+  open: PropTypes.bool.isRequired,
+  /** Callback that signals intent to close window -
+   * boolean passed to 'open' prop can be set using
+   * callback does not actually close the modal.
+   */
+  onClose: PropTypes.func,
+  /** Callback triggered when modal opens */
+  onOpen: PropTypes.func,
+  /** Size defaults to 60% the scope element's width.
+   * "Small" can be applied for 40% and "Large" for 90%.
+   */
+  size: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
+  /** Parent element for modal.
+   * Defaults to 'module' which keeps the main navigation visible.
+   * A value of 'root' covers the entire view.
+   */
+  scope: PropTypes.oneOf([ // eslint-disable-line react/no-unused-prop-types
+    'root',
+    'module',
+  ]),
+  /** Unique identifier for modal window. */
+  id: PropTypes.string,
+  /** Modal can be dismissed by clicking the background overlay */
+  closeOnBackgroundClick: PropTypes.bool,
+  /** Descriptive title for top of modal - also fills aria-label attribute for screen readers. */
+  label: PropTypes.string.isRequired,
+  /** If true, renders a close 'X' in the starting corner of the modal */
+  dismissible: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  showHeader: PropTypes.bool,
+  footer: PropTypes.node,
+};
+
+const defaultProps = {
+  scope: 'module',
+  onOpen: () => { },
+  closeOnBackgroundClick: false,
+  dismissible: false,
+  open: false,
+  showHeader: true,
+};
+
+const Modal = (props) => {
+  function getModalScope() {
+    let container;
+    switch (props.scope) {
+      case 'module':
+        container = document.getElementById('ModuleContainer');
+        break;
+      default:
+        break;
+    }
+    return container;
+  }
+
+  function getModalClass() {
+    return classNames(
+      css.modal,
+      { [`${css.small}`]: props.size === 'small' },
+      { [`${css.large}`]: props.size === 'large' },
+    );
+  }
+
+  return (
+    <OverlayModal
+      show={props.open}
+      backdropClassName={css.backdrop}
+      className={css.modalRoot}
+      container={getModalScope()}
+      onHide={props.onClose}
+      onShow={props.onOpen}
+      onBackdropClick={props.closeOnBackgroundClick ? props.onClose : () => { }}
+    >
+      <div
+        className={getModalClass()}
+        aria-label={props['aria-label'] || props.label} // eslint-disable-line react/prop-types
+        id={props.id}
+      >
+        { props.showHeader &&
+          <div className={css.modalHeader}>
+            <div className={css.modalLabel}>
+              {props.label}
+            </div>
+            <div className={css.modalControls}>
+              {props.dismissible &&
+                <button
+                  className={css.closeModal}
+                  onClick={props.onClose}
+                  title="Dismiss modal"
+                  aria-label="Dismiss modal"
+                >
+                  <Icon icon="closeX" />
+                </button>
+              }
+            </div>
+          </div>
+        }
+        <div className={css.modalContent}>
+          {props.children}
+        </div>
+        <div className={css.modalFooter}>
+          {props.footer}
+        </div>
+      </div>
+    </OverlayModal>
+  );
+};
+
+Modal.propTypes = propTypes;
+Modal.defaultProps = defaultProps;
+
+export default Modal;

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -1,140 +1,204 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import Icon from '@folio/stripes-components/lib/Icon';
 import IconButton from '@folio/stripes-components/lib/IconButton';
 import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
+import Button from '@folio/stripes-components/lib/Button';
 
 import Link from '../link';
 import KeyValueLabel from '../key-value-label';
 import List from '../list';
 import TitleListItem from '../title-list-item';
 import ToggleSwitch from '../toggle-switch';
+import Modal from '../modal';
 import { formatISODateWithoutTime } from '../utilities';
 import styles from './package-show.css';
 
-export default function PackageShow({ model, toggleSelected }, { intl, router, queryParams }) {
-  let historyState = router.history.location.state;
+export default class PackageShow extends Component {
+  static propTypes = {
+    model: PropTypes.object.isRequired,
+    toggleSelected: PropTypes.func.isRequired
+  };
 
-  return (
-    <div>
-      {!queryParams.searchType && (
-        <PaneHeader
-          firstMenu={historyState && historyState.eholdings && (
-            <PaneMenu>
-              <div data-test-eholdings-package-details-back-button>
-                <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
+  static contextTypes = {
+    intl: PropTypes.object,
+    router: PropTypes.object,
+    queryParams: PropTypes.object
+  };
+
+  state = {
+    showSelectionModal: false,
+    packageSelected: this.props.model.isSelected
+  };
+
+  componentWillReceiveProps({ model }) {
+    if (!model.isSaving) {
+      this.setState({ packageSelected: model.isSelected });
+    }
+  }
+
+  handleSelectionToggle = () => {
+    this.setState({ packageSelected: !this.props.model.isSelected });
+    if (this.props.model.isSelected) {
+      this.setState({ showSelectionModal: true });
+    } else {
+      this.props.toggleSelected();
+    }
+  };
+
+  commitSelectionToggle = () => {
+    this.setState({ showSelectionModal: false });
+    this.props.toggleSelected();
+  };
+
+  cancelSelectionToggle = () => {
+    this.setState({
+      showSelectionModal: false,
+      packageSelected: this.props.model.isSelected
+    });
+  };
+
+  render() {
+    let { model } = this.props;
+    let { intl, router, queryParams } = this.context;
+    let { showSelectionModal, packageSelected } = this.state;
+    let historyState = router.history.location.state;
+
+    return (
+      <div>
+        {!queryParams.searchType && (
+          <PaneHeader
+            firstMenu={historyState && historyState.eholdings && (
+              <PaneMenu>
+                <div data-test-eholdings-package-details-back-button>
+                  <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
+                </div>
+              </PaneMenu>
+            )}
+          />
+        )}
+        <div className={styles['detail-container']} data-test-eholdings-package-details>
+          {model.isLoaded ? (
+            <div>
+              <div className={styles['detail-container-header']}>
+                <KeyValueLabel label="Package">
+                  <h1 data-test-eholdings-package-details-name>
+                    {model.name}
+                  </h1>
+                </KeyValueLabel>
               </div>
-            </PaneMenu>
-          )}
-        />
-      )}
-      <div className={styles['detail-container']} data-test-eholdings-package-details>
-        {model.isLoaded ? (
-          <div>
-            <div className={styles['detail-container-header']}>
-              <KeyValueLabel label="Package">
-                <h1 data-test-eholdings-package-details-name>
-                  {model.name}
-                </h1>
-              </KeyValueLabel>
-            </div>
 
-            <KeyValueLabel label="Vendor">
-              <div data-test-eholdings-package-details-vendor>
-                <Link to={`/eholdings/vendors/${model.vendorId}`}>{model.vendorName}</Link>
-              </div>
-            </KeyValueLabel>
-
-            {model.contentType && (
-              <KeyValueLabel label="Content Type">
-                <div data-test-eholdings-package-details-content-type>
-                  {model.contentType}
+              <KeyValueLabel label="Vendor">
+                <div data-test-eholdings-package-details-vendor>
+                  <Link to={`/eholdings/vendors/${model.vendorId}`}>{model.vendorName}</Link>
                 </div>
               </KeyValueLabel>
-            ) }
 
-            <KeyValueLabel label="Titles Selected">
-              <div data-test-eholdings-package-details-titles-selected>
-                {model.selectedCount}
-              </div>
-            </KeyValueLabel>
+              {model.contentType && (
+                <KeyValueLabel label="Content Type">
+                  <div data-test-eholdings-package-details-content-type>
+                    {model.contentType}
+                  </div>
+                </KeyValueLabel>
+              ) }
 
-            <KeyValueLabel label="Total Titles">
-              <div data-test-eholdings-package-details-titles-total>
-                {model.titleCount}
-              </div>
-            </KeyValueLabel>
-
-            {(model.customCoverage.beginCoverage || model.customCoverage.endCoverage) && (
-              <KeyValueLabel label="Custom Coverage">
-                <div data-test-eholdings-package-details-custom-coverage>
-                  {formatISODateWithoutTime(model.customCoverage.beginCoverage, intl)} - {formatISODateWithoutTime(model.customCoverage.endCoverage, intl)}
+              <KeyValueLabel label="Titles Selected">
+                <div data-test-eholdings-package-details-titles-selected>
+                  {model.selectedCount}
                 </div>
               </KeyValueLabel>
-            )}
 
-            <hr />
+              <KeyValueLabel label="Total Titles">
+                <div data-test-eholdings-package-details-titles-total>
+                  {model.titleCount}
+                </div>
+              </KeyValueLabel>
 
-            <label
-              data-test-eholdings-package-details-selected
-              htmlFor="package-details-toggle-switch"
-            >
-              <h4>{model.isSelected ? 'Selected' : 'Not Selected'}</h4>
-              <ToggleSwitch
-                onChange={toggleSelected}
-                checked={model.isSelected}
-                isPending={model.update.isPending}
-
-                id="package-details-toggle-switch"
-              />
-            </label>
-
-            {model.visibilityData.isHidden && (
-              <div data-test-eholdings-package-details-is-hidden>
-                <p><strong>This package is hidden.</strong></p>
-                <p><em>{model.visibilityData.reason}</em></p>
-                <hr />
-              </div>
-            )}
-
-            <h3>Titles</h3>
-            <List data-test-eholdings-package-details-title-list>
-              {model.customerResources.isLoading ? (
-                <Icon icon="spinner-ellipsis" />
-              ) : (
-                model.customerResources.map(item => (
-                  <li key={item.id} data-test-eholdings-title-list-item>
-                    <TitleListItem
-                      item={item}
-                      link={`/eholdings/customer-resources/${item.id}`}
-                      showSelected
-                    />
-                  </li>
-                ))
+              {(model.customCoverage.beginCoverage || model.customCoverage.endCoverage) && (
+                <KeyValueLabel label="Custom Coverage">
+                  <div data-test-eholdings-package-details-custom-coverage>
+                    {formatISODateWithoutTime(model.customCoverage.beginCoverage, intl)} - {formatISODateWithoutTime(model.customCoverage.endCoverage, intl)}
+                  </div>
+                </KeyValueLabel>
               )}
-            </List>
-          </div>
-        ) : model.request.isRejected ? (
-          <p data-test-eholdings-package-details-error>
-            {model.request.errors[0].title}
-          </p>
-        ) : model.isLoading ? (
-          <Icon icon="spinner-ellipsis" />
-        ) : null}
+
+              <hr />
+
+              <label
+                data-test-eholdings-package-details-selected
+                htmlFor="package-details-toggle-switch"
+              >
+                <h4>{model.isSelected ? 'Selected' : 'Not Selected'}</h4>
+                <ToggleSwitch
+                  onChange={this.handleSelectionToggle}
+                  checked={packageSelected}
+                  isPending={model.update.isPending}
+                  id="package-details-toggle-switch"
+                />
+              </label>
+
+              {model.visibilityData.isHidden && (
+                <div data-test-eholdings-package-details-is-hidden>
+                  <p><strong>This package is hidden.</strong></p>
+                  <p><em>{model.visibilityData.reason}</em></p>
+                  <hr />
+                </div>
+              )}
+
+              <h3>Titles</h3>
+              <List data-test-eholdings-package-details-title-list>
+                {model.customerResources.isLoading ? (
+                  <Icon icon="spinner-ellipsis" />
+                ) : (
+                  model.customerResources.map(item => (
+                    <li key={item.id} data-test-eholdings-title-list-item>
+                      <TitleListItem
+                        item={item}
+                        link={`/eholdings/customer-resources/${item.id}`}
+                        showSelected
+                      />
+                    </li>
+                  ))
+                )}
+              </List>
+            </div>
+          ) : model.request.isRejected ? (
+            <p data-test-eholdings-package-details-error>
+              {model.request.errors[0].title}
+            </p>
+          ) : model.isLoading ? (
+            <Icon icon="spinner-ellipsis" />
+          ) : null}
+        </div>
+        <Modal
+          open={showSelectionModal}
+          size="small"
+          label="Remove package from holdings?"
+          scope="root"
+          footer={(
+            <div>
+              <Button
+                buttonStyle="primary"
+                onClick={this.commitSelectionToggle}
+                data-test-eholdings-package-deselection-confirmation-modal-yes
+              >
+                Yes, remove
+              </Button>
+              <Button
+                hollow
+                onClick={this.cancelSelectionToggle}
+                data-test-eholdings-package-deselection-confirmation-modal-no
+              >
+                No, do not remove
+              </Button>
+            </div>
+          )}
+        >
+          Are you sure you want to remove this package and all its titles from your holdings? All customizations will be lost.
+        </Modal>
       </div>
-    </div>
-  );
+    );
+  }
 }
-
-PackageShow.propTypes = {
-  model: PropTypes.object.isRequired,
-  toggleSelected: PropTypes.func.isRequired
-};
-
-PackageShow.contextTypes = {
-  intl: PropTypes.object,
-  router: PropTypes.object,
-  queryParams: PropTypes.object
-};

--- a/tests/package-show-selection-test.js
+++ b/tests/package-show-selection-test.js
@@ -1,0 +1,147 @@
+/* global describe, beforeEach, afterEach */
+import { expect } from 'chai';
+import it, { convergeOn } from './it-will';
+
+import { describeApplication } from './helpers';
+import PackageShowPage from './pages/package-show';
+
+describeApplication('PackageShowSelection', () => {
+  let vendor,
+    vendorPackage;
+
+  beforeEach(function () {
+    vendor = this.server.create('vendor', {
+      name: 'Cool Vendor'
+    });
+
+    vendorPackage = this.server.create('package', 'withTitles', {
+      vendor,
+      name: 'Cool Package',
+      contentType: 'E-Book',
+      isSelected: false,
+      titleCount: 5
+    });
+  });
+
+  describe('visiting the package details page', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/packages/${vendorPackage.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    describe('successfully selecting a package title to add to my holdings', () => {
+      beforeEach(function () {
+        /*
+         * The expectations in the convergent `it` blocks
+         * get run once every 10ms.  We were seeing test flakiness
+         * when a toggle action dispatched and resolved before an
+         * expectation had the chance to run.  We sidestep this by
+         * temporarily increasing the mirage server's response time
+         * to 50ms.
+         * TODO: control timing directly with Mirage
+         */
+        this.server.timing = 50;
+        return PackageShowPage.toggleIsSelected();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('reflects the desired state (Selected)', () => {
+        expect(PackageShowPage.isSelected).to.equal(true);
+      });
+
+      it('indicates it working to get to desired state', () => {
+        expect(PackageShowPage.isSelecting).to.equal(true);
+      });
+
+      it('cannot be interacted with while the request is in flight', () => {
+        expect(PackageShowPage.isSelectedToggleable).to.equal(false);
+      });
+
+      describe('when the request succeeds', () => {
+        it('reflect the desired state was set', () => {
+          expect(PackageShowPage.isSelected).to.equal(true);
+        });
+
+        it('indicates it is no longer working', () => {
+          expect(PackageShowPage.isSelecting).to.equal(false);
+        });
+
+        it('should show the package titles are all selected', () => {
+          expect(PackageShowPage.allTitlesSelected).to.equal(true);
+        });
+
+        it('updates the selected title count', () => {
+          expect(PackageShowPage.numTitlesSelected).to.equal(`${vendorPackage.titleCount}`);
+        });
+      });
+
+      describe('and deselecting the package', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            // wait for the package to become toggleable again
+            expect(PackageShowPage.isSelectedToggleable).to.equal(true);
+          }).then(() => PackageShowPage.toggleIsSelected());
+        });
+
+        it('reflects the desired state (not selected)', () => {
+          expect(PackageShowPage.isSelected).to.equal(false);
+        });
+
+        it('should show all package titles are not selected', () => {
+          expect(PackageShowPage.allTitlesSelected).to.equal(false);
+        });
+
+        it('updates the selected title count', () => {
+          expect(PackageShowPage.numTitlesSelected).to.equal('0');
+        });
+      });
+    });
+
+    describe('unsuccessfully selecting a package title to add to my holdings', () => {
+      beforeEach(function () {
+        this.server.put('/packages/:packageId', {
+          errors: [{
+            title: 'There was an error'
+          }]
+        }, 500);
+
+        this.server.timing = 50;
+        return PackageShowPage.toggleIsSelected();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('reflects the desired state (Selected)', () => {
+        expect(PackageShowPage.isSelected).to.equal(true);
+      });
+
+      it('indicates it working to get to desired state', () => {
+        expect(PackageShowPage.isSelecting).to.equal(true);
+      });
+
+      it('cannot be interacted with while the request is in flight', () => {
+        expect(PackageShowPage.isSelectedToggleable).to.equal(false);
+      });
+
+      describe('when the request fails', () => {
+        it('reflect the desired state was not set', () => {
+          expect(PackageShowPage.isSelected).to.equal(false);
+        });
+
+        it('indicates it is no longer working', () => {
+          expect(PackageShowPage.isSelecting).to.equal(false);
+        });
+
+        it.skip('logs an Error somewhere', () => {
+          expect(PackageShowPage.flashError).to.match(/unable to select/i);
+        });
+      });
+    });
+  });
+});

--- a/tests/package-show-selection-test.js
+++ b/tests/package-show-selection-test.js
@@ -53,7 +53,7 @@ describeApplication('PackageShowSelection', () => {
         expect(PackageShowPage.isSelected).to.equal(true);
       });
 
-      it('indicates it working to get to desired state', () => {
+      it('indicates it is working to get to desired state', () => {
         expect(PackageShowPage.isSelecting).to.equal(true);
       });
 
@@ -95,8 +95,55 @@ describeApplication('PackageShowSelection', () => {
           expect(PackageShowPage.allTitlesSelected).to.equal(false);
         });
 
-        it('updates the selected title count', () => {
-          expect(PackageShowPage.numTitlesSelected).to.equal('0');
+        describe('canceling the deselection', () => {
+          beforeEach(() => {
+            PackageShowPage.cancelDeselection();
+          });
+
+          it('reverts back to the selected state', () => {
+            expect(PackageShowPage.isSelected).to.equal(true);
+          });
+        });
+
+        describe('confirming the deselection', () => {
+          beforeEach(function () {
+            this.server.timing = 50;
+            PackageShowPage.confirmDeselection();
+          });
+
+          afterEach(function () {
+            this.server.timing = 0;
+          });
+
+          it('reflects the desired state (Unselected)', () => {
+            expect(PackageShowPage.isSelected).to.equal(false);
+          });
+
+          it('indicates it is working to get to desired state', () => {
+            expect(PackageShowPage.isSelecting).to.equal(true);
+          });
+
+          it('cannot be interacted with while the request is in flight', () => {
+            expect(PackageShowPage.isSelectedToggleable).to.equal(false);
+          });
+
+          describe('when the request succeeds', () => {
+            it('reflect the desired state was set', () => {
+              expect(PackageShowPage.isSelected).to.equal(false);
+            });
+
+            it('indicates it is no longer working', () => {
+              expect(PackageShowPage.isSelecting).to.equal(false);
+            });
+
+            it('should show the package titles are not all selected', () => {
+              expect(PackageShowPage.allTitlesSelected).to.equal(false);
+            });
+
+            it('updates the selected title count', () => {
+              expect(PackageShowPage.numTitlesSelected).to.equal(`${vendorPackage.titleCount}`);
+            });
+          });
         });
       });
     });

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -1,6 +1,6 @@
-/* global describe, beforeEach, afterEach */
+/* global describe, beforeEach */
 import { expect } from 'chai';
-import it, { convergeOn } from './it-will';
+import it from './it-will';
 
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/package-show';
@@ -67,120 +67,6 @@ describeApplication('PackageShow', () => {
 
     it.still('should not display a back button', () => {
       expect(PackageShowPage.$backButton).to.not.exist;
-    });
-
-    describe('successfully selecting a package title to add to my holdings', () => {
-      beforeEach(function () {
-        /*
-         * The expectations in the convergent `it` blocks
-         * get run once every 10ms.  We were seeing test flakiness
-         * when a toggle action dispatched and resolved before an
-         * expectation had the chance to run.  We sidestep this by
-         * temporarily increasing the mirage server's response time
-         * to 50ms.
-         * TODO: control timing directly with Mirage
-         */
-        this.server.timing = 50;
-        return PackageShowPage.toggleIsSelected();
-      });
-
-      afterEach(function () {
-        this.server.timing = 0;
-      });
-
-      it('reflects the desired state (Selected)', () => {
-        expect(PackageShowPage.isSelected).to.equal(true);
-      });
-
-      it('indicates it working to get to desired state', () => {
-        expect(PackageShowPage.isSelecting).to.equal(true);
-      });
-
-      it('cannot be interacted with while the request is in flight', () => {
-        expect(PackageShowPage.isSelectedToggleable).to.equal(false);
-      });
-
-      describe('when the request succeeds', () => {
-        it('reflect the desired state was set', () => {
-          expect(PackageShowPage.isSelected).to.equal(true);
-        });
-
-        it('indicates it is no longer working', () => {
-          expect(PackageShowPage.isSelecting).to.equal(false);
-        });
-
-        it('should show the package titles are all selected', () => {
-          expect(PackageShowPage.allTitlesSelected).to.equal(true);
-        });
-
-        it('updates the selected title count', () => {
-          expect(PackageShowPage.numTitlesSelected).to.equal(`${vendorPackage.titleCount}`);
-        });
-      });
-
-      describe('and deselecting the package', () => {
-        beforeEach(() => {
-          return convergeOn(() => {
-            // wait for the package to become toggleable again
-            expect(PackageShowPage.isSelectedToggleable).to.equal(true);
-          }).then(() => PackageShowPage.toggleIsSelected());
-        });
-
-        it('reflects the desired state (not selected)', () => {
-          expect(PackageShowPage.isSelected).to.equal(false);
-        });
-
-        it('should show all package titles are not selected', () => {
-          expect(PackageShowPage.allTitlesSelected).to.equal(false);
-        });
-
-        it('updates the selected title count', () => {
-          expect(PackageShowPage.numTitlesSelected).to.equal('0');
-        });
-      });
-    });
-
-    describe('unsuccessfully selecting a package title to add to my holdings', () => {
-      beforeEach(function () {
-        this.server.put('/packages/:packageId', {
-          errors: [{
-            title: 'There was an error'
-          }]
-        }, 500);
-
-        this.server.timing = 50;
-        return PackageShowPage.toggleIsSelected();
-      });
-
-      afterEach(function () {
-        this.server.timing = 0;
-      });
-
-      it('reflects the desired state (Selected)', () => {
-        expect(PackageShowPage.isSelected).to.equal(true);
-      });
-
-      it('indicates it working to get to desired state', () => {
-        expect(PackageShowPage.isSelecting).to.equal(true);
-      });
-
-      it('cannot be interacted with while the request is in flight', () => {
-        expect(PackageShowPage.isSelectedToggleable).to.equal(false);
-      });
-
-      describe('when the request fails', () => {
-        it('reflect the desired state was not set', () => {
-          expect(PackageShowPage.isSelected).to.equal(false);
-        });
-
-        it('indicates it is no longer working', () => {
-          expect(PackageShowPage.isSelecting).to.equal(false);
-        });
-
-        it.skip('logs an Error somewhere', () => {
-          expect(PackageShowPage.flashError).to.match(/unable to select/i);
-        });
-      });
     });
   });
 

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -69,6 +69,14 @@ export default {
     return !!this.titleList.length && this.titleList.every(title => title.isSelected);
   },
 
+  confirmDeselection() {
+    return $('[data-test-eholdings-package-deselection-confirmation-modal-yes]').trigger('click');
+  },
+
+  cancelDeselection() {
+    return $('[data-test-eholdings-package-deselection-confirmation-modal-no]').trigger('click');
+  },
+
   get hasErrors() {
     return $('[data-test-eholdings-package-details-error]').length > 0;
   },


### PR DESCRIPTION
## Purpose
If a user wants to deselect a package, ask them in a confirmation modal whether they actually want to commit that destructive action.

Part of https://issues.folio.org/browse/UIEH-34

## Approach
The key to making this feature work was keeping the state of the selection toggle independent of the model state. With a toggle component, it would've been strange if you clicked it, the toggle didn't move, but you received a confirmation modal. The UI feels more natural when the toggle always moves with a click/touch, but reverts back if the user decides to cancel the action or the server runs into a problem.

The current `stripes-components` modal was incompatible with `ui-eholdings`. I copy-and-pasted it over and made some necessary modifications. That's not sustainable, but requires more thought and care at the FOLIO project-wide level. What needs to be addressed with the `stripes-components` modal:
  1. there's no z-index, so it ends up layered behind the responsive search panes; there's no comprehensive strategy for managing z-indices in FOLIO
  2. there's no footer space defined for buttons; not a dealbreaker like number 1, but inconvenient
  3. mobile-unfriendly
  4. visual styles are less refined than areas of FOLIO that have received some TLC

## Screenshots
![rsasj71n7a](https://user-images.githubusercontent.com/230597/34645016-d5580eb6-f308-11e7-8820-0a1e30bd202d.gif)

### Modal at larger sizes
<img width="329" alt="screen shot 2018-01-06 at 5 43 04 pm" src="https://user-images.githubusercontent.com/230597/34645025-1c24c9c4-f309-11e7-91db-a12441214a01.png">

