### PR TITLE
Fix search type segmented control active state

### DIFF
--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -46,13 +46,13 @@ export default class SearchForm extends Component {
 
     return (
       <div className={styles['search-form-container']} data-test-search-form={searchType}>
-        <div className={styles['search-switcher']}>
+        <div className={styles['search-switcher']} data-test-search-form-type-switcher>
           {validSearchTypes.map(type => (
             <Link
               key={type}
               title={`search ${type}`}
               to={searchTypeUrls[type]}
-              className={searchType === type && styles['is-active']}
+              className={searchType === type ? styles['is-active'] : undefined}
               data-test-search-type-button={type}
             >
               {capitalize(type)}

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -143,6 +143,10 @@ describeApplication('PackageSearch', () => {
         }).then(() => PackageSearchPage.changeSearchType('titles'));
       });
 
+      it('only shows one search type as selected', () => {
+        expect(PackageSearchPage.$selectedSearchType).to.have.lengthOf(1);
+      });
+
       it('displays an empty search', () => {
         expect(PackageSearchPage.$searchField).to.have.value('');
       });

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -66,6 +66,10 @@ export default {
     return $('[data-test-eholdings-package-details-back-button] button');
   },
 
+  get $selectedSearchType() {
+    return $('[data-test-search-form-type-switcher] a[class^="is-active--"]');
+  },
+
   clickSearchVignette() {
     return $('[data-test-search-vignette]').trigger('click');
   },

--- a/tests/pages/provider-search.js
+++ b/tests/pages/provider-search.js
@@ -62,6 +62,10 @@ export default {
     return $('[data-test-eholdings-provider-details-back-button] button');
   },
 
+  get $selectedSearchType() {
+    return $('[data-test-search-form-type-switcher] a[class^="is-active--"]');
+  },
+
   clickSearchVignette() {
     return $('[data-test-search-vignette]').trigger('click');
   },

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -66,6 +66,10 @@ export default {
     return $('[data-test-eholdings-title-show-back-button] button');
   },
 
+  get $selectedSearchType() {
+    return $('[data-test-search-form-type-switcher] a[class^="is-active--"]');
+  },
+
   clickSearchVignette() {
     return $('[data-test-search-vignette]').trigger('click');
   },

--- a/tests/provider-search-test.js
+++ b/tests/provider-search-test.js
@@ -128,6 +128,10 @@ describeApplication('ProviderSearch', () => {
         }).then(() => ProviderSearchPage.changeSearchType('packages'));
       });
 
+      it('only shows one search type as selected', () => {
+        expect(ProviderSearchPage.$selectedSearchType).to.have.lengthOf(1);
+      });
+
       it('displays an empty search', () => {
         expect(ProviderSearchPage.$searchField).to.have.value('');
       });

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -128,6 +128,10 @@ describeApplication('TitleSearch', () => {
         }).then(() => TitleSearchPage.changeSearchType('providers'));
       });
 
+      it('only shows one search type as selected', () => {
+        expect(TitleSearchPage.$selectedSearchType).to.have.lengthOf(1);
+      });
+
       it('displays an empty search', () => {
         expect(TitleSearchPage.$searchField).to.have.value('');
       });


### PR DESCRIPTION
## Purpose
After the upgrade to React 16, the segmented control for selecting search type (Providers/Packages/Titles) could get in a state where more than one link was active.

![image](https://user-images.githubusercontent.com/230597/36106610-7a8fa1c8-0fdd-11e8-8a9f-65c3fde192ca.png)

It also started throwing a warning to the console:

![screen shot 2018-02-12 at 9 38 41 am](https://user-images.githubusercontent.com/230597/36106634-83c582d0-0fdd-11e8-9041-eb8ad8957e2c.png)

## Approach
In React 16, `className` can't accept a statement that evaluates to false. Luckily, that console warning was very helpful: we can use a ternary that returns undefined if the condition evaluates to false.

I added tests that would've failed before this change.

## Learning
https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html