### PR TITLE
Show loading indicator for loading the total results count

### DIFF
--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -21,6 +21,7 @@ export default class SearchPaneset extends React.Component {
     resultsView: PropTypes.node,
     detailsView: PropTypes.node,
     totalResults: PropTypes.number,
+    isLoading: PropTypes.bool,
     location: PropTypes.object
   };
 
@@ -67,7 +68,8 @@ export default class SearchPaneset extends React.Component {
       resultsType,
       resultsView,
       detailsView,
-      totalResults
+      totalResults,
+      isLoading
     } = this.props;
     let { intl } = this.context;
 
@@ -104,7 +106,7 @@ export default class SearchPaneset extends React.Component {
             <div data-test-eholdings-search-results-header>
               <PaneHeader
                 paneTitle={capitalize(resultsType)}
-                paneSub={`${intl.formatNumber(totalResults)} search results`}
+                paneSub={isLoading ? 'Loading...' : `${intl.formatNumber(totalResults)} search results`}
                 firstMenu={
                   <div className={styles['results-pane-search-toggle']}>
                     <PaneMenu>

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -230,6 +230,7 @@ class SearchRoute extends Component {
             resultsView={this.renderResults()}
             detailsView={!hideDetails && children}
             totalResults={results.length}
+            isLoading={!results.hasLoaded}
             searchForm={(
               <SearchForm
                 searchType={searchType}

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -45,6 +45,10 @@ describeApplication('PackageSearch', () => {
       expect(PackageSearchPage.packageList[0].vendorName).to.equal(pkgs[0].vendor.name);
     });
 
+    it('displays a loading indicator where the total results will be', () => {
+      expect(PackageSearchPage.totalResults).to.equal('Loading...');
+    });
+
     it('displays the total number of search results', () => {
       expect(PackageSearchPage.totalResults).to.equal('3 search results');
     });
@@ -177,7 +181,7 @@ describeApplication('PackageSearch', () => {
           expect(PackageSearchPage.packageList[4].name).to.equal('Other Package 30');
         });
 
-        it('updates the page number in the URL', function () {
+        it('updates the offset in the URL', function () {
           expect(this.app.history.location.search).to.include('offset=26');
         });
       });
@@ -195,8 +199,31 @@ describeApplication('PackageSearch', () => {
         expect(PackageSearchPage.packageList[4].name).to.equal('Other Package 55');
       });
 
-      it('should retain the proper page', function () {
+      it('should retain the proper offset', function () {
         expect(this.app.history.location.search).to.include('offset=51');
+      });
+
+      describe('and then scrolling up', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(PackageSearchPage.packageList.length).to.be.gt(0);
+          }).then(() => {
+            PackageSearchPage.scrollToOffset(0);
+          });
+        });
+
+        // it might take a bit for the next request to be triggered after the scroll
+        it.still('shows the total results', () => {
+          expect(PackageSearchPage.totalResults).to.equal('75 search results');
+        }, 500);
+
+        it('shows the prev page of results', () => {
+          expect(PackageSearchPage.packageList[0].name).to.equal('Other Package 5');
+        });
+
+        it('updates the offset in the URL', function () {
+          expect(this.app.history.location.search).to.include('offset=0');
+        });
       });
     });
   });

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -47,6 +47,10 @@ describeApplication('TitleSearch', () => {
       expect(TitleSearchPage.titleList[0].publicationType).to.equal(titles[0].publicationType);
     });
 
+    it('displays a loading indicator where the total results will be', () => {
+      expect(TitleSearchPage.totalResults).to.equal('Loading...');
+    });
+
     it('displays the total number of search results', () => {
       expect(TitleSearchPage.totalResults).to.equal('3 search results');
     });
@@ -180,7 +184,7 @@ describeApplication('TitleSearch', () => {
           expect(TitleSearchPage.titleList[4].name).to.equal('Other Title 30');
         });
 
-        it('updates the page number in the URL', function () {
+        it('updates the offset in the URL', function () {
           expect(this.app.history.location.search).to.include('offset=26');
         });
       });
@@ -198,8 +202,31 @@ describeApplication('TitleSearch', () => {
         expect(TitleSearchPage.titleList[4].name).to.equal('Other Title 55');
       });
 
-      it('should retain the proper page', function () {
+      it('should retain the proper offset', function () {
         expect(this.app.history.location.search).to.include('offset=51');
+      });
+
+      describe('and then scrolling up', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(TitleSearchPage.titleList.length).to.be.gt(0);
+          }).then(() => {
+            TitleSearchPage.scrollToOffset(0);
+          });
+        });
+
+        // it might take a bit for the next request to be triggered after the scroll
+        it.still('shows the total results', () => {
+          expect(TitleSearchPage.totalResults).to.equal('75 search results');
+        }, 500);
+
+        it('shows the prev page of results', () => {
+          expect(TitleSearchPage.titleList[0].name).to.equal('Other Title 5');
+        });
+
+        it('updates the offset in the URL', function () {
+          expect(this.app.history.location.search).to.include('offset=0');
+        });
       });
     });
   });

--- a/tests/vendor-search-test.js
+++ b/tests/vendor-search-test.js
@@ -47,6 +47,10 @@ describeApplication('VendorSearch', () => {
       expect(VendorSearchPage.vendorList[0].numPackages).to.equal(3);
     });
 
+    it('displays a loading indicator where the total results will be', () => {
+      expect(VendorSearchPage.totalResults).to.equal('Loading...');
+    });
+
     it('displays the total number of search results', () => {
       expect(VendorSearchPage.totalResults).to.equal('3 search results');
     });
@@ -116,11 +120,6 @@ describeApplication('VendorSearch', () => {
       });
     });
 
-    describe('clicking on a result', () => {
-      it('shows vendor details');
-      it('shows packages for vendor');
-    });
-
     describe('clicking another search type', () => {
       beforeEach(() => {
         return convergeOn(() => {
@@ -184,7 +183,7 @@ describeApplication('VendorSearch', () => {
           expect(VendorSearchPage.vendorList[4].name).to.equal('Other Vendor 30');
         });
 
-        it('updates the page number in the URL', function () {
+        it('updates the offset in the URL', function () {
           expect(this.app.history.location.search).to.include('offset=26');
         });
       });
@@ -202,8 +201,31 @@ describeApplication('VendorSearch', () => {
         expect(VendorSearchPage.vendorList[4].name).to.equal('Other Vendor 55');
       });
 
-      it('should retain the proper page', function () {
+      it('should retain the proper offset', function () {
         expect(this.app.history.location.search).to.include('offset=51');
+      });
+
+      describe('and then scrolling up', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(VendorSearchPage.vendorList.length).to.be.gt(0);
+          }).then(() => {
+            VendorSearchPage.scrollToOffset(0);
+          });
+        });
+
+        // it might take a bit for the next request to be triggered after the scroll
+        it.still('shows the total results', () => {
+          expect(VendorSearchPage.totalResults).to.equal('75 search results');
+        }, 500);
+
+        it('shows the prev page of results', () => {
+          expect(VendorSearchPage.vendorList[0].name).to.equal('Other Vendor 5');
+        });
+
+        it('updates the offset in the URL', function () {
+          expect(this.app.history.location.search).to.include('offset=0');
+        });
       });
     });
   });


### PR DESCRIPTION
## Purpose
Display "Loading..." message in place of the total results count when loading search results.

## Approach
When a collection does not have any loaded records, show the "Loading..." message.

If we used the collection's `isLoading` property, that would return `true` when the requests for the _current page_ in the collection is pending.

The `isLoaded` property (renamed to `hasLoaded`) returns `true` when _any page's_ request for the collection are no longer pending (resolved or rejected).

The previous method for finding the first resolved request in a collection stopped looking for resolved pages after the current page. So if `page=5` is loaded and we view `page=1`, `hasLoaded` would be `false` even though `page=5` has indeed already loaded. 

This method has been updated to keep searching for resolved requests for up to 400 pages. The reason being that we cannot use `this.totalPages` as it uses `this.length` which in turn calls the getter for `request`, thereby entering an infinite loop. This page limit is arbitrary and was only chosen to ensure all pages are accounted for with up to 10,000 total results (with the default 25 record page size). The loop will exit and cache the request once a resolved request has been found.

## Tests
Since `isLoaded` returned `false` when viewing previous pages in the collection, when we scrolled up in a results list it would flash back to "Loading..." even though we already had the total search count. Additionally, the default `50ms` timeout for `it.still` did not catch this scenario since the following request happened after we scrolled and stopped for at least `300ms`. The tests added to account for this include setting the `it.still` timeout to `500ms`.

## Screenshots
![loading](https://user-images.githubusercontent.com/5005153/34689244-7190c8be-f47a-11e7-884e-fd56b54e339d.gif)



  