### PR TITLE
Implement Package Level Hiding UI Changes

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -161,11 +161,15 @@ export default function configure() {
     let body = JSON.parse(request.requestBody);
     let { isSelected } = body.data.attributes;
 
+    let { visibilityData } = body.data.attributes;
+
     let selectedCount = isSelected ? matchingCustomerResources.length : 0;
 
     matchingCustomerResources.update('isSelected', isSelected);
+    matchingCustomerResources.update('visibilityData', visibilityData);
     matchingPackage.update('isSelected', isSelected);
     matchingPackage.update('selectedCount', selectedCount);
+    matchingPackage.update('visibilityData', visibilityData);
 
     return matchingPackage;
   });
@@ -197,8 +201,10 @@ export default function configure() {
 
     let body = JSON.parse(request.requestBody);
     let { isSelected } = body.data.attributes;
+    let { visibilityData } = body.data.attributes;
 
     matchingCustomerResource.update('isSelected', isSelected);
+    matchingCustomerResource.update('visibilityData', visibilityData);
 
     return matchingCustomerResource;
   });

--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -34,7 +34,6 @@ export default Factory.extend({
       }
     }
   }),
-
   withVendor: trait({
     afterCreate(packageObj, server) {
       let vendor = server.create('vendor');
@@ -48,6 +47,15 @@ export default Factory.extend({
       let visibilityData = server.create('visibility-data', {
         isHidden: true,
         reason: 'The content is for mature audiences only.'
+      });
+      packageObj.update('visibilityData', visibilityData.toJSON());
+    }
+  }),
+  isHiddenWithoutReason: trait({
+    afterCreate(packageObj, server) {
+      let visibilityData = server.create('visibility-data', {
+        isHidden: true,
+        reason: ''
       });
       packageObj.update('visibilityData', visibilityData.toJSON());
     }

--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -59,6 +59,14 @@ export default function PackageListItem({
             <span>{item.titleCount === 1 ? 'Title' : 'Titles'}</span>
           </span>
         )}
+        {item.visibilityData.isHidden && (
+          <span>
+              &nbsp;&bull;&nbsp;
+            <span data-test-eholdings-package-list-item-title-hidden>
+              {'Hidden'}
+            </span>
+          </span>
+        )}
       </div>
     </Link>
   );

--- a/src/components/package-show/package-show.css
+++ b/src/components/package-show/package-show.css
@@ -19,3 +19,11 @@
 .detail-container-header {
   margin: 2rem 0;
 }
+.flex-container {
+   display: flex;
+   align-items: center;
+ }
+ .flex-item {
+   margin-right: 10px;
+ }
+

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -19,7 +19,8 @@ import styles from './package-show.css';
 export default class PackageShow extends Component {
   static propTypes = {
     model: PropTypes.object.isRequired,
-    toggleSelected: PropTypes.func.isRequired
+    toggleSelected: PropTypes.func.isRequired,
+    toggleHidden: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -30,12 +31,16 @@ export default class PackageShow extends Component {
 
   state = {
     showSelectionModal: false,
-    packageSelected: this.props.model.isSelected
+    packageSelected: this.props.model.isSelected,
+    packageHidden: this.props.model.visibilityData.isHidden
   };
 
   componentWillReceiveProps({ model }) {
     if (!model.isSaving) {
-      this.setState({ packageSelected: model.isSelected });
+      this.setState({
+        packageSelected: model.isSelected,
+        packageHidden: model.visibilityData.isHidden
+      });
     }
   }
 
@@ -63,7 +68,7 @@ export default class PackageShow extends Component {
   render() {
     let { model } = this.props;
     let { intl, router, queryParams } = this.context;
-    let { showSelectionModal, packageSelected } = this.state;
+    let { showSelectionModal, packageSelected, packageHidden } = this.state;
     let historyState = router.history.location.state;
 
     return (
@@ -138,15 +143,35 @@ export default class PackageShow extends Component {
                   id="package-details-toggle-switch"
                 />
               </label>
-
-              {model.visibilityData.isHidden && (
-                <div data-test-eholdings-package-details-is-hidden>
-                  <p><strong>This package is hidden.</strong></p>
-                  <p><em>{model.visibilityData.reason}</em></p>
-                  <hr />
+              <label
+                data-test-eholdings-package-details-hidden
+                htmlFor="package-details-toggle-hidden-switch"
+              >
+                <h4>{model.visibilityData.isHidden ? 'Hidden from patrons' : 'Visible to patrons'}</h4>
+                <div className={styles['flex-container']}>
+                  <div className={styles['flex-item']}>
+                    { packageSelected ? (
+                      <ToggleSwitch
+                        onChange={this.props.toggleHidden}
+                        checked={!packageHidden}
+                        isPending={model.update.isPending}
+                        id="package-details-toggle-hidden-switch"
+                      />
+                    ) : (
+                      <ToggleSwitch
+                        checked
+                        disabled
+                        id="package-details-toggle-hidden-switch"
+                      />
+                    )
+                    }
+                  </div>
+                  <div data-test-eholdings-package-details-is-hidden className={styles['flex-item']}>
+                    <p>{(model.visibilityData.isHidden ? model.visibilityData.reason : '')}</p>
+                  </div>
                 </div>
-              )}
-
+              </label>
+              <hr />
               <h3>Titles</h3>
               <List data-test-eholdings-package-details-title-list>
                 {model.customerResources.isLoading ? (

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -43,6 +43,14 @@ export default function TitleListItem({
       {showSelected && (
         <span data-test-eholdings-title-list-item-title-selected>
           {item.isSelected ? 'Selected' : 'Not Selected'}
+          {item.visibilityData.isHidden && (
+            <span>
+              &nbsp;&bull;&nbsp;
+              <span data-test-eholdings-title-list-item-title-hidden>
+                {'Hidden'}
+              </span>
+            </span>
+          )}
         </span>
       )}
     </Link>

--- a/src/components/toggle-switch/toggle-switch.css
+++ b/src/components/toggle-switch/toggle-switch.css
@@ -18,6 +18,10 @@
     transform: translateX(26px);
   }
 
+  & input:disabled + .toggle-switch-slider {
+    background-color: var(--secondary);
+  }
+
   &.is-pending .toggle-switch-slider {
     animation: toggle-pending 3s infinite ease-in-out;
   }

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -53,11 +53,18 @@ class PackageShowRoute extends Component {
     updatePackage(model);
   };
 
+  toggleHidden = () => {
+    let { model, updatePackage } = this.props;
+    model.visibilityData.isHidden = !model.visibilityData.isHidden;
+    updatePackage(model);
+  };
+
   render() {
     return (
       <View
         model={this.props.model}
         toggleSelected={this.toggleSelected}
+        toggleHidden={this.toggleHidden}
       />
     );
   }

--- a/tests/package-show-visibility-test.js
+++ b/tests/package-show-visibility-test.js
@@ -1,4 +1,4 @@
-/* global describe, beforeEach */
+/* global describe, beforeEach, afterEach */
 import { expect } from 'chai';
 import it from './it-will';
 
@@ -15,12 +15,13 @@ describeApplication('PackageShowVisibility', () => {
     });
   });
 
-  describe('visiting the package show page with a hidden package', () => {
+  describe('visiting the package show page with a hidden package with a hidden reason', () => {
     beforeEach(function () {
       pkg = this.server.create('package', 'isHidden', {
         vendor,
         name: 'Cool Package',
-        contentType: 'E-Book'
+        contentType: 'E-Book',
+        isSelected: true
       });
 
       return this.visit(`/eholdings/packages/${pkg.id}`, () => {
@@ -28,8 +29,35 @@ describeApplication('PackageShowVisibility', () => {
       });
     });
 
-    it('displays the hidden/reason section', () => {
+    it('displays an OFF Toggle (Hidden from patrons)', () => {
       expect(PackageShowPage.isHidden).to.be.true;
+    });
+
+    it('displays the hidden/reason section', () => {
+      expect(PackageShowPage.isHiddenMessage).to.be.true;
+    });
+  });
+
+  describe('visiting the package show page with a hidden package without a hidden reason', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', 'isHiddenWithoutReason', {
+        vendor,
+        name: 'Cool Package',
+        contentType: 'E-Book',
+        isSelected: true
+      });
+
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays an OFF Toggle (Hidden from patrons)', () => {
+      expect(PackageShowPage.isHidden).to.be.true;
+    });
+
+    it('does not displays the hidden/reason section', () => {
+      expect(PackageShowPage.isHiddenMessage).to.be.false;
     });
   });
 
@@ -38,7 +66,8 @@ describeApplication('PackageShowVisibility', () => {
       pkg = this.server.create('package', {
         vendor,
         name: 'Cool Package',
-        contentType: 'ebook'
+        contentType: 'ebook',
+        isSelected: true
       });
 
       return this.visit(`/eholdings/packages/${pkg.id}`, () => {
@@ -46,8 +75,140 @@ describeApplication('PackageShowVisibility', () => {
       });
     });
 
-    it('does not display the hidden/reason section', () => {
+    it('displays an ON Toggle (Visible to patrons)', () => {
       expect(PackageShowPage.isHidden).to.be.false;
+    });
+
+    it('does not display the hidden/reason section', () => {
+      expect(PackageShowPage.isHiddenMessage).to.be.false;
+    });
+  });
+
+  describe('visiting the package show page with a package that is not selected', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', {
+        vendor,
+        name: 'Cool Package',
+        contentType: 'ebook',
+        isSelected: false
+      });
+
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays an ON Toggle (Visible to patrons)', () => {
+      expect(PackageShowPage.isHidden).to.be.false;
+    });
+
+    it('displays a disabled Toggle', () => {
+      expect(PackageShowPage.isHiddenToggleable).to.equal(false);
+    });
+
+    it('does not display the hidden/reason section', () => {
+      expect(PackageShowPage.isHiddenMessage).to.be.false;
+    });
+  });
+
+  describe('visiting the package details page and Hiding a Package', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', 'withTitles', {
+        vendor,
+        name: 'Cool Package',
+        contentType: 'E-Book',
+        isSelected: true,
+        titleCount: 5
+      });
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays an ON Toggle (Visible to patrons)', () => {
+      expect(PackageShowPage.isHidden).to.be.false;
+    });
+
+    describe('successfully hiding a package', () => {
+      beforeEach(function () {
+        this.server.timing = 50;
+        return PackageShowPage.toggleIsHidden();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+      it('reflects the desired state OFF (Hidden from patrons)', () => {
+        expect(PackageShowPage.isHidden).to.equal(true);
+      });
+
+      it('cannot be interacted with while the request is in flight', () => {
+        expect(PackageShowPage.isHiddenToggleable).to.equal(false);
+      });
+
+      describe('when the request succeeds', () => {
+        it('reflects the desired state OFF (Hidden from patrons)', () => {
+          expect(PackageShowPage.isHidden).to.equal(true);
+        });
+
+        it('indicates it is no longer pending', () => {
+          expect(PackageShowPage.isHiding).to.equal(false);
+        });
+
+        it('shows the package titles are all hidden', () => {
+          expect(PackageShowPage.allTitlesHidden).to.equal(true);
+        });
+      });
+    });
+  });
+
+  describe('visiting the package details page and Showing a Package', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', 'isHidden', 'withTitles', {
+        vendor,
+        name: 'Cool Package',
+        contentType: 'E-Book',
+        isSelected: true,
+        titleCount: 5
+      });
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('reflects the desired initial state OFF (Hidden from patrons)', () => {
+      expect(PackageShowPage.isHidden).to.be.true;
+    });
+    describe('successfully showing a package', () => {
+      beforeEach(function () {
+        this.server.timing = 50;
+        return PackageShowPage.toggleIsHidden();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+      it('displays an ON Toggle (Visible to patrons)', () => {
+        expect(PackageShowPage.isHidden).to.equal(false);
+      });
+
+      it('cannot be interacted with while the request is in flight', () => {
+        expect(PackageShowPage.isHiddenToggleable).to.equal(false);
+      });
+
+      describe('when the request succeeds', () => {
+        it('reflects the desired state as ON Toggle (Visible to patrons)', () => {
+          expect(PackageShowPage.isHidden).to.equal(false);
+        });
+
+        it('indicates it is no longer pending', () => {
+          expect(PackageShowPage.isHiding).to.equal(false);
+        });
+
+        it('should show the package titles are all not hidden', () => {
+          expect(PackageShowPage.allTitlesHidden).to.equal(false);
+        });
+      });
     });
   });
 });

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -12,7 +12,12 @@ function createTitleObject(element) {
 
     get isSelected() {
       return $scope.find('[data-test-eholdings-title-list-item-title-selected]').text() === 'Selected';
+    },
+
+    get isHidden() {
+      return $scope.find('[data-test-eholdings-title-list-item-title-hidden]').text() === 'Hidden';
     }
+
   };
 }
 
@@ -84,8 +89,27 @@ export default {
   get titleList() {
     return $('[data-test-eholdings-package-details-title-list] li').toArray().map(createTitleObject);
   },
+  toggleIsHidden() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-package-details-hidden]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-package-details-hidden] input').click()
+    ));
+  },
+  get isHiding() {
+    return $('[data-test-eholdings-package-details-hidden] [data-test-toggle-switch]').attr('class').indexOf('is-pending--') !== -1;
+  },
 
+  get isHiddenToggleable() {
+    return $('[data-test-eholdings-package-details-hidden] input[type=checkbox]').prop('disabled') === false;
+  },
   get isHidden() {
+    return $('[data-test-eholdings-package-details-hidden] input').prop('checked') === false;
+  },
+  get allTitlesHidden() {
+    return !!this.titleList.length && this.titleList.every(title => title.isHidden);
+  },
+  get isHiddenMessage() {
     return $('[data-test-eholdings-package-details-is-hidden]').length === 1;
   },
 

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -21,6 +21,10 @@ function createTitleObject(element) {
 
     get isSelected() {
       return $scope.find('[data-test-eholdings-title-list-item-title-selected]').text() === 'Selected';
+    },
+
+    get isHidden() {
+      return $scope.find('[data-test-eholdings-title-list-item-title-hidden]').text() === 'Hidden';
     }
   };
 }

--- a/tests/pages/vendor-show.js
+++ b/tests/pages/vendor-show.js
@@ -14,6 +14,10 @@ function createPackageObject(element) {
 
     get numTitlesSelected() {
       return parseInt($scope.find('[data-test-eholdings-package-list-item-num-titles-selected]').text(), 10);
+    },
+
+    get isHidden() {
+      return $scope.find('[data-test-eholdings-package-list-item-title-hidden]').text() === 'Hidden';
     }
   };
 }

--- a/tests/vendor-show-test.js
+++ b/tests/vendor-show-test.js
@@ -16,6 +16,7 @@ describeApplication('VendorShow', () => {
     });
 
     packages = this.server.schema.where('package', { vendorId: vendor.id }).models;
+    packages[0].visibilityData.isHidden = true;
   });
 
   describe('visiting the vendor details page', () => {
@@ -51,6 +52,9 @@ describeApplication('VendorShow', () => {
 
     it('displays total number of titles for a package', () => {
       expect(VendorShowPage.packageList[0].numTitles).to.equal(packages[0].titleCount);
+    });
+    it('displays isHidden indicator', () => {
+      expect(VendorShowPage.packageList[0].isHidden).to.equal(packages[0].visibilityData.isHidden);
     });
 
     it.still('should not display the back button', () => {


### PR DESCRIPTION
## Purpose
Implement show/hide functionality at the Package Detail level.  This involves

- adding a toggle to package details that represents the isHidden state, toggle behaves as follows:
1. When the toggle is "off", isHidden=true: label is "Hidden from patrons"
2. When the toggle is "on", isHidden=false: label is "Visible to patrons"
- displaying a message to the right of toggle if package is hidden by ep  (message is Set by System - specific message text to be set in mod-kb-ebsco)
- displaying Hidden message in list of customer resources on Package details page
Also updated Vendor Detail page to show Hidden status on list of displayed packages
Updated Hide/Show toggle (disable if Package is Not Selected)

Related Jira Tickets

- https://issues.folio.org/browse/UIEH-116
- https://issues.folio.org/browse/UIEH-52
- https://issues.folio.org/browse/UIEH-117
- https://issues.folio.org/browse/UIEH-98

## Approach

Implementation is similar to Selected/Not Selected Toggle on Package Details page. Uses same Update Package functionality

#### TODOS and Open Questions

- [x] Still need to implement display of proper hidden message in mod-kb-ebsco for package level. Currently, module displays - "All titles in this package are hidden" if package is hidden and does not distinguish 'Hidden by EP' vs 'Hidden by Customer'
Completed - https://github.com/folio-org/mod-kb-ebsco/pull/67 (mod-kb-ebsco changes merged to master)
- [x] Still see a flickering of message when toggling hide/show setting - possible change at data layer or added status check needed. Note - flicker is visible in gif - not observed when testing
Updates suggested by Jeffrey have been made - flickering no longer observed
- [ ] Observe same issue as experience with selected toggle - when clicked, only first customer resource in list is displayed. Note - this issue is not observed with new pagination functionality

## Learning

## Screenshots
![package-hide-show](https://user-images.githubusercontent.com/19415226/35284406-b8fec17e-0028-11e8-867b-d4b11208c6c4.gif)

