### PR TITLE
Clear out model data when deselecting

### DIFF
--- a/mirage/models/customer-resource.js
+++ b/mirage/models/customer-resource.js
@@ -1,6 +1,7 @@
-import { Model, belongsTo } from 'mirage-server';
+import { Model, belongsTo, hasMany } from 'mirage-server';
 
 export default Model.extend({
   package: belongsTo(),
-  title: belongsTo()
+  title: belongsTo(),
+  customCoverages: hasMany()
 });

--- a/src/routes/customer-resource-show.js
+++ b/src/routes/customer-resource-show.js
@@ -36,6 +36,15 @@ class CustomerResourceShowRoute extends Component {
   toggleSelected = () => {
     let { model, updateResource } = this.props;
     model.isSelected = !model.isSelected;
+
+    // clear out any customizations before sending to server
+    if (!model.isSelected) {
+      model.visibilityData.isHidden = false;
+      model.customCoverages = [];
+      model.customEmbargoPeriod.embargoUnit = null;
+      model.customEmbargoPeriod.customEmbargoValue = 0;
+    }
+
     updateResource(model);
   }
 

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -43,6 +43,14 @@ class PackageShowRoute extends Component {
     let { model, updatePackage } = this.props;
     model.isSelected = !model.isSelected;
     model.selectedCount = model.isSelected ? model.titleCount : 0;
+
+    // clear out any customizations before sending to server
+    if (!model.isSelected) {
+      model.visibilityData.isHidden = false;
+      model.customCoverage.beginCoverage = null;
+      model.customCoverage.endCoverage = null;
+    }
+
     updatePackage(model);
   };
 

--- a/tests/customer-resource-deselection-test.js
+++ b/tests/customer-resource-deselection-test.js
@@ -125,6 +125,20 @@ describeApplication('CustomerResourceShow Deselection', () => {
             it('indicates it is no longer working', () => {
               expect(ResourcePage.isSelecting).to.equal(false);
             });
+
+            it('removes custom coverage', () => {
+              expect(resource.customCoverages.models.length).to.equal(0);
+            });
+
+            it('removes custom embargo', () => {
+              expect(resource.customEmbargoPeriod.embargoUnit).to.equal(null);
+              expect(resource.customEmbargoPeriod.embargoValue).to.equal(0);
+            });
+
+            it('is not hidden', () => {
+              expect(resource.visibilityData.isHidden).to.equal(false);
+              expect(ResourcePage.isHidden).to.equal(false);
+            });
           });
         });
       });

--- a/tests/package-show-selection-test.js
+++ b/tests/package-show-selection-test.js
@@ -143,6 +143,16 @@ describeApplication('PackageShowSelection', () => {
             it('updates the selected title count', () => {
               expect(PackageShowPage.numTitlesSelected).to.equal(`${vendorPackage.titleCount}`);
             });
+
+            it('removes custom coverage', () => {
+              expect(vendorPackage.customCoverage.beginCoverage).to.equal(null);
+              expect(vendorPackage.customCoverage.endCoverage).to.equal(null);
+            });
+
+            it('is not hidden', () => {
+              expect(vendorPackage.visibilityData.isHidden).to.equal(false);
+              expect(PackageShowPage.isHidden).to.equal(false);
+            });
           });
         });
       });


### PR DESCRIPTION
## Purpose
To be more explicit about RM API's side effects, `mod-kb-ebsco` is very strict about `isSelected`. If you `PUT` a package or package-title to `mod-kb-ebsco` with `isSelected` set to false but `customCoverage(s)`, `visibilityData`, or `customEmbargoPeriod` set, `mod-kb-ebsco` will reject the request.

`ui-eholdings` is not yet doing anything to ensure those values were dismissed,  so attempting to deselect a package or package-title with any customizations fails.

## Approach
Clear out those customizations in the route when switching `isSelected` to false.

## Alternatives
We may want to eventually do all the un-customization handling in the show component instead. Maybe. This solution is simpler at the moment.