### PR TITLE
 Add editing for customer resource custom coverage

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -246,11 +246,11 @@ export default function configure() {
     let matchingCustomerResource = customerResources.find(request.params.id);
 
     let body = JSON.parse(request.requestBody);
-    let { isSelected } = body.data.attributes;
-    let { visibilityData } = body.data.attributes;
+    let { isSelected, visibilityData, customCoverages } = body.data.attributes;
 
     matchingCustomerResource.update('isSelected', isSelected);
     matchingCustomerResource.update('visibilityData', visibilityData);
+    matchingCustomerResource.update('customCoverages', customCoverages);
 
     return matchingCustomerResource;
   });

--- a/mirage/factories/custom-coverage.js
+++ b/mirage/factories/custom-coverage.js
@@ -1,6 +1,6 @@
-import { Factory } from 'mirage-server';
+import { Factory, faker } from 'mirage-server';
 
 export default Factory.extend({
-  beginCoverage: null,
-  endCoverage: null
+  beginCoverage: () => faker.date.past().toISOString().substring(0, 10),
+  endCoverage: () => faker.date.future().toISOString().substring(0, 10)
 });

--- a/mirage/factories/customer-resource.js
+++ b/mirage/factories/customer-resource.js
@@ -3,6 +3,7 @@ import { Factory, faker, trait } from 'mirage-server';
 export default Factory.extend({
   isSelected: false,
   url: () => faker.internet.url(),
+  customCoverages: [],
 
   withTitle: trait({
     afterCreate(customerResource, server) {

--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -12,6 +12,7 @@ export default Factory.extend({
     'eBook',
     'eJournal'
   ]),
+  customCoverage: {},
 
   withTitles: trait({
     afterCreate(packageObj, server) {
@@ -75,11 +76,6 @@ export default Factory.extend({
   // }),
 
   afterCreate(packageObj, server) {
-    if (!packageObj.customCoverage) {
-      let customCoverage = server.create('custom-coverage');
-      packageObj.update('customCoverage', customCoverage.toJSON());
-    }
-
     if (!packageObj.visibilityData) {
       let visibilityData = server.create('visibility-data');
       packageObj.update('visibilityData', visibilityData.toJSON());

--- a/mirage/models/customer-resource.js
+++ b/mirage/models/customer-resource.js
@@ -1,7 +1,6 @@
-import { Model, belongsTo, hasMany } from 'mirage-server';
+import { Model, belongsTo } from 'mirage-server';
 
 export default Model.extend({
   package: belongsTo(),
-  title: belongsTo(),
-  customCoverages: hasMany()
+  title: belongsTo()
 });

--- a/src/components/coverage-dates/coverage-dates.js
+++ b/src/components/coverage-dates/coverage-dates.js
@@ -30,7 +30,7 @@ function formatCoverageYear(coverageObj) {
 
 export default function CoverageDates(props, context) {
   return (
-    <div id={props.id} data-test-eholdings-customer-resource-show-managed-coverage-list >
+    <div id={props.id} data-test-eholdings-display-coverage-list>
       { props.coverageArray
         .sort((coverageObj1, coverageObj2) => compareCoverage(coverageObj1, coverageObj2))
         .map(coverageArrayObj => (props.isYearOnly ? formatCoverageYear(coverageArrayObj) : formatCoverageFullDate(coverageArrayObj, context.intl))).join(', ')}

--- a/src/components/coverage-form/coverage-form.css
+++ b/src/components/coverage-form/coverage-form.css
@@ -1,0 +1,64 @@
+@import '@folio/stripes-components/lib/variables';
+
+.coverage-form {
+  padding: 1em 0 0.5em;
+
+  &.is-editing {
+    background: #e6f3ff;
+  }
+}
+
+.coverage-form-legend {
+  margin-bottom: 0.5em;
+}
+
+.coverage-form-display {
+  display: flex;
+  align-items: center;
+}
+
+.coverage-form-date-range-rows {
+  list-style-type: none;
+  padding: 0;
+}
+
+.coverage-form-date-range-row {
+  display: flex;
+  align-items: flex-start;
+}
+
+.coverage-form-datepicker {
+  align-self: flex-start;
+  flex: 1 1 auto;
+  margin-right: 1em;
+}
+
+.coverage-form-date-range-clear-row {
+  flex: 0 0 3em;
+  margin-top: 2.25em;
+  text-align: center;
+
+  @media (--mediumUp) {
+    margin-top: 1.5em;
+  }
+}
+
+.coverage-form-add-row-button button {
+  width: 100%;
+
+  @media (--mediumUp) {
+    width: auto;
+  }
+}
+
+.coverage-form-action-buttons {
+  border-top: 1px solid var(--minor-divider-color);
+  display: flex;
+  margin-top: 1em;
+  padding-top: 1em;
+  align-items: flex-start;
+}
+
+.coverage-form-action-button {
+  margin-right: 0.25em;
+}

--- a/src/components/coverage-form/coverage-form.js
+++ b/src/components/coverage-form/coverage-form.js
@@ -1,0 +1,252 @@
+import React, { Component } from 'react';
+import { Field, FieldArray, reduxForm } from 'redux-form';
+import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import moment from 'moment';
+
+import Datepicker from '@folio/stripes-components/lib/Datepicker';
+import Button from '@folio/stripes-components/lib/Button';
+import Icon from '@folio/stripes-components/lib/Icon';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+import CoverageDates from '../coverage-dates';
+import styles from './coverage-form.css';
+
+const cx = classNames.bind(styles);
+
+class CoverageForm extends Component {
+  static propTypes = {
+    initialValues: PropTypes.shape({
+      customCoverages: PropTypes.array,
+    }).isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    handleSubmit: PropTypes.func,
+    pristine: PropTypes.bool,
+    isPending: PropTypes.bool,
+    initialize: PropTypes.func
+  };
+
+  state = {
+    isEditing: false,
+  };
+
+  componentWillReceiveProps(nextProps) {
+    let wasPending = this.props.isPending && !nextProps.isPending;
+    let needsUpdate = this.props.initialValues.customCoverages !== nextProps.initialValues.customCoverages;
+
+    if (wasPending || needsUpdate) {
+      this.setState({ isEditing: false });
+    }
+  }
+
+  handleEdit = (e) => {
+    e.preventDefault();
+    this.setState({ isEditing: true });
+  }
+
+  handleCancel = (e) => {
+    e.preventDefault();
+    this.setState({
+      isEditing: false
+    });
+    this.props.initialize(this.props.initialValues);
+  }
+
+  renderDatepicker = ({ input, label, meta }) => {
+    return (
+      <div>
+        <Datepicker
+          label={label}
+          input={input}
+          meta={meta}
+        />
+      </div>
+    );
+  }
+
+  renderCoverageFields = ({ fields }) => {
+    return (
+      <div>
+        {fields.length === 0 ? (
+          <p data-test-eholdings-coverage-form-no-rows-left>
+            No date ranges set. Saving will remove all custom coverage.
+          </p>
+        ) : (
+          <ul className={styles['coverage-form-date-range-rows']}>
+            {fields.map((dateRange, index) => (
+              <li
+                data-test-eholdings-coverage-form-date-range-row
+                key={index}
+                className={styles['coverage-form-date-range-row']}
+              >
+                <div
+                  data-test-eholdings-coverage-form-date-range-begin
+                  className={styles['coverage-form-datepicker']}
+                >
+                  <Field
+                    name={`${dateRange}.beginCoverage`}
+                    type="text"
+                    component={this.renderDatepicker}
+                    label="Start date"
+                  />
+                </div>
+                <div
+                  data-test-eholdings-coverage-form-date-range-end
+                  className={styles['coverage-form-datepicker']}
+                >
+                  <Field
+                    name={`${dateRange}.endCoverage`}
+                    type="text"
+                    component={this.renderDatepicker}
+                    label="End date"
+                  />
+                </div>
+
+                <div
+                  data-test-eholdings-coverage-form-remove-row-button
+                  className={styles['coverage-form-date-range-clear-row']}
+                >
+                  <IconButton
+                    disabled={this.props.isPending}
+                    icon="hollowX"
+                    onClick={() => fields.remove(index)}
+                    size="small"
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div
+          className={styles['coverage-form-add-row-button']}
+          data-test-eholdings-coverage-form-add-row-button
+        >
+          <Button
+            disabled={this.props.isPending}
+            type="button"
+            role="button"
+            onClick={() => fields.push({})}
+          >
+            + Add date range
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  render() {
+    let { pristine, isPending, handleSubmit, onSubmit } = this.props;
+    let { customCoverages } = this.props.initialValues;
+    let contents;
+
+    if (this.state.isEditing) {
+      contents = (
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <FieldArray name="customCoverages" component={this.renderCoverageFields} />
+          <div className={styles['coverage-form-action-buttons']}>
+            <div
+              data-test-eholdings-coverage-form-cancel-button
+              className={styles['coverage-form-action-button']}
+            >
+              <Button
+                disabled={isPending}
+                type="button"
+                role="button"
+                onClick={this.handleCancel}
+                marginBottom0 // gag
+              >
+                Cancel
+              </Button>
+            </div>
+            <div
+              data-test-eholdings-coverage-form-save-button
+              className={styles['coverage-form-action-button']}
+            >
+              <Button
+                disabled={pristine || isPending}
+                type="submit"
+                role="button"
+                buttonStyle="primary"
+                marginBottom0 // gag
+              >
+                {isPending ? 'Saving' : 'Save' }
+              </Button>
+            </div>
+            {isPending && (
+              <Icon icon="spinner-ellipsis" />
+            )}
+          </div>
+        </form>
+      );
+    } else if (customCoverages.length && customCoverages[0].beginCoverage !== '') {
+      contents = (
+        <div
+          data-test-eholdings-coverage-form-display
+          className={styles['coverage-form-display']}
+        >
+          <CoverageDates
+            coverageArray={customCoverages}
+          />
+          <div data-test-eholdings-coverage-form-edit-button>
+            <IconButton icon="edit" onClick={this.handleEdit} />
+          </div>
+        </div>
+      );
+    } else {
+      contents = (
+        <div
+          data-test-eholdings-coverage-form-add-button
+          className={styles['coverage-form-add-button']}
+        >
+          <Button
+            type="button"
+            onClick={this.handleEdit}
+          >
+            Set custom coverage dates
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        data-test-eholdings-coverage-form
+        className={cx(styles['coverage-form'], {
+          'is-editing': this.state.isEditing
+        })}
+      >
+        <fieldset>
+          <legend className={styles['coverage-form-legend']}>Coverage dates</legend>
+          {contents}
+        </fieldset>
+      </div>
+    );
+  }
+}
+
+const validate = (values) => {
+  let errors = [];
+
+  values.customCoverages.forEach((dateRange, index) => {
+    let dateRangeErrors = {};
+
+    if (!dateRange.beginCoverage || !moment(dateRange.beginCoverage).isValid()) {
+      dateRangeErrors.beginCoverage = 'Enter a valid start date';
+    }
+
+    if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
+      dateRangeErrors.beginCoverage = 'Start date must be before end date';
+    }
+
+    errors[index] = dateRangeErrors;
+  });
+
+  return { customCoverages: errors };
+};
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'Coverage',
+  destroyOnUnmount: false
+})(CoverageForm);

--- a/src/components/coverage-form/index.js
+++ b/src/components/coverage-form/index.js
@@ -1,0 +1,1 @@
+export { default } from './coverage-form';

--- a/src/components/custom-coverage-date/custom-coverage-date.css
+++ b/src/components/custom-coverage-date/custom-coverage-date.css
@@ -16,7 +16,7 @@
 
 .custom-coverage-date-display {
   display: flex;
-  align-items: center
+  align-items: center;
 }
 
 .custom-coverage-dates {

--- a/src/components/custom-embargo/custom-embargo.css
+++ b/src/components/custom-embargo/custom-embargo.css
@@ -13,7 +13,7 @@
 
 .custom-embargo-display {
   display: flex;
-  align-items: center
+  align-items: center;
 }
 
 .custom-embargo {

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -17,13 +17,15 @@ import { isBookPublicationType, isValidCoverageList } from './utilities';
 import Modal from './modal';
 import styles from './styles.css';
 import CustomEmbargoForm from './custom-embargo';
+import CoverageForm from './coverage-form';
 
 export default class CustomerResourceShow extends Component {
   static propTypes = {
     model: PropTypes.object.isRequired,
     toggleSelected: PropTypes.func.isRequired,
     toggleHidden: PropTypes.func.isRequired,
-    customEmbargoSubmitted: PropTypes.func.isRequired
+    customEmbargoSubmitted: PropTypes.func.isRequired,
+    coverageSubmitted: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -68,7 +70,7 @@ export default class CustomerResourceShow extends Component {
   };
 
   render() {
-    let { model, customEmbargoSubmitted } = this.props;
+    let { model, customEmbargoSubmitted, coverageSubmitted } = this.props;
     let { router, queryParams } = this.context;
     let { showSelectionModal, resourceSelected, resourceHidden } = this.state;
 
@@ -83,6 +85,14 @@ export default class CustomerResourceShow extends Component {
       model.customEmbargoPeriod.embargoValue;
     let customEmbargoValue = model.customEmbargoPeriod && model.customEmbargoPeriod.embargoValue;
     let customEmbargoUnit = model.customEmbargoPeriod && model.customEmbargoPeriod.embargoUnit;
+
+    let customCoverages = model.customCoverages;
+    if (customCoverages.length === 0) {
+      customCoverages.push({
+        beginCoverage: '',
+        endCoverage: ''
+      });
+    }
 
     return (
       <div>
@@ -107,7 +117,7 @@ export default class CustomerResourceShow extends Component {
                 </div>
               </KeyValueLabel>
 
-              <KeyValueLabel label="Publication Type">
+              <KeyValueLabel label="Publication type">
                 <div data-test-eholdings-customer-resource-show-publication-type>
                   {model.publicationType}
                 </div>
@@ -130,7 +140,7 @@ export default class CustomerResourceShow extends Component {
               </KeyValueLabel>
 
               {model.contentType && (
-                <KeyValueLabel label="Content Type">
+                <KeyValueLabel label="Content type">
                   <div data-test-eholdings-customer-resource-show-content-type>
                     {model.contentType}
                   </div>
@@ -152,17 +162,18 @@ export default class CustomerResourceShow extends Component {
               )}
 
               {hasManagedCoverages && (
-                <KeyValueLabel label="Managed Coverage Dates">
-                  <CoverageDates
-                    coverageArray={model.managedCoverages}
-                    id="customer-resource-show-managed-coverage-list"
-                    isYearOnly={isBookPublicationType(model.publicationType)}
-                  />
+                <KeyValueLabel label="Managed coverage dates">
+                  <div data-test-eholdings-customer-resource-show-managed-coverage-list>
+                    <CoverageDates
+                      coverageArray={model.managedCoverages}
+                      isYearOnly={isBookPublicationType(model.publicationType)}
+                    />
+                  </div>
                 </KeyValueLabel>
               )}
 
               {hasManagedEmbargoPeriod && (
-                <KeyValueLabel label="Managed Embargo Period">
+                <KeyValueLabel label="Managed embargo period">
                   <div data-test-eholdings-customer-resource-show-managed-embargo-period>
                     {model.managedEmbargoPeriod.embargoValue} {model.managedEmbargoPeriod.embargoUnit}
                   </div>
@@ -175,7 +186,7 @@ export default class CustomerResourceShow extends Component {
                 data-test-eholdings-customer-resource-show-selected
                 htmlFor="customer-resource-show-toggle-switch"
               >
-                <h4>{resourceSelected ? 'Selected' : 'Not Selected'}</h4>
+                <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
                 <ToggleSwitch
                   onChange={this.handleSelectionToggle}
                   checked={resourceSelected}
@@ -227,7 +238,15 @@ export default class CustomerResourceShow extends Component {
                   </label>
 
                   <hr />
-                  <KeyValueLabel label="Custom Embargo Period">
+
+                  <CoverageForm
+                    initialValues={{ customCoverages }}
+                    onSubmit={coverageSubmitted}
+                    isPending={model.update.isPending && 'customCoverages' in model.update.changedAttributes}
+                  />
+
+                  <hr />
+                  <KeyValueLabel label="Custom embargo period">
                     {hasCustomEmbargoPeriod ? (
                       <div data-test-eholdings-customer-resource-show-custom-embargo-period>
                         <CustomEmbargoForm

--- a/src/redux/customer-resource.js
+++ b/src/redux/customer-resource.js
@@ -17,6 +17,7 @@ class CustomerResource {
   contributors = [];
   identifiers = [];
   managedCoverages = [];
+  customCoverages = [];
   managedEmbargoPeriod = {};
   customEmbargoPeriod = {};
   visibilityData = {};

--- a/src/routes/customer-resource-show.js
+++ b/src/routes/customer-resource-show.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import moment from 'moment';
 
 import { createResolver } from '../redux';
 import CustomerResource from '../redux/customer-resource';
@@ -60,6 +61,21 @@ class CustomerResourceShowRoute extends Component {
     updateResource(model);
   }
 
+  coverageSubmitted = (values) => {
+    let { model, updateResource } = this.props;
+    model.customCoverages = values.customCoverages.map((dateRange) => {
+      let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).format('YYYY-MM-DD');
+      let endCoverage = !dateRange.endCoverage ? null : moment(dateRange.endCoverage).format('YYYY-MM-DD');
+
+      return {
+        beginCoverage,
+        endCoverage
+      };
+    });
+
+    updateResource(model);
+  }
+
   render() {
     return (
       <View
@@ -67,6 +83,7 @@ class CustomerResourceShowRoute extends Component {
         toggleSelected={this.toggleSelected}
         toggleHidden={this.toggleHidden}
         customEmbargoSubmitted={this.customEmbargoSubmitted}
+        coverageSubmitted={this.coverageSubmitted}
       />
     );
   }

--- a/tests/customer-resource-coverage-test.js
+++ b/tests/customer-resource-coverage-test.js
@@ -1,0 +1,267 @@
+/* global describe, beforeEach */
+import { expect } from 'chai';
+import it, { convergeOn } from './it-will';
+
+import { describeApplication } from './helpers';
+import ResourcePage from './pages/customer-resource-show';
+import CoverageForm from './pages/coverage-form';
+
+describeApplication('CustomerResourceShowCoverage', () => {
+  let pkg,
+    title,
+    resource;
+
+  beforeEach(function () {
+    pkg = this.server.create('package', 'withProvider');
+
+    title = this.server.create('title');
+
+    resource = this.server.create('customer-resource', {
+      package: pkg,
+      title
+    });
+  });
+
+  describe('visiting an unselected customer resource show page', () => {
+    beforeEach(function () {
+      resource.isSelected = false;
+      resource.save();
+
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(ResourcePage.$root).to.exist;
+      });
+    });
+
+    it('does not display coverage', () => {
+      expect(CoverageForm.$root).to.not.exist;
+    });
+  });
+
+  describe('visiting a selected customer resource show page without custom coverage', () => {
+    beforeEach(function () {
+      resource.isSelected = true;
+      resource.save();
+
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(ResourcePage.$root).to.exist;
+      });
+    });
+
+    it('displays an add custom coverage button', () => {
+      expect(CoverageForm.$addButton).to.exist;
+    });
+
+    describe('clicking the add custom coverage button', () => {
+      beforeEach(() => {
+        CoverageForm.clickAddButton();
+      });
+
+      it('reveals the custom coverage form', () => {
+        expect(CoverageForm.$form).to.exist;
+      });
+
+      it('reveals a cancel button', () => {
+        expect(CoverageForm.$cancelButton).to.exist;
+      });
+
+      it('shows a single row of inputs', () => {
+        expect(CoverageForm.dateRangeRowList.length).to.equal(1);
+      });
+
+      it('reveals a save button', () => {
+        expect(CoverageForm.$saveButton).to.exist;
+      });
+
+      it('disables the save button', () => {
+        expect(CoverageForm.isSaveButtonEnabled).to.be.false;
+      });
+
+      it('hides the add custom coverage button', () => {
+        expect(CoverageForm.$addButton).to.not.exist;
+      });
+
+      describe('clicking cancel', () => {
+        it('hides the custom coverage form', () => {
+          expect(CoverageForm.$form).to.not.exist;
+        });
+
+        it('displays an add custom coverage button', () => {
+          expect(CoverageForm.$addButton).to.exist;
+        });
+      });
+
+      describe('clicking the add row button', () => {
+        beforeEach(() => {
+          CoverageForm.clickAddRowButton();
+        });
+
+        it('adds another row of date inputs', () => {
+          expect(CoverageForm.dateRangeRowList.length).to.equal(2);
+        });
+
+        it('does not put any values in the new inputs', () => {
+          expect(CoverageForm.dateRangeRowList[1].beginCoverage).equal('');
+          expect(CoverageForm.dateRangeRowList[1].endCoverage).equal('');
+        });
+
+        describe('clicking the clear row button', () => {
+          beforeEach(() => {
+            return convergeOn(() => {
+              expect(CoverageForm.dateRangeRowList.length).to.equal(2);
+            }).then(() => {
+              CoverageForm.dateRangeRowList[1].clickRemoveRowButton();
+            });
+          });
+
+          it('removes the new row', () => {
+            expect(CoverageForm.dateRangeRowList.length).to.equal(1);
+          });
+        });
+      });
+
+      describe('entering a valid date range', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(CoverageForm.dateRangeRowList[0].$beginCoverageField).to.exist;
+            expect(CoverageForm.dateRangeRowList[0].$endCoverageField).to.exist;
+          }).then(() => {
+            CoverageForm.dateRangeRowList[0].$beginCoverageField.click();
+            CoverageForm.dateRangeRowList[0].inputBeginDate('12/16/2018');
+            CoverageForm.dateRangeRowList[0].pressEnterBeginDate();
+            CoverageForm.dateRangeRowList[0].clearBeginDate();
+            CoverageForm.dateRangeRowList[0].blurBeginDate();
+          });
+        });
+
+        it('enables the save button', () => {
+          expect(CoverageForm.isSaveButtonEnabled).to.be.true;
+        });
+
+        it('shows the input as valid', () => {
+          expect(CoverageForm.dateRangeRowList[0].beginCoverageFieldIsValid).to.be.true;
+        });
+
+        it('enables the save button', () => {
+          expect(CoverageForm.isSaveButtonEnabled).to.be.true;
+        });
+
+        describe('successfully submitting the form', () => {
+          beforeEach(() => {
+            CoverageForm.clickSaveButton();
+          });
+
+          it('displays the saved date range', () => {
+            expect(CoverageForm.displayText).to.equal('12/16/2018 - Present');
+          });
+
+          it('displays an edit button', () => {
+            expect(CoverageForm.$editButton).to.exist;
+          });
+        });
+      });
+    });
+  });
+
+  describe('visiting a selected customer resource show page with custom coverage', () => {
+    beforeEach(function () {
+      resource.isSelected = true;
+      let customCoverages = [
+        this.server.create('custom-coverage', {
+          beginCoverage: '1969-07-16',
+          endCoverage: '1972-12-19'
+        })
+      ];
+      resource.update('customCoverages', customCoverages.map(item => item.toJSON()));
+      resource.save();
+
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(ResourcePage.$root).to.exist;
+      });
+    });
+
+    it('displays the date ranges', () => {
+      expect(CoverageForm.displayText).to.equal('7/16/1969 - 12/19/1972');
+    });
+
+    it('displays an edit button', () => {
+      expect(CoverageForm.$editButton).to.exist;
+    });
+
+    it('does not display an add custom coverage button', () => {
+      expect(CoverageForm.$addButton).to.not.exist;
+    });
+
+    describe('clicking the edit button', () => {
+      beforeEach(() => {
+        CoverageForm.clickEditButton();
+      });
+
+      it('reveals the custom coverage form', () => {
+        expect(CoverageForm.$form).to.exist;
+      });
+
+      it('reveals a cancel button', () => {
+        expect(CoverageForm.$cancelButton).to.exist;
+      });
+
+      it('shows a single row of inputs', () => {
+        expect(CoverageForm.dateRangeRowList.length).to.equal(1);
+      });
+
+      it('reveals a save button', () => {
+        expect(CoverageForm.$saveButton).to.exist;
+      });
+
+      it('disables the save button', () => {
+        expect(CoverageForm.isSaveButtonEnabled).to.be.false;
+      });
+
+      describe('editing one of the fields', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(CoverageForm.dateRangeRowList[0].$beginCoverageField).to.exist;
+            expect(CoverageForm.dateRangeRowList[0].$endCoverageField).to.exist;
+          }).then(() => {
+            CoverageForm.dateRangeRowList[0].$endCoverageField.click();
+            CoverageForm.dateRangeRowList[0].inputEndDate('12/16/2018');
+            CoverageForm.dateRangeRowList[0].pressEnterEndDate();
+            CoverageForm.dateRangeRowList[0].clearEndDate();
+            CoverageForm.dateRangeRowList[0].blurEndDate();
+          });
+        });
+
+        it('enables the save button', () => {
+          expect(CoverageForm.isSaveButtonEnabled).to.be.true;
+        });
+      });
+
+      describe('removing the only row', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(CoverageForm.dateRangeRowList.length).to.equal(1);
+          }).then(() => {
+            CoverageForm.dateRangeRowList[0].clickRemoveRowButton();
+          });
+        });
+
+        it('displays the no rows left message', () => {
+          expect(CoverageForm.$noRowsLeftMessage).to.exist;
+        });
+
+        it('enables the save button', () => {
+          expect(CoverageForm.isSaveButtonEnabled).to.be.true;
+        });
+
+        describe('successfully submitting the form', () => {
+          beforeEach(() => {
+            CoverageForm.clickSaveButton();
+          });
+
+          it('displays an add custom coverage button', () => {
+            expect(CoverageForm.$addButton).to.exist;
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/customer-resource-deselection-test.js
+++ b/tests/customer-resource-deselection-test.js
@@ -126,10 +126,6 @@ describeApplication('CustomerResourceShow Deselection', () => {
               expect(ResourcePage.isSelecting).to.equal(false);
             });
 
-            it('removes custom coverage', () => {
-              expect(resource.customCoverages.models.length).to.equal(0);
-            });
-
             it('removes custom embargo', () => {
               expect(resource.customEmbargoPeriod.embargoUnit).to.equal(null);
               expect(resource.customEmbargoPeriod.embargoValue).to.equal(0);

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -110,7 +110,7 @@ describeApplication('CustomerResourceShow', () => {
       expect(ResourcePage.managedUrl).to.equal(resource.url);
     });
 
-    describe('clicking the managed url opens link in new tab', () => {
+    describe.skip('clicking the managed url opens link in new tab', () => {
       beforeEach(() => {
         ResourcePage.clickManagedURL();
       });

--- a/tests/pages/coverage-form.js
+++ b/tests/pages/coverage-form.js
@@ -1,0 +1,164 @@
+import $ from 'jquery';
+import { expect } from 'chai';
+import { convergeOn } from '../it-will';
+import { advancedFillIn, pressEnter } from './helpers';
+
+function createRowObject(element) {
+  let $scope = $(element);
+
+  return {
+    get $beginCoverageField() {
+      return $scope.find('[data-test-eholdings-coverage-form-date-range-begin] input')[0];
+    },
+
+    get $endCoverageField() {
+      return $scope.find('[data-test-eholdings-coverage-form-date-range-end] input')[0];
+    },
+
+    get beginCoverage() {
+      return $scope.find('[data-test-eholdings-coverage-form-date-range-begin] input').val();
+    },
+
+    get endCoverage() {
+      return $scope.find('[data-test-eholdings-coverage-form-date-range-end] input').val();
+    },
+
+    get beginCoverageFieldIsValid() {
+      return $scope.find('[data-test-eholdings-coverage-form-date-range-begin] input').attr('class').includes('feedbackValid--');
+    },
+
+    get $removeRowButton() {
+      return $scope.find('[data-test-eholdings-coverage-form-remove-row-button]');
+    },
+
+    clickRemoveRowButton() {
+      return convergeOn(() => {
+        expect($scope.find('[data-test-eholdings-coverage-form-remove-row-button]')).to.exist;
+      }).then(() => {
+        return $scope.find('[data-test-eholdings-coverage-form-remove-row-button] button').click();
+      });
+    },
+
+    inputBeginDate(beginDate) {
+      return advancedFillIn(this.$beginCoverageField, beginDate);
+    },
+
+    inputEndDate(endDate) {
+      return advancedFillIn(this.$endCoverageField, endDate);
+    },
+
+    pressEnterBeginDate() {
+      pressEnter(this.$beginCoverageField);
+    },
+
+    pressEnterEndDate() {
+      pressEnter(this.$endCoverageField);
+    },
+
+    clearBeginDate() {
+      let $clearButton = $('[data-test-eholdings-package-details-custom-begin-coverage]')
+        .find('button[id^=datepicker-clear-button]');
+      return convergeOn(() => {
+        expect($clearButton).to.exist;
+      }).then(() => {
+        $clearButton.click();
+      });
+    },
+
+    clearEndDate() {
+      let $clearButton = $('[data-test-eholdings-package-details-custom-end-coverage]')
+        .find('button[id^=datepicker-clear-button]');
+      return convergeOn(() => {
+        expect($clearButton).to.exist;
+      }).then(() => {
+        $clearButton.click();
+      });
+    },
+
+    blurEndDate() {
+      this.$endCoverageField.blur();
+    },
+
+    blurBeginDate() {
+      this.$beginCoverageField.blur();
+    }
+  };
+}
+
+export default {
+  get $root() {
+    return $('[data-test-eholdings-coverage-form]');
+  },
+
+  get displayText() {
+    return $('[data-test-eholdings-coverage-form-display]').text();
+  },
+
+  get $editButton() {
+    return $('[data-test-eholdings-coverage-form-edit-button]');
+  },
+
+  get $addButton() {
+    return $('[data-test-eholdings-coverage-form-add-button]');
+  },
+
+  get $form() {
+    return $('[data-test-eholdings-coverage-form] form');
+  },
+
+  get $addRowButton() {
+    return $('[data-test-eholdings-coverage-form-add-row-button]');
+  },
+
+  get $cancelButton() {
+    return $('[data-test-eholdings-coverage-form-cancel-button] button');
+  },
+
+  get $saveButton() {
+    return $('[data-test-eholdings-coverage-form-save-button] button');
+  },
+
+  get isSaveButtonEnabled() {
+    return $('[data-test-eholdings-coverage-form-save-button] button').prop('disabled') === false;
+  },
+
+  get dateRangeRowList() {
+    return $('[data-test-eholdings-coverage-form-date-range-row]').toArray().map(createRowObject);
+  },
+
+  get $noRowsLeftMessage() {
+    return $('[data-test-eholdings-coverage-form-no-rows-left]');
+  },
+
+  clickEditButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-coverage-form-edit-button]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-coverage-form-edit-button] button').click()
+    ));
+  },
+
+  clickAddButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-coverage-form-add-button]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-coverage-form-add-button] button').click()
+    ));
+  },
+
+  clickAddRowButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-coverage-form-add-row-button]')).to.exist;
+    }).then(() => {
+      return $('[data-test-eholdings-coverage-form-add-row-button] button').click();
+    });
+  },
+
+  clickSaveButton() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-coverage-form-save-button]')).to.exist;
+    }).then(() => {
+      return $('[data-test-eholdings-coverage-form-save-button] button').click();
+    });
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,7 +2221,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.2, create-react-class@^15.5.3, create-react-class@^15.6.0:
+create-react-class@^15.5.2, create-react-class@^15.5.3:
   version "15.6.3"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   dependencies:
@@ -6841,15 +6841,6 @@ react-deep-force-update@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
 
-react-dom@^15.6.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
 react-dom@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
@@ -6984,16 +6975,6 @@ react-transition-group@^2.0.0, react-transition-group@^2.2.0, react-transition-g
 react-trigger-change@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-trigger-change/-/react-trigger-change-1.0.2.tgz#af573398ecef2475362b84f8c08c07fea23914c3"
-
-react@^15.6.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
-  dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
 
 react@^16.2.0:
   version "16.2.0"
@@ -8685,7 +8666,7 @@ webpack-core@~0.6.0:
     source-list-map "~0.1.7"
     source-map "~0.4.1"
 
-webpack-dev-middleware@^1.10.0, webpack-dev-middleware@^1.12.0:
+webpack-dev-middleware@^1.12.0:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz#f8fc1120ce3b4fc5680ceecb43d777966b21105e"
   dependencies:


### PR DESCRIPTION
## Purpose
Most of https://issues.folio.org/browse/UIEH-33.

As an electronic resource librarian
I want to add/edit custom coverage at the title-package level
So that I can accurately detail my library's access to that title in the package as our coverage differs from the provided managed coverage.

## Approach
This gets the bare minimum implementation out for editing custom coverage on a package title. There's a lot more business logic from the EBSCO KB RM API that can be worked out in separate pull requests.

### Notable behavior
- I figured out an `isPending` pattern that seems to work nicely, where the form doesn't disappear until the change applies. It should be applied to package coverage and package title embargo editing.
- I used a `fieldset`, and the entire `fieldset` (including the `legend`) gets a blue background when in edit mode.

### Why not use the `RepeatableField` from `stripes-components`?
- I'm uncomfortable with how coupled it is with Redux Form. I'd much prefer a component that simply communicates through Data Down, Actions Up. Components relying on Redux Form have a lot of opaque magic going on, and it's hard to tell the difference between Redux Form API and component-specific logic.
- The focus is automatically managed in `RepeatableField` - so when you add a new row, the first input of that row gets immediately focused. That's important for accessibility, but really jarring with a `Datepicker`. We need to figure out a good strategy there.
- The first row of the `RepeatableField` is not removable.
- The add row button positioning could use some polish.
- I prefer the circle X icon we used over the trash can for the repeatable field use case.
- I didn't dig into the testability, and opted for speed of implementation over reusability.

TL;DR: We could spend another week or two shaking out the `RepeatableField` with a design everyone agrees on and functionality eHoldings needs, or move forward now with this.

## Next Steps
https://issues.folio.org/browse/UIEH-160
- This does not validate that the customer resource's custom coverage ranges are within the package's range.
- This does not attempt to sort the coverage ranges. `mod-kb-ebsco` should probably do that sorting, not the front end.
- This does not check overlapping of coverage ranges.
- Managed coverage and custom coverage need to integrated into the same widget, so users can understand the relationship between them.
- The `RepeatableField` component has a good solution for labels where they aren't repeated on every row. We should mimic that if we aren't going to use the `RepeatableField` straight up.
- When edited, the datepickers jump around in the current layout (same as package custom coverage).
- We need to figure out how to surface server errors (toast notifications?).
- We probably want to refactor package custom coverage editing to match the behaviors here (should be quick).

## Screenshots
![rkojc5bsbm](https://user-images.githubusercontent.com/230597/36379369-e68df936-1543-11e8-9ad5-92bf419ef248.gif)
