### PR TITLE
Add "all" filter for title selection status

### DIFF
--- a/src/components/title-search-filters.js
+++ b/src/components/title-search-filters.js
@@ -5,6 +5,7 @@ import { Accordion, FilterAccordionHeader } from '@folio/stripes-components/lib/
 import RadioButton from '@folio/stripes-components/lib/RadioButton';
 
 const selectedFilters = [
+  { label: 'All', value: undefined },
   { label: 'Selected', value: 'true' },
   { label: 'Not Selected', value: 'false' },
   { label: 'Selected By EBSCO', value: 'ebsco' }


### PR DESCRIPTION
## Purpose
Adds an "all" option for title selection status to align with the publication type when no filter is selected.

## Approach
Just adds the "all" label and selects it when `filter[selected]` is `undefined`

## Screenshots
![image](https://user-images.githubusercontent.com/5005153/36398112-1e7daa48-158b-11e8-8ba9-125cf02824d9.png)
