### PR TITLE
Make coverage and embargo editing UX consistent

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -280,11 +280,17 @@ export default function configure() {
     let matchingCustomerResource = customerResources.find(request.params.id);
 
     let body = JSON.parse(request.requestBody);
-    let { isSelected, visibilityData, customCoverages } = body.data.attributes;
+    let {
+      isSelected,
+      visibilityData,
+      customCoverages,
+      customEmbargoPeriod
+    } = body.data.attributes;
 
     matchingCustomerResource.update('isSelected', isSelected);
     matchingCustomerResource.update('visibilityData', visibilityData);
     matchingCustomerResource.update('customCoverages', customCoverages);
+    matchingCustomerResource.update('customEmbargoPeriod', customEmbargoPeriod);
 
     return matchingCustomerResource;
   });

--- a/src/components/custom-embargo/custom-embargo.css
+++ b/src/components/custom-embargo/custom-embargo.css
@@ -1,10 +1,11 @@
-.custom-embargo-form,
-.custom-emabrgo-form-editing {
-  padding: 0.5em;
-}
+@import '@folio/stripes-components/lib/variables';
 
-.custom-embargo-form-editing {
-  background: #e6f3ff;
+.custom-embargo-form {
+  padding: 0.5em 1em 1em;
+
+  &.is-editing {
+    background: #e6f3ff;
+  }
 }
 
 .custom-embargo-add-button {
@@ -22,16 +23,20 @@
 }
 
 .custom-embargo-action-buttons {
+  border-top: 1px solid var(--minor-divider-color);
   display: flex;
   margin-top: 1em;
-  padding: 0.5em;
+  padding-top: 1em;
   align-items: flex-start;
+}
+
+.custom-embargo-action-button {
+  margin-right: 0.25em;
 }
 
 .custom-embargo-container {
   display: flex;
   align-items: flex-start;
-  padding: 0.5em;
 }
 
 .custom-embargo-text-field {
@@ -45,5 +50,5 @@
 }
 
 .error-message {
-  color: red;
+  color: var(--error);
 }

--- a/src/components/customer-resource-coverage/customer-resource-coverage.css
+++ b/src/components/customer-resource-coverage/customer-resource-coverage.css
@@ -1,7 +1,7 @@
 @import '@folio/stripes-components/lib/variables';
 
 .coverage-form {
-  padding: 1em 0 0.5em;
+  padding: 0.5em 1em 1em;
 
   &.is-editing {
     background: #e6f3ff;

--- a/src/components/customer-resource-coverage/customer-resource-coverage.js
+++ b/src/components/customer-resource-coverage/customer-resource-coverage.js
@@ -1,14 +1,16 @@
 import React, { Component } from 'react';
 import { Field, FieldArray, reduxForm } from 'redux-form';
 import PropTypes from 'prop-types';
-import classNames from 'classnames/bind';
 import moment from 'moment';
+import isEqual from 'lodash/isEqual';
+import classNames from 'classnames/bind';
 
 import Datepicker from '@folio/stripes-components/lib/Datepicker';
 import Button from '@folio/stripes-components/lib/Button';
 import Icon from '@folio/stripes-components/lib/Icon';
 import IconButton from '@folio/stripes-components/lib/IconButton';
 import CoverageDateList from '../coverage-date-list';
+import KeyValueLabel from '../key-value-label';
 import styles from './customer-resource-coverage.css';
 
 const cx = classNames.bind(styles);
@@ -32,7 +34,7 @@ class CustomerResourceCoverage extends Component {
 
   componentWillReceiveProps(nextProps) {
     let wasPending = this.props.isPending && !nextProps.isPending;
-    let needsUpdate = this.props.initialValues.customCoverages !== nextProps.initialValues.customCoverages;
+    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
 
     if (wasPending || needsUpdate) {
       this.setState({ isEditing: false });
@@ -54,13 +56,11 @@ class CustomerResourceCoverage extends Component {
 
   renderDatepicker = ({ input, label, meta }) => {
     return (
-      <div>
-        <Datepicker
-          label={label}
-          input={input}
-          meta={meta}
-        />
-      </div>
+      <Datepicker
+        label={label}
+        input={input}
+        meta={meta}
+      />
     );
   }
 
@@ -182,12 +182,15 @@ class CustomerResourceCoverage extends Component {
     } else if (customCoverages.length && customCoverages[0].beginCoverage !== '') {
       contents = (
         <div
-          data-test-eholdings-coverage-form-display
           className={styles['coverage-form-display']}
         >
-          <CoverageDateList
-            coverageArray={customCoverages}
-          />
+          <KeyValueLabel label="Custom">
+            <span data-test-eholdings-coverage-form-display>
+              <CoverageDateList
+                coverageArray={customCoverages}
+              />
+            </span>
+          </KeyValueLabel>
           <div data-test-eholdings-coverage-form-edit-button>
             <IconButton icon="edit" onClick={this.handleEdit} />
           </div>
@@ -216,10 +219,8 @@ class CustomerResourceCoverage extends Component {
           'is-editing': this.state.isEditing
         })}
       >
-        <fieldset>
-          <legend className={styles['coverage-form-legend']}>Coverage dates</legend>
-          {contents}
-        </fieldset>
+        <h4 className={styles['coverage-form-legend']}>Coverage dates</h4>
+        {contents}
       </div>
     );
   }

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -81,9 +81,6 @@ export default class CustomerResourceShow extends Component {
     let hasManagedEmbargoPeriod = model.managedEmbargoPeriod &&
       model.managedEmbargoPeriod.embargoUnit &&
       model.managedEmbargoPeriod.embargoValue;
-    let hasCustomEmbargoPeriod = model.customEmbargoPeriod &&
-      model.customEmbargoPeriod.embargoUnit &&
-      model.customEmbargoPeriod.embargoValue;
     let customEmbargoValue = model.customEmbargoPeriod && model.customEmbargoPeriod.embargoValue;
     let customEmbargoUnit = model.customEmbargoPeriod && model.customEmbargoPeriod.embargoUnit;
 
@@ -248,22 +245,12 @@ export default class CustomerResourceShow extends Component {
                   />
 
                   <hr />
-                  <KeyValueLabel label="Custom embargo period">
-                    {hasCustomEmbargoPeriod ? (
-                      <div data-test-eholdings-customer-resource-show-custom-embargo-period>
-                        <CustomEmbargoForm
-                          initialValues={{ customEmbargoValue, customEmbargoUnit }}
-                          onSubmit={customEmbargoSubmitted}
-                          isPending={model.update.isPending && 'customEmbargoPeriod' in model.update.changedAttributes}
-                        />
-                      </div>
-                    ) : (
-                      <CustomEmbargoForm
-                        initialValues={{ customEmbargoValue, customEmbargoUnit }}
-                        onSubmit={customEmbargoSubmitted}
-                      />
-                    )}
-                  </KeyValueLabel>
+
+                  <CustomEmbargoForm
+                    initialValues={{ customEmbargoValue, customEmbargoUnit }}
+                    onSubmit={customEmbargoSubmitted}
+                    isPending={model.update.isPending && 'customEmbargoPeriod' in model.update.changedAttributes}
+                  />
                 </div>
               )}
 

--- a/src/components/package-custom-coverage/package-custom-coverage.css
+++ b/src/components/package-custom-coverage/package-custom-coverage.css
@@ -1,17 +1,23 @@
 @import '@folio/stripes-components/lib/variables';
 
-.custom-coverage-form,
-.custom-coverage-form-editing {
-  padding: 0.5em;
-}
+.custom-coverage-form {
+  padding: 0.5em 1em 1em;
 
-.custom-coverage-form-editing {
-  background: #e6f3ff;
+  &.is-editing {
+    background: #e6f3ff;
+  }
 }
 
 .custom-coverage-action-buttons {
+  border-top: 1px solid var(--minor-divider-color);
   display: flex;
   margin-top: 1em;
+  padding-top: 1em;
+  align-items: flex-start;
+}
+
+.custom-coverage-action-button {
+  margin-right: 0.25em;
 }
 
 .custom-coverage-date-display {
@@ -19,21 +25,38 @@
   align-items: center;
 }
 
-.custom-coverage-dates {
+.custom-coverage-date-range-rows {
+  list-style-type: none;
+  padding: 0;
+}
+
+.custom-coverage-date-range-row {
   display: flex;
   align-items: flex-start;
 }
 
-.custom-coverage-date-clear-row {
-  flex: 0 0 3em;
-  margin-top: 1.5em;
-  text-align: center;
-}
-
-.custom-coverage-date-picker {
+.custom-coverage-datepicker {
   align-self: flex-start;
   flex: 1 1 200px;
   margin-right: 1em;
+}
+
+.custom-coverage-date-range-clear-row {
+  flex: 0 0 3em;
+  margin-top: 2.25em;
+  text-align: center;
+
+  @media (--mediumUp) {
+    margin-top: 1.5em;
+  }
+}
+
+.custom-coverage-add-row-button button {
+  width: 100%;
+
+  @media (--mediumUp) {
+    width: auto;
+  }
 }
 
 .custom-coverage-add-button {

--- a/src/components/package-custom-coverage/package-custom-coverage.js
+++ b/src/components/package-custom-coverage/package-custom-coverage.js
@@ -1,20 +1,24 @@
 import React, { Component } from 'react';
-import { Field, reduxForm } from 'redux-form';
+import { Field, FieldArray, reduxForm } from 'redux-form';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import isEqual from 'lodash/isEqual';
+import classNames from 'classnames/bind';
 
 import Datepicker from '@folio/stripes-components/lib/Datepicker';
+import Icon from '@folio/stripes-components/lib/Icon';
 import IconButton from '@folio/stripes-components/lib/IconButton';
 import Button from '@folio/stripes-components/lib/Button';
+import KeyValueLabel from '../key-value-label';
 import styles from './package-custom-coverage.css';
-
 import { formatISODateWithoutTime } from '../utilities';
+
+const cx = classNames.bind(styles);
 
 class PackageCustomCoverage extends Component {
   static propTypes = {
     initialValues: PropTypes.shape({
-      beginCoverage: PropTypes.string,
-      endCoverage: PropTypes.string
+      customCoverages: PropTypes.array
     }).isRequired,
     handleSubmit: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
@@ -32,17 +36,96 @@ class PackageCustomCoverage extends Component {
     isEditing: false
   }
 
+  componentWillReceiveProps(nextProps) {
+    let wasPending = this.props.isPending && !nextProps.isPending;
+    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+
+    if (wasPending || needsUpdate) {
+      this.setState({ isEditing: false });
+    }
+  }
+
   renderDatepicker = ({ input, label, meta }) => {
     return (
-      <div>
-        <Datepicker
-          label={label}
-          input={input}
-          meta={meta}
-        />
-      </div>
+      <Datepicker
+        label={label}
+        input={input}
+        meta={meta}
+      />
     );
   }
+
+  renderCoverageFields = ({ fields }) => {
+    return (
+      <div>
+        {fields.length === 0 ? (
+          <div>
+            <p data-test-eholdings-custom-coverage-no-rows-left>
+              No date range set. Saving will remove custom coverage.
+            </p>
+            <div
+              className={styles['custom-coverage-add-row-button']}
+              data-test-eholdings-custom-coverage-add-row-button
+            >
+              <Button
+                disabled={this.props.isPending}
+                type="button"
+                role="button"
+                onClick={() => fields.push({})}
+              >
+                + Add date range
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <ul className={styles['custom-coverage-date-range-rows']}>
+            {fields.map((dateRange, index) => (
+              <li
+                data-test-eholdings-custom-coverage-date-range-row
+                key={index}
+                className={styles['custom-coverage-date-range-row']}
+              >
+                <div
+                  data-test-eholdings-custom-coverage-date-range-begin
+                  className={styles['custom-coverage-datepicker']}
+                >
+                  <Field
+                    name={`${dateRange}.beginCoverage`}
+                    type="text"
+                    component={this.renderDatepicker}
+                    label="Start date"
+                  />
+                </div>
+                <div
+                  data-test-eholdings-custom-coverage-date-range-end
+                  className={styles['custom-coverage-datepicker']}
+                >
+                  <Field
+                    name={`${dateRange}.endCoverage`}
+                    type="text"
+                    component={this.renderDatepicker}
+                    label="End date"
+                  />
+                </div>
+
+                <div
+                  data-test-eholdings-custom-coverage-remove-row-button
+                  className={styles['custom-coverage-date-range-clear-row']}
+                >
+                  <IconButton
+                    disabled={this.props.isPending}
+                    icon="hollowX"
+                    onClick={() => fields.remove(index)}
+                    size="small"
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  };
 
   handleEditCustomCoverage = (event) => {
     let isEditing = !this.state.isEditing;
@@ -58,99 +141,87 @@ class PackageCustomCoverage extends Component {
     this.props.initialize(this.props.initialValues);
   }
 
-  handleDeleteCustomCoverage = (event) => {
-    event.preventDefault();
-    let data = {
-      beginCoverage: '',
-      endCoverage: ''
-    };
-
-    this.handleSubmit(data);
-  }
-
-  handleSubmit = (data) => {
-    this.setState({
-      isEditing: false
-    });
-    this.props.onSubmit(data);
-  }
-
-
   render() {
-    let { pristine, isPending } = this.props;
+    let { pristine, isPending, handleSubmit, onSubmit } = this.props;
     let { intl } = this.context;
+    let contents;
+    let { customCoverages } = this.props.initialValues;
 
-    const { beginCoverage, endCoverage } = this.props.initialValues;
     if (this.state.isEditing) {
-      return (
-        <form onSubmit={this.props.handleSubmit(this.handleSubmit)}>
-          <div
-            data-test-eholdings-package-details-custom-coverage-inputs
-            className={styles['custom-coverage-form-editing']}
-          >
-            <div className={styles['custom-coverage-dates']}>
-              <div data-test-eholdings-package-details-custom-begin-coverage className={styles['custom-coverage-date-picker']}>
-                <Field
-                  name='beginCoverage'
-                  component={this.renderDatepicker}
-                  label="Start Date"
-                />
-              </div>
-              <div data-test-eholdings-package-details-custom-end-coverage className={styles['custom-coverage-date-picker']}>
-                <Field
-                  name='endCoverage'
-                  component={this.renderDatepicker}
-                  label="End Date"
-                />
-              </div>
-              <div className={styles['custom-coverage-date-clear-row']}>
-                {this.props.initialValues.beginCoverage && (
-                  <IconButton icon="trashBin" onClick={this.handleDeleteCustomCoverage} size="small" />
-                )}
-              </div>
+      contents = (
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <FieldArray name="customCoverages" component={this.renderCoverageFields} />
+          <div className={styles['custom-coverage-action-buttons']}>
+            <div
+              data-test-eholdings-package-details-cancel-custom-coverage-button
+              className={styles['custom-coverage-action-button']}
+            >
+              <Button
+                disabled={isPending}
+                type="button"
+                role="button"
+                onClick={this.handleCancelCustomCoverage}
+                marginBottom0 // gag
+              >
+                Cancel
+              </Button>
             </div>
-            <div className={styles['custom-coverage-action-buttons']}>
-              <div data-test-eholdings-package-details-cancel-custom-coverage-button>
-                <Button disabled={isPending} type="button" role="button" onClick={this.handleCancelCustomCoverage}>
-                  Cancel
-                </Button>
-              </div>
-              <div data-test-eholdings-package-details-save-custom-coverage-button>
-                <Button disabled={pristine} type="submit" buttonStyle="primary" role="button">
-                  Save
-                </Button>
-              </div>
+            <div
+              data-test-eholdings-package-details-save-custom-coverage-button
+              className={styles['custom-coverage-action-button']}
+            >
+              <Button
+                disabled={pristine || isPending}
+                type="submit"
+                buttonStyle="primary"
+                role="button"
+                marginBottom0 // gag
+              >
+                {isPending ? 'Saving' : 'Save' }
+              </Button>
             </div>
+            {isPending && (
+              <Icon icon="spinner-ellipsis" />
+            )}
           </div>
         </form>
       );
-    } else if (beginCoverage) {
-      return (
-        <div className={styles['custom-coverage-form']}>
-          <div className={styles['custom-coverage-date-display']}>
+    } else if (customCoverages.length && customCoverages[0].beginCoverage !== '') {
+      contents = (
+        <div className={styles['custom-coverage-date-display']}>
+          <KeyValueLabel label="Custom">
             <div data-test-eholdings-package-details-custom-coverage-display className={styles['custom-coverage-dates']}>
-              {formatISODateWithoutTime(beginCoverage, intl)} - {formatISODateWithoutTime(endCoverage, intl) || 'Present'}
+              {formatISODateWithoutTime(customCoverages[0].beginCoverage, intl)} - {formatISODateWithoutTime(customCoverages[0].endCoverage, intl) || 'Present'}
             </div>
-            <div data-test-eholdings-package-details-edit-custom-coverage-button>
-              <IconButton icon="edit" onClick={this.handleEditCustomCoverage} />
-            </div>
+          </KeyValueLabel>
+          <div data-test-eholdings-package-details-edit-custom-coverage-button>
+            <IconButton icon="edit" onClick={this.handleEditCustomCoverage} />
           </div>
         </div>
       );
     } else {
-      return (
-        <div className={styles['custom-coverage-form']}>
-          <div data-test-eholdings-package-details-custom-coverage-button>
-            <Button
-              type="button"
-              onClick={this.handleEditCustomCoverage}
-            >
-              Add Custom Coverage
-            </Button>
-          </div>
+      contents = (
+        <div data-test-eholdings-package-details-custom-coverage-button>
+          <Button
+            type="button"
+            onClick={this.handleEditCustomCoverage}
+          >
+            Set custom coverage
+          </Button>
         </div>
       );
     }
+
+    return (
+      <div
+        className={cx(styles['custom-coverage-form'], {
+          'is-editing': this.state.isEditing
+        })}
+      >
+        <h4>Coverage dates</h4>
+        {contents}
+      </div>
+    );
   }
 }
 
@@ -162,15 +233,21 @@ function validate(values, props) {
   let dateFormat = moment.localeData()._longDateFormat.L;
   const errors = {};
 
-  if (!values.beginCoverage || !moment(values.beginCoverage).isValid()) {
-    errors.beginCoverage = `Enter date in ${dateFormat} format.`;
-  }
+  values.customCoverages.forEach((dateRange, index) => {
+    let dateRangeErrors = {};
 
-  if (values.endCoverage && moment(values.beginCoverage).isAfter(moment(values.endCoverage))) {
-    errors.beginCoverage = 'Start date must be before end date.';
-  }
+    if (!dateRange.beginCoverage || !moment(dateRange.beginCoverage).isValid()) {
+      dateRangeErrors.beginCoverage = `Enter date in ${dateFormat} format.`;
+    }
 
-  return errors;
+    if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
+      dateRangeErrors.beginCoverage = 'Start date must be before end date.';
+    }
+
+    errors[index] = dateRangeErrors;
+  });
+
+  return { customCoverages: errors };
 }
 
 export default reduxForm({

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -73,6 +73,11 @@ export default class PackageShow extends Component {
     let { showSelectionModal, packageSelected, packageHidden } = this.state;
     let historyState = router.history.location.state;
 
+    let customCoverages = [{
+      beginCoverage: model.customCoverage.beginCoverage,
+      endCoverage: model.customCoverage.endCoverage
+    }];
+
     return (
       <div>
         <DetailsView
@@ -162,15 +167,13 @@ export default class PackageShow extends Component {
 
                   <hr />
 
-                  <KeyValueLabel label="Custom Coverage">
-                    <div data-test-eholdings-package-details-custom-coverage>
-                      <PackageCustomCoverage
-                        initialValues={model.customCoverage}
-                        onSubmit={customCoverageSubmitted}
-                        isPending={model.update.isPending && 'customCoverage' in model.update.changedAttributes}
-                      />
-                    </div>
-                  </KeyValueLabel>
+                  <div data-test-eholdings-package-details-custom-coverage>
+                    <PackageCustomCoverage
+                      initialValues={{ customCoverages }}
+                      onSubmit={customCoverageSubmitted}
+                      isPending={model.update.isPending && 'customCoverage' in model.update.changedAttributes}
+                    />
+                  </div>
                 </div>
               )}
 

--- a/src/routes/customer-resource-show.js
+++ b/src/routes/customer-resource-show.js
@@ -56,8 +56,10 @@ class CustomerResourceShowRoute extends Component {
 
   customEmbargoSubmitted = (values) => {
     let { model, updateResource } = this.props;
-    model.customEmbargoPeriod.embargoValue = values.customEmbargoValue;
-    model.customEmbargoPeriod.embargoUnit = values.customEmbargoUnit;
+    model.customEmbargoPeriod = {
+      embargoValue: values.customEmbargoValue,
+      embargoUnit: values.customEmbargoUnit
+    };
     updateResource(model);
   }
 

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -71,8 +71,18 @@ class PackageShowRoute extends Component {
 
   customCoverageSubmitted = (values) => {
     let { model, updatePackage } = this.props;
-    model.customCoverage.beginCoverage = !values.beginCoverage ? null : moment(values.beginCoverage).format('YYYY-MM-DD');
-    model.customCoverage.endCoverage = !values.endCoverage ? null : moment(values.endCoverage).format('YYYY-MM-DD');
+    let beginCoverage = '';
+    let endCoverage = '';
+
+    if (values.customCoverages[0]) {
+      beginCoverage = !values.customCoverages[0].beginCoverage ? '' : moment(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD');
+      endCoverage = !values.customCoverages[0].endCoverage ? '' : moment(values.customCoverages[0].endCoverage).format('YYYY-MM-DD');
+    }
+
+    model.customCoverage = {
+      beginCoverage,
+      endCoverage
+    };
     updatePackage(model);
   };
 

--- a/tests/customer-resource-deselection-test.js
+++ b/tests/customer-resource-deselection-test.js
@@ -127,8 +127,7 @@ describeApplication('CustomerResourceDeselection', () => {
             });
 
             it('removes custom embargo', () => {
-              expect(resource.customEmbargoPeriod.embargoUnit).to.equal(null);
-              expect(resource.customEmbargoPeriod.embargoValue).to.equal(0);
+              expect(ResourcePage.customEmbargoPeriod).to.equal('');
             });
 
             it('is not hidden', () => {

--- a/tests/package-custom-coverage-test.js
+++ b/tests/package-custom-coverage-test.js
@@ -96,7 +96,8 @@ describeApplication('PackageCustomCoverage', () => {
       });
 
       it('displays the date input fields', () => {
-        expect(PackageShowPage.$customCoverageInputs).to.exist;
+        expect(PackageShowPage.$beginDateField).to.exist;
+        expect(PackageShowPage.$endDateField).to.exist;
       });
     });
   });
@@ -133,7 +134,8 @@ describeApplication('PackageCustomCoverage', () => {
       });
 
       it('displays custom coverage date inputs', () => {
-        expect(PackageShowPage.$customCoverageInputs).to.exist;
+        expect(PackageShowPage.$beginDateField).to.exist;
+        expect(PackageShowPage.$endDateField).to.exist;
       });
 
       describe('entering valid coverage', () => {
@@ -171,7 +173,8 @@ describeApplication('PackageCustomCoverage', () => {
             });
 
             it('removes the custom coverage input fields', () => {
-              expect(PackageShowPage.$customCoverageInputs).to.not.exist;
+              expect(PackageShowPage.$beginDateField).to.not.exist;
+              expect(PackageShowPage.$endDateField).to.not.exist;
             });
 
             it('does not display the button to add custom coverage', () => {
@@ -202,7 +205,8 @@ describeApplication('PackageCustomCoverage', () => {
             });
 
             it('removes the custom coverage input fields', () => {
-              expect(PackageShowPage.$customCoverageInputs).to.not.exist;
+              expect(PackageShowPage.$beginDateField).to.not.exist;
+              expect(PackageShowPage.$endDateField).to.not.exist;
             });
 
             it('does not display the button to add custom coverage', () => {
@@ -265,7 +269,8 @@ describeApplication('PackageCustomCoverage', () => {
         });
 
         it('removes the custom coverage input fields', () => {
-          expect(PackageShowPage.$customCoverageInputs).to.not.exist;
+          expect(PackageShowPage.$beginDateField).to.not.exist;
+          expect(PackageShowPage.$endDateField).to.not.exist;
         });
 
         it('displays the button to add custom coverage', () => {

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -114,7 +114,7 @@ export default {
   },
 
   get customEmbargoPeriod() {
-    return $('[data-test-eholdings-customer-resource-show-custom-embargo-period]').text();
+    return $('[data-test-eholdings-customer-resource-custom-embargo-display]').text();
   },
 
   get identifiersList() {

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -139,6 +139,7 @@ export default {
   get titleList() {
     return $('[data-test-query-list="package-titles"] li a').toArray().map(createTitleObject);
   },
+
   toggleIsHidden() {
     return convergeOn(() => {
       expect($('[data-test-eholdings-package-details-hidden]')).to.exist;
@@ -146,6 +147,7 @@ export default {
       $('[data-test-eholdings-package-details-hidden] input').click()
     ));
   },
+
   get isHiding() {
     return $('[data-test-eholdings-package-details-hidden] [data-test-toggle-switch]').attr('class').indexOf('is-pending--') !== -1;
   },
@@ -153,6 +155,7 @@ export default {
   get isHiddenToggleable() {
     return $('[data-test-eholdings-package-details-hidden] input[type=checkbox]').prop('disabled') === false;
   },
+
   get isHidden() {
     return $('[data-test-eholdings-package-details-hidden] input').prop('checked') === false;
   },
@@ -184,23 +187,19 @@ export default {
     return $('[data-test-eholdings-package-details-cancel-custom-coverage-button] button');
   },
 
-  get $customCoverageInputs() {
-    return $('[data-test-eholdings-package-details-custom-coverage-inputs]');
-  },
-
   get $customCoverageAddButton() {
     return $('[data-test-eholdings-package-details-custom-coverage-button] button');
   },
 
   get $beginDateField() {
-    return $('[data-test-eholdings-package-details-custom-begin-coverage] input')[0];
+    return $('[data-test-eholdings-custom-coverage-date-range-begin] input')[0];
   },
   get $endDateField() {
-    return $('[data-test-eholdings-package-details-custom-end-coverage] input')[0];
+    return $('[data-test-eholdings-custom-coverage-date-range-end] input')[0];
   },
 
   get validationError() {
-    return $('[data-test-eholdings-package-details-custom-begin-coverage] [class^="feedbackError"]').text();
+    return $('[data-test-eholdings-custom-coverage-date-range-begin] [class^="feedbackError"]').text();
   },
 
   inputBeginDate(beginDate) {
@@ -210,12 +209,15 @@ export default {
   inputEndDate(endDate) {
     return advancedFillIn(this.$endDateField, endDate);
   },
+
   pressEnterBeginDate() {
     pressEnter(this.$beginDateField);
   },
+
   pressEnterEndDate() {
     pressEnter(this.$endDateField);
   },
+
   clearBeginDate() {
     let $clearButton = $('[data-test-eholdings-package-details-custom-begin-coverage]')
       .find('button[id^=datepicker-clear-button]');
@@ -225,6 +227,7 @@ export default {
       $clearButton.click();
     });
   },
+
   clearEndDate() {
     let $clearButton = $('[data-test-eholdings-package-details-custom-end-coverage]')
       .find('button[id^=datepicker-clear-button]');
@@ -234,9 +237,11 @@ export default {
       $clearButton.click();
     });
   },
+
   blurEndDate() {
     this.$endDateField.blur();
   },
+
   blurBeginDate() {
     this.$beginDateField.blur();
   }


### PR DESCRIPTION
## Purpose
The inline editing for package custom coverage, package-title custom coverage, and package-title custom embargo should be very similar experiences.

## Approach
Now they have consistent designs and the same `isPending` behavior. Package custom coverage borrowed the `FieldArray` setup from package-title custom coverage, but with modifications that it can only have one row.

## Screenshots
![package custom coverage](https://user-images.githubusercontent.com/230597/36506207-840ff65e-171b-11e8-96b1-70522d2319f8.gif)

![custom embargo](https://user-images.githubusercontent.com/230597/36506212-861ae3e6-171b-11e8-80db-5102d366a7f2.gif)


