### PR TITLE
Update title case to sentence case

### DIFF
--- a/src/components/customer-resource-coverage/customer-resource-coverage.js
+++ b/src/components/customer-resource-coverage/customer-resource-coverage.js
@@ -291,7 +291,7 @@ const validateWithinPackageRange = (dateRange, packageCoverage, intl) => {
     let packageEndCoverageDate = packageEndCoverage ? moment(packageEndCoverage) : moment();
     let packageRange = moment.range(packageBeginCoverageDate, packageEndCoverageDate);
 
-    const message = `Dates must be within Package's date range (${
+    const message = `Dates must be within package's date range (${
       formatISODateWithoutTime(packageBeginCoverageDate.format('YYYY-MM-DD'), intl)
     } - ${
       packageEndCoverage

--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -44,7 +44,7 @@ export default function PackageListItem({
 
       <div>
         <span data-test-eholdings-package-list-item-selected>
-          {item.isSelected ? 'Selected' : 'Not Selected'}
+          {item.isSelected ? 'Selected' : 'Not selected'}
         </span>
 
         {showTitleCount && (

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -95,20 +95,20 @@ export default class PackageShow extends Component {
               </KeyValueLabel>
 
               {model.contentType && (
-                <KeyValueLabel label="Content Type">
+                <KeyValueLabel label="Content type">
                   <div data-test-eholdings-package-details-content-type>
                     {model.contentType}
                   </div>
                 </KeyValueLabel>
               )}
 
-              <KeyValueLabel label="Titles Selected">
+              <KeyValueLabel label="Titles selected">
                 <div data-test-eholdings-package-details-titles-selected>
                   {intl.formatNumber(model.selectedCount)}
                 </div>
               </KeyValueLabel>
 
-              <KeyValueLabel label="Total Titles">
+              <KeyValueLabel label="Total titles">
                 <div data-test-eholdings-package-details-titles-total>
                   {intl.formatNumber(model.titleCount)}
                 </div>
@@ -118,7 +118,7 @@ export default class PackageShow extends Component {
                 data-test-eholdings-package-details-selected
                 htmlFor="package-details-toggle-switch"
               >
-                <h4>{packageSelected ? 'Selected' : 'Not Selected'}</h4>
+                <h4>{packageSelected ? 'Selected' : 'Not selected'}</h4>
                 <ToggleSwitch
                   onChange={this.handleSelectionToggle}
                   checked={packageSelected}

--- a/src/components/provider-show.js
+++ b/src/components/provider-show.js
@@ -19,13 +19,13 @@ export default function ProviderShow({
       paneTitle={model.name}
       bodyContent={(
         <div>
-          <KeyValueLabel label="Packages Selected">
+          <KeyValueLabel label="Packages selected">
             <div data-test-eholdings-provider-details-packages-selected>
               {intl.formatNumber(model.packagesSelected)}
             </div>
           </KeyValueLabel>
 
-          <KeyValueLabel label="Total Packages">
+          <KeyValueLabel label="Total packages">
             <div data-test-eholdings-provider-details-packages-total>
               {intl.formatNumber(model.packagesTotal)}
             </div>

--- a/src/components/query-list/query-list.js
+++ b/src/components/query-list/query-list.js
@@ -25,7 +25,7 @@ export default class QueryList extends Component {
   };
 
   static defaultProps = {
-    notFoundMessage: 'Not Found'
+    notFoundMessage: 'Not found'
   }
 
   state = {

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -141,7 +141,7 @@ export default class Settings extends Component {
                 'has-error': invalidApiKey
               })}
             >
-              <label htmlFor="eholdings-settings-apikey">API Key</label>
+              <label htmlFor="eholdings-settings-apikey">API key</label>
               <input
                 id="eholdings-settings-apikey"
                 type="password"

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -49,7 +49,7 @@ export default function TitleListItem({
 
       {showSelected && (
         <span data-test-eholdings-title-list-item-title-selected>
-          {item.isSelected ? 'Selected' : 'Not Selected'}
+          {item.isSelected ? 'Selected' : 'Not selected'}
           {item.visibilityData.isHidden && (
             <span>
               &nbsp;&bull;&nbsp;

--- a/src/components/title-show.js
+++ b/src/components/title-show.js
@@ -24,7 +24,7 @@ export default function TitleShow({ model }) {
             </div>
           </KeyValueLabel>
 
-          <KeyValueLabel label="Publication Type">
+          <KeyValueLabel label="Publication type">
             <div data-test-eholdings-title-show-publication-type>
               {model.publicationType}
             </div>

--- a/tests/backend-configuration-test.js
+++ b/tests/backend-configuration-test.js
@@ -129,7 +129,7 @@ describeApplication('With valid backend configuration', () => {
         this.server.put('/configuration', () => {
           return new Response(422, {}, {
             errors: [{
-              title: 'RM-API Credentials Are Invalid'
+              title: 'RM-API credentials are invalid'
             }]
           });
         });
@@ -141,7 +141,7 @@ describeApplication('With valid backend configuration', () => {
       });
 
       it('reports the error to the interface', () => {
-        expect(SettingsPage.errorText).to.equal('RM-API Credentials Are Invalid');
+        expect(SettingsPage.errorText).to.equal('RM-API credentials are invalid');
       });
     });
 

--- a/tests/customer-resource-custom-coverage-test.js
+++ b/tests/customer-resource-custom-coverage-test.js
@@ -273,12 +273,12 @@ describeApplication('CustomerResourceCustomCoverage', () => {
 
           it('displays messaging that begin date is outside of package coverage range', () => {
             expect(CustomerResourceCoverage.dateRangeRowList[0].beginCoverageFieldValidationError).to.eq(
-              "Dates must be within Package's date range (12/1/2018 - 12/31/2018)."
+              "Dates must be within package's date range (12/1/2018 - 12/31/2018)."
             );
           });
           it('displays messaging that end date is outside of package coverage range', () => {
             expect(CustomerResourceCoverage.dateRangeRowList[0].endCoverageFieldValidationError).to.eq(
-              "Dates must be within Package's date range (12/1/2018 - 12/31/2018)."
+              "Dates must be within package's date range (12/1/2018 - 12/31/2018)."
             );
           });
         });

--- a/tests/customer-resource-visibility-test.js
+++ b/tests/customer-resource-visibility-test.js
@@ -61,7 +61,7 @@ describeApplication('CustomerResourceVisibility', () => {
 
       let visibilityData = this.server.create('visibility-data', {
         isHidden: true,
-        reason: 'Set by System'
+        reason: 'Set by system'
       }).toJSON();
 
       resource.update('visibilityData', visibilityData);
@@ -77,7 +77,7 @@ describeApplication('CustomerResourceVisibility', () => {
     });
 
     it('maps the hidden reason text', () => {
-      expect(CustomerResourceShowPage.hiddenReason).to.equal('Set by System');
+      expect(CustomerResourceShowPage.hiddenReason).to.equal('Set by system');
     });
   });
 


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-168, Folio uses sentence case, where as ui-eholdings uses Title case. Update title case where used to sentence case.

## Approach
- Go through each file, figure out where static text is in title case and update it to sentence case.
- Update associated tests as well that check for specific error messages.
- Update certain mirage files as well for consistency.

#### TODOS and Open Questions
- [ ] Need to make changes to mod-kb-ebsco to return certain customized error messages in sentence case. Open question is how pervasive we want to be with this change in mod-kb-ebsco, do we just want to modify the custom messages or also modify data returned by RM API, like package, provider, title names etc. to be in sentence case?

## Screenshots
![sentence_case](https://user-images.githubusercontent.com/33662516/37062594-e7e802a4-2164-11e8-862a-2cf1a852a15d.gif)
