### PR TITLE
update 'okapiInterfaces' to 'eholdings'; and two-part interface version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "route": "/eholdings",
     "hasSettings": true,
     "okapiInterfaces": {
-      "kb-ebsco": "0.1.0"
+      "eholdings": "0.1"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Purpose
Correct dependency mismatches between ui-eholdings and mod-kb-ebsco. 

## Approach
Update interface name and version (format) mismatches between the two modules. 

#### TODOS and Open Questions
Also see PR for mod-kb-ebsco.  https://github.com/folio-org/mod-kb-ebsco/pull/60
