### PR TITLE
Track specific attribute changes in redux store

### DIFF
--- a/src/components/customer-resource-show/customer-resource-show.js
+++ b/src/components/customer-resource-show/customer-resource-show.js
@@ -186,7 +186,7 @@ export default class CustomerResourceShow extends Component {
                 <ToggleSwitch
                   onChange={this.handleSelectionToggle}
                   checked={resourceSelected}
-                  isPending={model.update.isPending}
+                  isPending={model.update.isPending && 'isSelected' in model.update.changedAttributes}
                   id="customer-resource-show-toggle-switch"
                 />
               </label>

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -134,7 +134,7 @@ export default class PackageShow extends Component {
                 <ToggleSwitch
                   onChange={this.handleSelectionToggle}
                   checked={packageSelected}
-                  isPending={model.update.isPending}
+                  isPending={model.update.isPending && 'isSelected' in model.update.changedAttributes}
                   id="package-details-toggle-switch"
                 />
               </label>


### PR DESCRIPTION
## Purpose
When saving a change to a package's or customer resource's `isSelected` attribute, we were previously just relying on `model.update.isPending` to determine if the selection toggle should be in a loading state.

That was fine until we started trying to modify model attributes individually. For example, editing custom coverage does not change `isSelected`, and should not trigger a loading state for `isSelected`.

## Approach
Redux Form expects `onSubmit` to return a promise, but that doesn't jive with our use of observables. Instead, we can shove some extra data in the redux store to know which specific attributes have pending changes.

When saving a model, there will now be a `model.update.changedAttributes` object containing the keys of changed attributes, and an array of the old value and new value for each.

#### Example
From the state of an entry in `eholdings.data.packages.requests`:
```
changedAttributes: {
  selectedCount: [7,0]
  isSelected: [true, false]
}
```

#### TODOS and Open Questions
- [x] I didn't create any additional tests for this. Unsure how to proceed with that.
- [x] Should `changedAttributes()` be a property of every request in the redux store? Right now it only appears as part of save requests.

## Learning
Inspired by Ember Data's `changedAttributes()`: 
https://www.emberjs.com/api/ember-data/2.16/classes/DS.Model/methods/changedAttributes?anchor=changedAttributes
https://github.com/emberjs/data/blob/v2.16.0/addon/-private/system/model/internal-model.js#L698