### PR TITLE
Package/Title-Specific Custom Coverage Validations

### DIFF
--- a/src/components/customer-resource-coverage/customer-resource-coverage.js
+++ b/src/components/customer-resource-coverage/customer-resource-coverage.js
@@ -1,42 +1,46 @@
 import React, { Component } from 'react';
 import { Field, FieldArray, reduxForm } from 'redux-form';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 import moment from 'moment';
 import isEqual from 'lodash/isEqual';
-import classNames from 'classnames/bind';
 
 import Datepicker from '@folio/stripes-components/lib/Datepicker';
 import Button from '@folio/stripes-components/lib/Button';
 import Icon from '@folio/stripes-components/lib/Icon';
 import IconButton from '@folio/stripes-components/lib/IconButton';
-import CoverageDateList from '../coverage-date-list';
 import KeyValueLabel from '../key-value-label';
+
+import CoverageDateList from '../coverage-date-list';
 import styles from './customer-resource-coverage.css';
+import { formatISODateWithoutTime } from '../utilities';
 
 const cx = classNames.bind(styles);
 
 class CustomerResourceCoverage extends Component {
   static propTypes = {
     initialValues: PropTypes.shape({
-      customCoverages: PropTypes.array,
+      customCoverages: PropTypes.array
     }).isRequired,
+    packageCoverage: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     onSubmit: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func,
     pristine: PropTypes.bool,
     isPending: PropTypes.bool,
     initialize: PropTypes.func,
-    locale: PropTypes.string // eslint-disable-line react/no-unused-prop-types
+    locale: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
+    intl: PropTypes.object // eslint-disable-line react/no-unused-prop-types
   };
 
   state = {
-    isEditing: false,
+    isEditing: false
   };
 
   componentWillReceiveProps(nextProps) {
     let wasPending = this.props.isPending && !nextProps.isPending;
-    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+    let needsUpdate = !isEqual(this.props.initialValues.customCoverages, nextProps.initialValues.customCoverages);
 
-    if (wasPending || needsUpdate) {
+    if (wasPending && needsUpdate) {
       this.setState({ isEditing: false });
     }
   }
@@ -54,12 +58,13 @@ class CustomerResourceCoverage extends Component {
     this.props.initialize(this.props.initialValues);
   }
 
-  renderDatepicker = ({ input, label, meta }) => {
+  renderDatepicker = ({ input, label, meta, id }) => {
     return (
       <Datepicker
         label={label}
         input={input}
         meta={meta}
+        id={id}
       />
     );
   }
@@ -88,6 +93,7 @@ class CustomerResourceCoverage extends Component {
                     type="text"
                     component={this.renderDatepicker}
                     label="Start date"
+                    id="begin-coverage"
                   />
                 </div>
                 <div
@@ -99,6 +105,7 @@ class CustomerResourceCoverage extends Component {
                     type="text"
                     component={this.renderDatepicker}
                     label="End date"
+                    id="end-coverage"
                   />
                 </div>
 
@@ -226,21 +233,147 @@ class CustomerResourceCoverage extends Component {
   }
 }
 
-const validate = (values, props) => {
-  moment.locale(props.locale);
+/**
+ * Validator to ensure start date comes before end date chronologically
+ * @param {} dateRange - coverage date range to validate
+ * @returns {} - an error object if errors are found, or `false` otherwise
+ */
+const validateStartDateBeforeEndDate = (dateRange) => {
+  const message = 'Start date must be before end date';
+
+  if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
+    return { beginCoverage: message };
+  }
+
+  return false;
+};
+
+/**
+ * Validator to ensure begin date is present and entered dates are valid
+ * @param {} dateRange - coverage date range to validate
+ * @returns {} - an error object if errors are found, or `false` otherwise
+ */
+const validateDateFormat = (dateRange, locale) => {
+  moment.locale(locale);
   let dateFormat = moment.localeData()._longDateFormat.L;
+  const message = `Enter date in ${dateFormat} format.`;
+
+  if (!dateRange.beginCoverage || !moment(dateRange.beginCoverage).isValid()) {
+    return { beginCoverage: message };
+  }
+
+  return false;
+};
+
+/**
+ * Validator to ensure all coverage ranges are within the parent package's
+ * custom coverage range if one is present
+ * @param {} dateRange - coverage date range to validate
+ * @param {} packageCoverage - parent package's custom coverage range
+ * @param {} intl - object containing locale-specific data & formatting
+ * @returns {} - an error object if errors are found, or `false` otherwise
+ */
+const validateWithinPackageRange = (dateRange, packageCoverage, intl) => {
+  // javascript/moment has no mechanism for "infinite", so we
+  // use an absurd future date to represent the concept of "present"
+  let present = moment('9999-09-09T05:00:00.000Z');
+
+  if (packageCoverage && packageCoverage.beginCoverage) {
+    let {
+      beginCoverage: packageBeginCoverage,
+      endCoverage: packageEndCoverage
+    } = packageCoverage;
+
+    let beginCoverageDate = moment(dateRange.beginCoverage);
+    let endCoverageDate = dateRange.endCoverage ? moment(dateRange.endCoverage) : present;
+
+    let packageBeginCoverageDate = moment(packageBeginCoverage);
+    let packageEndCoverageDate = packageEndCoverage ? moment(packageEndCoverage) : moment();
+    let packageRange = moment.range(packageBeginCoverageDate, packageEndCoverageDate);
+
+    const message = `Dates must be within Package's date range (${
+      formatISODateWithoutTime(packageBeginCoverageDate.format('YYYY-MM-DD'), intl)
+    } - ${
+      packageEndCoverage
+        ? formatISODateWithoutTime(packageEndCoverageDate.format('YYYY-MM-DD'), intl)
+        : 'Present'
+    }).`;
+
+    let beginDateOutOfRange = !packageRange.contains(beginCoverageDate);
+    let endDateOutOfRange = !packageRange.contains(endCoverageDate);
+    if (beginDateOutOfRange || endDateOutOfRange) {
+      return {
+        beginCoverage: beginDateOutOfRange ? message : false,
+        endCoverage: endDateOutOfRange ? message : false
+      };
+    }
+  }
+
+  return false;
+};
+
+
+/**
+ * Validator to check that no date ranges overlap or are identical
+ * @param {} dateRange - coverage date range to validate
+ * @param {} customCoverages - all custom coverage ranges present in edit form
+ * @param {} index - index in the field array indicating which coverage range is
+ * presently being considered
+ * @param {} intl - object containing locale-specific data & formatting
+ * @returns {} - an error object if errors are found, or `false` otherwise
+ */
+const validateNoRangeOverlaps = (dateRange, customCoverages, index, intl) => {
+  let present = moment('9999-09-09T05:00:00.000Z');
+
+  let beginCoverageDate = moment(dateRange.beginCoverage);
+  let endCoverageDate = dateRange.endCoverage ? moment(dateRange.endCoverage) : present;
+  let coverageRange = moment.range(beginCoverageDate, endCoverageDate);
+
+  for (let overlapIndex = 0, len = customCoverages.length; overlapIndex < len; overlapIndex++) {
+    let overlapRange = customCoverages[overlapIndex];
+
+    // don't compare range to itself or to empty rows
+    if (index === overlapIndex || !overlapRange.beginCoverage) {
+      continue; // eslint-disable-line no-continue
+    }
+
+    let overlapCoverageBeginDate = moment(overlapRange.beginCoverage);
+    let overlapCoverageEndDate = overlapRange.endCoverage ? moment(overlapRange.endCoverage) : present;
+    let overlapCoverageRange = moment.range(overlapCoverageBeginDate, overlapCoverageEndDate);
+
+    const message = `Date range overlaps with ${
+      overlapRange.beginCoverage &&
+        formatISODateWithoutTime(overlapCoverageBeginDate.format('YYYY-MM-DD'), intl)
+    } - ${
+      overlapRange.endCoverage
+        ? formatISODateWithoutTime(overlapCoverageEndDate.format('YYYY-MM-DD'), intl)
+        : 'Present'
+    }`;
+
+    if (overlapCoverageRange.overlaps(coverageRange)
+        || overlapCoverageRange.isEqual(coverageRange)
+        || overlapCoverageRange.contains(coverageRange)) {
+      // set endCoverage: true to make box red without message
+      return { beginCoverage: message, endCoverage: true };
+    }
+  }
+
+  return false;
+};
+
+const validate = (values, props) => {
   let errors = [];
+
+  let { intl, packageCoverage, locale } = props;
 
   values.customCoverages.forEach((dateRange, index) => {
     let dateRangeErrors = {};
 
-    if (!dateRange.beginCoverage || !moment(dateRange.beginCoverage).isValid()) {
-      dateRangeErrors.beginCoverage = `Enter date in ${dateFormat} format.`;
-    }
-
-    if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
-      dateRangeErrors.beginCoverage = 'Start date must be before end date.';
-    }
+    dateRangeErrors =
+      validateDateFormat(dateRange, locale) ||
+      validateStartDateBeforeEndDate(dateRange) ||
+      validateNoRangeOverlaps(dateRange, values.customCoverages, index, intl) ||
+      validateWithinPackageRange(dateRange, packageCoverage, intl);
 
     errors[index] = dateRangeErrors;
   });

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -28,6 +28,7 @@ export default class CustomerResourceShow extends Component {
 
   static contextTypes = {
     locale: PropTypes.string,
+    intl: PropTypes.object,
     router: PropTypes.object,
     queryParams: PropTypes.object
   };
@@ -70,7 +71,7 @@ export default class CustomerResourceShow extends Component {
 
   render() {
     let { model, customEmbargoSubmitted, coverageSubmitted } = this.props;
-    let { locale } = this.context;
+    let { locale, intl } = this.context;
     let { showSelectionModal, resourceSelected, resourceHidden } = this.state;
 
     let hasManagedCoverages = model.managedCoverages.length > 0 &&
@@ -81,12 +82,18 @@ export default class CustomerResourceShow extends Component {
     let customEmbargoValue = model.customEmbargoPeriod && model.customEmbargoPeriod.embargoValue;
     let customEmbargoUnit = model.customEmbargoPeriod && model.customEmbargoPeriod.embargoUnit;
 
-    let customCoverages = model.customCoverages;
-    if (customCoverages.length === 0) {
-      customCoverages.push({
+    // in the event that the resource lacks custom coverage, we must
+    // add an artificial "blank" row of coverage at this level so
+    // the form initializes correctly when adding coverage.  unfortunately,
+    // due to redux-form eccentricity, we cannot do this in the CoverageForm
+    // component itself.  instead we clone the coverages off the model here,
+    // as mutating the model directly will break all other customizations.
+    let customCoverages = [...model.customCoverages];
+    if (customCoverages.length === 0 && model.isSelected) {
+      customCoverages = [{
         beginCoverage: '',
         endCoverage: ''
-      });
+      }];
     }
 
     return (
@@ -232,9 +239,11 @@ export default class CustomerResourceShow extends Component {
 
                   <CustomerResourceCoverage
                     initialValues={{ customCoverages }}
+                    packageCoverage={model.package.customCoverage}
                     onSubmit={coverageSubmitted}
                     isPending={model.update.isPending && 'customCoverages' in model.update.changedAttributes}
                     locale={locale}
+                    intl={intl}
                   />
 
                   <hr />

--- a/tests/pages/customer-resource-coverage.js
+++ b/tests/pages/customer-resource-coverage.js
@@ -7,158 +7,126 @@ function createRowObject(element) {
   let $scope = $(element);
 
   return {
+    // Elements
     get $beginCoverageField() {
-      return $scope.find('[data-test-eholdings-coverage-form-date-range-begin] input')[0];
+      return $scope.find('[data-test-eholdings-coverage-form-date-range-begin] input');
     },
-
     get $endCoverageField() {
-      return $scope.find('[data-test-eholdings-coverage-form-date-range-end] input')[0];
+      return $scope.find('[data-test-eholdings-coverage-form-date-range-end] input');
+    },
+    get $beginCoverageFeedback() {
+      return $scope.find('[data-test-eholdings-coverage-form-date-range-begin] div[class^=feedback]');
+    },
+    get $endCoverageFeedback() {
+      return $scope.find('[data-test-eholdings-coverage-form-date-range-end] div[class^=feedback]');
+    },
+    get $beginCoverageClearButton() {
+      return $scope.find('#datepicker-clear-button-begin-coverage');
+    },
+    get $endCoverageClearButton() {
+      return $scope.find('#datepicker-clear-button-end-coverage');
+    },
+    get $removeRowButton() {
+      return $scope.find('[data-test-eholdings-coverage-form-remove-row-button] button');
     },
 
-    get beginCoverage() {
-      return $scope.find('[data-test-eholdings-coverage-form-date-range-begin] input').val();
-    },
-
-    get endCoverage() {
-      return $scope.find('[data-test-eholdings-coverage-form-date-range-end] input').val();
-    },
+    // Observers
+    get beginCoverageFieldValidationError() { return this.$beginCoverageFeedback.text(); },
+    get endCoverageFieldValidationError() { return this.$endCoverageFeedback.text(); },
+    get beginCoverageValue() { return this.$beginCoverageField.val(); },
+    get endCoverageValue() { return this.$endCoverageField.val(); },
 
     get beginCoverageFieldIsValid() {
-      return $scope.find('[data-test-eholdings-coverage-form-date-range-begin] input').attr('class').includes('feedbackValid--');
+      return this.$beginCoverageField.attr('class').includes('feedbackValid--');
+    },
+    get beginCoverageFieldIsInvalid() {
+      return this.$beginCoverageField.attr('class').includes('feedbackError--');
+    },
+    get endCoverageFieldIsValid() {
+      return this.$endCoverageField.attr('class').includes('feedbackValid--');
+    },
+    get endCoverageFieldIsInvalid() {
+      return this.$endCoverageField.attr('class').includes('feedbackError--');
     },
 
-    get $removeRowButton() {
-      return $scope.find('[data-test-eholdings-coverage-form-remove-row-button]');
-    },
-
-    clickRemoveRowButton() {
-      return convergeOn(() => {
-        expect($scope.find('[data-test-eholdings-coverage-form-remove-row-button]')).to.exist;
-      }).then(() => {
-        return $scope.find('[data-test-eholdings-coverage-form-remove-row-button] button').click();
-      });
-    },
+    // Actions
+    pressEnterBeginDate() { pressEnter(this.$beginCoverageField); },
+    pressEnterEndDate() { pressEnter(this.$endCoverageField); },
 
     inputBeginDate(beginDate) {
-      return advancedFillIn(this.$beginCoverageField, beginDate);
+      return advancedFillIn(this.$beginCoverageField.get(0), beginDate);
     },
-
     inputEndDate(endDate) {
-      return advancedFillIn(this.$endCoverageField, endDate);
+      return advancedFillIn(this.$endCoverageField.get(0), endDate);
     },
-
-    pressEnterBeginDate() {
-      pressEnter(this.$beginCoverageField);
-    },
-
-    pressEnterEndDate() {
-      pressEnter(this.$endCoverageField);
-    },
-
     clearBeginDate() {
-      let $clearButton = $('[data-test-eholdings-package-details-custom-begin-coverage]')
-        .find('button[id^=datepicker-clear-button]');
-      return convergeOn(() => {
-        expect($clearButton).to.exist;
-      }).then(() => {
-        $clearButton.click();
-      });
+      return convergeOn(() => expect(this.$beginCoverageClearButton).to.exist)
+        .then(() => this.$beginCoverageClearButton.click());
     },
-
     clearEndDate() {
-      let $clearButton = $('[data-test-eholdings-package-details-custom-end-coverage]')
-        .find('button[id^=datepicker-clear-button]');
-      return convergeOn(() => {
-        expect($clearButton).to.exist;
-      }).then(() => {
-        $clearButton.click();
-      });
+      return convergeOn(() => expect(this.$endCoverageClearButton).to.exist)
+        .then(() => this.$endCoverageClearButton.click());
     },
-
-    blurEndDate() {
-      this.$endCoverageField.blur();
-    },
-
-    blurBeginDate() {
-      this.$beginCoverageField.blur();
+    clickRemoveRowButton() {
+      return convergeOn(() => expect(this.$removeRowButton).to.exist)
+        .then(() => this.$removeRowButton.click());
     }
   };
 }
 
 export default {
+  // Elements
   get $root() {
     return $('[data-test-eholdings-coverage-form]');
   },
-
-  get displayText() {
-    return $('[data-test-eholdings-coverage-form-display]').text();
-  },
-
-  get $editButton() {
-    return $('[data-test-eholdings-coverage-form-edit-button]');
-  },
-
-  get $addButton() {
-    return $('[data-test-eholdings-coverage-form-add-button]');
-  },
-
   get $form() {
     return $('[data-test-eholdings-coverage-form] form');
   },
-
-  get $addRowButton() {
-    return $('[data-test-eholdings-coverage-form-add-row-button]');
+  get $editButton() {
+    return $('[data-test-eholdings-coverage-form-edit-button] button');
   },
-
+  get $addButton() {
+    return $('[data-test-eholdings-coverage-form-add-button] button');
+  },
+  get $addRowButton() {
+    return $('[data-test-eholdings-coverage-form-add-row-button] button');
+  },
   get $cancelButton() {
     return $('[data-test-eholdings-coverage-form-cancel-button] button');
   },
-
   get $saveButton() {
     return $('[data-test-eholdings-coverage-form-save-button] button');
   },
-
-  get isSaveButtonEnabled() {
-    return $('[data-test-eholdings-coverage-form-save-button] button').prop('disabled') === false;
+  get $coverageDisplaySpan() {
+    return $('[data-test-eholdings-coverage-form-display]');
   },
-
-  get dateRangeRowList() {
-    return $('[data-test-eholdings-coverage-form-date-range-row]').toArray().map(createRowObject);
+  get $dateRangeRows() {
+    return $('[data-test-eholdings-coverage-form-date-range-row]');
   },
-
   get $noRowsLeftMessage() {
     return $('[data-test-eholdings-coverage-form-no-rows-left]');
   },
 
+  // Observers
+  get displayText() { return this.$coverageDisplaySpan.text(); },
+  get isSaveButtonEnabled() { return this.$saveButton.prop('disabled') === false; },
+  get dateRangeRowList() { return this.$dateRangeRows.toArray().map(createRowObject); },
+
+  // Actions
   clickEditButton() {
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-coverage-form-edit-button]')).to.exist;
-    }).then(() => (
-      $('[data-test-eholdings-coverage-form-edit-button] button').click()
-    ));
+    return convergeOn(() => expect(this.$editButton).to.exist)
+      .then(() => this.$editButton.click());
   },
-
   clickAddButton() {
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-coverage-form-add-button]')).to.exist;
-    }).then(() => (
-      $('[data-test-eholdings-coverage-form-add-button] button').click()
-    ));
+    return convergeOn(() => expect(this.$addButton).to.exist)
+      .then(() => this.$addButton.click());
   },
-
   clickAddRowButton() {
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-coverage-form-add-row-button]')).to.exist;
-    }).then(() => {
-      return $('[data-test-eholdings-coverage-form-add-row-button] button').click();
-    });
+    return convergeOn(() => expect(this.$addRowButton).to.exist)
+      .then(() => this.$addRowButton.click());
   },
-
   clickSaveButton() {
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-coverage-form-save-button]')).to.exist;
-    }).then(() => {
-      return $('[data-test-eholdings-coverage-form-save-button] button').click();
-    });
+    return convergeOn(() => expect(this.$saveButton).to.exist)
+      .then(() => this.$saveButton.click());
   }
 };


### PR DESCRIPTION
## Purpose
Package/Titles require more intensive custom coverage validation than
Package-level custom coverage.  Since Package/Titles can have multiple
custom coverage ranges, additional care must be taken to prevent
overlap among these ranges.  Additionally, Package/Titles must respect
the custom coverage range (if any) of their parent package.  If a
package has a custom coverage range set, all titles within that
package are relegated to custom coverage within the package's range.

## Approach
These new validations, being significantly more complex than those on
packages, crowded the `validate` method, and so all validations were
pulled out into functions and called in sequence during validation.

**NOTE**
_This replaces https://github.com/folio-org/ui-eholdings/pull/235.  The functionality is the same, but I manually patched it back onto master.  There were some weird issues with the remote tracking in the original branch which was making it impossible to rebase / squash commits._

## Screenshots
### Preventing Range Overlap
![overlap](http://g.recordit.co/KMnAURnFfN.gif)

### Restricting to Package Range
![package-coverage](http://g.recordit.co/KW7DvEAMTt.gif)