### PR TITLE
Fix eslint no-restricted-globals errors

### DIFF
--- a/src/components/custom-embargo/custom-embargo.js
+++ b/src/components/custom-embargo/custom-embargo.js
@@ -93,7 +93,7 @@ class CustomEmbargoForm extends Component {
                   <Field
                     name='customEmbargoValue'
                     type="number"
-                    parse={value => (!value ? null : (isNaN(value) ? '' : Number(value)))} // eslint-disable-line no-restricted-globals
+                    parse={value => (!value ? null : (Number.isNaN(value) ? '' : Number(value)))}
                     component={this.renderTextField}
                   />
                 </div>
@@ -163,7 +163,7 @@ class CustomEmbargoForm extends Component {
 const validate = (values) => {
   const errors = {};
 
-  if (isNaN(Number(values.customEmbargoValue))) { // eslint-disable-line no-restricted-globals
+  if (Number.isNaN(Number(values.customEmbargoValue))) {
     errors.customEmbargoValue = 'Must be a number';
   }
 


### PR DESCRIPTION
## Purpose
We had disabled linting on a few lines due to the `no-restricted-globals` rule.

## Learning
We can follow the rule just by changing `isNaN()` to `Number.isNaN()`.
https://github.com/airbnb/javascript#standard-library--isnan