### PR TITLE
Use skeleton loading css for list-item loading state

### DIFF
--- a/src/components/package-list-item/package-list-item.css
+++ b/src/components/package-list-item/package-list-item.css
@@ -1,5 +1,78 @@
-.name {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+.item {
+  height: 100%;
+
+  & h5, & div {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}
+
+.skeleton {
+  height: 100%;
+  background-repeat: no-repeat;
+  background-origin: content-box;
+  position: relative;
+  padding: 1em;
+
+  /* skeleton effect */
+  background-image:
+    linear-gradient(#eee, #eee 0.9em, transparent 0.9em), /* name */
+    linear-gradient(#eee, #eee 0.8em, transparent 0.8em); /* selected */
+  background-size:
+    20em 1.1em, /* name */
+    4em 1em;    /* selected */
+  background-position:
+    0 0.1em, /* name */
+    0 1.7em; /* selected */
+
+  &.is-vendor-name-visible {
+    background-image:
+      linear-gradient(#eee, #eee 0.9em, transparent 0.9em), /* name */
+      linear-gradient(#eee, #eee 0.8em, transparent 0.8em), /* vendor */
+      linear-gradient(#eee, #eee 0.8em, transparent 0.8em); /* selected */
+    background-size:
+      20em 1.1em, /* name */
+      10em 1em,   /* vendor */
+      5em 1em;    /* selected */
+    background-position:
+      0 0.1em, /* name */
+      0 1.7em, /* vendor */
+      0 2.7em; /* selected */
+  }
+
+  &.is-title-count-visible {
+    background-image:
+      linear-gradient(#eee, #eee 0.9em, transparent 0.9em), /* name */
+      linear-gradient(#eee, #eee 0.8em, transparent 0.8em), /* selected */
+      linear-gradient(#eee, #eee 0.8em, transparent 0.8em); /* count */
+    background-size:
+      20em 1.1em, /* name */
+      5em 1em,    /* selected */
+      8em 1em;    /* count */
+    background-position:
+      0 0.1em, /* name */
+      0 1.7em, /* selected */
+      0 2.7em; /* count */
+  }
+
+  /* shimmer effect */
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-repeat: no-repeat;
+    background-image: linear-gradient(to right, transparent, color(white a(30%)) 50%, transparent);
+    background-size: 10em 100%;
+    background-position: -10em 0;
+    animation: shimmer 3s infinite;
+  }
+}
+
+@keyframes shimmer {
+  from { background-position: -10em 0; }
+  to { background-position: calc(100% + 10em) 0; }
 }

--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 
 import styles from './package-list-item.css';
 import Link from '../link';
+
+const cx = classNames.bind(styles);
 
 export default function PackageListItem({
   item,
@@ -10,13 +13,19 @@ export default function PackageListItem({
   showTitleCount,
   showVendorName,
   packageName
-},
-{
+}, {
   intl
 }) {
-  return item && (
-    <Link to={link}>
-      <h5 className={styles.name} data-test-eholdings-package-list-item-name>
+  return !item ? (
+    <div
+      className={cx('skeleton', {
+        'is-vendor-name-visible': showVendorName,
+        'is-title-count-visible': showTitleCount
+      })}
+    />
+  ) : (
+    <Link to={link} className={styles.item}>
+      <h5 data-test-eholdings-package-list-item-name>
         {packageName || item.name}
       </h5>
 
@@ -34,10 +43,19 @@ export default function PackageListItem({
         {showTitleCount && (
           <span>
             &nbsp;&bull;&nbsp;
-            <span data-test-eholdings-package-list-item-num-titles-selected>{intl.formatNumber(item.selectedCount)}</span>
+
+            <span data-test-eholdings-package-list-item-num-titles-selected>
+              {intl.formatNumber(item.selectedCount)}
+            </span>
+
             &nbsp;/&nbsp;
-            <span data-test-eholdings-package-list-item-num-titles>{intl.formatNumber(item.titleCount)}</span>
+
+            <span data-test-eholdings-package-list-item-num-titles>
+              {intl.formatNumber(item.titleCount)}
+            </span>
+
             &nbsp;
+
             <span>{item.titleCount === 1 ? 'Title' : 'Titles'}</span>
           </span>
         )}

--- a/src/components/title-list-item/title-list-item.css
+++ b/src/components/title-list-item/title-list-item.css
@@ -1,5 +1,72 @@
-.name {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+.item {
+  height: 100%;
+
+  & h5, & div {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}
+
+.skeleton {
+  height: 100%;
+  background-repeat: no-repeat;
+  background-origin: content-box;
+  position: relative;
+  padding: 1em;
+
+  /* skeleton effect */
+  background-image:
+    linear-gradient(#eee, #eee 0.9em, transparent 0.9em); /* name */
+  background-size:
+    20em 1.1em; /* name */
+  background-position:
+    0 0.1em; /* name */
+
+  &.is-selected-visible {
+    background-image:
+      linear-gradient(#eee, #eee 0.9em, transparent 0.9em), /* name */
+      linear-gradient(#eee, #eee 0.8em, transparent 0.8em); /* selected */
+    background-size:
+      20em 1.1em, /* name */
+      5em 1em;    /* selected */
+    background-position:
+      0 0.1em, /* name */
+      0 1.7em, /* selected */
+  }
+
+  &.is-publisher-and-type-visible {
+    background-image:
+      linear-gradient(#eee, #eee 0.9em, transparent 0.9em), /* name */
+      linear-gradient(#eee, #eee 0.8em, transparent 0.8em), /* publisher */
+      linear-gradient(#eee, #eee 0.8em, transparent 0.8em); /* type */
+    background-size:
+      20em 1.1em, /* name */
+      10em 1em,   /* publisher */
+      5em 1em;    /* type */
+    background-position:
+      0 0.1em, /* name */
+      0 1.7em, /* publisher */
+      0 2.7em; /* type */
+  }
+
+  /* shimmer effect */
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-repeat: no-repeat;
+    background-image: linear-gradient(to right, transparent, color(white a(30%)) 50%, transparent);
+    background-size: 10em 100%;
+    background-position: -10em 0;
+    animation: shimmer 3s infinite;
+  }
+}
+
+@keyframes shimmer {
+  from { background-position: -10em 0; }
+  to { background-position: calc(100% + 10em) 0; }
 }

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 
 import styles from './title-list-item.css';
 import Link from '../link';
+
+const cx = classNames.bind(styles);
 
 export default function TitleListItem({
   item,
@@ -10,16 +13,30 @@ export default function TitleListItem({
   showSelected,
   showPublisherAndType
 }) {
-  return item && (
-    <Link to={link}>
-      <h5 className={styles.name} data-test-eholdings-title-list-item-title-name>
+  return !item ? (
+    <div
+      className={cx('skeleton', {
+        'is-selected-visible': showSelected,
+        'is-publisher-and-type-visible': showPublisherAndType
+      })}
+    />
+  ) : (
+    <Link to={link} className={styles.item}>
+      <h5 data-test-eholdings-title-list-item-title-name>
         {item.name}
       </h5>
 
       {showPublisherAndType && (
         <div>
-          <span data-test-eholdings-title-list-item-publisher-name>{item.publisherName}</span><br />
-          <span data-test-eholdings-title-list-item-publication-type>{item.publicationType}</span>
+          <span data-test-eholdings-title-list-item-publisher-name>
+            {item.publisherName}
+          </span>
+
+          <br />
+
+          <span data-test-eholdings-title-list-item-publication-type>
+            {item.publicationType}
+          </span>
         </div>
       )}
 

--- a/src/components/vendor-list-item/vendor-list-item.css
+++ b/src/components/vendor-list-item/vendor-list-item.css
@@ -1,5 +1,48 @@
-.name {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+.item {
+  height: 100%;
+
+  & h5, & div {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}
+
+.skeleton {
+  height: 100%;
+  background-repeat: no-repeat;
+  background-origin: content-box;
+  position: relative;
+  padding: 1em;
+
+  /* skeleton effect */
+  background-image:
+    linear-gradient(#eee, #eee 0.9em, transparent 0.9em), /* name */
+    linear-gradient(#eee, #eee 0.8em, transparent 0.8em); /* selection */
+  background-size:
+    20em 1.1em, /* name */
+    8em 1em;    /* selection */
+  background-position:
+    0 0.1em,     /* name */
+    0 1.7em; /* selection */
+
+  /* shimmer effect */
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-repeat: no-repeat;
+    background-image: linear-gradient(to right, transparent, color(white a(30%)) 50%, transparent);
+    background-size: 10em 100%;
+    background-position: -10em 0;
+    animation: shimmer 3s infinite;
+  }
+}
+
+@keyframes shimmer {
+  from { background-position: -10em 0; }
+  to { background-position: calc(100% + 10em) 0; }
 }

--- a/src/components/vendor-list-item/vendor-list-item.js
+++ b/src/components/vendor-list-item/vendor-list-item.js
@@ -5,16 +5,27 @@ import styles from './vendor-list-item.css';
 import Link from '../link';
 
 export default function VendorListItem({ item, link }, { intl }) {
-  return item && (
-    <Link to={link}>
-      <h5 className={styles.name} data-test-eholdings-vendor-list-item-name>
+  return !item ? (
+    <div className={styles.skeleton} />
+  ) : (
+    <Link to={link} className={styles.item}>
+      <h5 data-test-eholdings-vendor-list-item-name>
         {item.name}
       </h5>
+
       <div data-test-eholdings-vendor-list-item-selections>
-        <span data-test-eholdings-vendor-list-item-num-packages-selected>{intl.formatNumber(item.packagesSelected)}</span>
+        <span data-test-eholdings-vendor-list-item-num-packages-selected>
+          {intl.formatNumber(item.packagesSelected)}
+        </span>
+
         &nbsp;/&nbsp;
-        <span data-test-eholdings-vendor-list-item-num-packages-total>{intl.formatNumber(item.packagesTotal)}</span>
+
+        <span data-test-eholdings-vendor-list-item-num-packages-total>
+          {intl.formatNumber(item.packagesTotal)}
+        </span>
+
         &nbsp;
+
         <span>{item.packagesTotal === 1 ? 'Package' : 'Packages'}</span>
       </div>
     </Link>


### PR DESCRIPTION
## Purpose
Show a loading indicator for individual list-items within the search results list.

## Approach
Facebook's approach uses a single background with multiple divs clipping away from each visual element to hide parts of the background. This approach uses multiple css backgrounds, one for each skeleton element, and the shimmer effect is created using a psuedo element with some opacity.

#### Open Questions
- It might be more cross-browser friendly to use multiple divs like facebook (for browsers that do not support multiple backgrounds).

## Learning
[How the Facebook content placeholder works](https://cloudcannon.com/deconstructions/2014/11/15/facebook-content-placeholder-deconstruction.html)

## Screenshots
![skeleton](https://user-images.githubusercontent.com/5005153/34695889-2f172042-f492-11e7-9b8f-b345321d82cc.gif)
