### PR TITLE
Strip data-test attributes from production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@folio/stripes-components": "folio-org/stripes-components#master",
     "@folio/stripes-core": "folio-org/stripes-core#master",
     "babel-plugin-istanbul": "^4.1.5",
+    "babel-plugin-remove-jsx-attributes": "^0.0.2",
     "chai": "^4.0.2",
     "chai-jquery": "^2.0.0",
     "eslint": "^4.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,6 +927,10 @@ babel-plugin-react-transform@^2.0.2:
   dependencies:
     lodash "^4.6.1"
 
+babel-plugin-remove-jsx-attributes@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-remove-jsx-attributes/-/babel-plugin-remove-jsx-attributes-0.0.2.tgz#5174749800da5c3392ce7a61bdfa1a89120a0e9d"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"


### PR DESCRIPTION
## Purpose
We use attributes like `data-test-eholdings-contributors-list-item` as selectors for the `ui-eholdings` test suite to use. We don't need those in production builds.

https://issues.folio.org/browse/UIEH-112

## Approach
There were a lot of babel plugins out there doing more or less the same thing. I picked one that had >0 tests and took an array of regular expressions (vs. just a single string or array of strings).

This change barely made any impact in the size of the `dist` - I was hoping for more :)

This behavior is an excellent candidate to move into `stripes-core`.