### PR TITLE
Implement Provider Sort Options

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,56 +1,6 @@
 import { okapi } from 'stripes-config'; // eslint-disable-line import/no-unresolved
 import { Response } from '@bigtest/mirage';
-
-/**
- * Helper for creating a search route for a resource type.
- * Currently includes pagination and searching by name.
- * @param {String} resourceType - resource type's model name
- * @param {Function} [filter] - optional filter function
- * @returns {Function} route handler for a search route of this
- * resource type
- */
-function searchRouteFor(resourceType, filter = (model, req) => {
-  let query = req.queryParams.q.toLowerCase();
-  return model.name && model.name.toLowerCase().includes(query);
-}) {
-  return function (schema, req) { // eslint-disable-line func-names
-    let page = Math.max(parseInt(req.queryParams.page || 1, 10), 1);
-    let count = parseInt(req.queryParams.count || 25, 10);
-    let offset = (page - 1) * count;
-
-    let collection = schema[resourceType];
-    let json = this.serialize(collection.all().filter((model) => {
-      return filter(model, req);
-    }));
-
-    json.meta = { totalResults: json.data.length };
-    json.data = json.data.slice(offset, offset + count);
-    return json;
-  };
-}
-
-/**
- * Helper for creating a nested resource route. Currently only accepts
- * page and count params.
- * @param {String} foreignKey - parent resource foreign key prefix
- * @param {String} resourceType - nested resource's model name
- * @returns {Function} route handler for a nested resource
- */
-function nestedResourceRouteFor(foreignKey, resourceType) {
-  return function (schema, req) { // eslint-disable-line func-names
-    let page = Math.max(parseInt(req.queryParams.page || 1, 10), 1);
-    let count = parseInt(req.queryParams.count || 25, 10);
-    let offset = (page - 1) * count;
-
-    let json = this.serialize(schema[resourceType].where({
-      [`${foreignKey}Id`]: req.params.id
-    }));
-
-    json.meta = { totalResults: json.data.length };
-    json.data = json.data.slice(offset, offset + count);
-    return json;
-  };
-}
+import { searchRouteFor, nestedResourceRouteFor, includesWords } from './helpers';
 
 // typical mirage config export
 export default function configure() {
@@ -179,7 +129,7 @@ export default function configure() {
     let params = req.queryParams;
     let type = params['filter[type]'];
     let selected = params['filter[selected]'];
-    let filtered = pkg.name && pkg.name.toLowerCase().includes(query);
+    let filtered = pkg.name && includesWords(pkg.name, query);
 
     if (filtered && type && type !== 'all') {
       filtered = pkg.contentType.toLowerCase() === type;

--- a/mirage/helpers.js
+++ b/mirage/helpers.js
@@ -1,0 +1,142 @@
+/**
+ * Helper Name Compare function used when sorting results (A-Z in ascending order)
+ *
+ * Uses the following options from string localeCompare
+ *  numeric so that numbers are sorted naturally ( 1 < 2 < 10)
+ *  base for a case insensitive sort
+ */
+export function nameCompare(model, modelCompare) {
+  let name = model.attributes.name;
+  let compareName = modelCompare.attributes.name;
+  if (name && compareName) {
+    return name.localeCompare(compareName, undefined, { numeric: true, sensitivity: 'base' });
+  }
+  return 0;
+}
+
+/**
+ * Helper Relevance Compare function used when sorting results.
+ *
+ * Simulates sorting results by relevance
+ * Results contains the highest number of words from original query appear earlier in results
+ * Results containing the same number of words from original query use default nameCompare
+ *
+ */
+export function relevanceCompare(query) {
+  return function RelSort(model, modelCompare) {
+    let name = model.attributes.name;
+    let compareName = modelCompare.attributes.name;
+    if (name && compareName) {
+      let words = query.split(' ');
+      words.push(query);
+      let modelCount = words.reduce((total, word) => {
+        return name.toLowerCase().includes(word) ? total + 1 : total;
+      }, 0);
+      let modelCompareCount = words.reduce((total, word) => {
+        return compareName.toLowerCase().includes(word) ? total + 1 : total;
+      }, 0);
+      if (modelCount !== modelCompareCount) {
+        return modelCount < modelCompareCount;
+      }
+
+      return nameCompare(model, modelCompare);
+    }
+    return 0;
+  };
+}
+/**
+ * Helper function returns query based on request and resource type
+ * @param {String} resourceType - resource type (titles, providers, packages)
+ * @param {Object} req - request object
+ * @returns {String} query - lower case query string
+ */
+export function getQuery(resourceType, req) {
+  if (resourceType === 'titles') {
+    let name = req.queryParams['filter[name]'];
+    let isxn = req.queryParams['filter[isxn]'];
+    let subject = req.queryParams['filter[subject]'];
+    let publisher = req.queryParams['filter[publisher]'];
+
+    if (name) {
+      return name.toLowerCase();
+    } else if (isxn) {
+      return isxn.toLowerCase();
+    } else if (subject) {
+      return subject.toLowerCase();
+    } else if (publisher) {
+      return publisher.toLowerCase();
+    } else {
+      return '';
+    }
+  } else {
+    return req.queryParams.q.toLowerCase();
+  }
+}
+/**
+ * Helper function which tests a string to determine if it includes
+ * any words found within a query string.
+ */
+export function includesWords(testString, query) {
+  if (testString && query) {
+    return query.toLowerCase().split(' ').some(w => testString.toLowerCase().includes(w));
+  } else { return false; }
+}
+/**
+ * Helper for creating a search route for a resource type.
+ * Currently includes pagination and searching by name.
+ * @param {String} resourceType - resource type's model name
+ * @param {Function} [filter] - optional filter function
+ * @returns {Function} route handler for a search route of this
+ * resource type
+ */
+export function searchRouteFor(resourceType, filter = (model, req) => {
+  let query = req.queryParams.q.toLowerCase();
+  return model.name && includesWords(model.name, query);
+}) {
+  return function (schema, req) { // eslint-disable-line func-names
+    let page = Math.max(parseInt(req.queryParams.page || 1, 10), 1);
+    let count = parseInt(req.queryParams.count || 25, 10);
+    let offset = (page - 1) * count;
+
+    let collection = schema[resourceType];
+    let json = this.serialize(collection.all().filter((model) => {
+      return filter(model, req);
+    }));
+
+    json.meta = { totalResults: json.data.length };
+
+    let sort = req.queryParams.sort;
+
+    if (sort && sort === 'name') {
+      json.data = json.data.sort(nameCompare);
+    } else {
+      let query = getQuery(resourceType, req);
+      json.data = json.data.sort(relevanceCompare(query));
+    }
+    json.data = json.data.slice(offset, offset + count);
+    return json;
+  };
+}
+
+/**
+ * Helper for creating a nested resource route. Currently only accepts
+ * page and count params.
+ * @param {String} foreignKey - parent resource foreign key prefix
+ * @param {String} resourceType - nested resource's model name
+ * @returns {Function} route handler for a nested resource
+ */
+export function nestedResourceRouteFor(foreignKey, resourceType) {
+  return function (schema, req) { // eslint-disable-line func-names
+    let page = Math.max(parseInt(req.queryParams.page || 1, 10), 1);
+    let count = parseInt(req.queryParams.count || 25, 10);
+    let offset = (page - 1) * count;
+
+    let json = this.serialize(schema[resourceType].where({
+      [`${foreignKey}Id`]: req.params.id
+    }));
+
+    json.meta = { totalResults: json.data.length };
+    json.data = json.data.slice(offset, offset + count);
+    return json;
+  };
+}

--- a/src/components/provider-search-filters.js
+++ b/src/components/provider-search-filters.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import SearchFilters from './search-form/search-filters';
+
+/**
+ * Renders search filters with specific provider filters.
+ *
+ * Once the API supports returning these filters via an endpoint, this
+ * component should not be necessary. Instead the `search-form` should
+ * recieve the available filters from the route and render the
+ * search-filters component itself.
+ */
+export default function ProviderSearchFilters(props) {
+  return (
+    <SearchFilters
+      searchType="providers"
+      availableFilters={[{
+        name: 'sort',
+        label: 'Sort options',
+        defaultValue: 'relevance',
+        options: [
+          { label: 'Relevance', value: 'relevance' },
+          { label: 'Provider', value: 'name' }
+        ]
+      }]}
+      {...props}
+    />
+  );
+}

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -27,37 +27,53 @@ export default class SearchForm extends Component {
     onSearch: PropTypes.func.isRequired,
     searchString: PropTypes.string,
     filter: PropTypes.object,
-    searchfield: PropTypes.string
+    searchfield: PropTypes.string,
+    sort: PropTypes.string
   };
 
   state = {
     searchString: this.props.searchString || '',
     filter: this.props.filter || {},
-    searchfield: this.props.searchfield || 'title'
+    searchfield: this.props.searchfield || 'title',
+    sort: this.props.sort || 'relevance'
   };
 
-  componentWillReceiveProps({ searchString = '', filter = {}, searchfield }) {
+  componentWillReceiveProps({ searchString = '', filter = {}, searchfield, sort }) {
     if (searchString !== this.state.searchString) {
       this.setState({ searchString });
     }
 
-    if (!isEqual(filter, this.state.filter)) {
-      this.setState({ filter });
+    if (sort !== this.state.sort) {
+      this.setState({ sort });
     }
 
+    if (sort) {
+      let displayfilter = { ...filter, sort };
+      if (!isEqual(displayfilter, this.state.filter)) {
+        this.setState({ filter: displayfilter });
+      }
+    } else if (!isEqual(filter, this.state.filter)) {
+      this.setState({ filter });
+    }
     if (searchfield !== this.state.searchfield) {
       this.setState({ searchfield });
     }
   }
 
-  handleSearchSubmit = (e) => {
-    e.preventDefault();
+  submitSearch = () => {
+    let { sort, ...searchfilter } = this.state.filter;
 
     this.props.onSearch({
       q: this.state.searchString,
-      filter: this.state.filter,
-      searchfield: this.state.searchfield
+      filter: searchfilter,
+      searchfield: this.state.searchfield,
+      sort
     });
+  };
+
+  handleSearchSubmit = (e) => {
+    e.preventDefault();
+    this.submitSearch();
   };
 
   handleChangeSearch = (e) => {
@@ -65,7 +81,11 @@ export default class SearchForm extends Component {
   };
 
   handleUpdateFilter = (filter) => {
-    this.setState({ filter });
+    if (this.props.searchType === 'providers') {
+      this.setState({ filter }, () => this.submitSearch());
+    } else {
+      this.setState({ filter });
+    }
   };
 
   handleChangeIndex = (e) => {

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -7,6 +7,7 @@ import Provider from '../redux/provider';
 import Package from '../redux/package';
 import Title from '../redux/title';
 
+import ProviderSearchFilters from '../components/provider-search-filters';
 import ProviderSearchList from '../components/provider-search-list';
 import PackageSearchList from '../components/package-search-list';
 import PackageSearchFilters from '../components/package-search-filters';
@@ -212,6 +213,8 @@ class SearchRoute extends Component {
       return TitleSearchFilters;
     } else if (searchType === 'packages') {
       return PackageSearchFilters;
+    } else if (searchType === 'providers') {
+      return ProviderSearchFilters;
     }
 
     return null;
@@ -271,6 +274,7 @@ class SearchRoute extends Component {
                 searchString={params.q}
                 filter={params.filter}
                 searchfield={params.searchfield}
+                sort={params.sort}
                 searchTypeUrls={this.getSearchTypeUrls()}
                 filtersComponent={this.getFiltersComponent()}
                 onSearch={this.handleSearch}

--- a/tests/pages/provider-search.js
+++ b/tests/pages/provider-search.js
@@ -33,7 +33,26 @@ export default {
   get $searchField() {
     return $('[data-test-search-field]');
   },
+  get $searchFilters() {
+    return $('[data-test-eholdings-search-filters="providers"]');
+  },
 
+  getFilter(name) {
+    return this.$searchFilters.find(`input[name="${name}"]:checked`).val();
+  },
+
+  clickFilter(name, value) {
+    let $radio = this.$searchFilters.find(`input[name="${name}"][value="${value}"]`);
+    $radio.get(0).click();
+    return convergeOn(() => expect($radio).to.have.prop('checked'));
+  },
+
+  clearFilter(name) {
+    this.$searchFilters.find(`input[name="${name}"]`)
+      .closest('section').find('[role="heading"] button:nth-child(2)')
+      .get(0)
+      .click();
+  },
   get $searchResultsItems() {
     return $('[data-test-query-list="providers"] li a');
   },

--- a/tests/provider-search-test.js
+++ b/tests/provider-search-test.js
@@ -160,6 +160,160 @@ describeApplication('ProviderSearch', () => {
     });
   });
 
+  describe('sorting providers', () => {
+    beforeEach(function () {
+      this.server.create('provider', {
+        name: 'Health Associations'
+      });
+      this.server.create('provider', {
+        name: 'Analytics for everyone'
+      });
+      this.server.create('provider', {
+        name: 'Non Matching'
+      });
+      this.server.create('provider', {
+        name: 'My Health Analytics 2'
+      });
+      this.server.create('provider', {
+        name: 'My Health Analytics 10'
+      });
+    });
+
+    describe('searching for providers', () => {
+      beforeEach(() => {
+        ProviderSearchPage.search('health analytics');
+      });
+
+      it('has search filters', () => {
+        expect(ProviderSearchPage.$searchFilters).to.exist;
+      });
+
+      it('shows the default sort filter of relevance in the search form', () => {
+        expect(ProviderSearchPage.getFilter('sort')).to.equal('relevance');
+      });
+
+      it("displays provider entries related to 'health analytics'", () => {
+        expect(ProviderSearchPage.$searchResultsItems).to.have.lengthOf(4);
+      });
+
+      it('displays the providers sorted by relevance', () => {
+        expect(ProviderSearchPage.providerList[0].name).to.equal('My Health Analytics 2');
+        expect(ProviderSearchPage.providerList[1].name).to.equal('My Health Analytics 10');
+        expect(ProviderSearchPage.providerList[2].name).to.equal('Analytics for everyone');
+        expect(ProviderSearchPage.providerList[3].name).to.equal('Health Associations');
+      });
+
+      it.still('does not reflect the default sort=relevance in url', function () {
+        expect(this.app.history.location.search).to.not.include('sort=relevance');
+      });
+
+      describe('then filtering by sort options', () => {
+        beforeEach(() => {
+          return convergeOn(() => {
+            expect(ProviderSearchPage.providerList.length).to.be.gt(0);
+          }).then(() => (
+            ProviderSearchPage.clickFilter('sort', 'name')
+          ));
+        });
+
+        it('displays the providers sorted by provider name', () => {
+          expect(ProviderSearchPage.providerList[0].name).to.equal('Analytics for everyone');
+          expect(ProviderSearchPage.providerList[1].name).to.equal('Health Associations');
+          expect(ProviderSearchPage.providerList[2].name).to.equal('My Health Analytics 2');
+          expect(ProviderSearchPage.providerList[3].name).to.equal('My Health Analytics 10');
+        });
+
+        it('shows the sort filter of name in the search form', () => {
+          expect(ProviderSearchPage.getFilter('sort')).to.equal('name');
+        });
+
+        it('reflects the sort in the URL query params', function () {
+          expect(this.app.history.location.search).to.include('sort=name');
+        });
+
+        describe('then searching for other providers', () => {
+          beforeEach(() => {
+            ProviderSearchPage.search('analytics');
+          });
+
+          it('keeps the sort filter of name in the search form', () => {
+            expect(ProviderSearchPage.getFilter('sort')).to.equal('name');
+          });
+
+          it('displays the providers sorted by provider name', () => {
+            expect(ProviderSearchPage.providerList[0].name).to.equal('Analytics for everyone');
+            expect(ProviderSearchPage.providerList[1].name).to.equal('My Health Analytics 2');
+            expect(ProviderSearchPage.providerList[2].name).to.equal('My Health Analytics 10');
+          });
+
+          it('shows the sort filter of name in the search form', () => {
+            expect(ProviderSearchPage.getFilter('sort')).to.equal('name');
+          });
+
+          describe('then clicking another search type', () => {
+            beforeEach(() => {
+              return convergeOn(() => {
+                expect(ProviderSearchPage.$searchResultsItems).to.have.lengthOf(3);
+              }).then(() => ProviderSearchPage.changeSearchType('packages'));
+            });
+
+            it('does not display any results', () => {
+              expect(ProviderSearchPage.$searchResultsItems).to.have.lengthOf(0);
+            });
+
+            describe('navigating back to providers search', () => {
+              beforeEach(() => {
+                return ProviderSearchPage.changeSearchType('providers');
+              });
+
+              it('keeps the sort filter of name in the search form', () => {
+                expect(ProviderSearchPage.getFilter('sort')).to.equal('name');
+              });
+
+              it('displays the last results', () => {
+                expect(ProviderSearchPage.$searchResultsItems).to.have.lengthOf(3);
+              });
+
+              it('reflects the sort=name in the URL query params', function () {
+                expect(this.app.history.location.search).to.include('sort=name');
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe('visiting the page with an existing sort', () => {
+      beforeEach(function () {
+        return convergeOn(() => {
+          expect(ProviderSearchPage.$searchResultsItems).to.have.lengthOf(0);
+        }).then(() => {
+          return this.visit('/eholdings/?searchType=providers&q=health&sort=name', () => {
+            expect(ProviderSearchPage.$root).to.exist;
+          });
+        });
+      });
+
+      it('displays search field populated', () => {
+        expect(ProviderSearchPage.$searchField).to.have.value('health');
+      });
+
+      it('displays the sort filter of name as selected in the search form', () => {
+        expect(ProviderSearchPage.getFilter('sort')).to.equal('name');
+      });
+
+      it('displays the expected results', () => {
+        expect(ProviderSearchPage.$searchResultsItems).to.have.lengthOf(3);
+      });
+
+      it('displays results sorted by name', () => {
+        expect(ProviderSearchPage.providerList[0].name).to.equal('Health Associations');
+        expect(ProviderSearchPage.providerList[1].name).to.equal('My Health Analytics 2');
+        expect(ProviderSearchPage.providerList[2].name).to.equal('My Health Analytics 10');
+      });
+    });
+  });
+
   describe('with multiple pages of providers', () => {
     beforeEach(function () {
       this.server.createList('provider', 75, {


### PR DESCRIPTION
## Purpose
Adds functionality to sort providers by either provider name or relevance as described https://issues.folio.org/browse/UIEH-84

## Approach
- Followed same logic as used for filters on other search types to add sort filters
- Updates to Search Form to support a url of `sort=name`. Internal to component passes a filter object with sort onto child filters component.
- Updates to Search form to automatically search when the sort filter is selected. Change is made specific to provider sort filter. Another ticket - https://issues.folio.org/browse/UIEH-157 addresses behavior of filters for other search types
- Updated Mirage Config to support A-Z sorting and a simulated Relevance Sort
- A-Z uses string localeCompare so the sort can be done as case insensitive and can sort numbers naturally ( 1 < 2 < 10)
- Relevance sort is simulated based on behavior of RM API - results containing the largest number of words from a search query appear higher in sort order, otherwise fallback is to an A-Z sort
- Required updates to search logic for multiple word queries - considers a match if results contain any word in the query. This is also how A-Z searches function in RM API.
- There are other user stories https://issues.folio.org/browse/UIEH-119, https://issues.folio.org/browse/UIEH-121 address sorting for packages and titles

## Learning
https://medium.freecodecamp.org/functional-setstate-is-the-future-of-react-374f30401b6b
https://github.com/uberVU/react-guide/blob/master/props-vs-state.md

## Screenshots
![provider-sort-options](https://user-images.githubusercontent.com/19415226/36851682-cda02f06-1d37-11e8-82df-ed419b57486c.gif)

