### PR TITLE
Hide scrollbars for list-item elements

### DIFF
--- a/src/components/package-list-item/package-list-item.css
+++ b/src/components/package-list-item/package-list-item.css
@@ -3,7 +3,7 @@
 
   & h5,
   & div {
-    overflow-x: hidden;
+    overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
   }

--- a/src/components/title-list-item/title-list-item.css
+++ b/src/components/title-list-item/title-list-item.css
@@ -3,7 +3,7 @@
 
   & h5,
   & div {
-    overflow-x: hidden;
+    overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
   }

--- a/src/components/vendor-list-item/vendor-list-item.css
+++ b/src/components/vendor-list-item/vendor-list-item.css
@@ -3,7 +3,7 @@
 
   & h5,
   & div {
-    overflow-x: hidden;
+    overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
   }


### PR DESCRIPTION
## Purpose
Previously, the overflow-y was allowed to be visible due to descenders being cut off. The line-height has since been adjusted and the overflow-y property is causing permanent scrollbars to be visible for these elements. 

## Approach
Since the line-height is adjusted, we can safely hide the overflow on these elements without cutting off descenders.

## Screenshots
#### Before
<img width="375" alt="before" src="https://user-images.githubusercontent.com/5005153/35058210-d545a5d8-fb7c-11e7-968a-86f2e148a3de.png">

#### After
<img width="375" alt="after" src="https://user-images.githubusercontent.com/5005153/35058223-db598994-fb7c-11e7-94c0-17014a1a6a11.png">

