### PR TITLE
Fix new isNaN warning

### DIFF
--- a/src/components/custom-embargo/custom-embargo.js
+++ b/src/components/custom-embargo/custom-embargo.js
@@ -102,7 +102,7 @@ class CustomEmbargoForm extends Component {
                   <Field
                     name='customEmbargoValue'
                     type="number"
-                    parse={value => (!value ? null : (Number.isNaN(value) ? '' : Number(value)))}
+                    parse={value => (!value ? null : (Number.isNaN(Number(value)) ? '' : Number(value)))}
                     component={this.renderTextField}
                   />
                 </div>


### PR DESCRIPTION
## Purpose
https://github.com/folio-org/ui-eholdings/pull/226 introduced a new warning when running tests:
```ERROR: 'Warning: Received NaN for the `value` attribute. If this is expected, cast the value to a string.```

## Approach
I needed to take the approach Jason mentioned:
https://github.com/folio-org/ui-eholdings/pull/226#issuecomment-367519623
