### PR TITLE
Run tests in IE, Edge, and Firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,15 @@ language: node_js
 env:
   - BROWSER=Chrome_travis_ci
   - BROWSER=bs_safari_11
+  - BROWSER=bs_firefox_mac
+  - BROWSER=bs_ieEdge_windows
+  - BROWSER=bs_ie11_windows
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: BROWSER=bs_firefox_mac
+    - env: BROWSER=bs_ieEdge_windows
+    - env: BROWSER=bs_ie11_windows
 addons:
   chrome: stable
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: BROWSER=bs_firefox_mac
     - env: BROWSER=bs_ieEdge_windows
     - env: BROWSER=bs_ie11_windows
 addons:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,6 +13,27 @@ module.exports = (config) => {
         os_version: 'High Sierra',
         browser: 'safari',
         browser_version: '11.0'
+      },
+      bs_firefox_mac: {
+        base: 'BrowserStack',
+        browser: 'firefox',
+        browser_version: '57.0',
+        os: 'OS X',
+        os_version: 'Sierra'
+      },
+      bs_ieEdge_windows: {
+        base: 'BrowserStack',
+        browser: 'edge',
+        browser_version: '15.0',
+        os: 'Windows',
+        os_version: '10'
+      },
+      bs_ie11_windows: {
+        base: 'BrowserStack',
+        browser: 'ie',
+        browser_version: '11.0',
+        os: 'Windows',
+        os_version: '7'
       }
     },
 
@@ -46,10 +67,6 @@ module.exports = (config) => {
     };
     configuration.reporters.push('coverage');
     configuration.plugins.push('karma-coverage');
-  }
-
-  if (process.env.TRAVIS) {
-    configuration.browsers = ['Chrome_travis_ci'];
   }
 
   config.set(configuration);

--- a/tests/pages/helpers.js
+++ b/tests/pages/helpers.js
@@ -20,13 +20,12 @@ export function blur(el) {
   let node = $(el).get(0);
 
   if (node) {
-    let focusEvent = document.createEvent('UIEvents');
-    focusEvent.initEvent('focus', false, false);
-    node.dispatchEvent(focusEvent);
-
-    let blurEvent = document.createEvent('UIEvents');
-    blurEvent.initEvent('blur', false, false);
-    node.dispatchEvent(blurEvent);
+    node.dispatchEvent(
+      new MouseEvent('blur', {
+        bubbles: true,
+        cancelable: true
+      })
+    );
   } else {
     throw new Error('Blur node does not exist.');
   }

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -30,13 +30,11 @@ export default {
   },
 
   get customerIdFieldIsInvalid() {
-    return $('[data-test-eholdings-settings-customerid] label').css('color') === 'rgb(153, 0, 0)' &&
-      $('[data-test-eholdings-settings-customerid] input').css('border-color') === 'rgb(153, 0, 0)';
+    return $('[data-test-eholdings-settings-customerid]').get(0).className.includes('has-error--');
   },
 
   get apiKeyFieldIsInvalid() {
-    return $('[data-test-eholdings-settings-apikey] label').css('color') === 'rgb(153, 0, 0)' &&
-      $('[data-test-eholdings-settings-apikey] input').css('border-color') === 'rgb(153, 0, 0)';
+    return $('[data-test-eholdings-settings-apikey]').get(0).className.includes('has-error--');
   },
 
   get errorText() {


### PR DESCRIPTION
## Purpose
We can run our tests in more browsers on BrowserStack, but `allow_failures`.

## Approach
`fast_finish` tells Travis it doesn't have to wait for allowed failures before it can declare the build successful.

## Browser statuses
- Firefox: really close to passing, I would think it's an easy fix
- Edge: having some date issues
- IE11: doesn't even start running the tests