### PR TITLE
Don't link self when pulled in as a dependency.

### DIFF
--- a/bin/link-self
+++ b/bin/link-self
@@ -9,7 +9,13 @@
 # In other words, our test files can require('@folio/eholdings') and
 # our demo stripe platfrom can require('@folio/eholdings'). Without
 # this link it will throw an ModuleNotFound error.
-if ! [ -L node_modules/@folio/eholdings ]
+if ! [ -d node_modules ]
 then
-  ln -s `pwd` node_modules/@folio/eholdings
+    # if there is no node_modules/ dir, then this is not
+    # a test or self-demo build, but a build as part of a
+    # bigger application, so skip this step.
+    echo "node_modules dir does not exist, so link-self is a no-op"
+elif ! [ -L node_modules/@folio/eholdings ]
+then
+    ln -s `pwd` node_modules/@folio/eholdings
 fi


### PR DESCRIPTION
## Purpose

When ui-eholdings is being brought in as a dependency of a stripes platfom build, and is not the platform itself, the node_modules are flattened out into the module that contains eholdings as a dependency. This means that the `bin/link-self` script fails because it expects node_modules to exist already, but that won't happen until yarn links dependencies from the root directory.

## Approach
This is a bit of a hack, but we have the `link-self` script check for the availability of the node_modules directory _first_, and only then proceed if it exists.

This is acceptable since the entire `bin/link-self` script will go away completely once UI eholdings can be built on stripes-cli.