### PR TITLE
Add a pane title to detail views

### DIFF
--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -5,6 +5,9 @@ import capitalize from 'lodash/capitalize';
 
 import PaneHeader from '@folio/stripes-components/lib/PaneHeader';
 import Icon from '@folio/stripes-components/lib/Icon';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
+import Link from 'react-router-dom/Link';
 
 import KeyValueLabel from '../key-value-label';
 import styles from './details-view.css';
@@ -32,11 +35,14 @@ export default class DetailsView extends Component {
       isLoading: PropTypes.bool.isRequired,
       request: PropTypes.object.isRequired
     }).isRequired,
-    showPaneHeader: PropTypes.bool,
-    paneHeaderFirstMenu: PropTypes.node,
     bodyContent: PropTypes.node.isRequired,
     listHeader: PropTypes.string,
     renderList: PropTypes.func
+  };
+
+  static contextTypes = {
+    router: PropTypes.object,
+    queryParams: PropTypes.object
   };
 
   state = {
@@ -138,12 +144,16 @@ export default class DetailsView extends Component {
     let {
       type,
       model,
-      showPaneHeader,
-      paneHeaderFirstMenu,
       bodyContent,
       listHeader,
       renderList
     } = this.props;
+
+    let {
+      router,
+      queryParams
+    } = this.context;
+
     let {
       isSticky
     } = this.state;
@@ -152,11 +162,30 @@ export default class DetailsView extends Component {
       locked: isSticky
     });
 
+    let historyState = router.history.location.state;
+
     return (
       <div data-test-eholdings-details-view={type}>
-        {showPaneHeader && (
-          <PaneHeader firstMenu={paneHeaderFirstMenu} />
-        )}
+        <PaneHeader
+          firstMenu={queryParams.searchType ? (
+            <PaneMenu>
+              <Link to='/eholdings'>
+                <IconButton
+                  icon="closeX"
+                />
+              </Link>
+            </PaneMenu>
+          ) : historyState && historyState.eholdings && (
+            <PaneMenu>
+              <div data-test-eholdings-details-view-back-button>
+                <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
+              </div>
+            </PaneMenu>
+          )}
+          paneTitle={(
+            <div data-test-eholdings-details-view-pane-title>{model.name}</div>
+          )}
+        />
 
         <div
           ref={(n) => { this.$container = n; }}

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import IconButton from '@folio/stripes-components/lib/IconButton';
-import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import Button from '@folio/stripes-components/lib/Button';
 import Layout from '@folio/stripes-components/lib/Layout';
 import Icon from '@folio/stripes-components/lib/Icon';
@@ -74,9 +72,8 @@ export default class PackageShow extends Component {
 
   render() {
     let { model, fetchPackageTitles, customCoverageSubmitted } = this.props;
-    let { intl, router, queryParams } = this.context;
+    let { intl } = this.context;
     let { showSelectionModal, packageSelected, packageHidden, packageAllowedToAddTitles } = this.state;
-    let historyState = router.history.location.state;
 
     let customCoverages = [{
       beginCoverage: model.customCoverage.beginCoverage,
@@ -88,14 +85,6 @@ export default class PackageShow extends Component {
         <DetailsView
           type="package"
           model={model}
-          showPaneHeader={!queryParams.searchType}
-          paneHeaderFirstMenu={historyState && historyState.eholdings && (
-            <PaneMenu>
-              <div data-test-eholdings-package-details-back-button>
-                <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
-              </div>
-            </PaneMenu>
-          )}
           bodyContent={(
             <div>
               <KeyValueLabel label="Provider">

--- a/src/components/provider-show.js
+++ b/src/components/provider-show.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import IconButton from '@folio/stripes-components/lib/IconButton';
-import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
-
 import DetailsView from './details-view';
 import KeyValueLabel from './key-value-label';
 import QueryList from './query-list';
@@ -13,24 +10,12 @@ export default function ProviderShow({
   model,
   fetchPackages
 }, {
-  router,
-  queryParams,
   intl
 }) {
-  let historyState = router.history.location.state;
-
   return (
     <DetailsView
       type="provider"
       model={model}
-      showPaneHeader={!queryParams.searchType}
-      paneHeaderFirstMenu={historyState && historyState.eholdings && (
-        <PaneMenu>
-          <div data-test-eholdings-provider-details-back-button>
-            <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
-          </div>
-        </PaneMenu>
-      )}
       bodyContent={(
         <div>
           <KeyValueLabel label="Packages Selected">

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -127,17 +127,6 @@ export default class SearchPaneset extends React.Component {
 
         {!!detailsView && (
           <PreviewPane previewType={resultsType}>
-            <PaneHeader
-              firstMenu={(
-                <PaneMenu>
-                  <IconButton
-                    onClick={this.closePreview}
-                    icon="closeX"
-                  />
-                </PaneMenu>
-              )}
-            />
-
             {detailsView}
           </PreviewPane>
         )}

--- a/src/components/title-show.js
+++ b/src/components/title-show.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import IconButton from '@folio/stripes-components/lib/IconButton';
-import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
-
 import DetailsView from './details-view';
 import KeyValueLabel from './key-value-label';
 import ScrollView from './scroll-view';
@@ -11,21 +8,11 @@ import PackageListItem from './package-list-item';
 import IdentifiersList from './identifiers-list';
 import ContributorsList from './contributors-list';
 
-export default function TitleShow({ model }, { router, queryParams }) {
-  let historyState = router.history.location.state;
-
+export default function TitleShow({ model }) {
   return (
     <DetailsView
       type="title"
       model={model}
-      showPaneHeader={!queryParams.searchType}
-      paneHeaderFirstMenu={historyState && historyState.eholdings && (
-        <PaneMenu>
-          <div data-test-eholdings-title-show-back-button>
-            <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
-          </div>
-        </PaneMenu>
-      )}
       bodyContent={(
         <div>
           <ContributorsList data={model.contributors} />

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -63,6 +63,10 @@ describeApplication('CustomerResourceShow', () => {
       });
     });
 
+    it('displays the provider name in the pane header', () => {
+      expect(ResourcePage.paneTitle).to.equal('Best Title Ever');
+    });
+
     it('displays the title name', () => {
       expect(ResourcePage.titleName).to.equal('Best Title Ever');
     });

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -33,6 +33,10 @@ describeApplication('PackageShow', () => {
       });
     });
 
+    it('displays the provider name in the pane header', () => {
+      expect(PackageShowPage.paneTitle).to.equal('Cool Package');
+    });
+
     it('displays the package name', () => {
       expect(PackageShowPage.name).to.equal('Cool Package');
     });

--- a/tests/pages/bigtest/customer-resource-show.js
+++ b/tests/pages/bigtest/customer-resource-show.js
@@ -19,7 +19,8 @@ import {
   hasContentType = isPresent('[data-test-eholdings-customer-resource-show-content-type]');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
   isSelected = property('checked', '[data-test-eholdings-customer-resource-show-selected] input');
-  hasBackButton = isPresent('[data-test-eholdings-customer-resource-show-back-button] button');
+  hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
+  paneTitle = text('[data-test-eholdings-details-view-pane-title]');
 
   identifiersList = collection('[data-test-eholdings-identifiers-list-item]', {
     text: text()

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -126,7 +126,7 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-customer-resource-show-back-button] button');
+    return $('[data-test-eholdings-details-view-back-button] button');
   },
 
   get $deselectTitleWarning() {

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -71,7 +71,7 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-package-details-back-button] button');
+    return $('[data-test-eholdings-details-view-back-button] button');
   },
 
   get $selectedSearchType() {
@@ -126,7 +126,7 @@ export default {
   },
 
   clickBackButton() {
-    return $('[data-test-eholdings-customer-resource-show-back-button] button').trigger('click');
+    return $('[data-test-eholdings-details-view-back-button] button').trigger('click');
   },
 
   scrollToOffset(readOffset) {

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -189,7 +189,11 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-package-details-back-button] button');
+    return $('[data-test-eholdings-details-view-back-button] button');
+  },
+
+  get paneTitle() {
+    return $('[data-test-eholdings-details-view-pane-title]').text();
   },
 
   scrollToTitleOffset(readOffset) {

--- a/tests/pages/provider-search.js
+++ b/tests/pages/provider-search.js
@@ -59,7 +59,7 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-provider-details-back-button] button');
+    return $('[data-test-eholdings-details-view-back-button] button');
   },
 
   get $selectedSearchType() {
@@ -97,7 +97,7 @@ export default {
   },
 
   clickBackButton() {
-    return $('[data-test-eholdings-package-details-back-button] button').trigger('click');
+    return $('[data-test-eholdings-details-view-back-button] button').trigger('click');
   },
 
   scrollToOffset(readOffset) {

--- a/tests/pages/provider-show.js
+++ b/tests/pages/provider-show.js
@@ -52,7 +52,11 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-provider-details-back-button] button');
+    return $('[data-test-eholdings-details-view-back-button] button');
+  },
+
+  get paneTitle() {
+    return $('[data-test-eholdings-details-view-pane-title]').text();
   },
 
   scrollToPackageOffset(readOffset) {

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -61,7 +61,7 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-title-show-back-button] button');
+    return $('[data-test-eholdings-details-view-back-button] button');
   },
 
   get $selectedSearchType() {
@@ -122,7 +122,7 @@ export default {
   },
 
   clickBackButton() {
-    return $('[data-test-eholdings-customer-resource-show-back-button] button').trigger('click');
+    return $('[data-test-eholdings-details-view-back-button] button').trigger('click');
   },
 
   scrollToOffset(readOffset) {

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -60,7 +60,11 @@ export default {
   },
 
   get $backButton() {
-    return $('[data-test-eholdings-title-show-back-button] button');
+    return $('[data-test-eholdings-details-view-back-button] button');
+  },
+
+  get paneTitle() {
+    return $('[data-test-eholdings-details-view-pane-title]').text();
   },
 
   scrollToPackageOffset(readOffset) {

--- a/tests/provider-show-test.js
+++ b/tests/provider-show-test.js
@@ -26,6 +26,10 @@ describeApplication('ProviderShow', () => {
       });
     });
 
+    it('displays the provider name in the pane header', () => {
+      expect(ProviderShowPage.paneTitle).to.equal('League of Ordinary Men');
+    });
+
     it('displays the provider name', () => {
       expect(ProviderShowPage.name).to.equal('League of Ordinary Men');
     });

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -48,6 +48,10 @@ describeApplication('TitleShow', () => {
       });
     });
 
+    it('displays the provider name in the pane header', () => {
+      expect(TitleShowPage.paneTitle).to.equal('Cool Title');
+    });
+
     it('displays the title name', () => {
       expect(TitleShowPage.titleName).to.equal('Cool Title');
     });


### PR DESCRIPTION
## Purpose
Reference: https://issues.folio.org/browse/UIEH-187
In order to match the rest of FOLIO, this adds titles to preview pane headers.

## Approach
We moved the back button and the close pane logic into a single place.

## Learning
We learned that the `PaneHeader` paneTitle accepts a node as well as a string.

## Screenshots
<img width="591" alt="screen shot 2018-02-28 at 6 02 18 pm" src="https://user-images.githubusercontent.com/15052791/36820048-a0b6f5be-1cb1-11e8-8de0-846060468749.png">
