### PR TITLE
Rewrite impagination component

### DIFF
--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -4,6 +4,7 @@ import it, { convergeOn } from './it-will';
 
 import { describeApplication } from './helpers';
 import PackageSearchPage from './pages/package-search';
+import PackageShowPage from './pages/package-show';
 
 describeApplication('PackageSearch', () => {
   let pkgs;
@@ -11,8 +12,9 @@ describeApplication('PackageSearch', () => {
   beforeEach(function () {
     pkgs = this.server.createList('package', 3, 'withProvider', 'withTitles', {
       name: i => `Package${i + 1}`,
+      isSelected: i => !!i,
       titleCount: 3,
-      selectedCount: 1
+      selectedCount: i => i
     });
 
     this.server.create('package', 'withProvider', {
@@ -67,6 +69,21 @@ describeApplication('PackageSearch', () => {
 
       it('should not display button in UI', () => {
         expect(PackageSearchPage.$backButton).to.not.exist;
+      });
+
+      describe('selecting a package', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(PackageSearchPage.packageList[0].isSelected).to.be.false;
+            expect(PackageShowPage.$root).to.exist;
+          }).then(() => (
+            PackageShowPage.toggleIsSelected()
+          ));
+        });
+
+        it('reflects the selection in the results list', () => {
+          expect(PackageSearchPage.packageList[0].isSelected).to.be.true;
+        });
       });
 
       describe('clicking the vignette behind the preview pane', () => {

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -21,6 +21,10 @@ function createPackageObject(element) {
 
     get numTitlesSelected() {
       return parseInt($scope.find('[data-test-eholdings-package-list-item-num-titles-selected]').text(), 10);
+    },
+
+    get isSelected() {
+      return $scope.find('[data-test-eholdings-package-list-item-selected]').text().toLowerCase() === 'selected';
     }
   };
 }


### PR DESCRIPTION
## Purpose
When records are resolved, impagination keeps a reference to the record in our store. When the record is updated immutably, the old record becomes stale and is not reflected in UI using the impagination component.

## Approach
By using impagination's state machine directly we can resolve or reject records at will, without promises. This allows us to update any records currently in the load horizon with accurate records from our own data store.
