### PR TITLE
Remove detail pane upon conducting new search

### DIFF
--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -23,7 +23,8 @@ class SearchRoute extends Component {
     }).isRequired,
     history: PropTypes.shape({
       push: PropTypes.func.isRequired,
-      replace: PropTypes.func.isRequired
+      replace: PropTypes.func.isRequired,
+      location: PropTypes.object
     }).isRequired,
     searchProviders: PropTypes.func.isRequired,
     searchPackages: PropTypes.func.isRequired,
@@ -150,6 +151,11 @@ class SearchRoute extends Component {
     // if the new query is different from our location, update the location
     if (qs.stringify(params) !== qs.stringify(this.state.params)) {
       let url = this.buildSearchUrl(location.pathname, params);
+
+      // if new query is different from current query this will close detail pane
+      if (params.q !== this.state.params.q) {
+        url = this.buildSearchUrl('/eholdings', params);
+      }
       // if only the filters have changed, just replace the current location
       if (params.q === this.state.params.q) {
         history.replace(url);

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -76,6 +76,23 @@ describeApplication('PackageSearch', () => {
         expect(PackageSearchPage.$backButton).to.not.exist;
       });
 
+      describe('conducting a new search', () => {
+        beforeEach(() => {
+          PackageSearchPage.search('SomethingElse');
+        });
+
+        it('removes the preview detail pane', () => {
+          expect(PackageSearchPage.previewPaneIsVisible).to.not.be.true;
+        });
+
+        it('preserves the last history entry', function () {
+          // this is a check to make sure duplicate entries are not added
+          // to the history. Ensuring the back button works as expected
+          let history = this.app.history;
+          expect(history.entries[history.index - 1].search).to.include('q=Package');
+        });
+      });
+
       describe('selecting a package', () => {
         beforeEach(() => {
           return convergeOn(() => {

--- a/tests/provider-search-test.js
+++ b/tests/provider-search-test.js
@@ -71,8 +71,25 @@ describeApplication('ProviderSearch', () => {
         expect(ProviderSearchPage.previewPaneIsVisible).to.be.true;
       });
 
-      it('should not display button in UI', () => {
+      it('should not display back button in UI', () => {
         expect(ProviderSearchPage.$backButton).to.not.exist;
+      });
+
+      describe('conducting a new search', () => {
+        beforeEach(() => {
+          ProviderSearchPage.search('Totally Awesome Co');
+        });
+
+        it('removes the preview detail pane', () => {
+          expect(ProviderSearchPage.previewPaneIsVisible).to.not.be.true;
+        });
+
+        it('preserves the last history entry', function () {
+          // this is a check to make sure duplicate entries are not added
+          // to the history. Ensuring the back button works as expected
+          let history = this.app.history;
+          expect(history.entries[history.index - 1].search).to.include('q=Provider');
+        });
       });
 
       describe('clicking the vignette behind the preview pane', () => {

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -116,6 +116,23 @@ describeApplication('TitleSearch', () => {
         expect(TitleSearchPage.$backButton).to.not.exist;
       });
 
+      describe('conducting a new search', () => {
+        beforeEach(() => {
+          TitleSearchPage.search('SomethingSomethingWhoa');
+        });
+
+        it('removes the preview detail pane', () => {
+          expect(TitleSearchPage.previewPaneIsVisible).to.not.be.true;
+        });
+
+        it('preserves the last history entry', function () {
+          // this is a check to make sure duplicate entries are not added
+          // to the history. Ensuring the back button works as expected
+          let history = this.app.history;
+          expect(history.entries[history.index - 1].search).to.include('q=Title');
+        });
+      });
+
       describe('clicking the vignette behind the preview pane', () => {
         beforeEach(() => {
           TitleSearchPage.clickSearchVignette();


### PR DESCRIPTION
## Purpose
After conducting a search users are presented with a list of results and detail view associated with clicking on an item from the results list. When a user conducts a new search removing the detail view that contains the old  information from the last clicked item makes it a more pleasing user experience

## Approach
Remove the third pane after a new search it conducted in any Provider, Package, or Title search

## Jira
UIEH-104

## Screenshots
![2018-02-27 23 41 56](https://user-images.githubusercontent.com/1953098/36770812-81c344e2-1c1a-11e8-98fc-1d6150b07ec3.gif)

