### PR TITLE
Fix related resource pagination bugs

### DIFF
--- a/src/components/details-view/details-view.css
+++ b/src/components/details-view/details-view.css
@@ -34,6 +34,7 @@
   display: flex;
   flex-direction: column;
   margin-top: 0.5rem;
+  max-height: 100%;
 
   & h3 {
     padding: 1rem 1rem 0.75rem;

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -61,14 +61,19 @@ export default class DetailsView extends Component {
    * height, we have no need to handle any scroll behavior
    */
   handleLayout = () => {
-    if (this.$container && this.$sticky &&
-        this.$sticky.offsetHeight >= this.$container.offsetHeight) {
-      // this could also be `maxHeight` since the content is longer
-      // than what the container is able to accomidate
-      this.$sticky.style.height = `${this.$container.offsetHeight}px`;
-      this.shouldHandleScroll = true;
-    } else if (this.shouldHandleScroll) {
-      this.shouldHandleScroll = false;
+    if (this.$container && this.$sticky && this.$list) {
+      let stickyHeight = this.$sticky.offsetHeight;
+      let containerHeight = this.$container.offsetHeight;
+
+      this.shouldHandleScroll = stickyHeight >= containerHeight;
+
+      // the sticky wrapper needs an explicit height for child
+      // elements with percentage-based heights
+      if (this.shouldHandleScroll) {
+        this.$sticky.style.height = `${containerHeight}px`;
+      } else {
+        this.$sticky.style.height = '';
+      }
     }
   };
 

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -184,6 +184,7 @@ export default class PackageShow extends Component {
               type="package-titles"
               fetch={fetchPackageTitles}
               collection={model.customerResources}
+              length={model.titleCount}
               scrollable={scrollable}
               itemHeight={70}
               renderItem={item => (

--- a/src/components/provider-show.js
+++ b/src/components/provider-show.js
@@ -52,6 +52,7 @@ export default function ProviderShow({
           type="provider-packages"
           fetch={fetchPackages}
           collection={model.packages}
+          length={model.packagesTotal}
           scrollable={scrollable}
           itemHeight={70}
           renderItem={item => (

--- a/src/components/query-list/query-list.js
+++ b/src/components/query-list/query-list.js
@@ -20,7 +20,8 @@ export default class QueryList extends Component {
     collection: PropTypes.object.isRequired,
     fetch: PropTypes.func.isRequired,
     renderItem: PropTypes.func.isRequired,
-    onUpdateOffset: PropTypes.func
+    onUpdateOffset: PropTypes.func,
+    length: PropTypes.number
   };
 
   static defaultProps = {
@@ -56,7 +57,8 @@ export default class QueryList extends Component {
       collection,
       fetch,
       itemHeight,
-      renderItem
+      renderItem,
+      length
     } = this.props;
     let {
       offset
@@ -82,6 +84,7 @@ export default class QueryList extends Component {
           ) : (
             <ScrollView
               items={state}
+              length={length}
               offset={offset}
               itemHeight={itemHeight}
               onUpdate={this.updateOffset}

--- a/src/components/scroll-view/scroll-view.css
+++ b/src/components/scroll-view/scroll-view.css
@@ -1,5 +1,5 @@
 .list {
-  height: 100%;
+  max-height: 100%;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 

--- a/src/components/scroll-view/scroll-view.js
+++ b/src/components/scroll-view/scroll-view.js
@@ -14,6 +14,7 @@ export default class ScrollView extends Component {
       length: PropTypes.number.isRequired,
       slice: PropTypes.func.isRequired
     }).isRequired,
+    length: PropTypes.number,
     offset: PropTypes.number,
     scrollable: PropTypes.bool,
     itemHeight: PropTypes.number.isRequired,
@@ -118,12 +119,12 @@ export default class ScrollView extends Component {
   };
 
   renderChildren() {
-    let { items, itemHeight, children } = this.props;
+    let { items, length, itemHeight, children } = this.props;
     let { offset, visibleItems } = this.state;
 
     let threshold = 5;
     let lower = Math.max(offset - threshold, 0);
-    let upper = Math.min(offset + visibleItems + threshold, items.length - 1);
+    let upper = Math.min(offset + visibleItems + threshold, (length || items.length) - 1);
 
     // slice the visible items and map them to `children`
     return items.slice(lower, upper + 1).map((item, i) => {
@@ -145,9 +146,9 @@ export default class ScrollView extends Component {
   render() {
     // strip all other props to pass along the rest to the div
     // eslint-disable-next-line no-unused-vars
-    let { items, itemHeight, offset: _, onUpdate, scrollable, ...props } = this.props;
+    let { items, length, itemHeight, offset: _, onUpdate, scrollable, ...props } = this.props;
     let { offset, visibleItems } = this.state;
-    let listHeight = items.length * itemHeight;
+    let listHeight = (length || items.length) * itemHeight;
 
     // list height should be at least enough for the offset
     if (listHeight === 0) {

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -27,7 +27,7 @@ export class Collection {
     this.currentPage = parseInt(page, 10);
 
     // unique to a specific search regardless of page
-    this.key = `${type}/${qs.stringify(queryParams)}`;
+    this.key = `${type}::${path}?${qs.stringify(queryParams)}`;
   }
 
   /**

--- a/tests/details-view-test.js
+++ b/tests/details-view-test.js
@@ -28,9 +28,9 @@ describeApplication('DetailsView', () => {
 
     describe('scrolling to the bottom of the container', () => {
       beforeEach(() => {
-        // converge on the height being great enough to scroll
+        // converge on the titles being loaded
         return convergeOn(() => {
-          expect(PackageShowPage.$root.prop('scrollHeight')).to.be.gt(PackageShowPage.$root.height());
+          expect(PackageShowPage.titleList.length).to.be.gt(0);
         }).then(() => {
           PackageShowPage.$root.scrollTop(PackageShowPage.$root.prop('scrollHeight'));
         });

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -68,6 +68,34 @@ describeApplication('PackageShow', () => {
     it.still('should not display a back button', () => {
       expect(PackageShowPage.$backButton).to.not.exist;
     });
+
+    describe('then visiting another package details page', () => {
+      beforeEach(function () {
+        let otherPackage = this.server.create('package', 'withTitles', {
+          provider,
+          name: 'Other Package',
+          titleCount: 2
+        });
+
+        // converge on the previous package loading first
+        return convergeOn(() => {
+          expect(PackageShowPage.titleList.length).to.be.gt(0);
+        }).then(() => (
+          this.visit(`/eholdings/packages/${otherPackage.id}`, () => {
+            expect(PackageShowPage.$root).to.exist;
+          })
+        ));
+      });
+
+      it('displays the different package', () => {
+        expect(PackageShowPage.name).to.equal('Other Package');
+      });
+
+      it('displays different titles', () => {
+        expect(PackageShowPage.numTitles).to.equal('2');
+        expect(PackageShowPage.titleList[0].name).to.not.equal(customerResources[0].title.name);
+      });
+    });
   });
 
   describe('visiting the package details page with multiple pages of titles', () => {


### PR DESCRIPTION
## Purpose
This fixes two bugs with the details-view introduced with the paginated related resources.

1. When clicking on one package and then clicking on another package, the previous package's related customer-resources persisted on the second package's page.

2. When loading related resources, the list is scrollable with 25 items with loading states. However, on pages with few related resources, the list portion of details-view remains as tall as the container to allow scrolling the previous loading items. This causes extra white space when the items are actually loaded.

## Approach

1. Give collections a better unique `key` property. This unique key is used to reload the impagination component. Without including the `path`, this key evaluates to be the same for related customer-resources for any given package.

2. A. The logic around setting a height for lists longer than the container is unnecessary. Some simple CSS will work instead. (Took an embarrassing amount of time to figure this one out)

    B. For vendors and packages, we already know the amount of related resources there are before making the relation requests. We can supply this to the query-list (and then scroll-view) to only show the necessary amount of items with loading states.

## Screenshots

### Bug 1

#### Before
![1-before](https://user-images.githubusercontent.com/5005153/35708277-e75035de-0772-11e8-8f83-55e08ad6b831.gif)

#### After
![1-after](https://user-images.githubusercontent.com/5005153/35708280-eb200068-0772-11e8-9b42-eff097a5a4b8.gif)

### Bug 2

#### Before
![2-before](https://user-images.githubusercontent.com/5005153/35708329-2809dddc-0773-11e8-8f31-69defd3980d9.gif)

#### After
![2-after](https://user-images.githubusercontent.com/5005153/35708332-2ba0a28c-0773-11e8-9be9-0625f1f8814a.gif)


