### PR TITLE
Internationally format counts

### DIFF
--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -10,6 +10,9 @@ export default function PackageListItem({
   showTitleCount,
   showVendorName,
   packageName
+},
+{
+  intl
 }) {
   return item && (
     <Link to={link}>
@@ -31,9 +34,9 @@ export default function PackageListItem({
         {showTitleCount && (
           <span>
             &nbsp;&bull;&nbsp;
-            <span data-test-eholdings-package-list-item-num-titles-selected>{item.selectedCount}</span>
+            <span data-test-eholdings-package-list-item-num-titles-selected>{intl.formatNumber(item.selectedCount)}</span>
             &nbsp;/&nbsp;
-            <span data-test-eholdings-package-list-item-num-titles>{item.titleCount}</span>
+            <span data-test-eholdings-package-list-item-num-titles>{intl.formatNumber(item.titleCount)}</span>
             &nbsp;
             <span>{item.titleCount === 1 ? 'Title' : 'Titles'}</span>
           </span>
@@ -52,4 +55,8 @@ PackageListItem.propTypes = {
   showTitleCount: PropTypes.bool,
   showVendorName: PropTypes.bool,
   packageName: PropTypes.string
+};
+
+PackageListItem.contextTypes = {
+  intl: PropTypes.object
 };

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -106,13 +106,13 @@ export default class PackageShow extends Component {
 
               <KeyValueLabel label="Titles Selected">
                 <div data-test-eholdings-package-details-titles-selected>
-                  {model.selectedCount}
+                  {intl.formatNumber(model.selectedCount)}
                 </div>
               </KeyValueLabel>
 
               <KeyValueLabel label="Total Titles">
                 <div data-test-eholdings-package-details-titles-total>
-                  {model.titleCount}
+                  {intl.formatNumber(model.titleCount)}
                 </div>
               </KeyValueLabel>
 

--- a/src/components/vendor-list-item/vendor-list-item.js
+++ b/src/components/vendor-list-item/vendor-list-item.js
@@ -4,16 +4,16 @@ import PropTypes from 'prop-types';
 import styles from './vendor-list-item.css';
 import Link from '../link';
 
-export default function VendorListItem({ item, link }) {
+export default function VendorListItem({ item, link }, { intl }) {
   return item && (
     <Link to={link}>
       <h5 className={styles.name} data-test-eholdings-vendor-list-item-name>
         {item.name}
       </h5>
       <div data-test-eholdings-vendor-list-item-selections>
-        <span data-test-eholdings-vendor-list-item-num-packages-selected>{item.packagesSelected}</span>
+        <span data-test-eholdings-vendor-list-item-num-packages-selected>{intl.formatNumber(item.packagesSelected)}</span>
         &nbsp;/&nbsp;
-        <span data-test-eholdings-vendor-list-item-num-packages-total>{item.packagesTotal}</span>
+        <span data-test-eholdings-vendor-list-item-num-packages-total>{intl.formatNumber(item.packagesTotal)}</span>
         &nbsp;
         <span>{item.packagesTotal === 1 ? 'Package' : 'Packages'}</span>
       </div>
@@ -27,4 +27,8 @@ VendorListItem.propTypes = {
     PropTypes.string,
     PropTypes.object
   ])
+};
+
+VendorListItem.contextTypes = {
+  intl: PropTypes.object
 };

--- a/src/components/vendor-show/vendor-show.js
+++ b/src/components/vendor-show/vendor-show.js
@@ -11,7 +11,7 @@ import List from '../list';
 import PackageListItem from '../package-list-item';
 import styles from './vendor-show.css';
 
-export default function VendorShow({ model }, { router, queryParams }) {
+export default function VendorShow({ model }, { router, queryParams, intl }) {
   let historyState = router.history.location.state;
 
   return (
@@ -40,13 +40,13 @@ export default function VendorShow({ model }, { router, queryParams }) {
 
             <KeyValueLabel label="Packages Selected">
               <div data-test-eholdings-vendor-details-packages-selected>
-                {model.packagesSelected}
+                {intl.formatNumber(model.packagesSelected)}
               </div>
             </KeyValueLabel>
 
             <KeyValueLabel label="Total Packages">
               <div data-test-eholdings-vendor-details-packages-total>
-                {model.packagesTotal}
+                {intl.formatNumber(model.packagesTotal)}
               </div>
             </KeyValueLabel>
 
@@ -87,5 +87,6 @@ VendorShow.propTypes = {
 
 VendorShow.contextTypes = {
   router: PropTypes.object,
-  queryParams: PropTypes.object
+  queryParams: PropTypes.object,
+  intl: PropTypes.object
 };

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -70,6 +70,27 @@ describeApplication('PackageShow', () => {
     });
   });
 
+  describe('visiting the package details page for a large package', () => {
+    beforeEach(function () {
+      vendorPackage.selectedCount = 9000;
+      vendorPackage.titleCount = 10000;
+
+      return this.visit(`/eholdings/packages/${vendorPackage.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    describe('viewing large packages', () => {
+      it('correctly formats the number for selected title count', () => {
+        expect(PackageShowPage.numTitlesSelected).to.equal('9,000');
+      });
+
+      it('correctly formats the number for total title count', () => {
+        expect(PackageShowPage.numTitles).to.equal('10,000');
+      });
+    });
+  });
+
   describe('navigating to package show page', () => {
     beforeEach(function () {
       return this.visit({

--- a/tests/vendor-show-test.js
+++ b/tests/vendor-show-test.js
@@ -58,6 +58,27 @@ describeApplication('VendorShow', () => {
     });
   });
 
+  describe('visiting the vendor details page for a large vendor', () => {
+    beforeEach(function () {
+      vendor.packagesSelected = 9000;
+      vendor.packagesTotal = 10000;
+
+      return this.visit(`/eholdings/vendors/${vendor.id}`, () => {
+        expect(VendorShowPage.$root).to.exist;
+      });
+    });
+
+    describe('viewing large vendors', () => {
+      it('correctly formats the number for selected package count', () => {
+        expect(VendorShowPage.numPackagesSelected).to.equal('9,000');
+      });
+
+      it('correctly formats the number for total package count', () => {
+        expect(VendorShowPage.numPackages).to.equal('10,000');
+      });
+    });
+  });
+
   describe('navigating to vendor details page', () => {
     beforeEach(function () {
       return this.visit({


### PR DESCRIPTION
## Purpose
Whenever we show a number, we want to make sure it's internationalized. In many cases, this will add thousands-separating commas.

Closes https://issues.folio.org/browse/UIEH-26.

## Approach
Use `react-intl` provided by Stripes.

## Screenshots
![localhost_3000_eholdings_vendors_22_searchtype vendors q proquest iphone 7 1](https://user-images.githubusercontent.com/230597/34687326-f73ec206-f473-11e7-9e66-35f48e3bc81f.png)
