### PR TITLE
Fix a typo while clearing out customizations during deselection

### DIFF
--- a/src/routes/customer-resource-show.js
+++ b/src/routes/customer-resource-show.js
@@ -41,8 +41,7 @@ class CustomerResourceShowRoute extends Component {
     if (!model.isSelected) {
       model.visibilityData.isHidden = false;
       model.customCoverages = [];
-      model.customEmbargoPeriod.embargoUnit = null;
-      model.customEmbargoPeriod.customEmbargoValue = 0;
+      model.customEmbargoPeriod = {};
     }
 
     updateResource(model);

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -47,8 +47,7 @@ class PackageShowRoute extends Component {
     // clear out any customizations before sending to server
     if (!model.isSelected) {
       model.visibilityData.isHidden = false;
-      model.customCoverage.beginCoverage = null;
-      model.customCoverage.endCoverage = null;
+      model.customCoverage = {};
     }
 
     updatePackage(model);


### PR DESCRIPTION
We noticed an issue when deselecting customer resources, and traced it
to an issue with embargo values.  Looks like we had a typo in there,
and were clearing out the wrong field during deselection.  This work
adjusts the clear-out logic to use empty objects where possible, in
lieu of nulling out specific data members within those objects.

**Before**
![2018-01-18 09 21 16](https://user-images.githubusercontent.com/14239162/35111096-6d813490-fc48-11e7-86f6-9b4e30e723f4.gif)

**Typo in Embargo Payload**
<img width="456" alt="screen shot 2018-01-18 at 11 42 31 am" src="https://user-images.githubusercontent.com/14239162/35111392-29549c66-fc49-11e7-94f0-8ec2724dcaba.png">


**After**
![after_deselect](https://user-images.githubusercontent.com/14239162/35111237-cbb326a4-fc48-11e7-8e45-0cb67ffe9583.gif)


