### PR TITLE
Wrap settings in Pane for responsiveness

### DIFF
--- a/src/components/settings/settings.css
+++ b/src/components/settings/settings.css
@@ -1,8 +1,12 @@
 @import '@folio/stripes-components/lib/variables';
 
 .eholdings-settings {
-  padding: 2em;
+  padding: 0 2em;
   width: 100%;
+
+  & h2 {
+    margin: 0.83em 0;
+  }
 
   & form {
     max-width: 40em;
@@ -80,4 +84,10 @@
   align-items: center;
   flex-grow: 1;
   color: var(--error);
+}
+
+.eholdings-settings-back-button {
+  @media (--mediumUp) {
+    display: none;
+  }
 }

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -1,6 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
+import Link from 'react-router-dom/Link';
+import Pane from '@folio/stripes-components/lib/Pane';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+
 import styles from './settings.css';
 
 const cx = classNames.bind(styles);
@@ -93,71 +97,77 @@ export default class Settings extends Component {
     let isValid = customerId && apiKey;
 
     return (
-      <div className={styles['eholdings-settings']}>
-        <h1>eHoldings</h1>
+      <Pane
+        defaultWidth="fill"
+        paneTitle="eHoldings"
+        firstMenu={(
+          <Link to="/settings" className={styles['eholdings-settings-back-button']}><IconButton icon="left-arrow" /></Link>
+        )}
+      >
+        <div className={styles['eholdings-settings']}>
+          <h2 data-test-eholdings-settings-description>
+            EBSCO Knowledge Base
+          </h2>
 
-        <h2 data-test-eholdings-settings-description>
-          EBSCO Knowledge Base
-        </h2>
-
-        <form
-          onSubmit={this.handleSubmit}
-          data-test-eholdings-settings
-        >
-          {settings.request.isRejected && (
-            <p data-test-eholdings-settings-error>
-              {settings.request.errors[0].title}
-            </p>
-          )}
-
-          <div
-            data-test-eholdings-settings-customerid
-            className={cx(styles['eholdings-settings-field'], {
-              'has-error': invalidCustomerId
-            })}
+          <form
+            onSubmit={this.handleSubmit}
+            data-test-eholdings-settings
           >
-            <label htmlFor="eholdings-settings-customerid">Customer ID</label>
-            <input
-              id="eholdings-settings-customerid"
-              type="text"
-              autoComplete="off"
-              value={customerId}
-              onChange={this.updateCustomerId}
-              onBlur={this.validateCustomerId}
-            />
-          </div>
+            {settings.request.isRejected && (
+              <p data-test-eholdings-settings-error>
+                {settings.request.errors[0].title}
+              </p>
+            )}
 
-          <div
-            data-test-eholdings-settings-apikey
-            className={cx(styles['eholdings-settings-field'], {
-              'has-error': invalidApiKey
-            })}
-          >
-            <label htmlFor="eholdings-settings-apikey">API Key</label>
-            <input
-              id="eholdings-settings-apikey"
-              type="text"
-              autoComplete="off"
-              value={apiKey}
-              onChange={this.updateApiKey}
-              onBlur={this.validateApiKey}
-            />
-          </div>
-
-          {(isFresh || isDirty) && (
-            <div className={styles['eholdings-settings-form-actions']} data-test-eholdings-settings-actions>
-              <button type="submit" disabled={!isValid || settings.isSaving}>Save</button>
-              <button type="reset" onClick={this.handleClear}>Cancel</button>
-
-              {settings.update.isRejected && (
-                <div className={styles['eholdings-settings-save-error']} data-test-eholdings-settings-error>
-                  {settings.update.errors[0].title}
-                </div>
-              )}
+            <div
+              data-test-eholdings-settings-customerid
+              className={cx(styles['eholdings-settings-field'], {
+                'has-error': invalidCustomerId
+              })}
+            >
+              <label htmlFor="eholdings-settings-customerid">Customer ID</label>
+              <input
+                id="eholdings-settings-customerid"
+                type="text"
+                autoComplete="off"
+                value={customerId}
+                onChange={this.updateCustomerId}
+                onBlur={this.validateCustomerId}
+              />
             </div>
-          )}
-        </form>
-      </div>
+
+            <div
+              data-test-eholdings-settings-apikey
+              className={cx(styles['eholdings-settings-field'], {
+                'has-error': invalidApiKey
+              })}
+            >
+              <label htmlFor="eholdings-settings-apikey">API Key</label>
+              <input
+                id="eholdings-settings-apikey"
+                type="text"
+                autoComplete="off"
+                value={apiKey}
+                onChange={this.updateApiKey}
+                onBlur={this.validateApiKey}
+              />
+            </div>
+
+            {(isFresh || isDirty) && (
+              <div className={styles['eholdings-settings-form-actions']} data-test-eholdings-settings-actions>
+                <button type="submit" disabled={!isValid || settings.isSaving}>Save</button>
+                <button type="reset" onClick={this.handleClear}>Cancel</button>
+
+                {settings.update.isRejected && (
+                  <div className={styles['eholdings-settings-save-error']} data-test-eholdings-settings-error>
+                    {settings.update.errors[0].title}
+                  </div>
+                )}
+              </div>
+            )}
+          </form>
+        </div>
+      </Pane>
     );
   }
 }

--- a/src/routes/application/application.css
+++ b/src/routes/application/application.css
@@ -1,0 +1,3 @@
+.eholdings-application {
+  width: 100%;
+}

--- a/src/routes/application/application.js
+++ b/src/routes/application/application.js
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Icon from '@folio/stripes-components/lib/Icon';
 
-import { createResolver } from '../redux';
-import { Status } from '../redux/application';
-import NoBackendErrorScreen from '../components/error-screen/no-backend';
-import FailedBackendErrorScreen from '../components/error-screen/failed-backend';
-import InvalidBackendErrorScreen from '../components/error-screen/invalid-backend';
+import { createResolver } from '../../redux';
+import { Status } from '../../redux/application';
+import NoBackendErrorScreen from '../../components/error-screen/no-backend';
+import FailedBackendErrorScreen from '../../components/error-screen/failed-backend';
+import InvalidBackendErrorScreen from '../../components/error-screen/invalid-backend';
+import styles from './application.css';
 
 class ApplicationRoute extends Component {
   static propTypes = {
@@ -31,7 +32,7 @@ class ApplicationRoute extends Component {
     } = this.props;
 
     return (
-      <div className="eholdings-application" data-test-eholdings-application>
+      <div className={styles['eholdings-application']} data-test-eholdings-application>
         {version ? (status.isLoading ? (
           <Icon icon="spinner-ellipsis" />
         ) : status.request.isRejected ? (

--- a/src/routes/application/index.js
+++ b/src/routes/application/index.js
@@ -1,0 +1,1 @@
+export { default } from './application';


### PR DESCRIPTION
## Purpose
Because the eHoldings settings form was not in a `Pane`, the form was inaccessible on small screens.

## Approach
Wrapped the form in a `Pane` that has a back button. The back button only appears at small sizes.

## Screenshots
![localhost_3000_settings_eholdings iphone 7](https://user-images.githubusercontent.com/230597/34786512-ffdd2330-f5f9-11e7-9867-37b1a9e07e05.png)
