### PR TITLE
Add selected title search filter

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -213,10 +213,17 @@ export default function configure() {
   this.get('/titles', searchRouteFor('titles', (title, req) => {
     let params = req.queryParams;
     let type = params['filter[type]'];
+    let selected = params['filter[selected]'];
     let filtered = true;
 
     if (type && type !== 'all') {
       filtered = title.publicationType.toLowerCase() === type;
+    }
+
+    if (selected) {
+      filtered = title.customerResources.models.some((resource) => {
+        return resource.isSelected.toString() === selected;
+      });
     }
 
     return filtered;

--- a/src/components/title-search-filters.js
+++ b/src/components/title-search-filters.js
@@ -4,6 +4,12 @@ import PropTypes from 'prop-types';
 import { Accordion, FilterAccordionHeader } from '@folio/stripes-components/lib/Accordion';
 import RadioButton from '@folio/stripes-components/lib/RadioButton';
 
+const selectedFilters = [
+  { label: 'Selected', value: 'true' },
+  { label: 'Not Selected', value: 'false' },
+  { label: 'Selected By EBSCO', value: 'ebsco' }
+];
+
 const pubtypeFilters = [
   { label: 'All', value: 'all' },
   { label: 'Audio Book', value: 'audiobook' },
@@ -26,16 +32,40 @@ export default function TitleSearchFilters({
   filter = {},
   onUpdate
 }) {
-  let pubtype = filter.type || 'all';
+  let { type = 'all', selected } = filter;
 
   return (
     <div data-test-eholdings-title-search-filters>
+      <Accordion
+        name="selected"
+        label="Selection Status"
+        separator={false}
+        header={FilterAccordionHeader}
+        displayClearButton={!!selected}
+        onClearFilter={() => onUpdate({ ...filter, selected: undefined })}
+        closedByDefault={false}
+      >
+        {selectedFilters.map(({ label, value }, i) => (
+          <RadioButton
+            key={i}
+            name="selected"
+            id={`eholdings-title-search-filters-selected-${value}`}
+            label={label}
+            value={value}
+            checked={value === selected}
+            onChange={() => onUpdate({ ...filter, selected: value })}
+          />
+        ))}
+      </Accordion>
+
+      <hr />
+
       <Accordion
         name="pubtype"
         label="Publication Type"
         separator={false}
         header={FilterAccordionHeader}
-        displayClearButton={pubtype !== 'all'}
+        displayClearButton={type !== 'all'}
         onClearFilter={() => onUpdate({ ...filter, type: undefined })}
         closedByDefault={false}
       >
@@ -46,7 +76,7 @@ export default function TitleSearchFilters({
             id={`eholdings-title-search-filters-pubtype-${value}`}
             label={label}
             value={value}
-            checked={value === pubtype}
+            checked={value === type}
             onChange={() => onUpdate({ ...filter, type: value })}
           />
         ))}

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -86,7 +86,11 @@ class SearchRoute extends Component {
     let { offset = 0, ...queryParams } = params;
     let page = Math.floor(offset / 25) + 1;
 
-    return resolver.query(searchType, { ...queryParams, page });
+    return resolver.query(searchType, {
+      filter: undefined,
+      ...queryParams,
+      page
+    });
   }
 
   /**


### PR DESCRIPTION
## Purpose
Adds the selection status filter to title searches

## Approach
Adds another accordion component with radio buttons for the selection status.

#### TODOS and Open Questions
- We should really return the available filters from the API. Any suggestions on how that would look?

## Screenshots
![2018-02-14 15 12 24](https://user-images.githubusercontent.com/5005153/36228320-8a61b3b2-1199-11e8-84e2-3b7d9bf1ebbb.gif)

