### PR TITLE
Point ui-eholdings at okapi.frontside.io by default

### DIFF
--- a/demo/stripes.config.js
+++ b/demo/stripes.config.js
@@ -1,10 +1,10 @@
 const environment = process.env.NODE_ENV;
 let url;
 
-if (environment === 'production') {
-  url = 'https://okapi.frontside.io';
-} else {
+if (environment === 'sandbox') {
   url = 'https://okapi-sandbox.frontside.io';
+} else {
+  url = 'https://okapi.frontside.io';
 }
 
 module.exports = {


### PR DESCRIPTION
When spinning up ui-eholdings locally, the default would be to point
at okapi-sandbox.frontside.io unless the environment was explicitly
set to production.  Since okapi-sandbox is not in the automated deploy
pipeline and cannot be relied upon to have the most up-to-date backend
code, it's better to point at our prod instance by default and point
to sandbox only when explicitly told to do so.