### PR TITLE
Fix double scrollbars

### DIFF
--- a/src/components/search-paneset/search-paneset.css
+++ b/src/components/search-paneset/search-paneset.css
@@ -31,5 +31,5 @@
 
 .scrollable-container {
   height: calc(100vh - 88px);
-  overflow-y: scroll;
+  overflow-y: auto;
 }


### PR DESCRIPTION
## Purpose
`overflow: scroll` causes the scrollbar to always be visible even with no scrollable content. When there is nested scrollable content, this causes a double scrollbar.

This isn't noticable on an OS that hides scrollbars, but viewing on another OS, or setting the scrollbars to always be visible surfaces this issue.

## Approach
Use `overflow: auto` for the `.scrollable-container` class.

## Learning
To set scrollbars to be visible on MacOS, go to `System Preferences > General > Show Scrollbars`

## Screenshots
*before*
<img width="340" alt="before" src="https://user-images.githubusercontent.com/5005153/34680826-b9807b9e-f45f-11e7-8dbc-205c562206c4.png">

*after*
<img width="340" alt="after" src="https://user-images.githubusercontent.com/5005153/34680831-bf7e3edc-f45f-11e7-93d5-51feb517de56.png">

