### PR TITLE
upgrade to @folio/eslint-config-stripes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
       experimentalObjectRestSpread: true
     }
   },
-  extends: ['stripes'],
+  extends: ['@folio/eslint-config-stripes'],
   env: {
     browser: true
   },

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -111,8 +111,7 @@ export default function configure() {
         permissions: {
           permissions: []
         }
-      }
-    );
+      });
   });
 
   // mod-notify

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "chai": "^4.0.2",
     "chai-jquery": "^2.0.0",
     "eslint": "^4.8.0",
-    "eslint-config-stripes": "^1.0.0",
+    "@folio/eslint-config-stripes": "^1.1.0",
     "eslint-loader": "^1.9.0",
     "jquery": "^3.2.1",
     "karma-browserstack-launcher": "^1.3.0",

--- a/src/components/search-pane-vignette/search-pane-vignette.js
+++ b/src/components/search-pane-vignette/search-pane-vignette.js
@@ -5,9 +5,11 @@ import styles from './search-pane-vignette.css';
 
 const cx = classNames.bind(styles);
 
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 export default function SearchPaneVignette({ isHidden, onClick }) {
   return (
-    <div // eslint-disable-line jsx-a11y/no-static-element-interactions
+    <div
       data-test-search-vignette
       onClick={onClick}
       className={cx('search-pane-vignette', {


### PR DESCRIPTION
## Purpose
Move to a unified set of linter rules for Stripes repos and be able to pull the latest versions of those rules.

## Approach
Switch to the new folioci-based, @folio-scoped, eslint-config-stripes package.
