### PR TITLE
 Fail Travis build on eslint warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ install:
 cache:
   yarn: true
 script:
-  - yarn lint
+  - yarn lint --max-warnings=0
   - yarn test --karma.singleRun --karma.browsers=$BROWSER --coverage

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -1,4 +1,4 @@
-/* global describe, beforeEach, afterEach */
+/* global describe, beforeEach */
 import { expect } from 'chai';
 import it from './it-will';
 


### PR DESCRIPTION
## Purpose
An eslint warning snuck in because eslint wasn't returning >0 for warnings. Travis therefore didn't pick up that it should report a failure.

## Approach
ESLint's CLI has a [`--max-warnings`](https://eslint.org/docs/user-guide/command-line-interface#options) option.

I validated that the CI build will now fail: https://travis-ci.org/folio-org/ui-eholdings/builds/331831932

## Alternatives
`eslint-loader` has a [`failOnWarning`](https://github.com/MoOx/eslint-loader#failonwarning-default-false) option. That actually stops the bundle from building at all, which is probably too restrictive in a non-CI environment.

## Next Steps
We should revisit what ESLint config comes out of the box with `stripes-cli`, and make it sure it's the behavior we want. Related: should we provide boilerplate Travis/Circle CI configs in `stripes-cli`?