### PR TITLE
Check for foreign key attributes in `belongsTo` relationships

### DIFF
--- a/tests/unit/redux-model-test.js
+++ b/tests/unit/redux-model-test.js
@@ -92,7 +92,7 @@ describe('Redux Models', () => {
     });
   });
 
-  describe('with data', () => {
+  describe('with explicit relationship data', () => {
     beforeEach(() => {
       vendor = new VendorModel(1, resolver);
       pkg = new PackageModel(1, resolver);
@@ -163,6 +163,25 @@ describe('Redux Models', () => {
     it('should have empty belongsTo relationships', () => {
       expect(pkg.vendor.isLoaded).to.be.false;
       expect(pkg.vendor.name).to.equal('Default Vendor');
+    });
+
+    describe('with foreign key in attributes', () => {
+      beforeEach(() => {
+        INCOMPLETE_PACKAGE_JSON.attributes.vendorId = vendor.id;
+        INCOMPLETE_VENDOR_JSON.attributes.name = 'Awesome Vendor';
+
+        // we have to recreate these after state alteration
+        vendor = new VendorModel(1, resolver);
+        pkg = new PackageModel(1, resolver);
+      });
+
+      // not yet implemented
+      it('should have hasMany relationships');
+
+      it('should have belongsTo relationships', () => {
+        expect(pkg.vendor.isLoaded).to.be.true;
+        expect(pkg.vendor.name).to.equal('Awesome Vendor');
+      });
     });
   });
 });


### PR DESCRIPTION
This first surfaced earlier this week while we were investigating a UI hiccup.  The specific manifestation in the UI was a flickering of data being loaded from related resources when navigated to through a search or a parent detail view.  

For instance, our queries on the customer resource page use the `include` param to grab information about the related package so that the record is complete if the user navigates directly to that detail page.  However, through the parent, the data for the package had already been loaded but the relationship to the customer resource isn't realized until the customer resource detail page is loaded.  Since this was our sole linking mechanism, the data layer would lag a bit as it linked the records via `relationship`.  With this change it can link them immediately by searching the store for the customer resource's `packageId` attribute under the `packages` namespace.

**Before** - _Notice flicker on Show/Hide Toggle_
![xviuigffqd](https://user-images.githubusercontent.com/14239162/35108252-13375afc-fc41-11e7-8fcc-e67058a125f8.gif)

**After** - _Flicker is gone_
![after](https://user-images.githubusercontent.com/14239162/35108321-407e40b6-fc41-11e7-88bf-25f380a04e2a.gif)

This change allows for more reliable linking of related records already in the store, and eliminates some UI bugs that were found to be a result of incomplete linking functionality.  Now models can find their related models' data without an explicit use of JSONAPI's `include` parameter.

The internals of the `belongsTo` method for model classes has been augmented to check for possible foreign keys (i.e. packageId, vendorId, etc.) in a record's data attributes, in addition to the check it was already doing on the explicit `relationships` key.
