### PR TITLE
Fix flakey tests

### DIFF
--- a/tests/backend-configuration-test.js
+++ b/tests/backend-configuration-test.js
@@ -89,11 +89,11 @@ describeApplication('With unconfigured backend', {
           });
         });
 
-        it('does not display an error state for customer id', () => {
+        it.still('does not display an error state for customer id', () => {
           expect(SettingsPage.customerIdFieldIsInvalid).to.be.false;
         });
 
-        it('does not display an error state for api key', () => {
+        it.still('does not display an error state for api key', () => {
           expect(SettingsPage.apiKeyFieldIsInvalid).to.be.false;
         });
       });
@@ -211,7 +211,7 @@ describeApplication('With valid backend configuration', () => {
           SettingsPage.fillIn({ customerId: '' });
         });
 
-        it('does not enable the save button', () => {
+        it.still('does not enable the save button', () => {
           expect(SettingsPage.$saveButton).to.have.prop('disabled', true);
         });
       });

--- a/tests/customer-resource-show-coverage-test.js
+++ b/tests/customer-resource-show-coverage-test.js
@@ -30,7 +30,7 @@ describeApplication('CustomerResourceShowManagedCoverage', () => {
       });
     });
 
-    it('does not display the managed coverage section', () => {
+    it.still('does not display the managed coverage section', () => {
       expect(CustomerResourceShowPage.managedCoverageList).to.equal('');
     });
   });
@@ -44,7 +44,7 @@ describeApplication('CustomerResourceShowManagedCoverage', () => {
       });
     });
 
-    it('does not display the managed coverage section', () => {
+    it.still('does not display the managed coverage section', () => {
       expect(CustomerResourceShowPage.managedCoverageList).to.equal('');
     });
   });
@@ -239,7 +239,7 @@ describeApplication('CustomerResourceShowManagedCoverage', () => {
       });
     });
 
-    it('does not display managed coverage list', () => {
+    it.still('does not display managed coverage list', () => {
       expect(CustomerResourceShowPage.managedCoverageList).to.equal('');
     });
   });

--- a/tests/customer-resource-show-coverage-test.js
+++ b/tests/customer-resource-show-coverage-test.js
@@ -121,24 +121,6 @@ describeApplication('CustomerResourceShowManagedCoverage', () => {
     });
   });
 
-  describe('visiting the customer resource page with incorrectly formed coverage dates', () => {
-    beforeEach(function () {
-      resource.managedCoverages = this.server.createList('managed-coverage', 1, {
-        beginCoverage: '1969-07',
-        endCoverage: '1969-07-16'
-      }).map(m => m.toJSON());
-
-      resource.save();
-      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
-        expect(CustomerResourceShowPage.$root).to.exist;
-      });
-    });
-
-    it('does not display coverage dates', () => {
-      expect(CustomerResourceShowPage.managedCoverageList).to.equal('');
-    });
-  });
-
   describe('visiting the customer resource page with multiple managed coverage dates', () => {
     beforeEach(function () {
       resource.managedCoverages = [

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -174,11 +174,11 @@ describeApplication('CustomerResourceShow', () => {
       expect(ResourcePage.titleName).to.equal(resource.title.name);
     });
 
-    it('does not display a content type', () => {
+    it.still('does not display a content type', () => {
       expect(ResourcePage.contentType).to.equal('');
     });
 
-    it('does not display a publication type', () => {
+    it.still('does not display a publication type', () => {
       expect(ResourcePage.publicationType).to.equal('');
     });
   });
@@ -211,7 +211,7 @@ describeApplication('CustomerResourceShow', () => {
       expect(ResourcePage.titleName).to.equal(resource.title.name);
     });
 
-    it('does not display a content type', () => {
+    it('displays a content type', () => {
       expect(ResourcePage.contentType).to.equal('Isolinear Chip');
     });
 

--- a/tests/customer-resource-show-visibility-test.js
+++ b/tests/customer-resource-show-visibility-test.js
@@ -46,7 +46,7 @@ describeApplication('CustomerResourceShowVisibility', () => {
       });
     });
 
-    it('does not display the visibility toggle', () => {
+    it.still('does not display the visibility toggle', () => {
       expect(CustomerResourceShowPage.visibilitySection).to.not.exist;
     });
   });

--- a/tests/customer-resource-show-visibility-test.js
+++ b/tests/customer-resource-show-visibility-test.js
@@ -242,7 +242,7 @@ describeApplication('CustomerResourceShowVisibility', () => {
     });
 
     it('displays the visibility toggle with as switched to on', () => {
-      expect(CustomerResourceShowPage.isHidden).to.be.false;
+      expect(CustomerResourceShowPage.isHidden).to.be.true;
     });
 
     it('the visibility toggle is disabled', () => {

--- a/tests/package-show-custom-coverage-test.js
+++ b/tests/package-show-custom-coverage-test.js
@@ -85,7 +85,7 @@ describeApplication('PackageShowCustomCoverage', () => {
         });
       });
 
-      it('does not remove the custom coverage', () => {
+      it.still('does not remove the custom coverage', () => {
         expect(PackageShowPage.customCoverage).to.equal('7/16/1969 - 12/19/1972');
       });
     });

--- a/tests/package-show-visibility-test.js
+++ b/tests/package-show-visibility-test.js
@@ -34,7 +34,7 @@ describeApplication('PackageShowVisibility', () => {
     });
 
     it('displays the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessage).to.be.true;
+      expect(PackageShowPage.isHiddenMessage).to.equal('The content is for mature audiences only.');
     });
   });
 
@@ -56,8 +56,8 @@ describeApplication('PackageShowVisibility', () => {
       expect(PackageShowPage.isHidden).to.be.true;
     });
 
-    it('does not displays the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessage).to.be.false;
+    it.still('does not displays the hidden/reason section', () => {
+      expect(PackageShowPage.isHiddenMessage).to.equal('');
     });
   });
 
@@ -79,8 +79,8 @@ describeApplication('PackageShowVisibility', () => {
       expect(PackageShowPage.isHidden).to.be.false;
     });
 
-    it('does not display the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessage).to.be.false;
+    it.still('does not display the hidden/reason section', () => {
+      expect(PackageShowPage.isHiddenMessage).to.equal('');
     });
   });
 
@@ -103,11 +103,11 @@ describeApplication('PackageShowVisibility', () => {
     });
 
     it('displays a disabled Toggle', () => {
-      expect(PackageShowPage.isHiddenToggleable).to.equal(false);
+      expect(PackageShowPage.isHiddenToggleable).to.be.false;
     });
 
-    it('does not display the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessage).to.be.false;
+    it.still('does not display the hidden/reason section', () => {
+      expect(PackageShowPage.isHiddenMessage).to.equal('');
     });
   });
 

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -160,7 +160,7 @@ export default {
     return !!this.titleList.length && this.titleList.every(title => title.isHidden);
   },
   get isHiddenMessage() {
-    return $('[data-test-eholdings-package-details-is-hidden]').length === 1;
+    return $('[data-test-eholdings-package-details-is-hidden]').text();
   },
 
   get customCoverage() {

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -127,7 +127,7 @@ describeApplication('TitleShow', () => {
 
   describe('visiting the title page with some attributes undefined', () => {
     beforeEach(function () {
-      title = this.server.create('title', 'withPackages', {
+      title = this.server.create('title', {
         name: 'Cool Title',
         publisherName: 'Cool Publisher',
         publicationType: ''
@@ -148,27 +148,30 @@ describeApplication('TitleShow', () => {
       expect(TitleShowPage.publisherName).to.equal('Cool Publisher');
     });
 
-    it('does not displays the publication type', () => {
+    it.still('does not displays the publication type', () => {
       expect(TitleShowPage.publicationType).to.equal('');
     });
 
-    it('does not display identifiers', () => {
+    it.still('does not display identifiers', () => {
       expect(TitleShowPage.identifiersList.length).to.equal(0);
     });
-    it('does not display contributors', () => {
+
+    it.still('does not display contributors', () => {
       expect(TitleShowPage.contributorsList.length).to.equal(0);
     });
-    it('does not display package list', () => {
+
+    it.still('does not display package list', () => {
       expect(TitleShowPage.packageList.length).to.equal(0);
     });
-    it('does not display subjects list', () => {
+
+    it.still('does not display subjects list', () => {
       expect(TitleShowPage.subjectsList.length).to.equal(0);
     });
   });
 
   describe('visiting the title page with unknown attribute values', () => {
     beforeEach(function () {
-      title = this.server.create('title', 'withPackages', {
+      title = this.server.create('title', {
         name: 'Cool Title',
         publisherName: 'Cool Publisher',
         publicationType: 'UnknownPublicationType'
@@ -193,16 +196,19 @@ describeApplication('TitleShow', () => {
       expect(TitleShowPage.publicationType).to.equal('UnknownPublicationType');
     });
 
-    it('does not display identifiers', () => {
+    it.still('does not display identifiers', () => {
       expect(TitleShowPage.identifiersList.length).to.equal(0);
     });
-    it('does not display contributors', () => {
+
+    it.still('does not display contributors', () => {
       expect(TitleShowPage.contributorsList.length).to.equal(0);
     });
-    it('does not display package list', () => {
+
+    it.still('does not display package list', () => {
       expect(TitleShowPage.packageList.length).to.equal(0);
     });
-    it('does not display subjects list', () => {
+
+    it.still('does not display subjects list', () => {
       expect(TitleShowPage.subjectsList.length).to.equal(0);
     });
   });


### PR DESCRIPTION
## Purpose
Some of our tests can be flakey due to varying reasons. This attempts to fix some of that flakiness.

## Approach
- Fix customer-resource test where we were incorrectly testing for `false`.
- Remove coverage display test because there will never be a situation in which the API returns invalid dates.
- Use it.still for checking if states are not equal

#### TODOS and Open Questions
There are probably other flakey tests as well, but this is a good start to fixing some of them.

## Learning
- When writing tests for things that do not change, or for states that are not equal, we must use `it.still`. This is because when using the convergence `it`, it might pass before the DOM is updated to display the correct information. `it.still` will make sure the assertion passes for at least 50ms before considering it to actually be passing.

  [The readme for `@bigtest/mocha` explains this a little further](https://github.com/thefrontside/bigtest/tree/master/packages/mocha#writing-tests)
