### PR TITLE
Fix custom coverage datepicker row layout

### DIFF
--- a/src/components/coverage-form/coverage-form.css
+++ b/src/components/coverage-form/coverage-form.css
@@ -29,7 +29,7 @@
 
 .coverage-form-datepicker {
   align-self: flex-start;
-  flex: 1 1 auto;
+  flex: 1 1 200px;
   margin-right: 1em;
 }
 

--- a/src/components/custom-coverage-date/custom-coverage-date.css
+++ b/src/components/custom-coverage-date/custom-coverage-date.css
@@ -32,7 +32,7 @@
 
 .custom-coverage-date-picker {
   align-self: flex-start;
-  flex: 1 1 auto;
+  flex: 1 1 200px;
   margin-right: 1em;
 }
 


### PR DESCRIPTION
## Purpose
On both the package and the customer resource custom coverage forms, entering a value into either a start date or end date would cause the row's layout to recalculate. The datepicker inputs would then change size.

## Approach
The flex children that wrap the date pickers needed a `flex-basis` set (the third parameter of the `flex` shortcut).

## Learning
https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis

## Screenshots
### Before
![before](https://user-images.githubusercontent.com/230597/36432458-dd3d412a-161f-11e8-806e-a10af5828e6e.gif)

### After
![after](https://user-images.githubusercontent.com/230597/36432464-e030d950-161f-11e8-9ccc-72318e728a29.gif)
