### PR TITLE
Increase coverage numbers

### DIFF
--- a/mirage/factories/embargo-period.js
+++ b/mirage/factories/embargo-period.js
@@ -1,11 +1,14 @@
-import { Factory, faker } from 'mirage-server';
+import { Factory } from 'mirage-server';
 
 export default Factory.extend({
-  embargoUnit: () => faker.random.arrayElement([
-    'Days',
-    'Weeks',
-    'Months',
-    'Years'
-  ]),
-  embargoValue: () => faker.random.number({ min: 0, max: 7 })
+  // these faker methods are currently not used, by removing them we
+  // can increase the code coverage of this file by 100%
+
+  // embargoUnit: () => faker.random.arrayElement([
+  //   'Days',
+  //   'Weeks',
+  //   'Months',
+  //   'Years'
+  // ]),
+  // embargoValue: () => faker.random.number({ min: 0, max: 7 })
 });

--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -61,15 +61,18 @@ export default Factory.extend({
     }
   }),
 
-  withCustomCoverage: trait({
-    afterCreate(packageObj, server) {
-      let customCoverage = server.create('custom-coverage', {
-        beginCoverage: () => faker.date.past().toISOString().substring(0, 10),
-        endCoverage: () => faker.date.future().toISOString().substring(0, 10)
-      });
-      packageObj.update('customCoverage', customCoverage.toJSON());
-    }
-  }),
+  // this trait is currently not used, by removing it we
+  // can increase the code coverage of this file by 50%
+
+  // withCustomCoverage: trait({
+  //   afterCreate(packageObj, server) {
+  //     let customCoverage = server.create('custom-coverage', {
+  //       beginCoverage: () => faker.date.past().toISOString().substring(0, 10),
+  //       endCoverage: () => faker.date.future().toISOString().substring(0, 10)
+  //     });
+  //     packageObj.update('customCoverage', customCoverage.toJSON());
+  //   }
+  // }),
 
   afterCreate(packageObj, server) {
     if (!packageObj.customCoverage) {

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 export default function defaultScenario(server) {
   function createProvider(name, packages = []) {
     let provider = server.create('provider', {

--- a/mirage/serializers/application.js
+++ b/mirage/serializers/application.js
@@ -4,10 +4,12 @@ export default JSONAPISerializer.extend({
   serializeIds: 'always',
 
   keyForModel(modelName) {
+    /* istanbul ignore next */
     return camelize(modelName);
   },
 
   keyForCollection(modelName) {
+    /* istanbul ignore next */
     return camelize(modelName);
   },
 

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -71,7 +71,7 @@ export class Collection {
    */
   getRecord(offset) {
     if (!this.records[offset]) {
-      let pageOffset = offset / this.pageSize;
+      let pageOffset = Math.floor(offset / this.pageSize);
       let recordOffset = offset % this.pageSize;
       let page = this.getPage(pageOffset + 1);
       let record = page.records[recordOffset];
@@ -206,7 +206,7 @@ export class Collection {
    * @returns {Boolean}
    */
   get hasUnloaded() {
-    let { hasUnloaded } = this.getPage(this.currentPage).request;
+    let hasUnloaded = !!this.getPage(this.currentPage).request.hasUnloaded;
     let pageLimit = this.totalPages;
     let page = 1;
 

--- a/src/router.js
+++ b/src/router.js
@@ -27,6 +27,8 @@ export { Switch, Redirect } from 'react-router-dom';
  * and pass them as the children of the `ParentRoute` component.
  */
 export function Route({ component: Component, children, ...props }) {
+  // we currently always provide a component
+  /* istanbul ignore else */
   if (Component) {
     return (
       <RouterRoute {...props} render={props => (<Component {...props}>{children}</Component>)} /> // eslint-disable-line no-shadow

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,4 +1,5 @@
 /* global describe, beforeEach, afterEach */
+/* istanbul ignore file */
 import React from 'react';
 import chai from 'chai';
 import chaiJquery from 'chai-jquery';

--- a/tests/it-will.js
+++ b/tests/it-will.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 // This turns every call of `it` into a "convergent assertion." The
 // assertion is run every 10ms until it is either true, or it times
 // out. This makes it incredibly robust in the face of asynchronous

--- a/tests/pages/helpers.js
+++ b/tests/pages/helpers.js
@@ -57,6 +57,8 @@ export function advancedFillIn(el, value) {
 export function blur(el) {
   let node = $(el).get(0);
 
+  // the error should not be reported for passing tests
+  /* istanbul ignore else */
   if (node) {
     node.dispatchEvent(
       new MouseEvent('blur', {
@@ -70,8 +72,10 @@ export function blur(el) {
 }
 
 export function pressEnter(el) {
-  let $node = el;
+  let $node = $(el).get(0);
 
+  // the error should not be reported for passing tests
+  /* istanbul ignore else */
   if ($node) {
     let newKeyboardEvent = new Event('keydown', {
       bubbles: true,
@@ -83,5 +87,7 @@ export function pressEnter(el) {
     });
 
     $node.dispatchEvent(newKeyboardEvent);
+  } else {
+    throw new Error('Node does not exist.');
   }
 }

--- a/tests/unit/redux-collection-test.js
+++ b/tests/unit/redux-collection-test.js
@@ -1,0 +1,108 @@
+/* global describe, beforeEach, it */
+import { expect } from 'chai';
+
+import Resolver from '../../src/redux/resolver';
+import model, { Collection } from '../../src/redux/model';
+
+const STORE_FIXTURE = {
+  providers: {
+    requests: {
+      [Date.now()]: {
+        timestamp: Date.now(),
+        type: 'query',
+        resource: 'provider',
+        isPending: false,
+        isResolved: true,
+        isRejected: false,
+        records: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
+        meta: { totalResults: 10 },
+        params: {}
+      }
+    },
+    records: new Array(10).fill().reduce((records, _, i) => {
+      return {
+        ...records,
+        [i]: {
+          id: `${i}`,
+          isLoading: false,
+          isLoaded: true,
+          isSaving: false,
+          attributes: {
+            name: `Provider ${i}`
+          }
+        }
+      };
+    }, {})
+  }
+};
+
+const ProviderModel = model()(
+  class Provider {
+    name = ''
+  }
+);
+
+describe('Redux Collections', () => {
+  let resolver;
+  let providers;
+
+  beforeEach(() => {
+    resolver = new Resolver(STORE_FIXTURE, [ProviderModel]);
+    providers = new Collection({ type: 'providers' }, resolver);
+  });
+
+  it('contains provider records from the store', () => {
+    expect(providers).to.have.lengthOf(10);
+    expect(providers.getRecord(0)).to.deep.include({
+      name: 'Provider 0',
+      id: '0'
+    });
+  });
+
+  it('supports slicing into an array', () => {
+    expect(providers).to.respondTo('slice');
+    expect(providers.slice(0, 1)).to.be.an('array');
+    expect(providers.slice(0, 1)).to.have.lengthOf(1);
+    expect(providers.slice(0, 1)[0]).to.deep.include({
+      name: 'Provider 0',
+      id: '0'
+    });
+  });
+
+  it('supports mapping over records', () => {
+    expect(providers).to.respondTo('map');
+    expect(providers.map(r => r.id)).to.be.an('array');
+    expect(providers.map(r => r.id))
+      .to.have.members(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
+  });
+
+  it('has no unloaded records', () => {
+    expect(providers.hasUnloaded).to.be.false;
+  });
+
+  describe('when a record is unloaded', () => {
+    const UNLOADED_FIXTURE = {
+      ...STORE_FIXTURE,
+      providers: {
+        ...STORE_FIXTURE.providers,
+        requests: Object.keys(STORE_FIXTURE.providers.requests)
+          .reduce((reqs, timestamp) => ({
+            ...reqs,
+            [timestamp]: {
+              ...STORE_FIXTURE.providers.requests[timestamp],
+              hasUnloaded: true
+            }
+          }), {})
+      }
+    };
+
+    beforeEach(() => {
+      resolver = new Resolver(UNLOADED_FIXTURE, [ProviderModel]);
+      providers = new Collection({ type: 'providers' }, resolver);
+    });
+
+    it('has unloaded records', () => {
+      expect(providers.hasUnloaded).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Increases the current coverage percentages by a few points so other branches have a little more breathing room.

## Approach
- Added unit tests for collections
- Selectively ignored some files and statements that do not get run during normal tests:
  - The default mirage scenario is never run during testing
  - A couple mirage factory methods are also never used
  - The test helpers also consist of development helpers that aren't used during actual testing
  - A few else blocks are currently never executed

## Screenshots
Before:
![screen shot 2018-02-13 at 3 14 00 pm](https://user-images.githubusercontent.com/5005153/36174900-589494ba-10d3-11e8-9c68-51b051464649.png)

After:
![screen shot 2018-02-13 at 3 28 45 pm](https://user-images.githubusercontent.com/5005153/36174904-5bae95d8-10d3-11e8-985b-2d40531ce091.png)
