### PR TITLE
Fix visibility toggle loading bug

### DIFF
--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -209,7 +209,8 @@ export default class CustomerResourceShow extends Component {
                           <ToggleSwitch
                             onChange={this.props.toggleHidden}
                             checked={!resourceHidden}
-                            isPending={model.update.isPending}
+                            isPending={model.update.isPending &&
+                              ('visibilityData' in model.update.changedAttributes)}
                             id="customer-resource-show-hide-toggle-switch"
                           />
                         )}


### PR DESCRIPTION
When any update to the customer resource is submitted to the server, the visibility toggle goes into a loading state. It should only switch to a loading state if it is the attribute that's been changed.