### PR TITLE
Fix iOS scroll-view issues

### DIFF
--- a/src/components/package-list-item/package-list-item.css
+++ b/src/components/package-list-item/package-list-item.css
@@ -65,7 +65,7 @@
     width: 100%;
     height: 100%;
     background-repeat: no-repeat;
-    background-image: linear-gradient(to right, transparent, color(white a(30%)) 50%, transparent);
+    background-image: linear-gradient(to right, color(white a(0)), color(white a(30%)) 50%, color(white a(0)));
     background-size: 10em 100%;
     background-position: -10em 0;
     animation: shimmer 3s infinite;

--- a/src/components/scroll-view/scroll-view.css
+++ b/src/components/scroll-view/scroll-view.css
@@ -1,6 +1,7 @@
 .list {
   height: 100%;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 
   & > ul {
     position: relative;

--- a/src/components/search-paneset/search-paneset.css
+++ b/src/components/search-paneset/search-paneset.css
@@ -32,4 +32,5 @@
 .scrollable-container {
   height: calc(100vh - 88px);
   overflow-y: auto;
+  -webkit-overflow-scroll: touch;
 }

--- a/src/components/title-list-item/title-list-item.css
+++ b/src/components/title-list-item/title-list-item.css
@@ -59,7 +59,7 @@
     width: 100%;
     height: 100%;
     background-repeat: no-repeat;
-    background-image: linear-gradient(to right, transparent, color(white a(30%)) 50%, transparent);
+    background-image: linear-gradient(to right, color(white a(0)), color(white a(30%)) 50%, color(white a(0)));
     background-size: 10em 100%;
     background-position: -10em 0;
     animation: shimmer 3s infinite;

--- a/src/components/vendor-list-item/vendor-list-item.css
+++ b/src/components/vendor-list-item/vendor-list-item.css
@@ -35,7 +35,7 @@
     width: 100%;
     height: 100%;
     background-repeat: no-repeat;
-    background-image: linear-gradient(to right, transparent, color(white a(30%)) 50%, transparent);
+    background-image: linear-gradient(to right, color(white a(0)), color(white a(30%)) 50%, color(white a(0)));
     background-size: 10em 100%;
     background-position: -10em 0;
     animation: shimmer 3s infinite;


### PR DESCRIPTION
## Purpose
- Scrolling through a list of results should allow momentum scrolling. In iOS Safari, momentum scrolling is reserved for the root document so it is disabled by default on other elements.
- The shimmer skeleton loading effect should be white & transparent. In Webkit browsers, `transparent` is rendered as `rgba(0,0,0,0)` and the transition from white to transparent black produces some gray.

## Approach
- Set `-webkit-overflow-scrolling: touch` to enable momentum scrolling in scrollable elements.
- Use `color(white a(0))` instead of `transparent` when transitioning from white to transparent.

#### TODOS and Open Questions
- Stripes should have this enabled on some of it's components, but none of them are mobile-ready yet anyway.

## Learning
[-webkit-overflow-scrolling](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-overflow-scrolling)

## Screenshots
**Before**
![before](https://user-images.githubusercontent.com/5005153/34741997-4b4c7d6c-f54a-11e7-8a76-8ea783b0c76e.gif)

**After**
![after](https://user-images.githubusercontent.com/5005153/34742000-4ff2e874-f54a-11e7-97f2-fa6cd25f8a90.gif)


  