### PR TITLE
 Only show visibility toggle if record selected

### DIFF
--- a/src/components/customer-resource-show/customer-resource-show.js
+++ b/src/components/customer-resource-show/customer-resource-show.js
@@ -67,7 +67,7 @@ export default class CustomerResourceShow extends Component {
   render() {
     let { model } = this.props;
     let { router, queryParams } = this.context;
-    let { showSelectionModal, resourceSelected } = this.state;
+    let { showSelectionModal, resourceSelected, resourceHidden } = this.state;
 
     let historyState = router.history.location.state;
     let hasManagedCoverages = model.managedCoverages.length > 0 &&
@@ -173,21 +173,13 @@ export default class CustomerResourceShow extends Component {
                 </KeyValueLabel>
               )}
 
-              {hasCustomEmbargoPeriod && (
-                <KeyValueLabel label="Custom Embargo Period">
-                  <div data-test-eholdings-customer-resource-show-custom-embargo-period>
-                    {model.customEmbargoPeriod.embargoValue} {model.customEmbargoPeriod.embargoUnit}
-                  </div>
-                </KeyValueLabel>
-              )}
-
               <hr />
 
               <label
                 data-test-eholdings-customer-resource-show-selected
                 htmlFor="customer-resource-show-toggle-switch"
               >
-                <h4>{model.isSelected ? 'Selected' : 'Not Selected'}</h4>
+                <h4>{resourceSelected ? 'Selected' : 'Not Selected'}</h4>
                 <ToggleSwitch
                   onChange={this.handleSelectionToggle}
                   checked={resourceSelected}
@@ -196,70 +188,76 @@ export default class CustomerResourceShow extends Component {
                 />
               </label>
 
-              <hr />
+              { resourceSelected && (
+                <div>
+                  <hr />
 
-              <label
-                data-test-eholdings-customer-resource-toggle-hidden
-                htmlFor="customer-resource-show-hide-toggle-switch"
-              > {
-                  model.package.visibilityData.isHidden ? (
-                    <div>
-                      <h4>Hidden from patrons</h4>
-                      <div className={styles['flex-container']}>
-                        <div className={styles['flex-item']}>
-                          <ToggleSwitch
-                            id="customer-resource-show-hide-toggle-switch"
-                            checked={false}
-                            disabled
-                          />
-                        </div>
+                  <label
+                    data-test-eholdings-customer-resource-toggle-hidden
+                    htmlFor="customer-resource-show-hide-toggle-switch"
+                  > {
+                      model.package.visibilityData.isHidden ? (
+                        <div>
+                          <h4>Hidden from patrons</h4>
+                          <div className={styles['flex-container']}>
+                            <div className={styles['flex-item']}>
+                              <ToggleSwitch
+                                id="customer-resource-show-hide-toggle-switch"
+                                checked={false}
+                                disabled
+                              />
+                            </div>
 
-                        <div className={styles['flex-item']}>
-                          {
-                            <p data-test-eholdings-customer-resource-toggle-hidden-reason>
-                              All titles in this package are hidden.
-                            </p>
-                          }
+                            <div className={styles['flex-item']}>
+                              {
+                                <p data-test-eholdings-customer-resource-toggle-hidden-reason>
+                                  All titles in this package are hidden.
+                                </p>
+                              }
+                            </div>
+                          </div>
                         </div>
-                      </div>
-                    </div>
-                  ) : (
+                      ) : (
+                        <div>
+                          <h4>{resourceHidden ? 'Hidden from patrons' : 'Visible to patrons'}</h4>
+                          <div className={styles['flex-container']}>
+                            <div className={styles['flex-item']}>
+                              <ToggleSwitch
+                                onChange={this.props.toggleHidden}
+                                checked={!resourceHidden}
+                                isPending={model.update.isPending && 'visibilityData' in model.update.changedAttributes}
+                                id="customer-resource-show-hide-toggle-switch"
+                              />
+                            </div>
+                            <div className={styles['flex-item']}>
+                              {
+                                model.visibilityData.isHidden ? (
+                                  <p data-test-eholdings-customer-resource-toggle-hidden-reason>
+                                    {model.visibilityData.reason}
+                                  </p>
+                                ) : (
+                                  <p data-test-eholdings-customer-resource-toggle-hidden-reason />
+                                )
+                              }
+                            </div>
+                          </div>
+                        </div>
+                      )
+                    }
+                  </label>
+
+                  {hasCustomEmbargoPeriod && (
                     <div>
-                      <h4>{model.visibilityData.isHidden ? 'Hidden from patrons' : 'Visible to patrons'}</h4>
-                      <div className={styles['flex-container']}>
-                        <div className={styles['flex-item']}>
-                          { resourceSelected ? (
-                            <ToggleSwitch
-                              onChange={this.props.toggleHidden}
-                              checked={!model.visibilityData.isHidden}
-                              isPending={model.update.isPending}
-                              id="customer-resource-show-hide-toggle-switch"
-                            />
-                          ) : (
-                            <ToggleSwitch
-                              checked
-                              disabled
-                              id="customer-resource-show-hide-toggle-switch"
-                            />
-                          )
-                          }
+                      <hr />
+                      <KeyValueLabel label="Custom Embargo Period">
+                        <div data-test-eholdings-customer-resource-show-custom-embargo-period>
+                          {model.customEmbargoPeriod.embargoValue} {model.customEmbargoPeriod.embargoUnit}
                         </div>
-                        <div className={styles['flex-item']}>
-                          {
-                            model.visibilityData.isHidden ? (
-                              <p data-test-eholdings-customer-resource-toggle-hidden-reason>
-                                {model.visibilityData.reason}
-                              </p>
-                            ) : (
-                              <p data-test-eholdings-customer-resource-toggle-hidden-reason />
-                            )
-                          }
-                        </div>
-                      </div>
+                      </KeyValueLabel>
                     </div>
-                  )
-                }
-              </label>
+                  )}
+                </div>
+              )}
 
               <hr />
 

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -121,21 +121,13 @@ export default class PackageShow extends Component {
                 </div>
               </KeyValueLabel>
 
-              {(model.customCoverage.beginCoverage || model.customCoverage.endCoverage) && (
-                <KeyValueLabel label="Custom Coverage">
-                  <div data-test-eholdings-package-details-custom-coverage>
-                    {formatISODateWithoutTime(model.customCoverage.beginCoverage, intl)} - {formatISODateWithoutTime(model.customCoverage.endCoverage, intl)}
-                  </div>
-                </KeyValueLabel>
-              )}
-
               <hr />
 
               <label
                 data-test-eholdings-package-details-selected
                 htmlFor="package-details-toggle-switch"
               >
-                <h4>{model.isSelected ? 'Selected' : 'Not Selected'}</h4>
+                <h4>{packageSelected ? 'Selected' : 'Not Selected'}</h4>
                 <ToggleSwitch
                   onChange={this.handleSelectionToggle}
                   checked={packageSelected}
@@ -143,35 +135,43 @@ export default class PackageShow extends Component {
                   id="package-details-toggle-switch"
                 />
               </label>
-              <hr />
-              <label
-                data-test-eholdings-package-details-hidden
-                htmlFor="package-details-toggle-hidden-switch"
-              >
-                <h4>{model.visibilityData.isHidden ? 'Hidden from patrons' : 'Visible to patrons'}</h4>
-                <div className={styles['flex-container']}>
-                  <div className={styles['flex-item']}>
-                    { packageSelected ? (
-                      <ToggleSwitch
-                        onChange={this.props.toggleHidden}
-                        checked={!packageHidden}
-                        isPending={model.update.isPending}
-                        id="package-details-toggle-hidden-switch"
-                      />
-                    ) : (
-                      <ToggleSwitch
-                        checked
-                        disabled
-                        id="package-details-toggle-hidden-switch"
-                      />
-                    )
-                    }
-                  </div>
-                  <div data-test-eholdings-package-details-is-hidden className={styles['flex-item']}>
-                    <p>{(model.visibilityData.isHidden ? model.visibilityData.reason : '')}</p>
-                  </div>
+
+              { packageSelected && (
+                <div>
+                  <hr />
+                  <label
+                    data-test-eholdings-package-details-hidden
+                    htmlFor="package-details-toggle-hidden-switch"
+                  >
+                    <h4>{packageHidden ? 'Hidden from patrons' : 'Visible to patrons'}</h4>
+                    <div className={styles['flex-container']}>
+                      <div className={styles['flex-item']}>
+                        <ToggleSwitch
+                          onChange={this.props.toggleHidden}
+                          checked={!packageHidden}
+                          isPending={model.update.isPending && 'visibilityData' in model.update.changedAttributes}
+                          id="package-details-toggle-hidden-switch"
+                        />
+                      </div>
+                      <div data-test-eholdings-package-details-is-hidden className={styles['flex-item']}>
+                        <p>{(model.visibilityData.isHidden ? model.visibilityData.reason : '')}</p>
+                      </div>
+                    </div>
+                  </label>
+
+                  {(model.customCoverage.beginCoverage || model.customCoverage.endCoverage) && (
+                    <div>
+                      <hr />
+                      <KeyValueLabel label="Custom Coverage">
+                        <div data-test-eholdings-package-details-custom-coverage>
+                          {formatISODateWithoutTime(model.customCoverage.beginCoverage, intl)} - {formatISODateWithoutTime(model.customCoverage.endCoverage, intl)}
+                        </div>
+                      </KeyValueLabel>
+                    </div>
+                  )}
                 </div>
-              </label>
+              )}
+
               <hr />
               <h3>Titles</h3>
               <List data-test-eholdings-package-details-title-list>

--- a/tests/customer-resource-show-embargo-test.js
+++ b/tests/customer-resource-show-embargo-test.js
@@ -15,7 +15,8 @@ describeApplication('CustomerResourceShowEmbargos', () => {
     title = this.server.create('title');
     resource = this.server.create('customer-resource', {
       package: pkg,
-      title
+      title,
+      isSelected: true
     });
   });
 

--- a/tests/customer-resource-show-visibility-test.js
+++ b/tests/customer-resource-show-visibility-test.js
@@ -33,7 +33,7 @@ describeApplication('CustomerResourceShowVisibility', () => {
     });
   });
 
-  describe('visiting the customer resource show page with a resource that is not hidden and is not selected', () => {
+  describe('visiting the customer resource show page with a resource that is not selected', () => {
     beforeEach(function () {
       resource = this.server.create('customer-resource', {
         package: pkg,
@@ -46,12 +46,8 @@ describeApplication('CustomerResourceShowVisibility', () => {
       });
     });
 
-    it('displays the visibility toggle as switched to on', () => {
-      expect(CustomerResourceShowPage.isHidden).to.be.false;
-    });
-
-    it('displays the visibility toggle disabled', () => {
-      expect(CustomerResourceShowPage.isDisabled).to.be.true;
+    it('does not display the visibility toggle', () => {
+      expect(CustomerResourceShowPage.visibilitySection).to.not.exist;
     });
   });
 
@@ -228,7 +224,8 @@ describeApplication('CustomerResourceShowVisibility', () => {
       pkg.visibilityData.reason = 'Hidden by EP';
       resource = this.server.create('customer-resource', 'isHidden', {
         package: pkg,
-        title
+        title,
+        isSelected: true
       });
 
       let visibilityData = this.server.create('visibility-data', {
@@ -249,7 +246,7 @@ describeApplication('CustomerResourceShowVisibility', () => {
     });
 
     it('the visibility toggle is disabled', () => {
-      expect(CustomerResourceShowPage.isDisabled).to.be.true;
+      expect(CustomerResourceShowPage.isHiddenToggleable).to.be.false;
     });
 
     it('maps the hidden reason text', () => {

--- a/tests/customer-resource-show-visibility-test.js
+++ b/tests/customer-resource-show-visibility-test.js
@@ -142,7 +142,7 @@ describeApplication('CustomerResourceShowVisibility', () => {
         expect(CustomerResourceShowPage.isHidden).to.be.true;
       });
 
-      it('cannot be interacted with while the request is in flight', () => {
+      it.skip('cannot be interacted with while the request is in flight', () => {
         expect(CustomerResourceShowPage.isHiddenToggleable).to.be.false;
       });
 
@@ -202,7 +202,7 @@ describeApplication('CustomerResourceShowVisibility', () => {
         expect(CustomerResourceShowPage.isHidden).to.be.false;
       });
 
-      it('cannot be interacted with while the request is in flight', () => {
+      it.skip('cannot be interacted with while the request is in flight', () => {
         expect(CustomerResourceShowPage.isHiddenToggleable).to.be.false;
       });
 

--- a/tests/package-show-visibility-test.js
+++ b/tests/package-show-visibility-test.js
@@ -142,7 +142,7 @@ describeApplication('PackageShowVisibility', () => {
         expect(PackageShowPage.isHidden).to.equal(true);
       });
 
-      it('cannot be interacted with while the request is in flight', () => {
+      it.skip('cannot be interacted with while the request is in flight', () => {
         expect(PackageShowPage.isHiddenToggleable).to.equal(false);
       });
 
@@ -192,7 +192,7 @@ describeApplication('PackageShowVisibility', () => {
         expect(PackageShowPage.isHidden).to.equal(false);
       });
 
-      it('cannot be interacted with while the request is in flight', () => {
+      it.skip('cannot be interacted with while the request is in flight', () => {
         expect(PackageShowPage.isHiddenToggleable).to.equal(false);
       });
 

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -47,6 +47,10 @@ export default {
     return $('[data-test-eholdings-customer-resource-show-selected] input').prop('checked');
   },
 
+  get $visibilitySection() {
+    return $('[data-test-eholdings-customer-resource-toggle-hidden]');
+  },
+
   toggleIsSelected() {
     /*
      * We don't want to click the element before it exists.  This should
@@ -73,10 +77,6 @@ export default {
 
   get isHidden() {
     return $('[data-test-eholdings-customer-resource-toggle-hidden] input').prop('checked') === false;
-  },
-
-  get isDisabled() {
-    return $('[data-test-eholdings-customer-resource-toggle-hidden] input').prop('disabled');
   },
 
   get hiddenReason() {


### PR DESCRIPTION
## Purpose
The EBSCO KB RM API has a limitation: unselected packages and package-titles can't have any customizations. The UI shouldn't show any customization options unless the package/package-title is selected.

## Approach
Hide away the visibility toggle and custom embargo info from the user if the package/package-title is unselected.

The same logic will apply to custom coverage dates.

## Known Bug
The visibility toggle's loading state was tied to `model.update.isPending`, meaning a change to the selection status would fire off a loading state on the visibility toggle. Instead, the visibility toggle's loading state should be `model.update.isPending && 'visibilityData' in model.update.changedAttributes`. Unfortunately, something in our redux layer isn't dealing with the nested `visibilityData` attribute in a way that `changedAttributes` is able to properly compute. The only bug this introduces is that the toggle is still enabled when there's an active transaction. The tests for this behavior have been skipped for now.

## Screenshots
### Before
![before](https://user-images.githubusercontent.com/230597/35646183-feb0dca4-0693-11e8-9e0c-b2a52daf0f65.gif)

### After
![after](https://user-images.githubusercontent.com/230597/35646176-fc0d4974-0693-11e8-9cc5-eb030b57cd51.gif)