### PR TITLE
Show/Hide functionality for title-packages

### DIFF
--- a/src/components/customer-resource-show/customer-resource-show.css
+++ b/src/components/customer-resource-show/customer-resource-show.css
@@ -19,3 +19,13 @@
 .detail-container-header {
   margin: 2rem 0;
 }
+
+.flex-container {
+  display: flex;
+  align-items: center;
+}
+
+.flex-item {
+  margin-right: 10px;
+}
+

--- a/src/components/customer-resource-show/customer-resource-show.js
+++ b/src/components/customer-resource-show/customer-resource-show.js
@@ -19,7 +19,8 @@ import styles from './customer-resource-show.css';
 export default class CustomerResourceShow extends Component {
   static propTypes = {
     model: PropTypes.object.isRequired,
-    toggleSelected: PropTypes.func.isRequired
+    toggleSelected: PropTypes.func.isRequired,
+    toggleHidden: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -29,12 +30,16 @@ export default class CustomerResourceShow extends Component {
 
   state = {
     showSelectionModal: false,
-    resourceSelected: this.props.model.isSelected
+    resourceSelected: this.props.model.isSelected,
+    resourceHidden: this.props.model.visibilityData.isHidden
   };
 
   componentWillReceiveProps({ model }) {
     if (!model.isSaving) {
-      this.setState({ resourceSelected: model.isSelected });
+      this.setState({
+        resourceSelected: model.isSelected,
+        resourceHidden: model.visibilityData.isHidden
+      });
     }
   }
 
@@ -193,15 +198,70 @@ export default class CustomerResourceShow extends Component {
 
               <hr />
 
-              {model.visibilityData.isHidden && (
-                <div data-test-eholdings-customer-resource-show-is-hidden>
-                  <p><strong>This resource is hidden.</strong></p>
-                  <p data-test-eholdings-customer-resource-show-hidden-reason>
-                    <em>{model.visibilityData.reason}</em>
-                  </p>
-                  <hr />
-                </div>
-              )}
+              <label
+                data-test-eholdings-customer-resource-toggle-hidden
+                htmlFor="customer-resource-show-hide-toggle-switch"
+              > {
+                  model.package.visibilityData.isHidden ? (
+                    <div>
+                      <h4>Hidden from patrons</h4>
+                      <div className={styles['flex-container']}>
+                        <div className={styles['flex-item']}>
+                          <ToggleSwitch
+                            id="customer-resource-show-hide-toggle-switch"
+                            checked={false}
+                            disabled
+                          />
+                        </div>
+
+                        <div className={styles['flex-item']}>
+                          {
+                            <p data-test-eholdings-customer-resource-toggle-hidden-reason>
+                              All titles in this package are hidden.
+                            </p>
+                          }
+                        </div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div>
+                      <h4>{model.visibilityData.isHidden ? 'Hidden from patrons' : 'Visible to patrons'}</h4>
+                      <div className={styles['flex-container']}>
+                        <div className={styles['flex-item']}>
+                          { resourceSelected ? (
+                            <ToggleSwitch
+                              onChange={this.props.toggleHidden}
+                              checked={!model.visibilityData.isHidden}
+                              isPending={model.update.isPending}
+                              id="customer-resource-show-hide-toggle-switch"
+                            />
+                          ) : (
+                            <ToggleSwitch
+                              checked
+                              disabled
+                              id="customer-resource-show-hide-toggle-switch"
+                            />
+                          )
+                          }
+                        </div>
+                        <div className={styles['flex-item']}>
+                          {
+                            model.visibilityData.isHidden ? (
+                              <p data-test-eholdings-customer-resource-toggle-hidden-reason>
+                                {model.visibilityData.reason}
+                              </p>
+                            ) : (
+                              <p data-test-eholdings-customer-resource-toggle-hidden-reason />
+                            )
+                          }
+                        </div>
+                      </div>
+                    </div>
+                  )
+                }
+              </label>
+
+              <hr />
 
               <div>
                 <Link to={`/eholdings/titles/${model.titleId}`}>

--- a/src/components/toggle-switch/toggle-switch.css
+++ b/src/components/toggle-switch/toggle-switch.css
@@ -14,6 +14,10 @@
     background-color: var(--success);
   }
 
+  & input:disabled + .toggle-switch-slider {
+    background-color: var(--secondary);
+  }
+
   & input:checked + .toggle-switch-slider::before {
     transform: translateX(26px);
   }
@@ -35,7 +39,7 @@
 }
 
 .toggle-switch-slider {
-  background-color: #333;
+  background-color: var(--labelColor);
   border-radius: 34px;
   bottom: 0;
   cursor: pointer;

--- a/src/routes/customer-resource-show.js
+++ b/src/routes/customer-resource-show.js
@@ -47,11 +47,18 @@ class CustomerResourceShowRoute extends Component {
     updateResource(model);
   }
 
+  toggleHidden = () => {
+    let { model, updateResource } = this.props;
+    model.visibilityData.isHidden = !model.visibilityData.isHidden;
+    updateResource(model);
+  }
+
   render() {
     return (
       <View
         model={this.props.model}
         toggleSelected={this.toggleSelected}
+        toggleHidden={this.toggleHidden}
       />
     );
   }

--- a/tests/customer-resource-show-visibility-test.js
+++ b/tests/customer-resource-show-visibility-test.js
@@ -1,4 +1,4 @@
-/* global describe, beforeEach */
+/* global describe, beforeEach, afterEach */
 import { expect } from 'chai';
 import it from './it-will';
 
@@ -15,27 +15,11 @@ describeApplication('CustomerResourceShowVisibility', () => {
     title = this.server.create('title');
   });
 
-  describe('visiting the customer resource show page with a hidden resource', () => {
-    beforeEach(function () {
-      resource = this.server.create('customer-resource', 'isHidden', {
-        package: pkg,
-        title
-      });
-
-      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
-        expect(CustomerResourceShowPage.$root).to.exist;
-      });
-    });
-
-    it('displays the hidden/reason section', () => {
-      expect(CustomerResourceShowPage.isHidden).to.be.true;
-    });
-  });
-
-  describe('visiting the customer resource show page with a resource that is not hidden', () => {
+  describe('visiting the customer resource show page with a resource that is not hidden and is selected', () => {
     beforeEach(function () {
       resource = this.server.create('customer-resource', {
         package: pkg,
+        isSelected: true,
         title
       });
 
@@ -44,15 +28,38 @@ describeApplication('CustomerResourceShowVisibility', () => {
       });
     });
 
-    it('does not display the hidden/reason section', () => {
+    it('displays the visibility toggle as switched to on', () => {
       expect(CustomerResourceShowPage.isHidden).to.be.false;
     });
   });
 
-  describe('visiting the customer resource show page with a hidden resource and mapped reason text', () => {
+  describe('visiting the customer resource show page with a resource that is not hidden and is not selected', () => {
+    beforeEach(function () {
+      resource = this.server.create('customer-resource', {
+        package: pkg,
+        isSelected: false,
+        title
+      });
+
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the visibility toggle as switched to on', () => {
+      expect(CustomerResourceShowPage.isHidden).to.be.false;
+    });
+
+    it('displays the visibility toggle disabled', () => {
+      expect(CustomerResourceShowPage.isDisabled).to.be.true;
+    });
+  });
+
+  describe('visiting the customer resource show page with a hidden resource and a reason', () => {
     beforeEach(function () {
       resource = this.server.create('customer-resource', 'isHidden', {
         package: pkg,
+        isSelected: true,
         title
       });
 
@@ -69,8 +76,8 @@ describeApplication('CustomerResourceShowVisibility', () => {
       });
     });
 
-    it('displays the hidden/reason section', () => {
-      expect(CustomerResourceShowPage.isHidden).to.be.true;
+    it('displays the visibility toggle with as switched to on', () => {
+      expect(CustomerResourceShowPage.isHidden).to.be.false;
     });
 
     it('maps the hidden reason text', () => {
@@ -78,16 +85,17 @@ describeApplication('CustomerResourceShowVisibility', () => {
     });
   });
 
-  describe('visiting the customer resource show page with a hidden resource and reason text is not mapped', () => {
+  describe('visiting the customer resource show page with a hidden resource and no reason', () => {
     beforeEach(function () {
       resource = this.server.create('customer-resource', 'isHidden', {
         package: pkg,
+        isSelected: true,
         title
       });
 
       let visibilityData = this.server.create('visibility-data', {
         isHidden: true,
-        reason: 'Not Mapped Reason Text'
+        reason: ''
       }).toJSON();
 
       resource.update('visibilityData', visibilityData);
@@ -98,12 +106,154 @@ describeApplication('CustomerResourceShowVisibility', () => {
       });
     });
 
-    it('displays the hidden/reason section', () => {
-      expect(CustomerResourceShowPage.isHidden).to.be.true;
+    it('displays the visibility toggle with as switched to on', () => {
+      expect(CustomerResourceShowPage.isHidden).to.be.false;
     });
 
     it('maps the hidden reason text', () => {
-      expect(CustomerResourceShowPage.hiddenReason).to.equal('Not Mapped Reason Text');
+      expect(CustomerResourceShowPage.hiddenReason).to.equal('');
+    });
+  });
+
+  describe('visiting the customer resource show page and hiding a resource', () => {
+    beforeEach(function () {
+      resource = this.server.create('customer-resource', {
+        package: pkg,
+        isSelected: true,
+        title
+      });
+
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the visibility toggle with as switched to on', () => {
+      expect(CustomerResourceShowPage.isHidden).to.be.false;
+    });
+
+    describe('successfully hiding a customer resource', () => {
+      beforeEach(function () {
+        this.server.timing = 50;
+        return CustomerResourceShowPage.toggleIsHidden();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('reflects the desired state as switched to off', () => {
+        expect(CustomerResourceShowPage.isHidden).to.be.true;
+      });
+
+      it('cannot be interacted with while the request is in flight', () => {
+        expect(CustomerResourceShowPage.isHiddenToggleable).to.be.false;
+      });
+
+      describe('when the request succeeds', () => {
+        it('reflect the desired state was set as switched to off', () => {
+          expect(CustomerResourceShowPage.isHidden).to.be.true;
+        });
+
+        it('indicates it is no longer pending', () => {
+          expect(CustomerResourceShowPage.isHiding).to.be.false;
+        });
+      });
+    });
+  });
+
+  describe('visiting the customer resource show page and showing a hidden resource', () => {
+    beforeEach(function () {
+      pkg.isSelected = true;
+      resource = this.server.create('customer-resource', 'isHidden', {
+        package: pkg,
+        isSelected: true,
+        title
+      });
+
+      let visibilityData = this.server.create('visibility-data', {
+        isHidden: true,
+        reason: ''
+      }).toJSON();
+
+      resource.update('visibilityData', visibilityData);
+      resource.save();
+
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the visibility toggle as switched to on', () => {
+      expect(CustomerResourceShowPage.isHidden).to.be.false;
+    });
+
+    it('maps the hidden reason text', () => {
+      expect(CustomerResourceShowPage.hiddenReason).to.equal('');
+    });
+
+    describe('successfully showing a customer resource', () => {
+      beforeEach(function () {
+        this.server.timing = 50;
+        return CustomerResourceShowPage.toggleIsHidden();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('reflects the desired state (Show)', () => {
+        expect(CustomerResourceShowPage.isHidden).to.be.false;
+      });
+
+      it('cannot be interacted with while the request is in flight', () => {
+        expect(CustomerResourceShowPage.isHiddenToggleable).to.be.false;
+      });
+
+      describe('when the request succeeds', () => {
+        it('reflect the desired state was set (Show)', () => {
+          expect(CustomerResourceShowPage.isHidden).to.be.false;
+        });
+
+        it('indicates it is no longer pending', () => {
+          expect(CustomerResourceShowPage.isHiding).to.be.false;
+        });
+      });
+    });
+  });
+
+  describe('visiting the customer resource show page and all titles in package are hidden', () => {
+    beforeEach(function () {
+      pkg.visibilityData.isHidden = true;
+      pkg.visibilityData.reason = 'Hidden by EP';
+      resource = this.server.create('customer-resource', 'isHidden', {
+        package: pkg,
+        title
+      });
+
+      let visibilityData = this.server.create('visibility-data', {
+        isHidden: true,
+        reason: ''
+      }).toJSON();
+
+      resource.update('visibilityData', visibilityData);
+      resource.save();
+
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the visibility toggle with as switched to on', () => {
+      expect(CustomerResourceShowPage.isHidden).to.be.false;
+    });
+
+    it('the visibility toggle is disabled', () => {
+      expect(CustomerResourceShowPage.isDisabled).to.be.true;
+    });
+
+    it('maps the hidden reason text', () => {
+      expect(CustomerResourceShowPage.hiddenReason).to.equal('All titles in this package are hidden.');
     });
   });
 });

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -72,11 +72,35 @@ export default {
   },
 
   get isHidden() {
-    return $('[data-test-eholdings-customer-resource-show-is-hidden]').length === 1;
+    return $('[data-test-eholdings-customer-resource-toggle-hidden] input').prop('checked') === false;
+  },
+
+  get isDisabled() {
+    return $('[data-test-eholdings-customer-resource-toggle-hidden] input').prop('disabled');
   },
 
   get hiddenReason() {
-    return $('[data-test-eholdings-customer-resource-show-hidden-reason]').text();
+    return $('[data-test-eholdings-customer-resource-toggle-hidden-reason]').text();
+  },
+
+  toggleIsHidden() {
+    /*
+     * We don't want to click the element before it exists.  This should
+     * probably become a generic 'click' helper once we have more usage.
+     */
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-customer-resource-toggle-hidden]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-customer-resource-toggle-hidden] input').click()
+    ));
+  },
+
+  get isHiding() {
+    return $('[data-test-eholdings-customer-resource-toggle-hidden] [data-test-toggle-switch]').attr('class').indexOf('is-pending--') !== -1;
+  },
+
+  get isHiddenToggleable() {
+    return $('[data-test-eholdings-customer-resource-toggle-hidden] input[type=checkbox]').prop('disabled') === false;
   },
 
   get managedEmbargoPeriod() {


### PR DESCRIPTION
## Purpose
- Implement Show/Hide functionality for title-packages
- If the package is hidden or customer resource in a package is not selected, a toggle switch which is read-only and cannot be toggled will appear with a message. 
- Message in above case will be "All titles in this package are hidden." if the package is hidden. If the customer resource within package is not selected, there is no message.
- If a package is not hidden and if a package or customer resource is selected, a toggle switch reflecting current state of the title-package appears with the appropriate message, being 'Set by System' if it is 'Hidden by EP' from RM API or none if it is 'Hidden by Customer' or any other message from RM API
JIRA Tickets: 
https://issues.folio.org/browse/UIEH-47
https://issues.folio.org/browse/UIEH-36
Per change in requirement, when isHidden=true,label is "Hidden from patrons" and toggle is off
when isHidden=false, label is "Visible to patrons" and toggle is on

## Approach
- Use the existing toggle-switch component
- Implement the flex-container for having message on the right side of toggle switch
- Make .css modifications to get the toggle-switch to the required color and few modifications to use existing colors in Stripes rather than hard-coding
- Associated unit tests for the above functionality

#### TODOS and Open Questions
- [ ] Upload new recording after getting few more examples from Khalilah

## Learning
- https://reactjs.org/tutorial/tutorial.html

## Screenshots
![capture](https://user-images.githubusercontent.com/33662516/35299286-c86b12be-0052-11e8-94c5-ffc675261925.gif)



