### PR TITLE
Add editing for package custom coverage

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -159,12 +159,13 @@ export default function configure() {
     });
 
     let body = JSON.parse(request.requestBody);
-    let { isSelected } = body.data.attributes;
+    let { isSelected, customCoverage } = body.data.attributes;
 
     let selectedCount = isSelected ? matchingCustomerResources.length : 0;
 
     matchingCustomerResources.update('isSelected', isSelected);
     matchingPackage.update('isSelected', isSelected);
+    matchingPackage.update('customCoverage', customCoverage);
     matchingPackage.update('selectedCount', selectedCount);
 
     return matchingPackage;

--- a/src/components/custom-coverage-form/custom-coverage-form.css
+++ b/src/components/custom-coverage-form/custom-coverage-form.css
@@ -1,0 +1,42 @@
+@import '@folio/stripes-components/lib/variables';
+
+.custom-coverage-form,
+.custom-coverage-form-editing {
+  padding: 0.5em;
+}
+
+.custom-coverage-form-editing {
+  background: #e6f3ff;
+}
+
+.custom-coverage-action-buttons {
+  display: flex;
+  flex-direction: row-reverse;
+  margin-top: 1em;
+}
+
+.custom-coverage-date-display {
+  display: flex;
+  align-items: flex-start;
+}
+
+.custom-coverage-dates {
+  display: flex;
+  align-items: flex-start;
+}
+
+.custom-coverage-date-clear-row {
+  flex: 0 0 3em;
+  margin-top: 1.5em;
+  text-align: center;
+}
+
+.custom-coverage-date-picker {
+  align-self: flex-start;
+  flex: 1 1 auto;
+  margin-right: 1em;
+}
+
+.custom-coverage-add-button {
+  margin: 1em 0;
+}

--- a/src/components/custom-coverage-form/custom-coverage-form.js
+++ b/src/components/custom-coverage-form/custom-coverage-form.js
@@ -1,0 +1,186 @@
+import React, { Component } from 'react';
+import { Field, reduxForm } from 'redux-form';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+import Datepicker from '@folio/stripes-components/lib/Datepicker';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+import Button from '@folio/stripes-components/lib/Button';
+import KeyValueLabel from '../key-value-label';
+import { formatISODateWithoutTime } from '../utilities';
+import styles from './custom-coverage-form.css';
+
+class CustomCoverageForm extends Component {
+  static propTypes = {
+    initialValues: PropTypes.shape({
+      beginCoverage: PropTypes.string,
+      endCoverage: PropTypes.string
+    }).isRequired,
+    handleSubmit: PropTypes.func.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    pristine: PropTypes.bool,
+    initialize: PropTypes.func,
+    isPending: PropTypes.bool,
+    change: PropTypes.func
+  };
+
+  static contextTypes = {
+    intl: PropTypes.object
+  };
+
+  state = {
+    isEditing: false
+  };
+
+  renderDatepicker = ({ input, label, meta }) => {
+    return (
+      <div>
+        <Datepicker
+          label={label}
+          input={input}
+          onFocus={input.onFocus}
+          onChange={input.onChange}
+          value={input.value}
+          meta={meta}
+        />
+      </div>
+    );
+  }
+
+  handleEditCustomCoverage = (event) => {
+    let isEditing = !this.state.isEditing;
+    event.preventDefault();
+    this.setState({ isEditing });
+  }
+
+  handleCancelCustomCoverage = (event) => {
+    event.preventDefault();
+    this.setState({
+      isEditing: false
+    });
+    this.props.initialize(this.props.initialValues);
+  }
+
+  handleDeleteCustomCoverage = (event) => {
+    event.preventDefault();
+    this.props.change('beginCoverage', '');
+    this.props.change('endCoverage', '');
+  }
+
+  handleSubmit = (data) => {
+    this.setState({
+      isEditing: false
+    });
+    if (this.props.pristine) {
+      return;
+    }
+    this.props.onSubmit(data);
+  }
+
+  render() {
+    let { pristine, isPending } = this.props;
+    let { intl } = this.context;
+
+    const { beginCoverage, endCoverage } = this.props.initialValues;
+    if (this.state.isEditing) {
+      return (
+        <form onSubmit={this.props.handleSubmit(this.handleSubmit)} className={styles['custom-coverage-form-editing']}>
+          <KeyValueLabel label="Custom Coverage">
+            <div
+              data-test-eholdings-custom-coverage-inputs
+              className={styles['custom-coverage-dates']}
+            >
+              <div data-test-eholdings-custom-coverage-begin-coverage className={styles['custom-coverage-date-picker']}>
+                <Field
+                  name='beginCoverage'
+                  component={this.renderDatepicker}
+                  label="Start Date"
+                />
+              </div>
+              <div data-test-eholdings-custom-coverage-end-coverage className={styles['custom-coverage-date-picker']}>
+                <Field
+                  name='endCoverage'
+                  component={this.renderDatepicker}
+                  label="End Date"
+                />
+              </div>
+              <div data-test-eholdings-custom-coverage-clear-button className={styles['custom-coverage-date-clear-row']}>
+                {this.props.initialValues.beginCoverage && (
+                  <IconButton icon="hollowX" onClick={this.handleDeleteCustomCoverage} size="small" />
+                )}
+              </div>
+            </div>
+            <div className={styles['custom-coverage-action-buttons']}>
+              <div data-test-eholdings-custom-coverage-save-button>
+                <Button disabled={pristine} type="submit" role="button" buttonStyle="primary">
+                  Save
+                </Button>
+              </div>
+              <div data-test-eholdings-custom-coverage-cancel-custom-coverage-button>
+                <Button disabled={isPending} hollow type="button" role="button" onClick={this.handleCancelCustomCoverage} buttonStyle="secondary">
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          </KeyValueLabel>
+        </form>
+      );
+    } else if (beginCoverage) {
+      return (
+        <div className={styles['custom-coverage-form']}>
+          <div className={styles['custom-coverage-date-display']}>
+            <KeyValueLabel label="Custom Coverage">
+              <div data-test-eholdings-custom-coverage-display className={styles['custom-coverage-dates']}>
+                {formatISODateWithoutTime(beginCoverage, intl)} - {formatISODateWithoutTime(endCoverage, intl) || 'Present'}
+              </div>
+            </KeyValueLabel>
+            <div data-test-eholdings-custom-coverage-edit-button>
+              <IconButton icon="edit" onClick={this.handleEditCustomCoverage} />
+            </div>
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div className={styles['custom-coverage-form']}>
+          <KeyValueLabel label="Custom Coverage">
+            <div data-test-eholdings-custom-coverage-add-button className={styles['custom-coverage-add-button']}>
+              <Button
+                hollow
+                buttonStyle="primary"
+                type="button"
+                onClick={this.handleEditCustomCoverage}
+              >
+                Add Custom Coverage
+              </Button>
+            </div>
+          </KeyValueLabel>
+        </div>
+      );
+    }
+  }
+}
+
+// this function is a special function used by redux-form for form validation
+// the values from the from are passed into this function and then
+// validated based on the matching field with the same 'name' as value
+function validate(values, props) {
+  let dateFormat = props.intl.formatters.getDateTimeFormat().format();
+  const errors = {};
+
+  if (values.beginCoverage && !moment(values.beginCoverage).isValid()) {
+    errors.beginCoverage = `Enter Date in ${dateFormat} format.`;
+  }
+
+  if (values.endCoverage && moment(values.beginCoverage).isAfter(values.endCoverage)) {
+    errors.beginCoverage = 'Start Date must be before End Date';
+  }
+
+  return errors;
+}
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'CustomCoverage',
+})(CustomCoverageForm);

--- a/src/components/custom-coverage-form/index.js
+++ b/src/components/custom-coverage-form/index.js
@@ -1,0 +1,1 @@
+export { default } from './custom-coverage-form';

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -13,13 +13,14 @@ import List from '../list';
 import TitleListItem from '../title-list-item';
 import ToggleSwitch from '../toggle-switch';
 import Modal from '../modal';
-import { formatISODateWithoutTime } from '../utilities';
+import CustomCoverageForm from '../custom-coverage-form';
 import styles from './package-show.css';
 
 export default class PackageShow extends Component {
   static propTypes = {
     model: PropTypes.object.isRequired,
-    toggleSelected: PropTypes.func.isRequired
+    toggleSelected: PropTypes.func.isRequired,
+    customCoverageSubmitted: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -61,7 +62,7 @@ export default class PackageShow extends Component {
   };
 
   render() {
-    let { model } = this.props;
+    let { model, customCoverageSubmitted } = this.props;
     let { intl, router, queryParams } = this.context;
     let { showSelectionModal, packageSelected } = this.state;
     let historyState = router.history.location.state;
@@ -116,14 +117,6 @@ export default class PackageShow extends Component {
                 </div>
               </KeyValueLabel>
 
-              {(model.customCoverage.beginCoverage || model.customCoverage.endCoverage) && (
-                <KeyValueLabel label="Custom Coverage">
-                  <div data-test-eholdings-package-details-custom-coverage>
-                    {formatISODateWithoutTime(model.customCoverage.beginCoverage, intl)} - {formatISODateWithoutTime(model.customCoverage.endCoverage, intl)}
-                  </div>
-                </KeyValueLabel>
-              )}
-
               <hr />
 
               <label
@@ -139,10 +132,27 @@ export default class PackageShow extends Component {
                 />
               </label>
 
+              <hr />
+
               {model.visibilityData.isHidden && (
                 <div data-test-eholdings-package-details-is-hidden>
                   <p><strong>This package is hidden.</strong></p>
                   <p><em>{model.visibilityData.reason}</em></p>
+                  <hr />
+                </div>
+              )}
+
+              {model.isSelected && (
+                <div data-test-eholdings-package-details-custom-coverage>
+                  <CustomCoverageForm
+                    onSubmit={customCoverageSubmitted}
+                    intl={intl}
+                    initialValues={{
+                      beginCoverage: model.customCoverage.beginCoverage,
+                      endCoverage: model.customCoverage.endCoverage
+                    }}
+                    isPending={model.update.isPending && 'customCoverage' in model.update.changedAttributes}
+                  />
                   <hr />
                 </div>
               )}

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import moment from 'moment';
 
 import { createResolver } from '../redux';
 import Package from '../redux/package';
@@ -54,11 +55,19 @@ class PackageShowRoute extends Component {
     updatePackage(model);
   };
 
+  customCoverageSubmitted = (values) => {
+    let { model, updatePackage } = this.props;
+    model.customCoverage.beginCoverage = !values.beginCoverage ? null : moment(values.beginCoverage).format('YYYY-MM-DD');
+    model.customCoverage.endCoverage = !values.endCoverage ? null : moment(values.endCoverage).format('YYYY-MM-DD');
+    updatePackage(model);
+  }
+
   render() {
     return (
       <View
         model={this.props.model}
         toggleSelected={this.toggleSelected}
+        customCoverageSubmitted={this.customCoverageSubmitted}
       />
     );
   }

--- a/tests/package-show-custom-coverage-test.js
+++ b/tests/package-show-custom-coverage-test.js
@@ -4,6 +4,7 @@ import it from './it-will';
 
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/package-show';
+import CustomCoverageForm from './pages/custom-coverage-form';
 
 describeApplication('PackageShowCustomCoverage', () => {
   let vendor,
@@ -12,6 +13,25 @@ describeApplication('PackageShowCustomCoverage', () => {
   beforeEach(function () {
     vendor = this.server.create('vendor', {
       name: 'Cool Vendor'
+    });
+  });
+
+  describe('visiting the package show page and package is not selected', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', {
+        vendor,
+        name: 'Cool Package',
+        contentType: 'ebook',
+        isSelected: false
+      });
+
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('should not display custom coverage', () => {
+      expect(CustomCoverageForm.customCoverageText).to.equal('');
     });
   });
 
@@ -26,7 +46,8 @@ describeApplication('PackageShowCustomCoverage', () => {
         customCoverage,
         vendor,
         name: 'Cool Package',
-        contentType: 'E-Book'
+        contentType: 'E-Book',
+        isSelected: true
       });
 
       return this.visit(`/eholdings/packages/${pkg.id}`, () => {
@@ -35,7 +56,75 @@ describeApplication('PackageShowCustomCoverage', () => {
     });
 
     it('displays the custom coverage section', () => {
-      expect(PackageShowPage.customCoverage).to.equal('7/16/1969 - 12/19/1972');
+      expect(CustomCoverageForm.customCoverageText).to.equal('7/16/1969 - 12/19/1972');
+    });
+
+    it('should not display a button to add custom coverage', () => {
+      expect(CustomCoverageForm.$customCoverageButton).to.not.exist;
+    });
+
+    it('displays whether or not the package is selected', () => {
+      expect(PackageShowPage.isSelected).to.equal(true);
+    });
+
+    describe('clicking to toggle and deselect package and confirming deselection', () => {
+      beforeEach(() => {
+        return PackageShowPage.toggleIsSelected().then(() => {
+          return PackageShowPage.confirmDeselection();
+        });
+      });
+
+      it('removes the custom coverage', () => {
+        expect(CustomCoverageForm.customCoverageText).to.equal('');
+      });
+    });
+
+    describe('clicking to toggle and deselect package and canceling deselection', () => {
+      beforeEach(() => {
+        return PackageShowPage.toggleIsSelected().then(() => {
+          return PackageShowPage.cancelDeselection();
+        });
+      });
+
+      it('does not remove the custom coverage', () => {
+        expect(CustomCoverageForm.customCoverageText).to.equal('7/16/1969 - 12/19/1972');
+      });
+    });
+
+    describe('clicking the edit button', () => {
+      beforeEach(() => {
+        return CustomCoverageForm.clickCustomCoverageEditButton();
+      });
+
+      it('displays the date input fields', () => {
+        expect(CustomCoverageForm.$customCoverageInputs).to.exist;
+      });
+
+      it('contains the right value for beginCoverage', () => {
+        expect(CustomCoverageForm.$beginCoverageField.val()).to.equal('07/16/1969');
+      });
+
+      it('contains the right value for endCoverage', () => {
+        expect(CustomCoverageForm.$endCoverageField.val()).to.equal('12/19/1972');
+      });
+
+      describe('clicking the clear button', () => {
+        beforeEach(() => {
+          return CustomCoverageForm.clickCustomCoverageClearButton();
+        });
+
+        it('contains no value for beginCoverage', () => {
+          expect(CustomCoverageForm.$beginCoverageField.val()).to.equal('');
+        });
+
+        it('contains no value for endCoverage', () => {
+          expect(CustomCoverageForm.$endCoverageField.val()).to.equal('');
+        });
+
+        it('enables the save button', () => {
+          expect(CustomCoverageForm.$customCoverageSaveButton).to.have.prop('disabled', false);
+        });
+      });
     });
   });
 
@@ -44,7 +133,8 @@ describeApplication('PackageShowCustomCoverage', () => {
       pkg = this.server.create('package', {
         vendor,
         packageName: 'Cool Package',
-        contentType: 'ebook'
+        contentType: 'ebook',
+        isSelected: true
       });
 
       return this.visit(`/eholdings/packages/${pkg.id}`, () => {
@@ -53,7 +143,98 @@ describeApplication('PackageShowCustomCoverage', () => {
     });
 
     it.still('does not display the custom coverage section', () => {
-      expect(PackageShowPage.customCoverage).to.equal('');
+      expect(CustomCoverageForm.customCoverageText).to.equal('');
+    });
+
+    it('should display a button to add custom', () => {
+      expect(CustomCoverageForm.$customCoverageAddButton).to.exist;
+    });
+
+    describe('clicking on the add custom coverage button', () => {
+      beforeEach(() => {
+        CustomCoverageForm.clickCustomCoverageAddButton();
+      });
+
+      it('should remove the add custom coverage button', () => {
+        expect(CustomCoverageForm.$customCoverageAddButton).to.not.exist;
+      });
+
+      it('displays custom coverage date inputs', () => {
+        expect(CustomCoverageForm.$customCoverageInputs).to.exist;
+      });
+
+      describe('clicking the cancel button', () => {
+        beforeEach(() => {
+          CustomCoverageForm.clickCustomCoverageCancelButton();
+        });
+
+        it('removes the custom coverage input fields', () => {
+          expect(CustomCoverageForm.$customCoverageInputs).to.not.exist;
+        });
+
+        it('displays the button to add custom coverage', () => {
+          expect(CustomCoverageForm.$customCoverageAddButton).to.exist;
+        });
+      });
+
+      describe('submitting the form successfully', () => {
+        beforeEach(() => {
+          CustomCoverageForm.fillInCustomCoverage({
+            beginCoverage: '01/01/2018',
+            endCoverage: '02/01/2018'
+          });
+        });
+
+        it('does not display an error for beginCoverage', () => {
+          expect(CustomCoverageForm.beginCoverageFieldIsInvalid).to.be.false;
+        });
+
+        it('does not display an error for endCoverage', () => {
+          expect(CustomCoverageForm.endCoverageFieldIsInvalid).to.be.false;
+        });
+
+        it('enables the save button', () => {
+          expect(CustomCoverageForm.$customCoverageSaveButton).to.have.prop('disabled', false);
+        });
+
+        describe('saving the changes', () => {
+          beforeEach(() => {
+            CustomCoverageForm.clickCustomCoverageSaveButton();
+          });
+
+          // mirage may respond too quick to properly test loading states
+          it.skip('disables the save button', () => {
+            expect(CustomCoverageForm.$customCoverageSaveButton).to.have.prop('disabled', true);
+          });
+
+          describe('when the changes succeed', () => {
+            it('hides the form actions', () => {
+              expect(CustomCoverageForm.$customCoverageInputs).to.not.exist;
+            });
+          });
+        });
+      });
+
+      describe('filling out the form with an invalid date pair', () => {
+        beforeEach(() => {
+          CustomCoverageForm.fillInCustomCoverage({
+            beginCoverage: '03/01/2018',
+            endCoverage: '02/01/2018'
+          });
+        });
+
+        it('displays an error for beginCoverage', () => {
+          expect(CustomCoverageForm.beginCoverageFieldIsInvalid).to.be.true;
+        });
+
+        it('does not enable the save button', () => {
+          expect(CustomCoverageForm.$saveCustomCoverageButton).to.have.prop('disabled', true);
+        });
+      });
+
+      describe('getting back an error from the server when submitting the form', () => {
+        it.skip('shows an error state');
+      });
     });
   });
 });

--- a/tests/pages/custom-coverage-form.js
+++ b/tests/pages/custom-coverage-form.js
@@ -1,0 +1,97 @@
+import $ from 'jquery';
+import { expect } from 'chai';
+import { convergeOn } from '../it-will';
+import { fillIn } from './helpers';
+
+export default {
+  get customCoverageText() {
+    return $('[data-test-eholdings-custom-coverage-display]').text();
+  },
+
+  get $customCoverageAddButton() {
+    return $('[data-test-eholdings-custom-coverage-add-button] button');
+  },
+
+  get $customCoverageEditButton() {
+    return $('[data-test-eholdings-custom-coverage-edit-button] button');
+  },
+
+  get $customCoverageInputs() {
+    return $('[data-test-eholdings-custom-coverage-inputs]');
+  },
+
+  get $beginCoverageField() {
+    return $('[data-test-eholdings-custom-coverage-begin-coverage] input');
+  },
+
+  get $endCoverageField() {
+    return $('[data-test-eholdings-custom-coverage-end-coverage] input');
+  },
+
+  get $customCoverageClearButton() {
+    return $('[data-test-eholdings-custom-coverage-clear-button] button');
+  },
+
+  get $customCoverageCancelButton() {
+    return $('[data-test-eholdings-custom-coverage-cancel-button] button');
+  },
+
+  get $customCoverageSaveButton() {
+    return $('[data-test-eholdings-custom-coverage-save-button] button');
+  },
+
+  get beginCoverageFieldIsInvalid() {
+    return this.$beginCoverageField.attr('class').indexOf('feedbackError--') !== -1;
+  },
+
+  get endCoverageFieldIsInvalid() {
+    return this.$endCoverageField.attr('class').indexOf('feedbackError--') !== -1;
+  },
+
+  fillInCustomCoverage({ beginCoverage, endCoverage }) {
+    return Promise.all([
+      fillIn(this.$beginCoverageField, beginCoverage),
+      fillIn(this.$endCoverageField, endCoverage)
+    ]);
+  },
+
+  clickCustomCoverageAddButton() {
+    return convergeOn(() => {
+      expect(this.$customCoverageAddButton).to.exist;
+    }).then(() => (
+      this.$customCoverageAddButton.click()
+    ));
+  },
+
+  clickCustomCoverageEditButton() {
+    return convergeOn(() => {
+      expect(this.$customCoverageEditButton).to.exist;
+    }).then(() => (
+      this.$customCoverageEditButton.click()
+    ));
+  },
+
+  clickCustomCoverageClearButton() {
+    return convergeOn(() => {
+      expect(this.$customCoverageClearButton).to.exist;
+    }).then(() => (
+      this.$customCoverageClearButton.click()
+    ));
+  },
+
+  clickCustomCoverageCancelButton() {
+    return convergeOn(() => {
+      expect(this.$customCoverageCancelButton).to.exist;
+    }).then(() => (
+      this.$customCoverageCancelButton.click()
+    ));
+  },
+
+  clickCustomCoverageSaveButton() {
+    return convergeOn(() => {
+      expect(this.$customCoverageSaveButton).to.exist;
+    }).then(() => {
+      return this.$customCoverageSaveButton.click();
+    });
+  }
+};

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -89,10 +89,6 @@ export default {
     return $('[data-test-eholdings-package-details-is-hidden]').length === 1;
   },
 
-  get customCoverage() {
-    return $('[data-test-eholdings-package-details-custom-coverage]').text();
-  },
-
   get $backButton() {
     return $('[data-test-eholdings-package-details-back-button] button');
   }


### PR DESCRIPTION
## Purpose
Builds on the work from https://github.com/folio-org/ui-eholdings/pull/151. Probably replaces it, but we'll leave both open until we get one to the finish line.

## Approach
Major UX changes:
- Instead of a trash can that immediately removes the custom coverage, there's a clear button that just clears out both rows. I think that will work nicer with the multiple-row situation in package-titles. It also makes it so there's always an explicit Save action.
- You can submit blank values in the form.
- All the custom coverage stuff has been moved out to a `CustomCoverageForm` component.
- There's now a background color on the form.

#### TODOS and Open Questions
- [ ] Fix failing test assertions using `fillIn()`.
- [ ] How do we deal with server errors? @elrickvm might now have some insights

## Screenshots
![l65ih9xonw](https://user-images.githubusercontent.com/230597/35075560-66ba94ec-fbb9-11e7-9cda-c4fa1d80a491.gif)