### PR TITLE
Add pane sub to customer resources

### DIFF
--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import IconButton from '@folio/stripes-components/lib/IconButton';
-import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import Button from '@folio/stripes-components/lib/Button';
 import Layout from '@folio/stripes-components/lib/Layout';
 
@@ -72,10 +70,9 @@ export default class CustomerResourceShow extends Component {
 
   render() {
     let { model, customEmbargoSubmitted, coverageSubmitted } = this.props;
-    let { locale, router, queryParams } = this.context;
+    let { locale } = this.context;
     let { showSelectionModal, resourceSelected, resourceHidden } = this.state;
 
-    let historyState = router.history.location.state;
     let hasManagedCoverages = model.managedCoverages.length > 0 &&
       isValidCoverageList(model.managedCoverages);
     let hasManagedEmbargoPeriod = model.managedEmbargoPeriod &&
@@ -97,14 +94,8 @@ export default class CustomerResourceShow extends Component {
         <DetailsView
           type="resource"
           model={model}
-          showPaneHeader={!queryParams.searchType}
-          paneHeaderFirstMenu={historyState && historyState.eholdings && (
-            <PaneMenu>
-              <div data-test-eholdings-customer-resource-show-back-button>
-                <IconButton icon="left-arrow" onClick={() => router.history.goBack()} />
-              </div>
-            </PaneMenu>
-          )}
+          paneTitle={model.name}
+          paneSub={model.packageName}
           bodyContent={(
             <div>
               <ContributorsList data={model.contributors} />

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -35,6 +35,8 @@ export default class DetailsView extends Component {
       isLoading: PropTypes.bool.isRequired,
       request: PropTypes.object.isRequired
     }).isRequired,
+    paneTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
+    paneSub: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
     bodyContent: PropTypes.node.isRequired,
     listHeader: PropTypes.string,
     renderList: PropTypes.func
@@ -146,7 +148,9 @@ export default class DetailsView extends Component {
       model,
       bodyContent,
       listHeader,
-      renderList
+      renderList,
+      paneTitle,
+      paneSub
     } = this.props;
 
     let {
@@ -183,7 +187,10 @@ export default class DetailsView extends Component {
             </PaneMenu>
           )}
           paneTitle={(
-            <div data-test-eholdings-details-view-pane-title>{model.name}</div>
+            <span data-test-eholdings-details-view-pane-title>{paneTitle}</span>
+          )}
+          paneSub={(
+            <span data-test-eholdings-details-view-pane-sub>{paneSub}</span>
           )}
         />
 

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -85,6 +85,7 @@ export default class PackageShow extends Component {
         <DetailsView
           type="package"
           model={model}
+          paneTitle={model.name}
           bodyContent={(
             <div>
               <KeyValueLabel label="Provider">

--- a/src/components/provider-show.js
+++ b/src/components/provider-show.js
@@ -16,6 +16,7 @@ export default function ProviderShow({
     <DetailsView
       type="provider"
       model={model}
+      paneTitle={model.name}
       bodyContent={(
         <div>
           <KeyValueLabel label="Packages Selected">

--- a/src/components/title-show.js
+++ b/src/components/title-show.js
@@ -13,6 +13,7 @@ export default function TitleShow({ model }) {
     <DetailsView
       type="title"
       model={model}
+      paneTitle={model.name}
       bodyContent={(
         <div>
           <ContributorsList data={model.contributors} />

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -63,8 +63,12 @@ describeApplication('CustomerResourceShow', () => {
       });
     });
 
-    it('displays the provider name in the pane header', () => {
+    it('displays the title name in the pane header', () => {
       expect(ResourcePage.paneTitle).to.equal('Best Title Ever');
+    });
+
+    it('displays the package name in the pane header', () => {
+      expect(ResourcePage.paneSub).to.equal('Cool Package');
     });
 
     it('displays the title name', () => {

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -33,7 +33,7 @@ describeApplication('PackageShow', () => {
       });
     });
 
-    it('displays the provider name in the pane header', () => {
+    it('displays the package name in the pane header', () => {
       expect(PackageShowPage.paneTitle).to.equal('Cool Package');
     });
 

--- a/tests/pages/bigtest/customer-resource-show.js
+++ b/tests/pages/bigtest/customer-resource-show.js
@@ -21,6 +21,7 @@ import {
   isSelected = property('checked', '[data-test-eholdings-customer-resource-show-selected] input');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
+  paneSub = text('[data-test-eholdings-details-view-pane-sub]');
 
   identifiersList = collection('[data-test-eholdings-identifiers-list-item]', {
     text: text()

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -48,7 +48,7 @@ describeApplication('TitleShow', () => {
       });
     });
 
-    it('displays the provider name in the pane header', () => {
+    it('displays the title name in the pane header', () => {
       expect(TitleShowPage.paneTitle).to.equal('Cool Title');
     });
 


### PR DESCRIPTION
## Purpose
Reference: https://issues.folio.org/browse/UIEH-187
Continuation of PR #243 to add sub title. We wanted to show sub titles just for package-titles.

## Approach
Fixed some naming of test assertion.

## Learning
Build threw warning when trying to put a `<div>` inside of a `<span>`. 

## Screenshots
![panesub](https://user-images.githubusercontent.com/25858667/36871899-3bdd1232-1d69-11e8-8948-ece9be4d619a.png)

