### PR TITLE
Prevent a JS Console Warning in Details View

### DIFF
--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -119,6 +119,9 @@ export default class DetailsView extends Component {
    * the way up already.
    */
   handleWheel = (e) => {
+    // this does not need to run if we do not have a list element
+    if (!this.$list) return;
+
     let { isSticky } = this.state;
     let scrollingUp = e.deltaY < 0;
     let notInList = !this.$list.contains(e.target);


### PR DESCRIPTION
## Purpose
Prevent a warning in JS console getting thrown because a mousewheel event is being triggered with no list element

## Approach
If the list is empty, then do not run the rest of the handleWheel function and return

## Learning
- Consultation with Wil
