### PR TITLE
Highlight selected provider/package/title

### DIFF
--- a/src/components/package-list-item/package-list-item.css
+++ b/src/components/package-list-item/package-list-item.css
@@ -1,6 +1,17 @@
 .item {
   height: 100%;
 
+  &.is-selected {
+    background-color: rgba(0,0,0,.5);
+    color: #FFFFFF;
+    &:hover {
+      background-color: rgba(0,0,0,.5);
+    }
+    & h5 {
+      color: #FFFFFF;
+    }
+  }
+
   & h5,
   & div {
     overflow: hidden;

--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -10,6 +10,7 @@ const cx = classNames.bind(styles);
 export default function PackageListItem({
   item,
   link,
+  active,
   showTitleCount,
   showProviderName,
   packageName
@@ -24,7 +25,13 @@ export default function PackageListItem({
       })}
     />
   ) : (
-    <Link to={link} className={styles.item}>
+    <Link
+      data-test-eholdings-package-list-item-active
+      to={link}
+      className={cx('item', {
+        'is-selected': active
+      })}
+    >
       <h5 data-test-eholdings-package-list-item-name>
         {packageName || item.name}
       </h5>
@@ -78,6 +85,7 @@ PackageListItem.propTypes = {
     PropTypes.string,
     PropTypes.object
   ]),
+  active: PropTypes.bool,
   showTitleCount: PropTypes.bool,
   showProviderName: PropTypes.bool,
   packageName: PropTypes.string

--- a/src/components/package-search-list.js
+++ b/src/components/package-search-list.js
@@ -10,7 +10,10 @@ export default function PackageSearchList({
   collection,
   fetch,
   onUpdateOffset
-}) {
+}, { router }) {
+  let { params: routeParams } = router.route.match;
+  let isPackagePage = routeParams.type === 'packages';
+
   return (
     <QueryList
       type="packages"
@@ -28,6 +31,7 @@ export default function PackageSearchList({
             pathname: `/eholdings/packages/${item.content.id}`,
             search: location.search
           }}
+          active={item.content && isPackagePage && routeParams.id === item.content.id}
         />
       )}
     />
@@ -40,4 +44,8 @@ PackageSearchList.propTypes = {
   collection: PropTypes.object.isRequired,
   fetch: PropTypes.func.isRequired,
   onUpdateOffset: PropTypes.func.isRequired
+};
+
+PackageSearchList.contextTypes = {
+  router: PropTypes.object
 };

--- a/src/components/provider-list-item/provider-list-item.css
+++ b/src/components/provider-list-item/provider-list-item.css
@@ -1,6 +1,17 @@
 .item {
   height: 100%;
 
+  &.is-selected {
+    background-color: rgba(0,0,0,.5);
+    color: #FFFFFF;
+    &:hover {
+      background-color: rgba(0,0,0,.5);
+    }
+    & h5 {
+      color: #FFFFFF;
+    }
+  }
+
   & h5,
   & div {
     overflow: hidden;

--- a/src/components/provider-list-item/provider-list-item.js
+++ b/src/components/provider-list-item/provider-list-item.js
@@ -1,14 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 
 import styles from './provider-list-item.css';
 import Link from '../link';
 
-export default function ProviderListItem({ item, link }, { intl }) {
+const cx = classNames.bind(styles);
+
+export default function ProviderListItem({ item, link, active }, { intl }) {
   return !item ? (
     <div className={styles.skeleton} />
   ) : (
-    <Link to={link} className={styles.item}>
+    <Link
+      data-test-eholdings-provider-list-item-active
+      to={link}
+      className={cx('item', {
+        'is-selected': active
+      })}
+    >
       <h5 data-test-eholdings-provider-list-item-name>
         {item.name}
       </h5>
@@ -37,9 +46,10 @@ ProviderListItem.propTypes = {
   link: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object
-  ])
+  ]),
+  active: PropTypes.bool,
 };
 
 ProviderListItem.contextTypes = {
-  intl: PropTypes.object
+  intl: PropTypes.object,
 };

--- a/src/components/provider-search-list.js
+++ b/src/components/provider-search-list.js
@@ -9,8 +9,11 @@ export default function ProviderSearchList({
   params,
   collection,
   fetch,
-  onUpdateOffset
-}) {
+  onUpdateOffset,
+}, { router }) {
+  let { params: routeParams } = router.route.match;
+  let isProviderPage = routeParams.type === 'providers';
+
   return (
     <QueryList
       type="providers"
@@ -27,6 +30,7 @@ export default function ProviderSearchList({
             pathname: `/eholdings/providers/${item.content.id}`,
             search: location.search
           }}
+          active={item.content && isProviderPage && routeParams.id === item.content.id}
         />
       )}
     />
@@ -39,4 +43,8 @@ ProviderSearchList.propTypes = {
   collection: PropTypes.object.isRequired,
   fetch: PropTypes.func.isRequired,
   onUpdateOffset: PropTypes.func.isRequired
+};
+
+ProviderSearchList.contextTypes = {
+  router: PropTypes.object
 };

--- a/src/components/title-list-item/title-list-item.css
+++ b/src/components/title-list-item/title-list-item.css
@@ -1,6 +1,17 @@
 .item {
   height: 100%;
 
+  &.is-selected {
+    background-color: rgba(0,0,0,.5);
+    color: #FFFFFF;
+    &:hover {
+      background-color: rgba(0,0,0,.5);
+    }
+    & h5 {
+      color: #FFFFFF;
+    }
+  }
+
   & h5,
   & div {
     overflow: hidden;

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -10,6 +10,7 @@ const cx = classNames.bind(styles);
 export default function TitleListItem({
   item,
   link,
+  active,
   showSelected,
   showPublisherAndType
 }) {
@@ -21,7 +22,13 @@ export default function TitleListItem({
       })}
     />
   ) : (
-    <Link to={link} className={styles.item}>
+    <Link
+      data-test-eholdings-title-list-item-active
+      to={link}
+      className={cx('item', {
+        'is-selected': active
+      })}
+    >
       <h5 data-test-eholdings-title-list-item-title-name>
         {item.name}
       </h5>
@@ -63,6 +70,7 @@ TitleListItem.propTypes = {
     PropTypes.string,
     PropTypes.object
   ]),
+  active: PropTypes.bool,
   showSelected: PropTypes.bool,
   showPublisherAndType: PropTypes.bool
 };

--- a/src/components/title-search-list.js
+++ b/src/components/title-search-list.js
@@ -10,7 +10,10 @@ export default function TitleSearchList({
   collection,
   fetch,
   onUpdateOffset
-}) {
+}, { router }) {
+  let { params: routeParams } = router.route.match;
+  let isTitlePage = routeParams.type === 'titles';
+
   return (
     <QueryList
       type="titles"
@@ -28,6 +31,7 @@ export default function TitleSearchList({
             pathname: `/eholdings/titles/${item.content.id}`,
             search: location.search
           }}
+          active={item.content && isTitlePage && routeParams.id === item.content.id}
         />
       )}
     />
@@ -40,4 +44,8 @@ TitleSearchList.propTypes = {
   collection: PropTypes.object.isRequired,
   fetch: PropTypes.func.isRequired,
   onUpdateOffset: PropTypes.func.isRequired
+};
+
+TitleSearchList.contextTypes = {
+  router: PropTypes.object
 };

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export default class EHoldings extends Component {
       <Route path={rootPath} component={SettingsRoute} />
     ) : (
       <Route path={rootPath} component={ApplicationRoute}>
-        <Route path={rootPath} component={SearchRoute}>
+        <Route path={`${rootPath}/:type?/:id?`} component={SearchRoute}>
           <Switch>
             <Route path={`${rootPath}/providers/:providerId`} exact component={ProviderShow} />
             <Route path={`${rootPath}/packages/:packageId`} exact component={PackageShow} />

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -64,6 +64,10 @@ describeApplication('PackageSearch', () => {
         }).then(() => PackageSearchPage.$searchResultsItems[0].click());
       });
 
+      it('clicked item has an active state', () => {
+        expect(PackageSearchPage.packageList[0].isActive).to.be.true;
+      });
+
       it('shows the preview pane', () => {
         expect(PackageSearchPage.previewPaneIsVisible).to.be.true;
       });

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -25,6 +25,10 @@ function createPackageObject(element) {
 
     get isSelected() {
       return $scope.find('[data-test-eholdings-package-list-item-selected]').text().toLowerCase() === 'selected';
+    },
+
+    get isActive() {
+      return $scope.attr('class').indexOf('is-selected---') !== -1;
     }
   };
 }

--- a/tests/pages/provider-search.js
+++ b/tests/pages/provider-search.js
@@ -17,6 +17,10 @@ function createProviderObject(element) {
 
     get numPackagesSelected() {
       return parseInt($scope.find('[data-test-eholdings-provider-list-item-num-packages-selected]').text(), 10);
+    },
+
+    get isActive() {
+      return $scope.attr('class').indexOf('is-selected---') !== -1;
     }
   };
 }

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -17,6 +17,10 @@ function createTitleObject(element) {
 
     get publicationType() {
       return $scope.find('[data-test-eholdings-title-list-item-publication-type]').text();
+    },
+
+    get isActive() {
+      return $scope.attr('class').indexOf('is-selected---') !== -1;
     }
   };
 }

--- a/tests/provider-search-test.js
+++ b/tests/provider-search-test.js
@@ -63,6 +63,10 @@ describeApplication('ProviderSearch', () => {
         }).then(() => ProviderSearchPage.$searchResultsItems[0].click());
       });
 
+      it('clicked item has an active state', () => {
+        expect(ProviderSearchPage.providerList[0].isActive).to.be.true;
+      });
+
       it('shows the preview pane', () => {
         expect(ProviderSearchPage.previewPaneIsVisible).to.be.true;
       });

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -104,6 +104,10 @@ describeApplication('TitleSearch', () => {
         }).then(() => TitleSearchPage.$searchResultsItems[0].click());
       });
 
+      it('clicked item has an active state', () => {
+        expect(TitleSearchPage.titleList[0].isActive).to.be.true;
+      });
+
       it('shows the preview pane', () => {
         expect(TitleSearchPage.previewPaneIsVisible).to.be.true;
       });


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-172, when user conducts a search and selects a result in the provider/package/title result list pane, the selected result should be highlighted within the result list pane. 

## Approach
- Modify index.js to pass 'type' and 'id' of the provider/package/title being selected in search route. 
- Within search list, compare the 'type' and 'id' to identify which item has been selected
- If an item has been selected, set its corresponding "active" prop type to true; else false
- Modify css of the selected item to have a gray background color, white text and the hover color to match the background color
- Also, add associated unit tests

## Learning
- CSS Selectors and Combinators
- react-cx

## Screenshots
![highlightselection](https://user-images.githubusercontent.com/33662516/36810742-9f33eae8-1c99-11e8-9968-1d07db7d17a1.gif)

