### PR TITLE
Fix coverage reporting

### DIFF
--- a/.stripesclirc.js
+++ b/.stripesclirc.js
@@ -76,18 +76,22 @@ const testPlugin = {
         return rule.loader === 'babel-loader';
       });
 
-      if (options.coverage || options.karma.coverage) {
-        // Brittle way of injecting babel-plugin-istanbul into the webpack config.
-        // Should probably be moved to stripes-core when it has more test infrastructure.
-        config.module.rules[babelLoaderConfigIndex].options.plugins = [
-          require.resolve('babel-plugin-istanbul')
-        ];
+      if(!config.module.rules[babelLoaderConfigIndex].options.plugins) {
+        config.module.rules[babelLoaderConfigIndex].options.plugins = [];
       }
 
       // Make decorators possible
-      config.module.rules[babelLoaderConfigIndex].options.plugins = [
+      config.module.rules[babelLoaderConfigIndex].options.plugins.push(
         [require.resolve('babel-plugin-transform-decorators-legacy')]
-      ];
+      );
+
+      // Brittle way of injecting babel-plugin-istanbul into the webpack config.
+      // Should probably be moved to stripes-core when it has more test infrastructure.
+      if (options.coverage || options.karma.coverage) {
+        config.module.rules[babelLoaderConfigIndex].options.plugins.push(
+          require.resolve('babel-plugin-istanbul')
+        );
+      }
 
       return config;
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,7 +302,7 @@
     react-router-dom "^4.0.0"
     redux-form "^7.0.3"
 
-"@folio/ui-testing@github:folio-org/ui-testing#framework-only":
+"@folio/ui-testing@folio-org/ui-testing#framework-only":
   version "4.0.0"
   resolved "https://codeload.github.com/folio-org/ui-testing/tar.gz/90a425c1a8d12552e04c72dfeec2f623a81af629"
   dependencies:


### PR DESCRIPTION
## Purpose
Code coverage reporting is broken. It reports 100% for everything and doesn't generate any files.

## Approach
I broke it by improperly adding `babel-plugin-transform-decorators-legacy` in https://github.com/folio-org/ui-eholdings/pull/231. I overwrote the `babel-loader`'s plugins instead of just adding to them.

I rearranged the `plugins` additions to work properly.