### PR TITLE
Warn user on deselection of final title in package

### DIFF
--- a/src/components/customer-resource-show/customer-resource-show.js
+++ b/src/components/customer-resource-show/customer-resource-show.js
@@ -247,17 +247,19 @@ export default class CustomerResourceShow extends Component {
                selects and then immediately deselects the
                customerResource
             */
-            model.package.selectedCount <= 1
-              ? (
-                <span data-test-eholdings-final-title-warning>
-                  Are you sure you want to remove this title from your holdings?
-                  It is also the last title selected in this package. By removing
-                  this title, you will also remove this package from your holdings
-                  and all customizations will be lost.
-                </span>
-              )
-              : 'Are you sure you want to remove this title from your holdings? ' +
-                'All customizations will be lost.'
+            model.package.selectedCount <= 1 ? (
+              <span data-test-eholdings-deselect-final-title-warning>
+                Are you sure you want to remove this title from your holdings?
+                It is also the last title selected in this package. By removing
+                this title, you will also remove this package from your holdings
+                and all customizations will be lost.
+              </span>
+            ) : (
+              <span data-test-eholdings-deselect-title-warning>
+                Are you sure you want to remove this title from your holdings?
+                All customizations will be lost.
+              </span>
+            )
           }
         </Modal>
       </div>

--- a/src/components/customer-resource-show/customer-resource-show.js
+++ b/src/components/customer-resource-show/customer-resource-show.js
@@ -241,7 +241,24 @@ export default class CustomerResourceShow extends Component {
             </div>
           )}
         >
-          Are you sure you want to remove this title from your holdings? All customizations will be lost.
+          {
+            /*
+               we use <= here to account for the case where a user
+               selects and then immediately deselects the
+               customerResource
+            */
+            model.package.selectedCount <= 1
+              ? (
+                <span data-test-eholdings-final-title-warning>
+                  Are you sure you want to remove this title from your holdings?
+                  It is also the last title selected in this package. By removing
+                  this title, you will also remove this package from your holdings
+                  and all customizations will be lost.
+                </span>
+              )
+              : 'Are you sure you want to remove this title from your holdings? ' +
+                'All customizations will be lost.'
+          }
         </Modal>
       </div>
     );

--- a/src/redux/customer-resource.js
+++ b/src/redux/customer-resource.js
@@ -1,4 +1,4 @@
-import model from './model';
+import model, { belongsTo } from './model';
 
 class CustomerResource {
   name = '';
@@ -7,6 +7,7 @@ class CustomerResource {
   vendorName = '';
   packageId = 0;
   packageName = '';
+  package = belongsTo();
   publisherName = '';
   publicationType = '';
   contentType = '';

--- a/src/routes/customer-resource-show.js
+++ b/src/routes/customer-resource-show.js
@@ -53,7 +53,7 @@ export default connect(
   ({ eholdings: { data } }, { match }) => ({
     model: createResolver(data).find('customerResources', match.params.id)
   }), {
-    getCustomerResource: id => CustomerResource.find(id),
+    getCustomerResource: id => CustomerResource.find(id, { include: 'package' }),
     updateResource: model => CustomerResource.save(model)
   }
 )(CustomerResourceShowRoute);

--- a/tests/customer-resource-deselection-test.js
+++ b/tests/customer-resource-deselection-test.js
@@ -1,0 +1,133 @@
+/* global describe, beforeEach, afterEach */
+import { expect } from 'chai';
+import it from './it-will';
+
+import { describeApplication } from './helpers';
+import ResourcePage from './pages/customer-resource-show';
+
+describeApplication('CustomerResourceShow Deselection', () => {
+  let vendor,
+    title,
+    vendorPackage,
+    resource;
+
+  beforeEach(function () {
+    vendor = this.server.create('vendor', {
+      name: 'Cool Vendor'
+    });
+
+    title = this.server.create('title', {
+      publicationType: 'Streaming Video'
+    });
+
+    vendorPackage = this.server.create('package', {
+      vendor,
+      name: 'Cool Package',
+      contentType: 'E-Book',
+      titleCount: 1,
+      selectedCount: 1
+    });
+
+    resource = this.server.create('customer-resource', {
+      package: vendorPackage,
+      isSelected: true,
+      title
+    });
+  });
+
+  describe('visiting the customer resource page', () => {
+    describe('part of a package with only one selected title', () => {
+      beforeEach(function () {
+        return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+          expect(ResourcePage.$root).to.exist;
+        });
+      });
+
+      it('indicates that the resource is selected', () => {
+        expect(ResourcePage.isSelected).to.equal(true);
+      });
+
+      describe('deselecting', () => {
+        beforeEach(() => {
+          ResourcePage.toggleIsSelected();
+        });
+
+        it('warns the user they are deselecting the final title in the package', () => {
+          expect(ResourcePage.$deselectFinalTitleWarning).to.exist;
+        });
+      });
+    });
+
+    describe('part of a package with several selected titles', () => {
+      beforeEach(function () {
+        vendorPackage.titleCount = 5;
+        vendorPackage.selectedCount = 2;
+
+        return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+          expect(ResourcePage.$root).to.exist;
+        });
+      });
+
+      it('indicates that the resource is selected', () => {
+        expect(ResourcePage.isSelected).to.equal(true);
+      });
+
+      describe('deselecting', () => {
+        beforeEach(() => {
+          return ResourcePage.toggleIsSelected();
+        });
+
+        it('warns the user they are deselecting', () => {
+          expect(ResourcePage.$deselectTitleWarning).to.exist;
+        });
+
+        it('reflects the desired state (not selected)', () => {
+          expect(ResourcePage.isSelected).to.equal(false);
+        });
+
+        describe('canceling the deselection', () => {
+          beforeEach(() => {
+            return ResourcePage.cancelDeselection();
+          });
+
+          it('reverts back to the selected state', () => {
+            expect(ResourcePage.isSelected).to.equal(true);
+          });
+        });
+
+        describe('confirming the deselection', () => {
+          beforeEach(function () {
+            this.server.timing = 50;
+            ResourcePage.confirmDeselection();
+          });
+
+          afterEach(function () {
+            this.server.timing = 0;
+          });
+
+          it('reflects the desired state (not selected)', () => {
+            expect(ResourcePage.isSelected).to.equal(false);
+          });
+
+          it('indicates it is working to get to desired state', () => {
+            expect(ResourcePage.isSelecting).to.equal(true);
+          });
+
+          it('cannot be interacted with while the request is in flight', () => {
+            expect(ResourcePage.isSelectedToggleable).to.equal(false);
+          });
+
+          describe('when the request succeeds', () => {
+            it('reflects the desired state was set', () => {
+              expect(ResourcePage.isSelected).to.equal(false);
+            });
+
+            it('indicates it is no longer working', () => {
+              expect(ResourcePage.isSelecting).to.equal(false);
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/customer-resource-selection-test.js
+++ b/tests/customer-resource-selection-test.js
@@ -97,6 +97,10 @@ describeApplication('CustomerResourceShow', () => {
           expect(ResourcePage.isSelected).to.equal(false);
         });
 
+        it('warns the user that they are deselecting the final title in the package', () => {
+          expect(ResourcePage.$finalTitleWarning).to.exist;
+        });
+
         describe('canceling the deselection', () => {
           beforeEach(() => {
             ResourcePage.cancelDeselection();

--- a/tests/customer-resource-selection-test.js
+++ b/tests/customer-resource-selection-test.js
@@ -1,11 +1,11 @@
 /* global describe, beforeEach, afterEach */
 import { expect } from 'chai';
-import it, { convergeOn } from './it-will';
+import it from './it-will';
 
 import { describeApplication } from './helpers';
 import ResourcePage from './pages/customer-resource-show';
 
-describeApplication('CustomerResourceShow', () => {
+describeApplication('CustomerResourceShow Selection', () => {
   let vendor,
     vendorPackage,
     resource;
@@ -35,7 +35,7 @@ describeApplication('CustomerResourceShow', () => {
 
   describe('visiting the customer resource page', () => {
     beforeEach(function () {
-      return this.visit(`/eholdings/customer-resources/${resource.titleId}`, () => {
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
         expect(ResourcePage.$root).to.exist;
       });
     });
@@ -84,68 +84,7 @@ describeApplication('CustomerResourceShow', () => {
           expect(ResourcePage.isSelecting).to.equal(false);
         });
       });
-
-      describe('and deselecting the package', () => {
-        beforeEach(() => {
-          return convergeOn(() => {
-            // wait for the customer resource to become toggleable again
-            expect(ResourcePage.isSelectedToggleable).to.equal(true);
-          }).then(() => ResourcePage.toggleIsSelected());
-        });
-
-        it('reflects the desired state (not selected)', () => {
-          expect(ResourcePage.isSelected).to.equal(false);
-        });
-
-        it('warns the user that they are deselecting the final title in the package', () => {
-          expect(ResourcePage.$finalTitleWarning).to.exist;
-        });
-
-        describe('canceling the deselection', () => {
-          beforeEach(() => {
-            ResourcePage.cancelDeselection();
-          });
-
-          it('reverts back to the selected state', () => {
-            expect(ResourcePage.isSelected).to.equal(true);
-          });
-        });
-
-        describe('confirming the deselection', () => {
-          beforeEach(function () {
-            this.server.timing = 50;
-            ResourcePage.confirmDeselection();
-          });
-
-          afterEach(function () {
-            this.server.timing = 0;
-          });
-
-          it('reflects the desired state (Unselected)', () => {
-            expect(ResourcePage.isSelected).to.equal(false);
-          });
-
-          it('indicates it is working to get to desired state', () => {
-            expect(ResourcePage.isSelecting).to.equal(true);
-          });
-
-          it('cannot be interacted with while the request is in flight', () => {
-            expect(ResourcePage.isSelectedToggleable).to.equal(false);
-          });
-
-          describe('when the request succeeds', () => {
-            it('reflects the desired state was set', () => {
-              expect(ResourcePage.isSelected).to.equal(false);
-            });
-
-            it('indicates it is no longer working', () => {
-              expect(ResourcePage.isSelecting).to.equal(false);
-            });
-          });
-        });
-      });
     });
-
 
     describe('unsuccessfully selecting a package title to add to my holdings', () => {
       beforeEach(function () {

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -103,8 +103,12 @@ export default {
     return $('[data-test-eholdings-customer-resource-show-back-button] button');
   },
 
-  get $finalTitleWarning() {
-    return $('[data-test-eholdings-final-title-warning]');
+  get $deselectTitleWarning() {
+    return $('[data-test-eholdings-deselect-title-warning]');
+  },
+
+  get $deselectFinalTitleWarning() {
+    return $('[data-test-eholdings-deselect-final-title-warning]');
   },
 
   confirmDeselection() {

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -103,6 +103,10 @@ export default {
     return $('[data-test-eholdings-customer-resource-show-back-button] button');
   },
 
+  get $finalTitleWarning() {
+    return $('[data-test-eholdings-final-title-warning]');
+  },
+
   confirmDeselection() {
     return $('[data-test-eholdings-customer-resource-deselection-confirmation-modal-yes]').trigger('click');
   },


### PR DESCRIPTION
When the final title in a package is deselected, the entire package
itself is also deselected.  This will eliminate all package-level
customization, so we warn the user of this before proceeding.

![esveeuxwqm](https://user-images.githubusercontent.com/14239162/34744203-7212653c-f55a-11e7-8038-76926f365f4a.gif)


  