### PR TITLE
Refactor package-add-new-titles-test to use BigTest

### DIFF
--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -225,6 +225,7 @@ export default class PackageShow extends Component {
           size="small"
           label="Remove package from holdings?"
           scope="root"
+          id="eholdings-package-confirmation-modal"
           footer={(
             <div>
               <Button

--- a/tests/package-add-new-titles-test.js
+++ b/tests/package-add-new-titles-test.js
@@ -1,8 +1,8 @@
-import { beforeEach, afterEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
+import { beforeEach, describe, it } from '@bigtest/mocha';
 
 import { describeApplication } from './helpers';
-import PackageShowPage from './pages/package-show';
+import PackageShowPage from './pages/bigtest/package-show';
 
 describeApplication('PackageShowAllowKbToAddTitles', () => {
   let provider,
@@ -69,15 +69,15 @@ describeApplication('PackageShowAllowKbToAddTitles', () => {
     });
 
     it('sets the state of allow KB to add titles to false', () => {
-      expect(PackageShowPage.allowKbToAddTitles).to.be.false;
+      expect(PackageShowPage.hasAllowKbToAddTitles).to.be.false;
     });
 
     it.always('does not display the allow KB to add titles toggle switch', () => {
-      expect(PackageShowPage.allowKbToAddTitlesToggle).to.not.exist;
+      expect(PackageShowPage.hasAllowKbToAddTitlesToggle).to.be.false;
     });
   });
 
-  describe('visiting the package show page with a package that is not selected and selecting a package', () => {
+  describe('visiting the package show page with a package that is not selected', () => {
     beforeEach(function () {
       pkg = this.server.create('package', {
         provider,
@@ -92,30 +92,18 @@ describeApplication('PackageShowAllowKbToAddTitles', () => {
       });
     });
 
-    beforeEach(function () {
-      /*
-       * The expectations in the convergent `it` blocks
-       * get run once every 10ms.  We were seeing test flakiness
-       * when a toggle action dispatched and resolved before an
-       * expectation had the chance to run.  We sidestep this by
-       * temporarily increasing the mirage server's response time
-       * to 50ms.
-       * TODO: control timing directly with Mirage
-       */
-      this.server.timing = 50;
-      return PackageShowPage.toggleIsSelected();
-    });
+    describe('selecting a package', () => {
+      beforeEach(() => {
+        return PackageShowPage.toggleIsSelected();
+      });
 
-    afterEach(function () {
-      this.server.timing = 0;
-    });
+      it('reflects the desired state (Selected)', () => {
+        expect(PackageShowPage.isSelected).to.be.true;
+      });
 
-    it('reflects the desired state (Selected)', () => {
-      expect(PackageShowPage.isSelected).to.equal(true);
-    });
-
-    it('displays an ON Toggle for allow KB to add titles', () => {
-      expect(PackageShowPage.allowKbToAddTitles).to.equal(true);
+      it('displays an ON Toggle for allow KB to add titles', () => {
+        expect(PackageShowPage.allowKbToAddTitles).to.be.true;
+      });
     });
   });
 
@@ -140,21 +128,21 @@ describeApplication('PackageShowAllowKbToAddTitles', () => {
 
     describe('toggling to deselect a package and confirming deselection', () => {
       beforeEach(() => {
-        return PackageShowPage.toggleIsSelected().then(() => {
-          return PackageShowPage.confirmDeselection();
-        });
+        return PackageShowPage
+          .toggleIsSelected()
+          .append(PackageShowPage.modal.confirmDeselection());
       });
 
       it('removes allow KB to add titles toggle switch', () => {
-        expect(PackageShowPage.allowKbToAddTitlesToggle).to.not.exist;
+        expect(PackageShowPage.hasAllowKbToAddTitlesToggle).to.be.false;
       });
     });
 
     describe('toggling to deselect a package and canceling deselection', () => {
       beforeEach(() => {
-        return PackageShowPage.toggleIsSelected().then(() => {
-          return PackageShowPage.cancelDeselection();
-        });
+        return PackageShowPage
+          .toggleIsSelected()
+          .append(PackageShowPage.modal.cancelDeselection());
       });
 
       it('displays an ON Toggle', () => {
@@ -183,17 +171,12 @@ describeApplication('PackageShowAllowKbToAddTitles', () => {
     });
 
     describe('successfully toggling add new titles', () => {
-      beforeEach(function () {
-        this.server.timing = 50;
+      beforeEach(() => {
         return PackageShowPage.toggleAllowKbToAddTitles();
       });
 
-      afterEach(function () {
-        this.server.timing = 0;
-      });
-
       it('reflects the desired state OFF', () => {
-        expect(PackageShowPage.allowKbToAddTitles).to.equal(false);
+        expect(PackageShowPage.allowKbToAddTitles).to.be.false;
       });
     });
   });
@@ -218,17 +201,12 @@ describeApplication('PackageShowAllowKbToAddTitles', () => {
     });
 
     describe('successfully toggling add new titles', () => {
-      beforeEach(function () {
-        this.server.timing = 50;
+      beforeEach(() => {
         return PackageShowPage.toggleAllowKbToAddTitles();
       });
 
-      afterEach(function () {
-        this.server.timing = 0;
-      });
-
       it('reflects the desired state ON', () => {
-        expect(PackageShowPage.allowKbToAddTitles).to.equal(true);
+        expect(PackageShowPage.allowKbToAddTitles).to.be.true;
       });
     });
   });

--- a/tests/pages/bigtest/package-show.js
+++ b/tests/pages/bigtest/package-show.js
@@ -1,0 +1,23 @@
+import {
+  clickable,
+  isPresent,
+  page,
+  property,
+} from '@bigtest/interaction';
+
+@page class PackageShowModal {
+  confirmDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-yes]');
+  cancelDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-no]');
+}
+
+@page class PackageShowPage {
+  allowKbToAddTitles = property('checked', '[data-test-eholdings-package-details-allow-add-new-titles] input');
+  hasAllowKbToAddTitles = isPresent('[data-test-eholdings-package-details-toggle-allow-add-new-titles] input');
+  hasAllowKbToAddTitlesToggle = isPresent('[package-details-toggle-allow-add-new-titles-switch]');
+  isSelected = property('checked', '[data-test-eholdings-package-details-selected] input');
+  modal = new PackageShowModal('#eholdings-package-confirmation-modal');
+  toggleAllowKbToAddTitles = clickable('[data-test-eholdings-package-details-allow-add-new-titles] input');
+  toggleIsSelected = clickable('[data-test-eholdings-package-details-selected] input');
+}
+
+export default new PackageShowPage('[data-test-eholdings-details-view="package"]');


### PR DESCRIPTION
## Purpose
Change `package-add-new-titles-test` to use BigTest page objects and assertions.

## Learning
Ran into an issue around clicking confirmation modal buttons. The confirmation modal is being rendered directly into the `body` rather than as a child of the `package-show` component. Since BigTest page objects are all scoped to `$root` this meant adding a separate page object for the modal. Once that was added, simply appending the two interactions together works as a nice clean fix.
