### PR TITLE
Implement editable custom embargo

### DIFF
--- a/src/components/custom-embargo/custom-embargo.css
+++ b/src/components/custom-embargo/custom-embargo.css
@@ -1,0 +1,49 @@
+.custom-embargo-form,
+.custom-emabrgo-form-editing {
+  padding: 0.5em;
+}
+
+.custom-embargo-form-editing {
+  background: #e6f3ff;
+}
+
+.custom-embargo-add-button {
+  margin: 1em 0;
+}
+
+.custom-embargo-display {
+  display: flex;
+  align-items: center
+}
+
+.custom-embargo {
+  display: flex;
+  align-items: flex-start;
+}
+
+.custom-embargo-action-buttons {
+  display: flex;
+  margin-top: 1em;
+  padding: 0.5em;
+  align-items: flex-start;
+}
+
+.custom-embargo-container {
+  display: flex;
+  align-items: flex-start;
+  padding: 0.5em;
+}
+
+.custom-embargo-text-field {
+  align-self: flex-start;
+  flex: 1 1 auto;
+  margin-right: 1em;
+}
+
+.custom-embargo-component-width {
+  width: 13em;
+}
+
+.error-message {
+  color: red;
+}

--- a/src/components/custom-embargo/custom-embargo.js
+++ b/src/components/custom-embargo/custom-embargo.js
@@ -1,0 +1,189 @@
+import React, { Component } from 'react';
+import { Field, reduxForm } from 'redux-form';
+import PropTypes from 'prop-types';
+
+import Button from '@folio/stripes-components/lib/Button';
+import TextField from '@folio/stripes-components/lib/TextField';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+import Select from '@folio/stripes-components/lib/Select';
+import styles from './custom-embargo.css';
+
+class CustomEmbargoForm extends Component {
+  static propTypes = {
+    initialValues: PropTypes.shape({
+      customEmbargoValue: PropTypes.number,
+      customEmbargoUnit: PropTypes.string,
+    }).isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    isPending: PropTypes.bool,
+    handleSubmit: PropTypes.func.isRequired,
+    initialize: PropTypes.func,
+    change: PropTypes.func
+  };
+
+  state = {
+    isEditing: false,
+  };
+
+  handleEditCustomEmbargo = (e) => {
+    let isEditing = !this.state.isEditing;
+    e.preventDefault();
+    this.setState({ isEditing });
+  }
+
+  handleSubmit = (data) => {
+    this.setState({
+      isEditing: false
+    });
+    this.props.onSubmit(data);
+  }
+
+  handleCancelCustomEmbargo = (e) => {
+    e.preventDefault();
+    this.setState({
+      isEditing: false
+    });
+    this.props.initialize(this.props.initialValues);
+  }
+
+  renderTextField = ({ input, meta: { touched, error } }) => {
+    return (
+      <div>
+        <TextField
+          {...input}
+        />
+        {touched && ((error && <span className={styles['error-message']}>{error}</span>))}
+      </div>
+    );
+  }
+
+  renderDropDown = ({ input, meta: { touched, error } }) => {
+    return (
+      <div>
+        <Select
+          {...input}
+          dataOptions={[
+            { value: '', label: 'None' },
+            { value: 'Days', label: 'Days' },
+            { value: 'Weeks', label: 'Weeks' },
+            { value: 'Months', label: 'Months' },
+            { value: 'Years', label: 'Years' }
+          ]}
+        />
+        {touched && ((error && <span className={styles['error-message']}>{error}</span>))}
+      </div>
+    );
+  }
+
+  render() {
+    let { isPending, change } = this.props;
+
+    const { customEmbargoValue, customEmbargoUnit } = this.props.initialValues;
+
+    if (this.state.isEditing) {
+      return (
+        <form onSubmit={this.props.handleSubmit(this.handleSubmit)}>
+          <div
+            data-test-eholdings-customer-resource-custom-embargo-form
+            className={styles['custom-embargo-form-editing']}
+          >
+            <div className={styles['custom-embargo-container']}>
+              <div className={styles['custom-embargo-component-width']}>
+                <div data-test-eholdings-customer-resource-custom-embargo-textfield className={styles['custom-embargo-text-field']}>
+                  <Field
+                    name='customEmbargoValue'
+                    type="number"
+                    parse={value => (!value ? null : (isNaN(value) ? '' : Number(value)))} // eslint-disable-line no-restricted-globals
+                    component={this.renderTextField}
+                  />
+                </div>
+              </div>
+              <div className={styles['custom-embargo-component-width']}>
+                <div data-test-eholdings-customer-resource-custom-embargo-select className={styles['flex-item-right-bottom-margin']}>
+                  <Field
+                    name='customEmbargoUnit'
+                    component={this.renderDropDown}
+                    onChange={(event, newValue) => {
+                      if (newValue === '') {
+                        change('customEmbargoValue', 0);
+                      }
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className={styles['custom-embargo-action-buttons']}>
+              <div data-test-eholdings-customer-resource-cancel-custom-embargo-button>
+                <Button disabled={isPending} type="button" role="button" onClick={this.handleCancelCustomEmbargo}>
+                  Cancel
+                </Button>
+              </div>
+              <div data-test-eholdings-customer-resource-save-custom-embargo-button>
+                <Button type="submit" role="button" buttonStyle="primary">
+                  Save
+                </Button>
+              </div>
+            </div>
+          </div>
+        </form>
+      );
+    } else if (customEmbargoValue && customEmbargoUnit) {
+      return (
+        <div className={styles['custom-embargo-form']}>
+          <div className={styles['custom-embargo-display']}>
+            <div data-test-eholdings-customer-resource-custom-embargo-display className={styles['custom-embargo']}>
+              {customEmbargoValue} {customEmbargoUnit}
+            </div>
+            <div data-test-eholdings-customer-resource-edit-custom-embargo-button>
+              <IconButton icon="edit" onClick={this.handleEditCustomEmbargo} />
+            </div>
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div className={styles['custom-embargo-form']}>
+          <div data-test-eholdings-customer-resource-add-custom-embargo-button>
+            <Button
+              type="button"
+              onClick={this.handleEditCustomEmbargo}
+            >
+              Add Custom Embargo
+            </Button>
+          </div>
+        </div>
+      );
+    }
+  }
+}
+
+// this function is a special function used by redux-form for form validation
+// the values from the form are passed into this function and then
+// validated based on the matching field with the same 'name' as value
+const validate = (values) => {
+  const errors = {};
+
+  if (isNaN(Number(values.customEmbargoValue))) { // eslint-disable-line no-restricted-globals
+    errors.customEmbargoValue = 'Must be a number';
+  }
+
+  if (values.customEmbargoValue === null) {
+    errors.customEmbargoValue = 'Value cannot be null';
+  }
+
+  if (values.customEmbargoValue < 0 || (values.customEmbargoValue === 0 && values.customEmbargoUnit !== '')) {
+    errors.customEmbargoValue = 'Enter value greater than 0';
+  }
+
+  if (values.customEmbargoValue > 0 && values.customEmbargoUnit === '') {
+    errors.customEmbargoUnit = 'Select a valid unit';
+  }
+  return errors;
+};
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'CustomEmbargo',
+  destroyOnUnmount: false
+})(CustomEmbargoForm);

--- a/src/components/custom-embargo/index.js
+++ b/src/components/custom-embargo/index.js
@@ -1,0 +1,1 @@
+export { default } from './custom-embargo';

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -16,12 +16,14 @@ import CoverageDates from './coverage-dates';
 import { isBookPublicationType, isValidCoverageList } from './utilities';
 import Modal from './modal';
 import styles from './styles.css';
+import CustomEmbargoForm from './custom-embargo';
 
 export default class CustomerResourceShow extends Component {
   static propTypes = {
     model: PropTypes.object.isRequired,
     toggleSelected: PropTypes.func.isRequired,
-    toggleHidden: PropTypes.func.isRequired
+    toggleHidden: PropTypes.func.isRequired,
+    customEmbargoSubmitted: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -66,7 +68,7 @@ export default class CustomerResourceShow extends Component {
   };
 
   render() {
-    let { model } = this.props;
+    let { model, customEmbargoSubmitted } = this.props;
     let { router, queryParams } = this.context;
     let { showSelectionModal, resourceSelected, resourceHidden } = this.state;
 
@@ -79,6 +81,8 @@ export default class CustomerResourceShow extends Component {
     let hasCustomEmbargoPeriod = model.customEmbargoPeriod &&
       model.customEmbargoPeriod.embargoUnit &&
       model.customEmbargoPeriod.embargoValue;
+    let customEmbargoValue = model.customEmbargoPeriod && model.customEmbargoPeriod.embargoValue;
+    let customEmbargoUnit = model.customEmbargoPeriod && model.customEmbargoPeriod.embargoUnit;
 
     return (
       <div>
@@ -221,17 +225,23 @@ export default class CustomerResourceShow extends Component {
                     </Layout>
                   </label>
 
-                  {hasCustomEmbargoPeriod && (
-                    <div>
-                      <hr />
-
-                      <KeyValueLabel label="Custom Embargo Period">
-                        <div data-test-eholdings-customer-resource-show-custom-embargo-period>
-                          {model.customEmbargoPeriod.embargoValue} {model.customEmbargoPeriod.embargoUnit}
-                        </div>
-                      </KeyValueLabel>
-                    </div>
-                  )}
+                  <hr />
+                  <KeyValueLabel label="Custom Embargo Period">
+                    {hasCustomEmbargoPeriod ? (
+                      <div data-test-eholdings-customer-resource-show-custom-embargo-period>
+                        <CustomEmbargoForm
+                          initialValues={{ customEmbargoValue, customEmbargoUnit }}
+                          onSubmit={customEmbargoSubmitted}
+                          isPending={model.update.isPending && 'customEmbargoPeriod' in model.update.changedAttributes}
+                        />
+                      </div>
+                    ) : (
+                      <CustomEmbargoForm
+                        initialValues={{ customEmbargoValue, customEmbargoUnit }}
+                        onSubmit={customEmbargoSubmitted}
+                      />
+                    )}
+                  </KeyValueLabel>
                 </div>
               )}
 

--- a/src/routes/customer-resource-show.js
+++ b/src/routes/customer-resource-show.js
@@ -53,12 +53,20 @@ class CustomerResourceShowRoute extends Component {
     updateResource(model);
   }
 
+  customEmbargoSubmitted = (values) => {
+    let { model, updateResource } = this.props;
+    model.customEmbargoPeriod.embargoValue = values.customEmbargoValue;
+    model.customEmbargoPeriod.embargoUnit = values.customEmbargoUnit;
+    updateResource(model);
+  }
+
   render() {
     return (
       <View
         model={this.props.model}
         toggleSelected={this.toggleSelected}
         toggleHidden={this.toggleHidden}
+        customEmbargoSubmitted={this.customEmbargoSubmitted}
       />
     );
   }

--- a/tests/customer-resource-show-embargo-test.js
+++ b/tests/customer-resource-show-embargo-test.js
@@ -1,6 +1,6 @@
 /* global describe, beforeEach */
 import { expect } from 'chai';
-import it from './it-will';
+import it, { convergeOn } from './it-will';
 
 import { describeApplication } from './helpers';
 import CustomerResourceShowPage from './pages/customer-resource-show';
@@ -59,8 +59,174 @@ describeApplication('CustomerResourceShowEmbargos', () => {
       expect(CustomerResourceShowPage.managedEmbargoPeriod).to.equal('');
     });
 
-    it.still('does not display the custom embargo section', () => {
+    it.still('does not display the custom embargo period', () => {
       expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+    });
+
+    it('displays a button to add custom embargo', () => {
+      expect(CustomerResourceShowPage.$customEmbargoAddButton).to.exist;
+    });
+
+    describe('clicking on the add custom embargo button', () => {
+      beforeEach(() => {
+        CustomerResourceShowPage.clickCustomEmbargoAddButton();
+      });
+
+      it('should remove the add custom embargo button', () => {
+        expect(CustomerResourceShowPage.$customEmbargoAddButton).to.not.exist;
+      });
+
+      it('displays the custom embargo form', () => {
+        expect(CustomerResourceShowPage.$customEmbargoForm).to.exist;
+      });
+
+      describe('entering valid custom embargo value and selecting unit', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(CustomerResourceShowPage.$customEmbargoTextField).to.exist;
+            expect(CustomerResourceShowPage.$customEmbargoSelect).to.exist;
+          });
+        });
+
+        describe('with valid embargo value and unit', () => {
+          beforeEach(() => {
+            CustomerResourceShowPage.inputEmbargoValue('30');
+            CustomerResourceShowPage.selectEmbargoUnit('Weeks');
+          });
+
+          it('accepts valid custom embargo value', () => {
+            expect(CustomerResourceShowPage.$customEmbargoTextField.value).to.equal('30');
+          });
+
+          it('accepts valid custom embargo unit selection', () => {
+            expect(CustomerResourceShowPage.$customEmbargoSelect.value).to.equal('Weeks');
+          });
+
+          it('save button is present', () => {
+            expect(CustomerResourceShowPage.$customEmbargoSaveButton).to.exist;
+          });
+
+          it('save button is enabled', () => {
+            expect(CustomerResourceShowPage.isCustomEmbargoSavable).to.be.true;
+          });
+
+          it('cancel button is present', () => {
+            expect(CustomerResourceShowPage.$customEmbargoCancelButton).to.exist;
+          });
+
+          it('cancel button is enabled', () => {
+            expect(CustomerResourceShowPage.isCustomEmbargoCancellable).to.be.true;
+          });
+
+          describe('saving updated custom embargo', () => {
+            beforeEach(() => {
+              CustomerResourceShowPage.clickCustomEmbargoSaveButton();
+            });
+
+            it('displays new custom embargo period', () => {
+              expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('30 Weeks');
+            });
+
+            it('does not display button to add custom embargo', () => {
+              expect(CustomerResourceShowPage.$customEmbargoAddButton).to.not.exist;
+            });
+
+            it('removes the custom embargo form', () => {
+              expect(CustomerResourceShowPage.$customEmbargoForm).to.not.exist;
+            });
+          });
+
+          describe('cancelling updated custom embargo', () => {
+            beforeEach(() => {
+              CustomerResourceShowPage.clickCustomEmbargoCancelButton();
+            });
+
+            it('displays existing custom embargo period', () => {
+              expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+            });
+
+            it('removes the custom embargo form', () => {
+              expect(CustomerResourceShowPage.$customEmbargoForm).to.not.exist;
+            });
+
+            it('does not display the button to add custom embargo', () => {
+              expect(CustomerResourceShowPage.$customEmbargoAddButton).to.not.exist;
+            });
+          });
+
+          describe('selecting none as custom embargo unit should update value to zero', () => {
+            beforeEach(() => {
+              CustomerResourceShowPage.inputEmbargoValue(50);
+              CustomerResourceShowPage.selectEmbargoUnit('None');
+              CustomerResourceShowPage.clickCustomEmbargoSaveButton();
+            });
+
+            it('displays new custom embargo period', () => {
+              expect(CustomerResourceShowPage.$customEmbargoTextField.value).to.equal('0');
+            });
+          });
+
+          describe('custom embargo value as zero and unit as not None should throw validation error', () => {
+            beforeEach(() => {
+              CustomerResourceShowPage.inputEmbargoValue(0);
+              CustomerResourceShowPage.selectEmbargoUnit('Months');
+            });
+
+            it('rejects embargo value', () => {
+              convergeOn(() => {
+                expect(CustomerResourceShowPage.validationErrorOnTextField).to.exist;
+              }).then(() => {
+                expect(CustomerResourceShowPage.validationErrorOnTextField).to.equal('Enter value greater than 0');
+              });
+            });
+          });
+
+          describe('custom embargo value that cannot be parsed as number should throw validation error', () => {
+            beforeEach(() => {
+              CustomerResourceShowPage.inputEmbargoValue('abcdef');
+              CustomerResourceShowPage.selectEmbargoUnit('Months');
+            });
+
+            it('rejects embargo value', () => {
+              convergeOn(() => {
+                expect(CustomerResourceShowPage.validationErrorOnTextField).to.exist;
+              }).then(() => {
+                expect(CustomerResourceShowPage.validationErrorOnTextField).to.equal('Must be a number');
+              });
+            });
+          });
+
+          describe('blank custom embargo value should throw validation error', () => {
+            beforeEach(() => {
+              CustomerResourceShowPage.inputEmbargoValue('');
+              CustomerResourceShowPage.selectEmbargoUnit('Months');
+            });
+
+            it('rejects embargo value', () => {
+              convergeOn(() => {
+                expect(CustomerResourceShowPage.validationErrorOnTextField).to.exist;
+              }).then(() => {
+                expect(CustomerResourceShowPage.validationErrorOnTextField).to.equal('Value cannot be null');
+              });
+            });
+          });
+
+          describe('custom embargo value greater than zero and unit as None should throw validation error', () => {
+            beforeEach(() => {
+              CustomerResourceShowPage.inputEmbargoValue(50);
+              CustomerResourceShowPage.selectEmbargoUnit('None');
+            });
+
+            it('rejects embargo value', () => {
+              convergeOn(() => {
+                expect(CustomerResourceShowPage.validationErrorOnSelect).to.exist;
+              }).then(() => {
+                expect(CustomerResourceShowPage.validationErrorOnSelect).to.equal('Select a valid unit');
+              });
+            });
+          });
+        });
+      });
     });
   });
 
@@ -108,6 +274,93 @@ describeApplication('CustomerResourceShowEmbargos', () => {
 
     it.still('does not display the custom embargo section', () => {
       expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+    });
+  });
+
+  describe('visiting the customer resource show page with title package not selected', () => {
+    beforeEach(function () {
+      resource.isSelected = false;
+      resource.customEmbargoPeriod = this.server.create('embargo-period', {
+        embargoUnit: 'Weeks',
+        embargoValue: null
+      }).toJSON();
+
+      resource.save();
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it.still('does not display the custom embargo section', () => {
+      expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+    });
+  });
+
+  describe('visiting the customer resource show page with title package selected', () => {
+    beforeEach(function () {
+      resource.customEmbargoPeriod = this.server.create('embargo-period', {
+        embargoUnit: 'Weeks',
+        embargoValue: 10
+      }).toJSON();
+
+      resource.save();
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the custom embargo section', () => {
+      expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('10 Weeks');
+    });
+
+    it('displays the edit button in the custom embargo section', () => {
+      expect(CustomerResourceShowPage.$customEmbargoEditButton).to.exist;
+    });
+
+    it('does not display the add custom embargo button', () => {
+      expect(CustomerResourceShowPage.$customEmbargoAddButton).to.not.exist;
+    });
+
+    it('displays whether the title package is selected', () => {
+      expect(CustomerResourceShowPage.isSelected).to.equal(true);
+    });
+
+    describe('toggling to deselect a title package and confirming deselection', () => {
+      beforeEach(() => {
+        return CustomerResourceShowPage.toggleIsSelected().then(() => {
+          return CustomerResourceShowPage.confirmDeselection();
+        });
+      });
+
+      it('removes custom embargo', () => {
+        expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+      });
+    });
+
+    describe('toggling to deselect a title package and canceling deselection', () => {
+      beforeEach(() => {
+        return CustomerResourceShowPage.toggleIsSelected().then(() => {
+          return CustomerResourceShowPage.cancelDeselection();
+        });
+      });
+
+      it('does not remove custom embargo', () => {
+        expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('10 Weeks');
+      });
+
+      it('displays the edit button in the custom embargo section', () => {
+        expect(CustomerResourceShowPage.$customEmbargoEditButton).to.exist;
+      });
+    });
+
+    describe('clicking the edit button', () => {
+      beforeEach(() => {
+        return CustomerResourceShowPage.clickCustomEmbargoEditButton();
+      });
+
+      it('displays the custom embargo form', () => {
+        expect(CustomerResourceShowPage.$customEmbargoForm).to.exist;
+      });
     });
   });
 });

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -1,6 +1,8 @@
 import $ from 'jquery';
 import { expect } from 'chai';
 import { convergeOn } from '../it-will';
+import { advancedFillIn } from './helpers';
+import { triggerChange } from '../helpers';
 
 export default {
   get $root() {
@@ -145,5 +147,98 @@ export default {
 
   clickManagedURL() {
     return $('[data-test-eholdings-customer-resource-show-managed-url]').trigger('click');
+  },
+
+  get $customEmbargoAddButton() {
+    return $('[data-test-eholdings-customer-resource-add-custom-embargo-button] button');
+  },
+
+  get $customEmbargoEditButton() {
+    return $('[data-test-eholdings-customer-resource-edit-custom-embargo-button]');
+  },
+
+  clickCustomEmbargoEditButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-customer-resource-edit-custom-embargo-button]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-customer-resource-edit-custom-embargo-button] button').click()
+    ));
+  },
+
+  get $customEmbargoForm() {
+    return $('[data-test-eholdings-customer-resource-custom-embargo-form]');
+  },
+
+  clickCustomEmbargoAddButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-customer-resource-add-custom-embargo-button]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-customer-resource-add-custom-embargo-button] button').click()
+    ));
+  },
+
+  get $customEmbargoTextField() {
+    return $('[data-test-eholdings-customer-resource-custom-embargo-textfield]').find('input[name="customEmbargoValue"]')[0];
+  },
+
+  get $customEmbargoSelect() {
+    return $('[data-test-eholdings-customer-resource-custom-embargo-select]').find('select[name="customEmbargoUnit"]')[0];
+  },
+
+  get $customEmbargoFormCancelButton() {
+    return $('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button');
+  },
+
+  get $customEmbargoFormSaveButton() {
+    return $('[data-test-eholdings-customer-resource-save-custom-embargo-button] button');
+  },
+
+  inputEmbargoValue(customEmbargoValue) {
+    return advancedFillIn(this.$customEmbargoTextField, customEmbargoValue);
+  },
+
+  selectEmbargoUnit(customEmbargoUnit) {
+    let $input = $('[data-test-eholdings-customer-resource-custom-embargo-select]').find('select[name="customEmbargoUnit"]').val(customEmbargoUnit);
+    return triggerChange($input.get(0));
+  },
+
+  get isCustomEmbargoSavable() {
+    return $('[data-test-eholdings-customer-resource-save-custom-embargo-button] button').prop('disabled') === false;
+  },
+
+  get isCustomEmbargoCancellable() {
+    return $('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button').prop('disabled') === false;
+  },
+
+  get $customEmbargoCancelButton() {
+    return $('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button');
+  },
+
+  get $customEmbargoSaveButton() {
+    return $('[data-test-eholdings-customer-resource-save-custom-embargo-button] button');
+  },
+
+  clickCustomEmbargoSaveButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-customer-resource-save-custom-embargo-button]')).to.exist;
+    }).then(() => {
+      return $('[data-test-eholdings-customer-resource-save-custom-embargo-button] button').click();
+    });
+  },
+
+  clickCustomEmbargoCancelButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-customer-resource-cancel-custom-embargo-button]')).to.exist;
+    }).then(() => {
+      return $('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button').click();
+    });
+  },
+
+  get validationErrorOnTextField() {
+    return $('[data-test-eholdings-customer-resource-custom-embargo-textfield] [class^="feedbackError"]').text();
+  },
+
+  get validationErrorOnSelect() {
+    return $('[data-test-eholdings-customer-resource-custom-embargo-select] [class^="feedbackError"]').text();
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,7 +81,7 @@
 
 "@folio/stripes-components@folio-org/stripes-components#master":
   version "2.0.1"
-  resolved "https://codeload.github.com/folio-org/stripes-components/tar.gz/f13f762baf7736fc278caac547b5f19fd1ef2763"
+  resolved "https://codeload.github.com/folio-org/stripes-components/tar.gz/b836083df670e9c588579f4edeb6573ba85589b1"
   dependencies:
     "@folio/stripes-form" "^0.8.2"
     "@folio/stripes-react-hotkeys" "^1.0.0"


### PR DESCRIPTION
## Purpose
Initially, custom embargo was only readable but could not be edited. This implementation makes the custom embargo editable. 

## Approach
- Custom Embargo Section should show up and be editable only when a title-package is selected, if not, it should be hidden
- If custom embargo is not present, "Add custom embargo" button should show up
   - When the user clicks on the button, a form should open up containing a textfield to input embargo 
      value, a dropdown to select embargo unit, a save button and a cancel button
- If custom embargo is present, that value should be displayed with a edit icon next to it, clicking on which the custom embargo form should open up
- User should be able to enter only positive integers in the text field
- User should be able to select one of None, Days, Weeks, Months, Years as embargo unit
- When user selects "None" textfield should automatically update to "0"
- If user enters 0 and selects a unit other than None, error message shows up preventing the user from clicking "Save" button
- If user enters valid value and selects "None", error message shows up asking the user to select a valid unit
- On clicking "Save", embargo value and unit get updated and show the new value on the screen
- On clicking "cancel", old embargo value is retained and nothing gets updated
- Added associated unit tests

#### TODOS and Open Questions
- [ ] There is a warning in JavaScript console that appears because Stripes UI TextField component does not support numbers as proptypes, and we input only numbers because client side validation checks for it as well as RM API expects a number for custom embargo value. Discussed the fix with Joe and Jeffrey and merged a PR to master in Stripes UI TextField component for supporting numbers and strings https://github.com/folio-org/stripes-components/pull/234
Tested in local using yarn link that this fix actually fixes the JS console warning we have been seeing earlier.

## Learning
https://davidkpiano.github.io/react-redux-form/docs.html
https://facebook.github.io/jest/docs/en/tutorial-react.html

## Screenshots
![custom-embargo](https://user-images.githubusercontent.com/33662516/36159768-8e60f3ca-10ad-11e8-890e-7c929606086b.gif)

