### PR TITLE
Use newer version of yarn on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ before_install:
   - export CHROME_BIN=google-chrome-stable
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.1.0
-  - export PATH=$HOME/.yarn/bin:$PATH
   - npm config set @folio:registry https://repository.folio.org/repository/npm-folioci/
 install:
   - yarn


### PR DESCRIPTION
## Purpose
I noticed we're installing an older version of `yarn` over the one already on Travis.

<img width="553" alt="screen shot 2018-02-14 at 1 35 53 pm" src="https://user-images.githubusercontent.com/230597/36224113-2edc244e-118c-11e8-8b00-6264e87e3346.png">

Yarn is at a much more stable point now than it was six months ago, so just going with the `yarn` version already installed seems pretty safe.

## Approach
Let's just stick with the version of `yarn` that comes by default on the Travis boxes.
