### PR TITLE
Add package search filters for content type and selection status

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -175,16 +175,17 @@ export default function configure() {
 
   // Package resources
   this.get('/packages', searchRouteFor('packages', (pkg, req) => {
+    let query = req.queryParams.q.toLowerCase();
     let params = req.queryParams;
     let type = params['filter[type]'];
     let selected = params['filter[selected]'];
-    let filtered = true;
+    let filtered = pkg.name && pkg.name.toLowerCase().includes(query);
 
-    if (type && type !== 'all') {
+    if (filtered && type && type !== 'all') {
       filtered = pkg.contentType.toLowerCase() === type;
     }
 
-    if (selected) {
+    if (filtered && selected) {
       filtered = pkg.isSelected.toString() === selected;
     }
 
@@ -237,30 +238,29 @@ export default function configure() {
     let isxn = params['filter[isxn]'];
     let subject = params['filter[subject]'];
     let publisher = params['filter[publisher]'];
-    let queryFiltered = true;
     let filtered = true;
 
     if (name) {
-      queryFiltered = title.name && title.name.toLowerCase().includes(name.toLowerCase());
+      filtered = title.name && title.name.toLowerCase().includes(name.toLowerCase());
     } else if (isxn) {
-      queryFiltered = title.identifiers && title.identifiers.some(i => i.id.toLowerCase().includes(isxn.toLowerCase()));
+      filtered = title.identifiers && title.identifiers.some(i => i.id.toLowerCase().includes(isxn.toLowerCase()));
     } else if (subject) {
-      queryFiltered = title.subjects && title.subjects.some(s => s.subject.toLowerCase().includes(subject.toLowerCase()));
+      filtered = title.subjects && title.subjects.some(s => s.subject.toLowerCase().includes(subject.toLowerCase()));
     } else if (publisher) {
-      queryFiltered = title.publisherName && title.publisherName.toLowerCase().includes(publisher.toLowerCase());
+      filtered = title.publisherName && title.publisherName.toLowerCase().includes(publisher.toLowerCase());
     }
 
-    if (type && type !== 'all') {
+    if (filtered && type && type !== 'all') {
       filtered = title.publicationType.toLowerCase() === type;
     }
 
-    if (selected) {
+    if (filtered && selected) {
       filtered = title.customerResources.models.some((resource) => {
         return resource.isSelected.toString() === selected;
       });
     }
 
-    return filtered && queryFiltered;
+    return filtered;
   }));
 
   this.get('/titles/:id', ({ titles }, request) => {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -174,7 +174,22 @@ export default function configure() {
   this.get('/providers/:id/packages', nestedResourceRouteFor('provider', 'packages'));
 
   // Package resources
-  this.get('/packages', searchRouteFor('packages'));
+  this.get('/packages', searchRouteFor('packages', (pkg, req) => {
+    let params = req.queryParams;
+    let type = params['filter[type]'];
+    let selected = params['filter[selected]'];
+    let filtered = true;
+
+    if (type && type !== 'all') {
+      filtered = pkg.contentType.toLowerCase() === type;
+    }
+
+    if (selected) {
+      filtered = pkg.isSelected.toString() === selected;
+    }
+
+    return filtered;
+  }));
 
   this.get('/titles/:id', ({ titles }, request) => {
     return titles.find(request.params.id);

--- a/src/components/package-search-filters.js
+++ b/src/components/package-search-filters.js
@@ -30,12 +30,12 @@ export default function PackageSearchFilters(props) {
         defaultValue: 'all',
         options: [
           { label: 'All', value: 'all' },
-          { label: 'Aggregated Full Text', value: 'aggregatedfulltext' },
-          { label: 'Abstract and Index', value: 'abstractandindex' },
-          { label: 'E-Book', value: 'ebook' },
-          { label: 'E-Journal', value: 'ejournal' },
+          { label: 'Aggregated full text', value: 'aggregatedfulltext' },
+          { label: 'Abstract and index', value: 'abstractandindex' },
+          { label: 'E-book', value: 'ebook' },
+          { label: 'E-journal', value: 'ejournal' },
           { label: 'Print', value: 'print' },
-          { label: 'Online Reference', value: 'onlinereference' },
+          { label: 'Online reference', value: 'onlinereference' },
           { label: 'Unknown', value: 'unknown' }
         ]
       }]}

--- a/src/components/package-search-filters.js
+++ b/src/components/package-search-filters.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import SearchFilters from './search-form/search-filters';
+
+/**
+ * Renders search filters with specific package filters.
+ *
+ * Once the API supports returning these filters via an endpoint, this
+ * component should not be necessary. Instead the `search-form` should
+ * recieve the available filters from the route and render the
+ * search-filters component itself.
+ */
+export default function PackageSearchFilters(props) {
+  return (
+    <SearchFilters
+      searchType="packages"
+      availableFilters={[{
+        name: 'selected',
+        label: 'Selection status',
+        defaultValue: 'all',
+        options: [
+          { label: 'All', value: 'all' },
+          { label: 'Selected', value: 'true' },
+          { label: 'Not selected', value: 'false' },
+          { label: 'Selected by EBSCO', value: 'ebsco' }
+        ]
+      }, {
+        name: 'type',
+        label: 'Content type',
+        defaultValue: 'all',
+        options: [
+          { label: 'All', value: 'all' },
+          { label: 'Aggregated Full Text', value: 'aggregatedfulltext' },
+          { label: 'Abstract and Index', value: 'abstractandindex' },
+          { label: 'E-Book', value: 'ebook' },
+          { label: 'E-Journal', value: 'ejournal' },
+          { label: 'Print', value: 'print' },
+          { label: 'Online Reference', value: 'onlinereference' },
+          { label: 'Unknown', value: 'unknown' }
+        ]
+      }]}
+      {...props}
+    />
+  );
+}

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -9,6 +9,7 @@ import Title from '../redux/title';
 
 import ProviderSearchList from '../components/provider-search-list';
 import PackageSearchList from '../components/package-search-list';
+import PackageSearchFilters from '../components/package-search-filters';
 import TitleSearchList from '../components/title-search-list';
 import TitleSearchFilters from '../components/title-search-filters';
 import SearchPaneset from '../components/search-paneset';
@@ -209,6 +210,8 @@ class SearchRoute extends Component {
 
     if (searchType === 'titles') {
       return TitleSearchFilters;
+    } else if (searchType === 'packages') {
+      return PackageSearchFilters;
     }
 
     return null;

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -14,7 +14,8 @@ describeApplication('PackageSearch', () => {
       name: i => `Package${i + 1}`,
       isSelected: i => !!i,
       titleCount: 3,
-      selectedCount: i => i
+      selectedCount: i => i,
+      contentType: i => (!i ? 'ebook' : 'ejournal')
     });
 
     this.server.create('package', 'withProvider', {
@@ -121,7 +122,120 @@ describeApplication('PackageSearch', () => {
       });
     });
 
-    describe('filtering the search results further', () => {
+    describe('filtering by content type', () => {
+      beforeEach(() => {
+        return convergeOn(() => {
+          expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(3);
+        }).then(() => (
+          PackageSearchPage.clickFilter('type', 'ebook')
+        )).then(() => (
+          PackageSearchPage.search('Package')
+        ));
+      });
+
+      it('only shows results for ebook content types', () => {
+        expect(PackageSearchPage.packageList).to.have.lengthOf(1);
+      });
+
+      it('reflects the filter in the URL query params', function () {
+        expect(this.app.history.location.search).to.include('filter[type]=ebook');
+      });
+
+      describe('clearing the filters', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(1);
+          }).then(() => (
+            PackageSearchPage.clearFilter('type')
+          )).then(() => (
+            PackageSearchPage.search('Package')
+          ));
+        });
+
+        it.still('removes the filter from the URL query params', function () {
+          expect(this.app.history.location.search).to.not.include('filter[type]');
+        });
+      });
+
+      describe('visiting the page with an existing filter', () => {
+        beforeEach(function () {
+          return convergeOn(() => {
+            expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(1);
+          }).then(() => {
+            return this.visit('/eholdings/?searchType=packages&q=Package&filter[type]=ejournal', () => {
+              expect(PackageSearchPage.$root).to.exist;
+            });
+          });
+        });
+
+        it('shows the existing filter in the search form', () => {
+          expect(PackageSearchPage.getFilter('type')).to.equal('ejournal');
+        });
+
+        it('only shows results for e-journal content types', () => {
+          expect(PackageSearchPage.packageList).to.have.lengthOf(2);
+        });
+      });
+    });
+
+    describe('filtering by selection status', () => {
+      beforeEach(() => {
+        return convergeOn(() => {
+          expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(3);
+        }).then(() => (
+          PackageSearchPage.clickFilter('selected', 'true')
+        )).then(() => (
+          PackageSearchPage.search('Package')
+        ));
+      });
+
+      it('only shows results for selected packages', () => {
+        expect(PackageSearchPage.packageList).to.have.lengthOf(2);
+        expect(PackageSearchPage.packageList[0].isSelected).to.be.true;
+      });
+
+      it('reflects the filter in the URL query params', function () {
+        expect(this.app.history.location.search).to.include('filter[selected]=true');
+      });
+
+      describe('clearing the filters', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(2);
+          }).then(() => (
+            PackageSearchPage.clearFilter('selected')
+          )).then(() => (
+            PackageSearchPage.search('Package')
+          ));
+        });
+
+        it.still('removes the filter from the URL query params', function () {
+          expect(this.app.history.location.search).to.not.include('filter[selected]');
+        });
+      });
+
+      describe('visiting the page with an existing filter', () => {
+        beforeEach(function () {
+          return convergeOn(() => {
+            expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(2);
+          }).then(() => {
+            return this.visit('/eholdings/?searchType=packages&q=Package&filter[selected]=false', () => {
+              expect(PackageSearchPage.$root).to.exist;
+            });
+          });
+        });
+
+        it('shows the existing filter in the search form', () => {
+          expect(PackageSearchPage.getFilter('selected')).to.equal('false');
+        });
+
+        it('only shows results for non-selected packages', () => {
+          expect(PackageSearchPage.packageList).to.have.lengthOf(1);
+        });
+      });
+    });
+
+    describe('with a more specific query', () => {
       beforeEach(() => {
         return convergeOn(() => {
           expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(3);

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -37,9 +37,15 @@ export default {
   get $searchField() {
     return $('[data-test-search-field]');
   },
+
   get $titleSearchField() {
     return $('[data-test-title-search-field]').find('input[name="search"]');
   },
+
+  get $searchFilters() {
+    return $('[data-test-eholdings-search-filters="packages"]');
+  },
+
   get $searchResultsItems() {
     return $('[data-test-query-list="packages"] li a');
   },
@@ -85,6 +91,23 @@ export default {
     }).then(() => {
       $('[data-test-search-submit]').trigger('click');
     });
+  },
+
+  getFilter(name) {
+    return this.$searchFilters.find(`input[name="${name}"]:checked`).val();
+  },
+
+  clickFilter(name, value) {
+    let $radio = this.$searchFilters.find(`input[name="${name}"][value="${value}"]`);
+    $radio.get(0).click();
+    return convergeOn(() => expect($radio).to.have.prop('checked'));
+  },
+
+  clearFilter(name) {
+    this.$searchFilters.find(`input[name="${name}"]`)
+      .closest('section').find('[role="heading"] button:nth-child(2)')
+      .get(0)
+      .click();
   },
 
   changeSearchType(searchType) {


### PR DESCRIPTION
## Purpose
Adds package search filters for content type and selection status using the filters `filter[type]` and `filter[selected]` respectively.

## Approach
For the most part, copy and pasted the filter component for titles and just changed the relevant pieces to reflect the package filters. Same copy-paste method for the tests as well.

## Screenshots
![gif](https://user-images.githubusercontent.com/5005153/36399609-37e73d8a-1592-11e8-87e4-95467fbcfa30.gif)

