### PR TITLE
Implement allow KB to add titles functionality

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -213,7 +213,7 @@ export default function configure() {
     });
 
     let body = JSON.parse(request.requestBody);
-    let { isSelected, customCoverage, visibilityData } = body.data.attributes;
+    let { isSelected, allowKbToAddTitles, customCoverage, visibilityData } = body.data.attributes;
 
     let selectedCount = isSelected ? matchingCustomerResources.length : 0;
 
@@ -223,6 +223,7 @@ export default function configure() {
     matchingPackage.update('customCoverage', customCoverage);
     matchingPackage.update('selectedCount', selectedCount);
     matchingPackage.update('visibilityData', visibilityData);
+    matchingPackage.update('allowKbToAddTitles', allowKbToAddTitles);
 
     return matchingPackage;
   });

--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -5,6 +5,7 @@ export default Factory.extend({
   titleCount: 0,
   isSelected: true,
   selectedCount: 0,
+  allowKbToAddTitles: true,
   contentType: () => faker.random.arrayElement([
     'OnlineReference',
     'AggregatedFullText',

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -5,6 +5,7 @@ import IconButton from '@folio/stripes-components/lib/IconButton';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import Button from '@folio/stripes-components/lib/Button';
 import Layout from '@folio/stripes-components/lib/Layout';
+import Icon from '@folio/stripes-components/lib/Icon';
 
 import DetailsView from './details-view';
 import QueryList from './query-list';
@@ -187,7 +188,7 @@ export default class PackageShow extends Component {
                         />
                       </div>
                       ) : (
-                        <p>Loading...</p>
+                        <Icon icon="spinner-ellipsis" />
                       )}
                   </label>
 

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -22,7 +22,8 @@ export default class PackageShow extends Component {
     fetchPackageTitles: PropTypes.func.isRequired,
     toggleSelected: PropTypes.func.isRequired,
     toggleHidden: PropTypes.func.isRequired,
-    customCoverageSubmitted: PropTypes.func.isRequired
+    customCoverageSubmitted: PropTypes.func.isRequired,
+    toggleAllowKbToAddTitles: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -34,14 +35,16 @@ export default class PackageShow extends Component {
   state = {
     showSelectionModal: false,
     packageSelected: this.props.model.isSelected,
-    packageHidden: this.props.model.visibilityData.isHidden
+    packageHidden: this.props.model.visibilityData.isHidden,
+    packageAllowedToAddTitles: this.props.model.allowKbToAddTitles
   };
 
   componentWillReceiveProps({ model }) {
     if (!model.isSaving) {
       this.setState({
         packageSelected: model.isSelected,
-        packageHidden: model.visibilityData.isHidden
+        packageHidden: model.visibilityData.isHidden,
+        packageAllowedToAddTitles: model.allowKbToAddTitles
       });
     }
   }
@@ -51,6 +54,7 @@ export default class PackageShow extends Component {
     if (this.props.model.isSelected) {
       this.setState({ showSelectionModal: true });
     } else {
+      this.setState({ packageAllowedToAddTitles: true });
       this.props.toggleSelected();
     }
   };
@@ -70,7 +74,7 @@ export default class PackageShow extends Component {
   render() {
     let { model, fetchPackageTitles, customCoverageSubmitted } = this.props;
     let { intl, router, queryParams } = this.context;
-    let { showSelectionModal, packageSelected, packageHidden } = this.state;
+    let { showSelectionModal, packageSelected, packageHidden, packageAllowedToAddTitles } = this.state;
     let historyState = router.history.location.state;
 
     return (
@@ -158,6 +162,33 @@ export default class PackageShow extends Component {
                         </div>
                       )}
                     </Layout>
+                  </label>
+
+                  <hr />
+
+                  <label
+                    data-test-eholdings-package-details-allow-add-new-titles
+                    htmlFor="package-details-toggle-allow-add-new-titles-switch"
+                  >
+                    {/* The check below for null could be refactored after RM API starts sending this attribute
+                    in list of packages to mod-kb-ebsco */}
+                    {packageAllowedToAddTitles != null ? (
+                      <div>
+                        <h4>
+                          {packageAllowedToAddTitles
+                            ? 'Allow KB to add new titles'
+                            : 'Do not allow KB to add new titles'}
+                        </h4>
+                        <ToggleSwitch
+                          onChange={this.props.toggleAllowKbToAddTitles}
+                          checked={packageAllowedToAddTitles}
+                          isPending={model.update.isPending && 'allowKbToAddTitles' in model.update.changedAttributes}
+                          id="package-details-toggle-allow-add-new-titles-switch"
+                        />
+                      </div>
+                      ) : (
+                        <p>Loading...</p>
+                      )}
                   </label>
 
                   <hr />

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -5,6 +5,7 @@ class Package {
   providerId = null;
   providerName = '';
   isSelected = false;
+  allowKbToAddTitles = null; // This could default to false after RM API starts sending this attribute in packages list to mod-kb-ebsco
   contentType = '';
   selectedCount = 0;
   titleCount = 0;

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -47,10 +47,15 @@ class PackageShowRoute extends Component {
     model.isSelected = !model.isSelected;
     model.selectedCount = model.isSelected ? model.titleCount : 0;
 
+    // If package is selected, allowKbToAddTitles should be true
+    if (model.isSelected) {
+      model.allowKbToAddTitles = true;
+    }
     // clear out any customizations before sending to server
     if (!model.isSelected) {
       model.visibilityData.isHidden = false;
       model.customCoverage = {};
+      model.allowKbToAddTitles = false;
     }
 
     updatePackage(model);
@@ -76,6 +81,12 @@ class PackageShowRoute extends Component {
     updatePackage(model);
   };
 
+  toggleAllowKbToAddTitles = () => {
+    let { model, updatePackage } = this.props;
+    model.allowKbToAddTitles = !model.allowKbToAddTitles;
+    updatePackage(model);
+  };
+
   render() {
     return (
       <View
@@ -84,6 +95,7 @@ class PackageShowRoute extends Component {
         toggleSelected={this.toggleSelected}
         toggleHidden={this.toggleHidden}
         customCoverageSubmitted={this.customCoverageSubmitted}
+        toggleAllowKbToAddTitles={this.toggleAllowKbToAddTitles}
       />
     );
   }

--- a/tests/package-add-new-titles-test.js
+++ b/tests/package-add-new-titles-test.js
@@ -1,0 +1,235 @@
+/* global describe, beforeEach, afterEach */
+import { expect } from 'chai';
+import it from './it-will';
+import { describeApplication } from './helpers';
+import PackageShowPage from './pages/package-show';
+
+describeApplication('PackageShowAllowKbToAddTitles', () => {
+  let provider,
+    pkg;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+  });
+
+  describe('visiting the package show page with a selected package allowing KB to add new titles', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', {
+        provider,
+        name: 'Cool Package',
+        contentType: 'E-Book',
+        isSelected: true,
+        allowKbToAddTitles: true
+      });
+
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays an ON Toggle', () => {
+      expect(PackageShowPage.allowKbToAddTitles).to.be.true;
+    });
+  });
+
+  describe('visiting the package show page with a selected package not allowing KB to add new titles', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', {
+        provider,
+        name: 'Cool Package',
+        contentType: 'E-Book',
+        isSelected: true,
+        allowKbToAddTitles: false
+      });
+
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays an OFF Toggle', () => {
+      expect(PackageShowPage.allowKbToAddTitles).to.be.false;
+    });
+  });
+
+  describe('visiting the package show page with a package that is not selected', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', {
+        provider,
+        name: 'Cool Package',
+        contentType: 'ebook',
+        isSelected: false
+      });
+
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('sets the state of allow KB to add titles to false', () => {
+      expect(PackageShowPage.allowKbToAddTitles).to.be.false;
+    });
+
+    it.still('does not display the allow KB to add titles toggle switch', () => {
+      expect(PackageShowPage.allowKbToAddTitlesToggle).to.not.exist;
+    });
+  });
+
+  describe('visiting the package show page with a package that is not selected and selecting a package', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', {
+        provider,
+        name: 'Cool Package',
+        contentType: 'ebook',
+        isSelected: false,
+        allowKbToAddTitles: false
+      });
+
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    beforeEach(function () {
+      /*
+       * The expectations in the convergent `it` blocks
+       * get run once every 10ms.  We were seeing test flakiness
+       * when a toggle action dispatched and resolved before an
+       * expectation had the chance to run.  We sidestep this by
+       * temporarily increasing the mirage server's response time
+       * to 50ms.
+       * TODO: control timing directly with Mirage
+       */
+      this.server.timing = 50;
+      return PackageShowPage.toggleIsSelected();
+    });
+
+    afterEach(function () {
+      this.server.timing = 0;
+    });
+
+    it('reflects the desired state (Selected)', () => {
+      expect(PackageShowPage.isSelected).to.equal(true);
+    });
+
+    it('displays an ON Toggle for allow KB to add titles', () => {
+      expect(PackageShowPage.allowKbToAddTitles).to.equal(true);
+    });
+  });
+
+  describe('visiting the package show page with a package that is selected and de-selecting a package', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', {
+        provider,
+        name: 'Cool Package',
+        contentType: 'ebook',
+        isSelected: true,
+        allowKbToAddTitles: true
+      });
+
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays an ON Toggle', () => {
+      expect(PackageShowPage.allowKbToAddTitles).to.be.true;
+    });
+
+    describe('toggling to deselect a package and confirming deselection', () => {
+      beforeEach(() => {
+        return PackageShowPage.toggleIsSelected().then(() => {
+          return PackageShowPage.confirmDeselection();
+        });
+      });
+
+      it('removes allow KB to add titles toggle switch', () => {
+        expect(PackageShowPage.allowKbToAddTitlesToggle).to.not.exist;
+      });
+    });
+
+    describe('toggling to deselect a package and canceling deselection', () => {
+      beforeEach(() => {
+        return PackageShowPage.toggleIsSelected().then(() => {
+          return PackageShowPage.cancelDeselection();
+        });
+      });
+
+      it('displays an ON Toggle', () => {
+        expect(PackageShowPage.allowKbToAddTitles).to.be.true;
+      });
+    });
+  });
+
+  describe('visiting the package details page allowing KB to add new titles and toggling it', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', 'withTitles', {
+        provider,
+        name: 'Cool Package',
+        contentType: 'E-Book',
+        isSelected: true,
+        allowKbToAddTitles: true,
+        titleCount: 5
+      });
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays an ON Toggle', () => {
+      expect(PackageShowPage.allowKbToAddTitles).to.be.true;
+    });
+
+    describe('successfully toggling add new titles', () => {
+      beforeEach(function () {
+        this.server.timing = 50;
+        return PackageShowPage.toggleAllowKbToAddTitles();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('reflects the desired state OFF', () => {
+        expect(PackageShowPage.allowKbToAddTitles).to.equal(false);
+      });
+    });
+  });
+
+  describe('visiting the package details page not allowing KB to add new titles and toggling it', () => {
+    beforeEach(function () {
+      pkg = this.server.create('package', 'withTitles', {
+        provider,
+        name: 'Cool Package',
+        contentType: 'E-Book',
+        isSelected: true,
+        allowKbToAddTitles: false,
+        titleCount: 5
+      });
+      return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays an OFF Toggle', () => {
+      expect(PackageShowPage.allowKbToAddTitles).to.be.false;
+    });
+
+    describe('successfully toggling add new titles', () => {
+      beforeEach(function () {
+        this.server.timing = 50;
+        return PackageShowPage.toggleAllowKbToAddTitles();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('reflects the desired state ON', () => {
+        expect(PackageShowPage.allowKbToAddTitles).to.equal(true);
+      });
+    });
+  });
+});

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -146,6 +146,13 @@ export default {
       $('[data-test-eholdings-package-details-hidden] input').click()
     ));
   },
+  toggleAllowKbToAddTitles() {
+    return convergeOn(() => {
+      expect($('[data-test-eholdings-package-details-allow-add-new-titles]')).to.exist;
+    }).then(() => (
+      $('[data-test-eholdings-package-details-allow-add-new-titles] input').click()
+    ));
+  },
   get isHiding() {
     return $('[data-test-eholdings-package-details-hidden] [data-test-toggle-switch]').attr('class').indexOf('is-pending--') !== -1;
   },
@@ -155,6 +162,12 @@ export default {
   },
   get isHidden() {
     return $('[data-test-eholdings-package-details-hidden] input').prop('checked') === false;
+  },
+  get allowKbToAddTitles() {
+    return $('[data-test-eholdings-package-details-allow-add-new-titles] input').prop('checked') === true;
+  },
+  get allowKbToAddTitlesToggle() {
+    return $('[package-details-toggle-allow-add-new-titles-switch]');
   },
   get allTitlesHidden() {
     return !!this.titleList.length && this.titleList.every(title => title.isHidden);


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-54, implement functionality for allowing knowledge bases to add titles at package level. For now, the only KB ui-eholdings interacts with is Ebsco KB.

## Approach
- Leverage the toggle-switch component for this functionality
- Toggle switch reflects the value of "allowKbToAddTitles" that we receive from mod-kb-ebsco
- User has the ability to toggle the switch and appropriate update is saved to "allowKbToAddTitles" in mod-kb-ebsco
- When user selects a package, then "allowKbToAddTitles" toggle should be set to true by default
- When user deselects a package, then "allowKbToAddTitles" should be reset to false
- Add associated unit tests for this functionality

#### TODOS and Open Questions
- [ ] When user refreshes the page, although the state of "allowKbToAddTitles" is true, I see an effect of this toggle go from false to true. At this point, seeing the response from backend, I do not see a reason why this should happen except that in redux, we are setting the default of "allowKbToAddTitles" to false. Elrick mentioned that this could be a VM thing too and that he would try to see if this happens on his machine using my branch. 
- Update to previous comment: Investigated to find out that RM API does not send "allowEbscoToAddTitles" in package list, so turns out that in mod-kb-ebsco we send that as null to ui-eholdings and redux state transitions from null to true which is why we see the transition of the toggle. 
To make that effect less prominent, we are rendering the toggle component only if the value is not null
- Once while testing mnaually, I was able to see that the toggle got stuck loading without updating its state with the response from the latest request, Jeffrey could not reproduce it and I could not reproduce it except that once. 

## Screenshots
![allowtitles](https://user-images.githubusercontent.com/33662516/36565406-6325a690-17ee-11e8-9d1b-1f0da04ddd62.gif)

