### PR TITLE
Get date format string from moment

### DIFF
--- a/src/components/coverage-form/coverage-form.js
+++ b/src/components/coverage-form/coverage-form.js
@@ -22,7 +22,8 @@ class CoverageForm extends Component {
     handleSubmit: PropTypes.func,
     pristine: PropTypes.bool,
     isPending: PropTypes.bool,
-    initialize: PropTypes.func
+    initialize: PropTypes.func,
+    locale: PropTypes.string // eslint-disable-line react/no-unused-prop-types
   };
 
   state = {
@@ -224,18 +225,20 @@ class CoverageForm extends Component {
   }
 }
 
-const validate = (values) => {
+const validate = (values, props) => {
+  moment.locale(props.locale);
+  let dateFormat = moment.localeData()._longDateFormat.L;
   let errors = [];
 
   values.customCoverages.forEach((dateRange, index) => {
     let dateRangeErrors = {};
 
     if (!dateRange.beginCoverage || !moment(dateRange.beginCoverage).isValid()) {
-      dateRangeErrors.beginCoverage = 'Enter a valid start date';
+      dateRangeErrors.beginCoverage = `Enter date in ${dateFormat} format.`;
     }
 
     if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
-      dateRangeErrors.beginCoverage = 'Start date must be before end date';
+      dateRangeErrors.beginCoverage = 'Start date must be before end date.';
     }
 
     errors[index] = dateRangeErrors;

--- a/src/components/custom-coverage-date/custom-coverage-date.js
+++ b/src/components/custom-coverage-date/custom-coverage-date.js
@@ -20,7 +20,8 @@ class CustomCoverageDate extends Component {
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
     initialize: PropTypes.func,
-    isPending: PropTypes.bool
+    isPending: PropTypes.bool,
+    locale: PropTypes.string // eslint-disable-line react/no-unused-prop-types
   }
 
   static contextTypes = {
@@ -110,12 +111,12 @@ class CustomCoverageDate extends Component {
             </div>
             <div className={styles['custom-coverage-action-buttons']}>
               <div data-test-eholdings-package-details-cancel-custom-coverage-button>
-                <Button disabled={isPending} type="button" role="button" buttonStyle="secondary" onClick={this.handleCancelCustomCoverage}>
+                <Button disabled={isPending} type="button" role="button" onClick={this.handleCancelCustomCoverage}>
                   Cancel
                 </Button>
               </div>
               <div data-test-eholdings-package-details-save-custom-coverage-button>
-                <Button disabled={pristine} type="submit" role="button">
+                <Button disabled={pristine} type="submit" buttonStyle="primary" role="button">
                   Save
                 </Button>
               </div>
@@ -157,15 +158,16 @@ class CustomCoverageDate extends Component {
 // the values from the from are passed into this function and then
 // validated based on the matching field with the same 'name' as value
 function validate(values, props) {
-  let dateFormat = props.intl.formatters.getDateTimeFormat().format();
+  moment.locale(props.locale);
+  let dateFormat = moment.localeData()._longDateFormat.L;
   const errors = {};
 
   if (!values.beginCoverage || !moment(values.beginCoverage).isValid()) {
-    errors.beginCoverage = `Enter Date in ${dateFormat} format.`;
+    errors.beginCoverage = `Enter date in ${dateFormat} format.`;
   }
 
   if (values.endCoverage && moment(values.beginCoverage).isAfter(moment(values.endCoverage))) {
-    errors.beginCoverage = 'Start Date must be before End Date';
+    errors.beginCoverage = 'Start date must be before end date.';
   }
 
   return errors;

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -29,6 +29,7 @@ export default class CustomerResourceShow extends Component {
   };
 
   static contextTypes = {
+    locale: PropTypes.string,
     router: PropTypes.object,
     queryParams: PropTypes.object
   };
@@ -71,7 +72,7 @@ export default class CustomerResourceShow extends Component {
 
   render() {
     let { model, customEmbargoSubmitted, coverageSubmitted } = this.props;
-    let { router, queryParams } = this.context;
+    let { locale, router, queryParams } = this.context;
     let { showSelectionModal, resourceSelected, resourceHidden } = this.state;
 
     let historyState = router.history.location.state;
@@ -243,6 +244,7 @@ export default class CustomerResourceShow extends Component {
                     initialValues={{ customCoverages }}
                     onSubmit={coverageSubmitted}
                     isPending={model.update.isPending && 'customCoverages' in model.update.changedAttributes}
+                    locale={locale}
                   />
 
                   <hr />

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,8 @@ export default class EHoldings extends Component {
       path: PropTypes.string.isRequired
     }).isRequired,
     stripes: PropTypes.shape({
-      intl: PropTypes.object.isRequired
+      intl: PropTypes.object.isRequired,
+      locale: PropTypes.string.isRequired
     }).isRequired,
     showSettings: PropTypes.bool
   };
@@ -30,12 +31,14 @@ export default class EHoldings extends Component {
   };
 
   static childContextTypes = {
-    intl: PropTypes.object
+    intl: PropTypes.object,
+    locale: PropTypes.string
   }
 
   getChildContext() {
     return {
-      intl: this.props.stripes.intl
+      intl: this.props.stripes.intl,
+      locale: this.props.stripes.locale
     };
   }
 

--- a/tests/package-show-custom-coverage-test.js
+++ b/tests/package-show-custom-coverage-test.js
@@ -233,7 +233,7 @@ describeApplication('PackageShowCustomCoverage', () => {
             convergeOn(() => {
               expect(PackageShowPage.validationError).to.exist;
             }).then(() => {
-              expect(PackageShowPage.validationError).to.match(/\bEnter Date in.*\b/);
+              expect(PackageShowPage.validationError).to.match(/\bEnter date in.*\b/);
             });
           });
         });
@@ -253,7 +253,7 @@ describeApplication('PackageShowCustomCoverage', () => {
 
 
           it('throws validation error', () => {
-            expect(PackageShowPage.validationError).to.include('Start Date must be before End Date');
+            expect(PackageShowPage.validationError).to.include('Start date must be before end date.');
           });
         });
       });


### PR DESCRIPTION
## Purpose
Part of https://issues.folio.org/browse/UIEH-33

Previously, we were showing the error message "Enter Date in 02/19/2018 format."

## Approach
Instead we can peel off the format string using `moment`. This is how the `stripes-components` `Datepicker` determines its placeholder.

New: "Enter Date in MM/DD/YYYY format."

Applied to package and package-title custom coverage editing.

## Screenshots
![screen shot 2018-02-19 at 3 13 21 pm](https://user-images.githubusercontent.com/230597/36397319-f52ab01c-1587-11e8-8f8a-114871ea4426.png)
