### PR TITLE
Editable custom coverage date on package

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -191,15 +191,14 @@ export default function configure() {
     });
 
     let body = JSON.parse(request.requestBody);
-    let { isSelected } = body.data.attributes;
-
-    let { visibilityData } = body.data.attributes;
+    let { isSelected, customCoverage, visibilityData } = body.data.attributes;
 
     let selectedCount = isSelected ? matchingCustomerResources.length : 0;
 
     matchingCustomerResources.update('isSelected', isSelected);
     matchingCustomerResources.update('visibilityData', visibilityData);
     matchingPackage.update('isSelected', isSelected);
+    matchingPackage.update('customCoverage', customCoverage);
     matchingPackage.update('selectedCount', selectedCount);
     matchingPackage.update('visibilityData', visibilityData);
 

--- a/src/components/custom-coverage-date/custom-coverage-date.css
+++ b/src/components/custom-coverage-date/custom-coverage-date.css
@@ -11,7 +11,6 @@
 
 .custom-coverage-action-buttons {
   display: flex;
-  flex-direction: row-reverse;
   margin-top: 1em;
 }
 

--- a/src/components/custom-coverage-date/custom-coverage-date.css
+++ b/src/components/custom-coverage-date/custom-coverage-date.css
@@ -1,0 +1,42 @@
+@import '@folio/stripes-components/lib/variables';
+
+.custom-coverage-form,
+.custom-coverage-form-editing {
+  padding: 0.5em;
+}
+
+.custom-coverage-form-editing {
+  background: #e6f3ff;
+}
+
+.custom-coverage-action-buttons {
+  display: flex;
+  flex-direction: row-reverse;
+  margin-top: 1em;
+}
+
+.custom-coverage-date-display {
+  display: flex;
+  align-items: center
+}
+
+.custom-coverage-dates {
+  display: flex;
+  align-items: flex-start;
+}
+
+.custom-coverage-date-clear-row {
+  flex: 0 0 3em;
+  margin-top: 1.5em;
+  text-align: center;
+}
+
+.custom-coverage-date-picker {
+  align-self: flex-start;
+  flex: 1 1 auto;
+  margin-right: 1em;
+}
+
+.custom-coverage-add-button {
+  margin: 1em 0;
+}

--- a/src/components/custom-coverage-date/custom-coverage-date.js
+++ b/src/components/custom-coverage-date/custom-coverage-date.js
@@ -1,0 +1,179 @@
+import React, { Component } from 'react';
+import { Field, reduxForm } from 'redux-form';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+import Datepicker from '@folio/stripes-components/lib/Datepicker';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+import Button from '@folio/stripes-components/lib/Button';
+import styles from './custom-coverage-date.css';
+
+import { formatISODateWithoutTime } from '../utilities';
+
+class CustomCoverageDate extends Component {
+  static propTypes = {
+    initialValues: PropTypes.shape({
+      beginCoverage: PropTypes.string,
+      endCoverage: PropTypes.string
+    }).isRequired,
+    handleSubmit: PropTypes.func.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    pristine: PropTypes.bool,
+    initialize: PropTypes.func,
+    isPending: PropTypes.bool
+  }
+
+  static contextTypes = {
+    intl: PropTypes.object
+  }
+
+  state = {
+    isEditing: false
+  }
+
+  renderDatepicker = ({ input, label, meta }) => {
+    return (
+      <div>
+        <Datepicker
+          label={label}
+          input={input}
+          meta={meta}
+        />
+      </div>
+    );
+  }
+
+  handleEditCustomCoverage = (event) => {
+    let isEditing = !this.state.isEditing;
+    event.preventDefault();
+    this.setState({ isEditing });
+  }
+
+  handleCancelCustomCoverage = (event) => {
+    event.preventDefault();
+    this.setState({
+      isEditing: false
+    });
+    this.props.initialize(this.props.initialValues);
+  }
+
+  handleDeleteCustomCoverage = (event) => {
+    event.preventDefault();
+    let data = {
+      beginCoverage: '',
+      endCoverage: ''
+    };
+
+    this.handleSubmit(data);
+  }
+
+  handleSubmit = (data) => {
+    this.setState({
+      isEditing: false
+    });
+    this.props.onSubmit(data);
+  }
+
+
+  render() {
+    let { pristine, isPending } = this.props;
+    let { intl } = this.context;
+
+    const { beginCoverage, endCoverage } = this.props.initialValues;
+    if (this.state.isEditing) {
+      return (
+        <form onSubmit={this.props.handleSubmit(this.handleSubmit)}>
+          <div
+            data-test-eholdings-package-details-custom-coverage-inputs
+            className={styles['custom-coverage-form-editing']}
+          >
+            <div className={styles['custom-coverage-dates']}>
+              <div data-test-eholdings-package-details-custom-begin-coverage className={styles['custom-coverage-date-picker']}>
+                <Field
+                  name='beginCoverage'
+                  component={this.renderDatepicker}
+                  label="Start Date"
+                />
+              </div>
+              <div data-test-eholdings-package-details-custom-end-coverage className={styles['custom-coverage-date-picker']}>
+                <Field
+                  name='endCoverage'
+                  component={this.renderDatepicker}
+                  label="End Date"
+                />
+              </div>
+              <div className={styles['custom-coverage-date-clear-row']}>
+                {this.props.initialValues.beginCoverage && (
+                  <IconButton icon="trashBin" onClick={this.handleDeleteCustomCoverage} size="small" />
+                )}
+              </div>
+            </div>
+            <div className={styles['custom-coverage-action-buttons']}>
+              <div data-test-eholdings-package-details-save-custom-coverage-button>
+                <Button disabled={pristine} type="submit" role="button" buttonStyle="primary">
+                  Save
+                </Button>
+              </div>
+              <div data-test-eholdings-package-details-cancel-custom-coverage-button>
+                <Button disabled={isPending} type="button" role="button" onClick={this.handleCancelCustomCoverage}>
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          </div>
+        </form>
+      );
+    } else if (beginCoverage) {
+      return (
+        <div className={styles['custom-coverage-form']}>
+          <div className={styles['custom-coverage-date-display']}>
+            <div data-test-eholdings-package-details-custom-coverage-display className={styles['custom-coverage-dates']}>
+              {formatISODateWithoutTime(beginCoverage, intl)} - {formatISODateWithoutTime(endCoverage, intl) || 'Present'}
+            </div>
+            <div data-test-eholdings-package-details-edit-custom-coverage-button>
+              <IconButton icon="edit" onClick={this.handleEditCustomCoverage} />
+            </div>
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div className={styles['custom-coverage-form']}>
+          <div data-test-eholdings-package-details-custom-coverage-button>
+            <Button
+              type="button"
+              onClick={this.handleEditCustomCoverage}
+            >
+              Add Custom Coverage
+            </Button>
+          </div>
+        </div>
+      );
+    }
+  }
+}
+
+// this function is a special function used by redux-form for form validation
+// the values from the from are passed into this function and then
+// validated based on the matching field with the same 'name' as value
+function validate(values, props) {
+  let dateFormat = props.intl.formatters.getDateTimeFormat().format();
+  const errors = {};
+
+  if (!values.beginCoverage || !moment(values.beginCoverage).isValid()) {
+    errors.beginCoverage = `Enter Date in ${dateFormat} format.`;
+  }
+
+  if (values.endCoverage && moment(values.beginCoverage).isAfter(moment(values.endCoverage))) {
+    errors.beginCoverage = 'Start Date must be before End Date';
+  }
+
+  return errors;
+}
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'CustomCoverage',
+  destroyOnUnmount: false
+})(CustomCoverageDate);

--- a/src/components/custom-coverage-date/custom-coverage-date.js
+++ b/src/components/custom-coverage-date/custom-coverage-date.js
@@ -109,14 +109,14 @@ class CustomCoverageDate extends Component {
               </div>
             </div>
             <div className={styles['custom-coverage-action-buttons']}>
-              <div data-test-eholdings-package-details-save-custom-coverage-button>
-                <Button disabled={pristine} type="submit" role="button" buttonStyle="primary">
-                  Save
+              <div data-test-eholdings-package-details-cancel-custom-coverage-button>
+                <Button disabled={isPending} type="button" role="button" buttonStyle="secondary" onClick={this.handleCancelCustomCoverage}>
+                  Cancel
                 </Button>
               </div>
-              <div data-test-eholdings-package-details-cancel-custom-coverage-button>
-                <Button disabled={isPending} type="button" role="button" onClick={this.handleCancelCustomCoverage}>
-                  Cancel
+              <div data-test-eholdings-package-details-save-custom-coverage-button>
+                <Button disabled={pristine} type="submit" role="button">
+                  Save
                 </Button>
               </div>
             </div>

--- a/src/components/custom-coverage-date/index.js
+++ b/src/components/custom-coverage-date/index.js
@@ -1,0 +1,1 @@
+export { default } from './custom-coverage-date';

--- a/src/components/package-custom-coverage/index.js
+++ b/src/components/package-custom-coverage/index.js
@@ -1,0 +1,1 @@
+export { default } from './package-custom-coverage';

--- a/src/components/package-custom-coverage/package-custom-coverage.js
+++ b/src/components/package-custom-coverage/package-custom-coverage.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import CustomCoverageDate from '../custom-coverage-date/custom-coverage-date';
+
+export default function PackageCustomCoverage({ onSubmit, isPending, intl, beginCoverage, endCoverage }) {
+  return (
+    <CustomCoverageDate onSubmit={onSubmit} isPending={isPending} intl={intl} initialValues={{ beginCoverage, endCoverage }} />
+  );
+}
+
+PackageCustomCoverage.propTypes = {
+  beginCoverage: PropTypes.string,
+  endCoverage: PropTypes.string,
+  onSubmit: PropTypes.func,
+  isPending: PropTypes.bool,
+  intl: PropTypes.object
+};
+

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -13,7 +13,7 @@ import KeyValueLabel from './key-value-label';
 import TitleListItem from './title-list-item';
 import ToggleSwitch from './toggle-switch';
 import Modal from './modal';
-import { formatISODateWithoutTime } from './utilities';
+import PackageCustomCoverage from './package-custom-coverage';
 import styles from './styles.css';
 
 export default class PackageShow extends Component {
@@ -21,7 +21,8 @@ export default class PackageShow extends Component {
     model: PropTypes.object.isRequired,
     fetchPackageTitles: PropTypes.func.isRequired,
     toggleSelected: PropTypes.func.isRequired,
-    toggleHidden: PropTypes.func.isRequired
+    toggleHidden: PropTypes.func.isRequired,
+    customCoverageSubmitted: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -67,7 +68,7 @@ export default class PackageShow extends Component {
   };
 
   render() {
-    let { model, fetchPackageTitles } = this.props;
+    let { model, fetchPackageTitles, customCoverageSubmitted } = this.props;
     let { intl, router, queryParams } = this.context;
     let { showSelectionModal, packageSelected, packageHidden } = this.state;
     let historyState = router.history.location.state;
@@ -112,8 +113,6 @@ export default class PackageShow extends Component {
                   {intl.formatNumber(model.titleCount)}
                 </div>
               </KeyValueLabel>
-
-              <hr />
 
               <label
                 data-test-eholdings-package-details-selected
@@ -161,17 +160,23 @@ export default class PackageShow extends Component {
                     </Layout>
                   </label>
 
-                  {(model.customCoverage.beginCoverage || model.customCoverage.endCoverage) && (
-                    <div>
-                      <hr />
+                  <hr />
 
-                      <KeyValueLabel label="Custom Coverage">
-                        <div data-test-eholdings-package-details-custom-coverage>
-                          {formatISODateWithoutTime(model.customCoverage.beginCoverage, intl)} - {formatISODateWithoutTime(model.customCoverage.endCoverage, intl)}
-                        </div>
-                      </KeyValueLabel>
-                    </div>
-                  )}
+                  <KeyValueLabel label="Custom Coverage">
+                    {model.customCoverage.beginCoverage ? (
+                      <div data-test-eholdings-package-details-custom-coverage>
+                        <PackageCustomCoverage
+                          beginCoverage={model.customCoverage.beginCoverage}
+                          endCoverage={model.customCoverage.endCoverage}
+                          onSubmit={customCoverageSubmitted}
+                          isPending={model.update.isPending && 'customCoverage' in model.update.changedAttributes}
+                          intl={intl}
+                        />
+                      </div>
+                    ) : (
+                      <PackageCustomCoverage onSubmit={customCoverageSubmitted} intl={intl} />
+                    )}
+                  </KeyValueLabel>
                 </div>
               )}
 

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import moment from 'moment';
 
 import { createResolver } from '../redux';
 import Package from '../redux/package';
@@ -68,6 +69,13 @@ class PackageShowRoute extends Component {
     getPackageTitles(packageId, { page });
   };
 
+  customCoverageSubmitted = (values) => {
+    let { model, updatePackage } = this.props;
+    model.customCoverage.beginCoverage = !values.beginCoverage ? null : moment(values.beginCoverage).format('YYYY-MM-DD');
+    model.customCoverage.endCoverage = !values.endCoverage ? null : moment(values.endCoverage).format('YYYY-MM-DD');
+    updatePackage(model);
+  };
+
   render() {
     return (
       <View
@@ -75,6 +83,7 @@ class PackageShowRoute extends Component {
         fetchPackageTitles={this.fetchPackageTitles}
         toggleSelected={this.toggleSelected}
         toggleHidden={this.toggleHidden}
+        customCoverageSubmitted={this.customCoverageSubmitted}
       />
     );
   }

--- a/tests/package-show-custom-coverage-test.js
+++ b/tests/package-show-custom-coverage-test.js
@@ -1,6 +1,6 @@
 /* global describe, beforeEach */
 import { expect } from 'chai';
-import it from './it-will';
+import it, { convergeOn } from './it-will';
 
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/package-show';
@@ -15,6 +15,25 @@ describeApplication('PackageShowCustomCoverage', () => {
     });
   });
 
+  describe('visting the packshow page and package is not selected', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', {
+        provider,
+        name: 'Cool Package',
+        contentType: 'ebook',
+        isSelected: false
+      });
+
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('should not display custom coverage', () => {
+      expect(PackageShowPage.customCoverage).to.equal('');
+    });
+  });
+
   describe('visiting the package show page with custom coverage', () => {
     beforeEach(function () {
       let customCoverage = this.server.create('custom-coverage', {
@@ -26,7 +45,8 @@ describeApplication('PackageShowCustomCoverage', () => {
         customCoverage,
         provider,
         name: 'Cool Package',
-        contentType: 'E-Book'
+        contentType: 'E-Book',
+        isSelected: true
       });
 
       return this.visit(`/eholdings/packages/${pkg.id}`, () => {
@@ -37,6 +57,48 @@ describeApplication('PackageShowCustomCoverage', () => {
     it('displays the custom coverage section', () => {
       expect(PackageShowPage.customCoverage).to.equal('7/16/1969 - 12/19/1972');
     });
+
+    it.still('should not display a button to add custom coverage', () => {
+      expect(PackageShowPage.$customCoverageButton).to.not.exist;
+    });
+
+    it('displays whether or not the package is selected', () => {
+      expect(PackageShowPage.isSelected).to.equal(true);
+    });
+
+    describe('clicking to toggle and deselect package and confirming deselection', () => {
+      beforeEach(() => {
+        return PackageShowPage.toggleIsSelected().then(() => {
+          return PackageShowPage.confirmDeselection();
+        });
+      });
+
+      it('removes the custom coverage', () => {
+        expect(PackageShowPage.customCoverage).to.equal('');
+      });
+    });
+
+    describe('clicking to toggle and deselect package and canceling deselection', () => {
+      beforeEach(() => {
+        return PackageShowPage.toggleIsSelected().then(() => {
+          return PackageShowPage.cancelDeselection();
+        });
+      });
+
+      it('does not remove the custom coverage', () => {
+        expect(PackageShowPage.customCoverage).to.equal('7/16/1969 - 12/19/1972');
+      });
+    });
+
+    describe('clicking the edit button', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickCustomCoverageEditButton();
+      });
+
+      it('displays the date input fields', () => {
+        expect(PackageShowPage.$customCoverageInputs).to.exist;
+      });
+    });
   });
 
   describe('visiting the package show page with a package without custom coverage', () => {
@@ -44,7 +106,8 @@ describeApplication('PackageShowCustomCoverage', () => {
       pkg = this.server.create('package', {
         provider,
         packageName: 'Cool Package',
-        contentType: 'ebook'
+        contentType: 'ebook',
+        isSelected: true
       });
 
       return this.visit(`/eholdings/packages/${pkg.id}`, () => {
@@ -54,6 +117,161 @@ describeApplication('PackageShowCustomCoverage', () => {
 
     it.still('does not display the custom coverage section', () => {
       expect(PackageShowPage.customCoverage).to.equal('');
+    });
+
+    it('should display a button to add custom', () => {
+      expect(PackageShowPage.$customCoverageAddButton).to.exist;
+    });
+
+    describe('clicking on the add custom coverage button', () => {
+      beforeEach(() => {
+        PackageShowPage.clickCustomCoverageAddButton();
+      });
+
+      it('should remove the add custom coverage button', () => {
+        expect(PackageShowPage.$customCoverageAddButton).to.not.exist;
+      });
+
+      it('displays custom coverage date inputs', () => {
+        expect(PackageShowPage.$customCoverageInputs).to.exist;
+      });
+
+      describe('entering valid coverage', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(PackageShowPage.$beginDateField).to.exist;
+            expect(PackageShowPage.$endDateField).to.exist;
+          });
+        });
+
+        describe('with begin date and end date', () => {
+          beforeEach(() => {
+            PackageShowPage.inputBeginDate('12/16/2018');
+            PackageShowPage.inputEndDate('12/24/2018');
+          });
+          it('accepts valid begin date', () => {
+            expect(PackageShowPage.$beginDateField.value).to.equal('12/16/2018');
+          });
+
+          it('accepts valid end date', () => {
+            expect(PackageShowPage.$endDateField.value).to.equal('12/24/2018');
+          });
+
+          it('save button is enabled', () => {
+            expect(PackageShowPage.isCustomCoverageSavable).to.be.true;
+          });
+
+          describe('saving coverage', () => {
+            beforeEach(() => {
+              PackageShowPage.clickCustomCoverageSaveButton();
+            });
+
+            it('shows new custom coverage on detail record', () => {
+              expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/24/2018');
+            });
+
+            it('removes the custom coverage input fields', () => {
+              expect(PackageShowPage.$customCoverageInputs).to.not.exist;
+            });
+
+            it('does not display the button to add custom coverage', () => {
+              expect(PackageShowPage.$customCoverageAddButton).to.not.exist;
+            });
+          });
+        });
+
+        describe('with begin date and no end date', () => {
+          beforeEach(() => {
+            PackageShowPage.inputBeginDate('12/16/2018');
+          });
+          it('accepts valid begin date', () => {
+            expect(PackageShowPage.$beginDateField.value).to.equal('12/16/2018');
+          });
+
+          it('save button is enabled', () => {
+            expect(PackageShowPage.isCustomCoverageSavable).to.be.true;
+          });
+
+          describe('saving coverage', () => {
+            beforeEach(() => {
+              PackageShowPage.clickCustomCoverageSaveButton();
+            });
+
+            it('shows new custom coverage on detail record', () => {
+              expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - Present');
+            });
+
+            it('removes the custom coverage input fields', () => {
+              expect(PackageShowPage.$customCoverageInputs).to.not.exist;
+            });
+
+            it('does not display the button to add custom coverage', () => {
+              expect(PackageShowPage.$customCoverageAddButton).to.not.exist;
+            });
+          });
+        });
+      });
+
+      describe('entering invalid coverage', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(PackageShowPage.$beginDateField).to.exist;
+            expect(PackageShowPage.$endDateField).to.exist;
+          });
+        });
+
+        describe('with no begin date', () => {
+          beforeEach(() => {
+            PackageShowPage.$beginDateField.click();
+            PackageShowPage.inputBeginDate('12/16/2018');
+            PackageShowPage.pressEnterBeginDate();
+            PackageShowPage.clearBeginDate();
+            PackageShowPage.blurBeginDate();
+          });
+
+          it('rejects invalid begin date', () => {
+            convergeOn(() => {
+              expect(PackageShowPage.validationError).to.exist;
+            }).then(() => {
+              expect(PackageShowPage.validationError).to.match(/\bEnter Date in.*\b/);
+            });
+          });
+        });
+
+        describe('with begin date after end date', () => {
+          beforeEach(() => {
+            PackageShowPage.$beginDateField.click();
+            PackageShowPage.inputBeginDate('12/24/2018');
+            PackageShowPage.pressEnterBeginDate();
+            PackageShowPage.blurBeginDate();
+
+            PackageShowPage.$endDateField.click();
+            PackageShowPage.inputEndDate('12/16/2018');
+            PackageShowPage.pressEnterEndDate();
+            PackageShowPage.blurEndDate();
+          });
+
+
+          it('throws validation error', () => {
+            expect(PackageShowPage.validationError).to.include('Start Date must be before End Date');
+          });
+        });
+      });
+
+
+      describe('clicking the cancel button', () => {
+        beforeEach(() => {
+          PackageShowPage.clickCustomCoverageCancelButton();
+        });
+
+        it('removes the custom coverage input fields', () => {
+          expect(PackageShowPage.$customCoverageInputs).to.not.exist;
+        });
+
+        it('displays the button to add custom coverage', () => {
+          expect(PackageShowPage.$customCoverageAddButton).to.exist;
+        });
+      });
     });
   });
 });

--- a/tests/package-show-selection-test.js
+++ b/tests/package-show-selection-test.js
@@ -145,12 +145,10 @@ describeApplication('PackageShowSelection', () => {
             });
 
             it('removes custom coverage', () => {
-              expect(providerPackage.customCoverage.beginCoverage).to.equal(null);
-              expect(providerPackage.customCoverage.endCoverage).to.equal(null);
+              expect(PackageShowPage.customCoverage).to.equal('');
             });
 
             it('is not hidden', () => {
-              expect(providerPackage.visibilityData.isHidden).to.equal(false);
               expect(PackageShowPage.isHidden).to.equal(false);
             });
           });

--- a/tests/pages/helpers.js
+++ b/tests/pages/helpers.js
@@ -16,6 +16,44 @@ export function fillIn(el, val) {
   });
 }
 
+/* Only used for datepicker component */
+export function advancedFillIn(el, value) {
+  let $node = el;
+  // cache artificial value property descriptor
+  let descriptor = Object.getOwnPropertyDescriptor($node, 'value');
+
+  // remove artificial value property
+  if (descriptor) delete $node.value;
+
+  // set the actual value
+  $node.value = value;
+
+  // dispatch input event
+  $node.dispatchEvent(
+    new Event('input', {
+      bubbles: true,
+      cancelable: true
+    })
+  );
+
+  // dispatch change event
+  $node.dispatchEvent(
+    new Event('change', {
+      bubbles: true,
+      cancelable: true
+    })
+  );
+
+  // restore artificial value property descriptor
+  if (descriptor) {
+    Object.defineProperty($node, 'value', descriptor);
+  }
+
+  return convergeOn(() => {
+    expect($node.value).to.equal(value);
+  });
+}
+
 export function blur(el) {
   let node = $(el).get(0);
 
@@ -28,5 +66,22 @@ export function blur(el) {
     );
   } else {
     throw new Error('Blur node does not exist.');
+  }
+}
+
+export function pressEnter(el) {
+  let $node = el;
+
+  if ($node) {
+    let newKeyboardEvent = new Event('keydown', {
+      bubbles: true,
+      cancelable: true
+    });
+
+    Object.assign(newKeyboardEvent, {
+      keyCode: 13
+    });
+
+    $node.dispatchEvent(newKeyboardEvent);
   }
 }

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -1,6 +1,8 @@
 import $ from 'jquery';
 import { expect } from 'chai';
+
 import { convergeOn } from '../it-will';
+import { advancedFillIn, pressEnter } from './helpers';
 
 function createTitleObject(element) {
   let $scope = $(element);
@@ -62,12 +64,52 @@ export default {
     ));
   },
 
+  clickCustomCoverageCancelButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-package-details-cancel-custom-coverage-button]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-package-details-cancel-custom-coverage-button] button').click()
+    ));
+  },
+
+  clickCustomCoverageEditButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-package-details-edit-custom-coverage-button]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-package-details-edit-custom-coverage-button] button').click()
+    ));
+  },
+
+  clickCustomCoverageSaveButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-package-details-save-custom-coverage-button]')).to.exist;
+    }).then(() => {
+      return $('[data-test-eholdings-package-details-save-custom-coverage-button] button').click();
+    });
+  },
+
+  clickCustomCoverageAddButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-package-details-custom-coverage-button] button')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-package-details-custom-coverage-button] button').click()
+    ));
+  },
+
+  get beginCoverage() {
+    return $('[data-test-eholdings-package-details-custom-begin-coverage]').find('input').val();
+  },
+
   get isSelecting() {
     return $('[data-test-eholdings-package-details-selected] [data-test-toggle-switch]').attr('class').indexOf('is-pending--') !== -1;
   },
 
   get isSelectedToggleable() {
     return $('[data-test-eholdings-package-details-selected] input[type=checkbox]').prop('disabled') === false;
+  },
+
+  get isCustomCoverageSavable() {
+    return $('[data-test-eholdings-package-details-save-custom-coverage-button] button').prop('disabled') === false;
   },
 
   get allTitlesSelected() {
@@ -122,7 +164,7 @@ export default {
   },
 
   get customCoverage() {
-    return $('[data-test-eholdings-package-details-custom-coverage]').text();
+    return $('[data-test-eholdings-package-details-custom-coverage-display]').text();
   },
 
   get $backButton() {
@@ -136,5 +178,66 @@ export default {
 
     $list.scrollTop = scrollOffset;
     $list.dispatchEvent(new Event('scroll'));
+  },
+
+  get $customCoverageCancelButton() {
+    return $('[data-test-eholdings-package-details-cancel-custom-coverage-button] button');
+  },
+
+  get $customCoverageInputs() {
+    return $('[data-test-eholdings-package-details-custom-coverage-inputs]');
+  },
+
+  get $customCoverageAddButton() {
+    return $('[data-test-eholdings-package-details-custom-coverage-button] button');
+  },
+
+  get $beginDateField() {
+    return $('[data-test-eholdings-package-details-custom-begin-coverage] input')[0];
+  },
+  get $endDateField() {
+    return $('[data-test-eholdings-package-details-custom-end-coverage] input')[0];
+  },
+
+  get validationError() {
+    return $('[data-test-eholdings-package-details-custom-begin-coverage] [class^="feedbackError"]').text();
+  },
+
+  inputBeginDate(beginDate) {
+    return advancedFillIn(this.$beginDateField, beginDate);
+  },
+
+  inputEndDate(endDate) {
+    return advancedFillIn(this.$endDateField, endDate);
+  },
+  pressEnterBeginDate() {
+    pressEnter(this.$beginDateField);
+  },
+  pressEnterEndDate() {
+    pressEnter(this.$endDateField);
+  },
+  clearBeginDate() {
+    let $clearButton = $('[data-test-eholdings-package-details-custom-begin-coverage]')
+      .find('button[id^=datepicker-clear-button]');
+    return convergeOn(() => {
+      expect($clearButton).to.exist;
+    }).then(() => {
+      $clearButton.click();
+    });
+  },
+  clearEndDate() {
+    let $clearButton = $('[data-test-eholdings-package-details-custom-end-coverage]')
+      .find('button[id^=datepicker-clear-button]');
+    return convergeOn(() => {
+      expect($clearButton).to.exist;
+    }).then(() => {
+      $clearButton.click();
+    });
+  },
+  blurEndDate() {
+    this.$endDateField.blur();
+  },
+  blurBeginDate() {
+    this.$beginDateField.blur();
   }
 };


### PR DESCRIPTION
## Purpose
A user needs to be able to perform CRUD (create, read, update, and delete) operations on custom coverage dates on a package.

## Approach
Create a custom-coverage-date component that encapsulates those CRUD operations and incorporate those actions into the application. Forms have a lot of state around them state that is 'internal' or a concern to the Form itself and state that is 'external' and a concern to the application and Redux-Store. To aid with this integration of 'internal', 'external' state, crud operations, dispatched actions to store and connecting and communicating with store and the like we employed the use of Redux-Form.

The validation around the custom-coverage-date component complies with https://issues.folio.org/browse/UIEH-50.

## Learning
[Form Design](https://www.lukew.com/resources/web_form_design.asp)
[Redux-Form](https://redux-form.com/7.2.0/)


## Screenshots
![2018-02-07 13 07 23](https://user-images.githubusercontent.com/1953098/35933298-34ca4da6-0c08-11e8-997f-e5dce1774db3.gif)
