### PR TITLE
Open managed URL in a new tab

### DIFF
--- a/src/components/customer-resource-show/customer-resource-show.js
+++ b/src/components/customer-resource-show/customer-resource-show.js
@@ -150,7 +150,7 @@ export default class CustomerResourceShow extends Component {
               {model.url && (
                 <KeyValueLabel label="Managed URL">
                   <div data-test-eholdings-customer-resource-show-managed-url>
-                    <a href={model.url}>{model.url}</a>
+                    <a href={model.url} target="_blank">{model.url}</a>
                   </div>
                 </KeyValueLabel>
               ) }

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -110,6 +110,17 @@ describeApplication('CustomerResourceShow', () => {
       expect(ResourcePage.managedUrl).to.equal(resource.url);
     });
 
+    describe('clicking the managed url opens link in new tab', () => {
+      beforeEach(() => {
+        ResourcePage.clickManagedURL();
+      });
+
+      it('opens in new tab', () => {
+        expect(window.history.length).to.equal(1);
+        expect(window.name.includes('ebscohost'));
+      });
+    });
+
     it('indicates that the resource is not yet selected', () => {
       expect(ResourcePage.isSelected).to.equal(false);
     });

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -141,5 +141,9 @@ export default {
 
   cancelDeselection() {
     return $('[data-test-eholdings-customer-resource-deselection-confirmation-modal-no]').trigger('click');
+  },
+
+  clickManagedURL() {
+    return $('[data-test-eholdings-customer-resource-show-managed-url]').trigger('click');
   }
 };


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-95, managed URL for a title-package should open in a new tab as opposed to the current behavior of opening in the same tab.

## Approach
- Add target="_blank" to open url in a new tab
- Add associated unit tests

#### TODOS and Open Questions
- [ ] Not sure if these unit tests are necessary and if this is the best approach for testing if the link opens in a new tab.
- [ ] Eventually, we need to implement this as well for this feature to be complete: https://issues.folio.org/browse/UIEH-129

## Learning
https://stackoverflow.com/questions/850058/is-it-possible-to-detect-if-a-user-has-opened-a-link-in-a-new-tab

## Screenshots
![ui-eholdings-managed-url](https://user-images.githubusercontent.com/33662516/35527692-975761c2-04f9-11e8-9177-6c7bd6514771.gif)

