### PR TITLE
Implement Package Sort Options

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -192,13 +192,13 @@ export default function configure() {
     let filtered = true;
 
     if (name) {
-      filtered = title.name && title.name.toLowerCase().includes(name.toLowerCase());
+      filtered = title.name && includesWords(title.name, name);
     } else if (isxn) {
-      filtered = title.identifiers && title.identifiers.some(i => i.id.toLowerCase().includes(isxn.toLowerCase()));
+      filtered = title.identifiers && title.identifiers.some(i => includesWords(i.id, isxn));
     } else if (subject) {
-      filtered = title.subjects && title.subjects.some(s => s.subject.toLowerCase().includes(subject.toLowerCase()));
+      filtered = title.subjects && title.subjects.some(s => includesWords(s.subject, subject));
     } else if (publisher) {
-      filtered = title.publisherName && title.publisherName.toLowerCase().includes(publisher.toLowerCase());
+      filtered = title.publisherName && includesWords(title.publisherName, publisher);
     }
 
     if (filtered && type && type !== 'all') {

--- a/src/components/package-search-filters.js
+++ b/src/components/package-search-filters.js
@@ -15,6 +15,15 @@ export default function PackageSearchFilters(props) {
     <SearchFilters
       searchType="packages"
       availableFilters={[{
+        name: 'sort',
+        label: 'Sort options',
+        defaultValue: 'relevance',
+        options: [
+          { label: 'Relevance', value: 'relevance' },
+          { label: 'Package', value: 'name' }
+        ]
+      },
+        {
         name: 'selected',
         label: 'Selection status',
         defaultValue: 'all',

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -81,11 +81,7 @@ export default class SearchForm extends Component {
   };
 
   handleUpdateFilter = (filter) => {
-    if (this.props.searchType === 'providers') {
-      this.setState({ filter }, () => this.submitSearch());
-    } else {
-      this.setState({ filter });
-    }
+    this.setState({ filter }, () => this.submitSearch());
   };
 
   handleChangeIndex = (e) => {

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -174,8 +174,6 @@ describeApplication('TitleSearch', () => {
           expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
         }).then(() => (
           TitleSearchPage.clickFilter('type', 'book')
-        )).then(() => (
-          TitleSearchPage.search('Title')
         ));
       });
 
@@ -194,8 +192,6 @@ describeApplication('TitleSearch', () => {
             expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(1);
           }).then(() => (
             TitleSearchPage.clearFilter('type')
-          )).then(() => (
-            TitleSearchPage.search('Title')
           ));
         });
 
@@ -232,8 +228,6 @@ describeApplication('TitleSearch', () => {
           expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
         }).then(() => (
           TitleSearchPage.clickFilter('selected', 'true')
-        )).then(() => (
-          TitleSearchPage.search('Title')
         ));
       });
 
@@ -251,8 +245,6 @@ describeApplication('TitleSearch', () => {
             expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(2);
           }).then(() => (
             TitleSearchPage.clearFilter('selected')
-          )).then(() => (
-            TitleSearchPage.search('Title')
           ));
         });
 


### PR DESCRIPTION
## Purpose
Adds sort options as filter to package search (as documented at https://issues.folio.org/browse/UIEH-119)

## Approach
- Added Sort Options as filter (similar to what was done for Providers)
- Updated filter behavior for all search types so that search is conducted upon selection of filter (not requiring a user to click the search button) - This functionality is required for https://issues.folio.org/browse/UIEH-157
- Updated filter tests so that search is not clicked on filter selection
- Updated Mirage search configuration so that title searches are handled in the same way as package and provider searches (results containing any word in a query are returned)

## Screenshots
![package-sort-options](https://user-images.githubusercontent.com/19415226/37046418-5068f5ec-2136-11e8-8102-f86e22b9a1bc.gif)
