### PR TITLE
Add <HR> to package hide/show to be consistent with package-title

### DIFF
--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -143,6 +143,7 @@ export default class PackageShow extends Component {
                   id="package-details-toggle-switch"
                 />
               </label>
+              <hr />
               <label
                 data-test-eholdings-package-details-hidden
                 htmlFor="package-details-toggle-hidden-switch"


### PR DESCRIPTION
## Purpose
Minor update to package level display to include ```<HR>```  between selected and hidden toggles to be consistent with package title level display

## Screenshots
![hide-show-hr](https://user-images.githubusercontent.com/19415226/35633481-5de08ff2-0677-11e8-9420-1709b2803e10.gif)

