### PR TITLE
Implement Targeted Search Options on Title List

### DIFF
--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -1,11 +1,19 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
+import SearchField from '@folio/stripes-components/lib/structures/SearchField';
 import capitalize from 'lodash/capitalize';
 import isEqual from 'lodash/isEqual';
 import styles from './search-form.css';
 
 const validSearchTypes = ['providers', 'packages', 'titles'];
+
+const searchableIndexes = [
+  { label: 'Title', value: 'title' },
+  { label: 'ISSN/ISBN', value: 'isxn' },
+  { label: 'Publisher', value: 'publisher' },
+  { label: 'Subject', value: 'subject' }
+];
 
 export default class SearchForm extends Component {
   static propTypes = {
@@ -18,21 +26,27 @@ export default class SearchForm extends Component {
     filtersComponent: PropTypes.func,
     onSearch: PropTypes.func.isRequired,
     searchString: PropTypes.string,
-    filter: PropTypes.object
+    filter: PropTypes.object,
+    searchfield: PropTypes.string
   };
 
   state = {
     searchString: this.props.searchString || '',
-    filter: this.props.filter || {}
+    filter: this.props.filter || {},
+    searchfield: this.props.searchfield || 'title'
   };
 
-  componentWillReceiveProps({ searchString = '', filter = {} }) {
+  componentWillReceiveProps({ searchString = '', filter = {}, searchfield }) {
     if (searchString !== this.state.searchString) {
       this.setState({ searchString });
     }
 
     if (!isEqual(filter, this.state.filter)) {
       this.setState({ filter });
+    }
+
+    if (searchfield !== this.state.searchfield) {
+      this.setState({ searchfield });
     }
   }
 
@@ -41,7 +55,8 @@ export default class SearchForm extends Component {
 
     this.props.onSearch({
       q: this.state.searchString,
-      filter: this.state.filter
+      filter: this.state.filter,
+      searchfield: this.state.searchfield
     });
   };
 
@@ -53,9 +68,13 @@ export default class SearchForm extends Component {
     this.setState({ filter });
   };
 
+  handleChangeIndex = (e) => {
+    this.setState({ searchfield: e.target.value });
+  };
+
   render() {
     const { searchType, searchTypeUrls, filtersComponent: Filters } = this.props;
-    const { searchString, filter } = this.state;
+    const { searchString, filter, searchfield } = this.state;
 
     return (
       <div className={styles['search-form-container']} data-test-search-form={searchType}>
@@ -73,15 +92,32 @@ export default class SearchForm extends Component {
           ))}
         </div>
         <form onSubmit={this.handleSearchSubmit}>
-          <input
-            className={styles['search-input']}
-            type="search"
-            name="search"
-            value={searchString}
-            placeholder={`Search for ${searchType}...`}
-            onChange={this.handleChangeSearch}
-            data-test-search-field
-          />
+          {(searchType === 'titles') ? (
+            <div data-test-title-search-field>
+              <SearchField
+                name="search"
+                id="eholdings-title-search-searchfield"
+                searchableIndexes={searchableIndexes}
+                selectedIndex={searchfield}
+                onChangeIndex={this.handleChangeIndex}
+                onChange={this.handleChangeSearch}
+                onClear={this.onClearSearch}
+                value={searchString}
+                placeholder={`Search for ${searchType}...`}
+              />
+            </div>
+          ) : (
+            <input
+              className={styles['search-input']}
+              type="search"
+              name="search"
+              value={searchString}
+              placeholder={`Search for ${searchType}...`}
+              onChange={this.handleChangeSearch}
+              data-test-search-field
+            />
+          )
+          }
           <button
             className={styles['search-submit']}
             type="submit"

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-
 import { qs } from '../components/utilities';
 import { createResolver } from '../redux';
 import Provider from '../redux/provider';
@@ -76,6 +75,21 @@ class SearchRoute extends Component {
   }
 
   /**
+   * Transforms UI params into search params
+   * @param {Object} parms - query param object
+   */
+
+  transformQueryParams(params) {
+    let { searchType } = this.state;
+    if (searchType === 'titles') {
+      let { q, searchfield = 'name', filter = {}, ...searchParams } = params;
+      if (searchfield === 'title') { searchfield = 'name'; }
+      let searchfilter = { ...filter, [searchfield]: q };
+      return { ...searchParams, filter: searchfilter };
+    } else { return params; }
+  }
+
+  /**
    * Uses the resolver to get a results collection for the current
    * search type and search params (including the page)
    * @returns {Collection} a collection instance
@@ -84,11 +98,12 @@ class SearchRoute extends Component {
     let { resolver } = this.props;
     let { searchType, params } = this.state;
     let { offset = 0, ...queryParams } = params;
+    let searchParams = this.transformQueryParams(queryParams);
     let page = Math.floor(offset / 25) + 1;
 
     return resolver.query(searchType, {
       filter: undefined,
-      ...queryParams,
+      ...searchParams,
       page
     });
   }
@@ -107,7 +122,6 @@ class SearchRoute extends Component {
     if (queryString) {
       url += `&${queryString}`;
     }
-
     return url;
   }
 
@@ -132,11 +146,9 @@ class SearchRoute extends Component {
    */
   updateURLParams(params) {
     let { location, history } = this.props;
-
     // if the new query is different from our location, update the location
     if (qs.stringify(params) !== qs.stringify(this.state.params)) {
       let url = this.buildSearchUrl(location.pathname, params);
-
       // if only the filters have changed, just replace the current location
       if (params.q === this.state.params.q) {
         history.replace(url);
@@ -151,10 +163,11 @@ class SearchRoute extends Component {
    * @param {Object} params - search params for the action
    */
   search(params) {
+    let searchParams = this.transformQueryParams(params);
     let { searchType } = this.state;
-    if (searchType === 'providers') this.props.searchProviders(params);
-    if (searchType === 'packages') this.props.searchPackages(params);
-    if (searchType === 'titles') this.props.searchTitles(params);
+    if (searchType === 'providers') this.props.searchProviders(searchParams);
+    if (searchType === 'packages') this.props.searchPackages(searchParams);
+    if (searchType === 'titles') this.props.searchTitles(searchParams);
   }
 
   /**
@@ -206,7 +219,6 @@ class SearchRoute extends Component {
    */
   renderResults() {
     let { searchType, params } = this.state;
-
     let props = {
       params,
       location: this.props.location,
@@ -255,6 +267,7 @@ class SearchRoute extends Component {
                 searchType={searchType}
                 searchString={params.q}
                 filter={params.filter}
+                searchfield={params.searchfield}
                 searchTypeUrls={this.getSearchTypeUrls()}
                 filtersComponent={this.getFiltersComponent()}
                 onSearch={this.handleSearch}

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -148,7 +148,7 @@ describeApplication('PackageSearch', () => {
       });
 
       it('displays an empty search', () => {
-        expect(PackageSearchPage.$searchField).to.have.value('');
+        expect(PackageSearchPage.$titleSearchField).to.have.value('');
       });
 
       it('does not display any more results', () => {

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -37,7 +37,9 @@ export default {
   get $searchField() {
     return $('[data-test-search-field]');
   },
-
+  get $titleSearchField() {
+    return $('[data-test-title-search-field]').find('input[name="search"]');
+  },
   get $searchResultsItems() {
     return $('[data-test-query-list="packages"] li a');
   },

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -27,9 +27,11 @@ export default {
   },
 
   get $searchField() {
+    return $('[data-test-title-search-field]').find('input[name="search"]');
+  },
+  get $providerSearchField() {
     return $('[data-test-search-field]');
   },
-
   get $searchFilters() {
     return $('[data-test-eholdings-title-search-filters]');
   },
@@ -69,9 +71,8 @@ export default {
   clickSearchVignette() {
     return $('[data-test-search-vignette]').trigger('click');
   },
-
   search(query) {
-    let $input = $('[data-test-search-field]').val(query);
+    let $input = $('[data-test-title-search-field]').find('input[name="search"]').val(query);
     triggerChange($input.get(0));
 
     return convergeOn(() => {
@@ -79,6 +80,13 @@ export default {
     }).then(() => {
       $('[data-test-search-submit]').trigger('click');
     });
+  },
+  get $searchFieldSelect() {
+    return $('[data-test-title-search-field]').find('select')[0];
+  },
+  selectSearchField(searchfield) {
+    let $input = $('[data-test-title-search-field]').find('select').val(searchfield);
+    return triggerChange($input.get(0));
   },
 
   getFilter(name) {


### PR DESCRIPTION
## Purpose
Implement Targeted Search Options for Title Searches.  This allows searching for titles by
- title (ie name)
- issn/isbn
- publisher
- subject
https://issues.folio.org/browse/UIEH-120

## Approach
- Search form is updated to use searchfield component ( (combines a select and text box) for Title searches. Continue to use simple search text box for Provider and Package searches
- eHoldings URL continues to use **q** parameter and adds a new **searchfield** parameter for Title search options, For example?q=education&searchfield=subject
- Supporting requests to mod-kb-ebsco are made using a JSON API filter syntax (for example, filter[subject]=education)
- Updates to mirage configuration to support new search filters
- When switching between search options (for example from publisher to subject), the search box maintains the search term

## Learning
- Used searchfield component as is used in codex search application
https://github.com/folio-org/stripes-components/blob/master/lib/structures/SearchField/readme.md
- https://www.npmjs.com/package/qs


## Screenshots
![targeted-search-revised](https://user-images.githubusercontent.com/19415226/36455517-73116818-166e-11e8-9f00-dc0063d6c72a.gif)
