### PR TITLE
Update Settings API Key field to not show encryption key

### DIFF
--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -145,7 +145,7 @@ export default class Settings extends Component {
               <label htmlFor="eholdings-settings-apikey">API Key</label>
               <input
                 id="eholdings-settings-apikey"
-                type="text"
+                type="password"
                 autoComplete="off"
                 value={apiKey}
                 onChange={this.updateApiKey}

--- a/tests/backend-configuration-test.js
+++ b/tests/backend-configuration-test.js
@@ -119,6 +119,10 @@ describeApplication('With valid backend configuration', () => {
       expect(SettingsPage.$apiKeyField).to.exist;
     });
 
+    it('field for the ebsco RM API key appears with text as password hidden', () => {
+      expect(SettingsPage.$apiKeyField).to.have.prop('type', 'password');
+    });
+
     it.still('does not have visible form action buttons', () => {
       expect(SettingsPage.$actions).to.not.exist;
     });


### PR DESCRIPTION
## Purpose
Hide the RM-API encryption key on the settings page
https://issues.folio.org/browse/UIEH-105

## Approach
Simply set input type to password to hide text of api key

#### TODOS and Open Questions
- [ ] Update mod-kb-ebsco to return desired message "Invalid Knowledge Base API credentials. Please try again or contact your Knowledge Base provider.". if an attempt is made to enter invalid credentials on the settings page.  Currently "Invalid base" is returned as error title.  Also need to confirm is error title or error detail field is intended location for this text

## Learning
Not sure if a react component is needed here - https://www.npmjs.com/package/react-component-password

## Screenshots
![hide-api-key](https://user-images.githubusercontent.com/19415226/35595948-55ed3e8a-05e6-11e8-9ce4-8b4c1dabab24.gif)

