### PR TITLE
Upgrade to React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "lodash": "^4.17.4",
     "mirage-server": "cowboyd/mirage-server",
     "moment": "^2.17.1",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
     "react-hot-loader": "next",
     "react-trigger-change": "^1.0.2",
     "stylelint": "^8.2.0",
@@ -42,6 +40,10 @@
     "isomorphic-fetch": "^2.2.1",
     "query-string": "^5.0.0",
     "redux-actions": "^2.2.1"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
   },
   "stripes": {
     "type": "app",


### PR DESCRIPTION
## Purpose
To allow for a easier transition to React 16 and future React version bumps.

## Approach
Moves react and react-dom to peerDependencies.
