### PR TITLE
Get global styles to appear in karma runs

### DIFF
--- a/src/routes/application/application.css
+++ b/src/routes/application/application.css
@@ -1,3 +1,6 @@
+/* Supposed to be coming from webpack entry, but we explicitly import
+   here so karma-webpack will pick it up.
+ */
 @import '@folio/stripes-components/lib/global';
 
 .eholdings-application {

--- a/src/routes/application/application.css
+++ b/src/routes/application/application.css
@@ -1,3 +1,5 @@
+@import '@folio/stripes-components/lib/global';
+
 .eholdings-application {
   width: 100%;
 }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -36,6 +36,7 @@ export function describeApplication(name, setup, describe = window.describe) {
     beforeEach(function () {
       rootElement = document.createElement('div');
       rootElement.id = 'react-testing';
+      rootElement.style = 'height: 100%;';
       document.body.appendChild(rootElement);
 
       this.server = startMirage(setup.scenarios);


### PR DESCRIPTION
## Purpose
Karma runs haven't been loading in the `global.css` from `stripes-components`. It wasn't that big of a deal until I realized an absolutely positioned `Paneset` was inside of a relatively-positioned div with no height set. That causes the parent to have a calculated height of 0. The contents of the `Paneset` (the eHoldings settings form) weren't visible in Karma runs, even though the contents were in the DOM.
https://issues.folio.org/browse/UIEH-111

## Approach
This feels hacky (a superior strategy would involve changes in the `stripes` ecosystem), but it solves the immediate problem that the eHoldings settings form wasn't visible.

This still doesn't load Source Sans Pro, so the font in karma falls back to the system sans serif.

## Screenshot
![localhost_9876__id 26575445](https://user-images.githubusercontent.com/230597/36681588-b188277a-1ade-11e8-8918-f7686768daad.png)
