### PR TITLE
Make `inflected` and `query-string` primary dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "eslint": "^4.8.0",
     "eslint-config-stripes": "^1.0.0",
     "eslint-loader": "^1.9.0",
-    "inflected": "^2.0.3",
     "jquery": "^3.2.1",
     "karma": "^1.7.0",
     "karma-browserstack-launcher": "^1.3.0",
@@ -38,7 +37,6 @@
     "mirage-server": "cowboyd/mirage-server",
     "mocha": "^3.4.2",
     "moment": "^2.17.1",
-    "query-string": "^5.0.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-hot-loader": "next",
@@ -51,7 +49,9 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "impagination": "^1.0.0-alpha.3",
+    "inflected": "^2.0.3",
     "isomorphic-fetch": "^2.2.1",
+    "query-string": "^5.0.0",
     "redux-actions": "^2.2.1"
   },
   "stripes": {


### PR DESCRIPTION
## Purpose
When using ui-eholdings as a dependency, it doesn't install its devDependencies. This isn't a problem when running the CI build because it's installed as the root package so all the dev-dependencies make it in, but when running it as part of a containing stripes platform, it breaks because it doesn't bring in things it needs to build.


## Approach

This adds:

- inflected
- query-string

as hard dependencies of ui-eholdings so that it will always get pulled into every build of which it is a part.