### PR TITLE
Make common-component for search-filters

### DIFF
--- a/src/components/search-form/search-filters.js
+++ b/src/components/search-form/search-filters.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Accordion, FilterAccordionHeader } from '@folio/stripes-components/lib/Accordion';
+import RadioButton from '@folio/stripes-components/lib/RadioButton';
+
+import styles from './search-form.css';
+
+export default function SearchFilters({
+  searchType,
+  activeFilters = {},
+  availableFilters,
+  onUpdate
+}) {
+  return (
+    <div className={styles['search-filters']} data-test-eholdings-search-filters={searchType}>
+      {availableFilters.map(({ name, label, defaultValue, options }) => (
+        <Accordion
+          key={name}
+          name={name}
+          label={label}
+          separator={false}
+          closedByDefault={false}
+          header={FilterAccordionHeader}
+          displayClearButton={!!activeFilters[name] && activeFilters[name] !== defaultValue}
+          onClearFilter={() => onUpdate({ ...activeFilters, [name]: undefined })}
+        >
+          {options.map(({ label, value }, i) => ( // eslint-disable-line no-shadow
+            <RadioButton
+              key={i}
+              name={name}
+              id={`eholdings-search-filters-${searchType}-${name}-${value}`}
+              label={label}
+              value={value}
+              checked={value === (activeFilters[name] || defaultValue)}
+              onChange={() => onUpdate({
+                ...activeFilters,
+                // if this option is a default, clear the filter
+                [name]: value === defaultValue ? undefined : value
+              })}
+            />
+          ))}
+        </Accordion>
+      ))}
+    </div>
+  );
+}
+
+SearchFilters.propTypes = {
+  searchType: PropTypes.string.isRequired,
+  activeFilters: PropTypes.object,
+  availableFilters: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    defaultValue: PropTypes.string,
+    options: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired
+    })).isRequired
+  })).isRequired,
+  onUpdate: PropTypes.func.isRequired
+};

--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -92,3 +92,14 @@
   margin: 1em 0;
   padding-left: 0;
 }
+
+.search-filters {
+
+  & section {
+    margin-bottom: 1em;
+  }
+
+  & [role="tabpanel"] {
+    padding-left: 1em;
+  }
+}

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -131,7 +131,7 @@ export default class SearchForm extends Component {
 
           {Filters && (
             <Filters
-              filter={filter}
+              activeFilters={filter}
               onUpdate={this.handleUpdateFilter}
             />
           )}

--- a/src/components/title-search-filters.js
+++ b/src/components/title-search-filters.js
@@ -16,32 +16,32 @@ export default function TitleSearchFilters(props) {
       searchType="titles"
       availableFilters={[{
         name: 'selected',
-        label: 'Selection Status',
+        label: 'Selection status',
         defaultValue: 'all',
         options: [
           { label: 'All', value: 'all' },
           { label: 'Selected', value: 'true' },
-          { label: 'Not Selected', value: 'false' },
-          { label: 'Selected By EBSCO', value: 'ebsco' }
+          { label: 'Not selected', value: 'false' },
+          { label: 'Selected by EBSCO', value: 'ebsco' }
         ]
       }, {
         name: 'type',
-        label: 'Publication Type',
+        label: 'Publication type',
         defaultValue: 'all',
         options: [
           { label: 'All', value: 'all' },
-          { label: 'Audio Book', value: 'audiobook' },
+          { label: 'Audio book', value: 'audiobook' },
           { label: 'Book', value: 'book' },
-          { label: 'Book Series', value: 'bookseries' },
+          { label: 'Book series', value: 'bookseries' },
           { label: 'Database', value: 'database' },
           { label: 'Journal', value: 'journal' },
           { label: 'Newsletter', value: 'newsletter' },
           { label: 'Newspaper', value: 'newspaper' },
           { label: 'Proceedings', value: 'proceedings' },
           { label: 'Report', value: 'report' },
-          { label: 'Streaming Audio', value: 'streamingaudio' },
-          { label: 'Streaming Video', value: 'streamingvideo' },
-          { label: 'Thesis & Dissertation', value: 'thesisdissertation' },
+          { label: 'Streaming audio', value: 'streamingaudio' },
+          { label: 'Streaming video', value: 'streamingvideo' },
+          { label: 'Thesis & dissertation', value: 'thesisdissertation' },
           { label: 'Website', value: 'website' },
           { label: 'Unspecified', value: 'unspecified' }
         ]

--- a/src/components/title-search-filters.js
+++ b/src/components/title-search-filters.js
@@ -1,92 +1,52 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Accordion, FilterAccordionHeader } from '@folio/stripes-components/lib/Accordion';
-import RadioButton from '@folio/stripes-components/lib/RadioButton';
+import SearchFilters from './search-form/search-filters';
 
-const selectedFilters = [
-  { label: 'All', value: undefined },
-  { label: 'Selected', value: 'true' },
-  { label: 'Not Selected', value: 'false' },
-  { label: 'Selected By EBSCO', value: 'ebsco' }
-];
-
-const pubtypeFilters = [
-  { label: 'All', value: 'all' },
-  { label: 'Audio Book', value: 'audiobook' },
-  { label: 'Book', value: 'book' },
-  { label: 'Book Series', value: 'bookseries' },
-  { label: 'Database', value: 'database' },
-  { label: 'Journal', value: 'journal' },
-  { label: 'Newsletter', value: 'newsletter' },
-  { label: 'Newspaper', value: 'newspaper' },
-  { label: 'Proceedings', value: 'proceedings' },
-  { label: 'Report', value: 'report' },
-  { label: 'Streaming Audio', value: 'streamingaudio' },
-  { label: 'Streaming Video', value: 'streamingvideo' },
-  { label: 'Thesis & Dissertation', value: 'thesisdissertation' },
-  { label: 'Website', value: 'website' },
-  { label: 'Unspecified', value: 'unspecified' }
-];
-
-export default function TitleSearchFilters({
-  filter = {},
-  onUpdate
-}) {
-  let { type = 'all', selected } = filter;
-
+/**
+ * Renders search filters with specific title filters.
+ *
+ * Once the API supports returning these filters via an endpoint, this
+ * component should not be necessary. Instead the `search-form` should
+ * recieve the available filters from the route and render the
+ * search-filters component itself.
+ */
+export default function TitleSearchFilters(props) {
   return (
-    <div data-test-eholdings-title-search-filters>
-      <Accordion
-        name="selected"
-        label="Selection Status"
-        separator={false}
-        header={FilterAccordionHeader}
-        displayClearButton={!!selected}
-        onClearFilter={() => onUpdate({ ...filter, selected: undefined })}
-        closedByDefault={false}
-      >
-        {selectedFilters.map(({ label, value }, i) => (
-          <RadioButton
-            key={i}
-            name="selected"
-            id={`eholdings-title-search-filters-selected-${value}`}
-            label={label}
-            value={value}
-            checked={value === selected}
-            onChange={() => onUpdate({ ...filter, selected: value })}
-          />
-        ))}
-      </Accordion>
-
-      <hr />
-
-      <Accordion
-        name="pubtype"
-        label="Publication Type"
-        separator={false}
-        header={FilterAccordionHeader}
-        displayClearButton={type !== 'all'}
-        onClearFilter={() => onUpdate({ ...filter, type: undefined })}
-        closedByDefault={false}
-      >
-        {pubtypeFilters.map(({ label, value }, i) => (
-          <RadioButton
-            key={i}
-            name="pubtype"
-            id={`eholdings-title-search-filters-pubtype-${value}`}
-            label={label}
-            value={value}
-            checked={value === type}
-            onChange={() => onUpdate({ ...filter, type: value })}
-          />
-        ))}
-      </Accordion>
-    </div>
+    <SearchFilters
+      searchType="titles"
+      availableFilters={[{
+        name: 'selected',
+        label: 'Selection Status',
+        defaultValue: 'all',
+        options: [
+          { label: 'All', value: 'all' },
+          { label: 'Selected', value: 'true' },
+          { label: 'Not Selected', value: 'false' },
+          { label: 'Selected By EBSCO', value: 'ebsco' }
+        ]
+      }, {
+        name: 'type',
+        label: 'Publication Type',
+        defaultValue: 'all',
+        options: [
+          { label: 'All', value: 'all' },
+          { label: 'Audio Book', value: 'audiobook' },
+          { label: 'Book', value: 'book' },
+          { label: 'Book Series', value: 'bookseries' },
+          { label: 'Database', value: 'database' },
+          { label: 'Journal', value: 'journal' },
+          { label: 'Newsletter', value: 'newsletter' },
+          { label: 'Newspaper', value: 'newspaper' },
+          { label: 'Proceedings', value: 'proceedings' },
+          { label: 'Report', value: 'report' },
+          { label: 'Streaming Audio', value: 'streamingaudio' },
+          { label: 'Streaming Video', value: 'streamingvideo' },
+          { label: 'Thesis & Dissertation', value: 'thesisdissertation' },
+          { label: 'Website', value: 'website' },
+          { label: 'Unspecified', value: 'unspecified' }
+        ]
+      }]}
+      {...props}
+    />
   );
 }
-
-TitleSearchFilters.propTypes = {
-  filter: PropTypes.object,
-  onUpdate: PropTypes.func.isRequired
-};

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -33,7 +33,7 @@ export default {
     return $('[data-test-search-field]');
   },
   get $searchFilters() {
-    return $('[data-test-eholdings-title-search-filters]');
+    return $('[data-test-eholdings-search-filters="titles"]');
   },
 
   get $searchResultsItems() {

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -152,7 +152,7 @@ describeApplication('TitleSearch', () => {
         return convergeOn(() => {
           expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
         }).then(() => (
-          TitleSearchPage.clickFilter('pubtype', 'book')
+          TitleSearchPage.clickFilter('type', 'book')
         )).then(() => (
           TitleSearchPage.search('Title')
         ));
@@ -172,7 +172,7 @@ describeApplication('TitleSearch', () => {
           return convergeOn(() => {
             expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(1);
           }).then(() => (
-            TitleSearchPage.clearFilter('pubtype')
+            TitleSearchPage.clearFilter('type')
           )).then(() => (
             TitleSearchPage.search('Title')
           ));
@@ -195,7 +195,7 @@ describeApplication('TitleSearch', () => {
         });
 
         it('shows the existing filter in the search form', () => {
-          expect(TitleSearchPage.getFilter('pubtype')).to.equal('journal');
+          expect(TitleSearchPage.getFilter('type')).to.equal('journal');
         });
 
         it('only shows results for journal publication types', () => {
@@ -415,7 +415,7 @@ describeApplication('TitleSearch', () => {
         }).then(() => (
           TitleSearchPage.selectSearchField('isxn')
         )).then(() => (
-          TitleSearchPage.clickFilter('pubtype', 'book')
+          TitleSearchPage.clickFilter('type', 'book')
         )).then(() => (
           TitleSearchPage.search('999-999')
         ));


### PR DESCRIPTION
## Purpose
Styles the search filters to match the stripes search-and-sort filter styles. 

## Approach
Since these styles will be used in other search filters, a common component was made

#### TODOS
- The current title-search-filters will be unnecessary once the API supports returning available filters via an endpoint. Instead, we can have the search-form render the search-filters component directly with the data returned from the API.

## Screenshots
*Before*
![image](https://user-images.githubusercontent.com/5005153/36492689-542da008-16f3-11e8-88a1-6fa25e5f0d1a.png)

*After*
![image](https://user-images.githubusercontent.com/5005153/36492735-7292e558-16f3-11e8-96fe-bf9157231197.png)
