### PR TITLE
Make PR template more user friendly.

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,66 @@
+<!--
+  TL;DR
+    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
+    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
+    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
+-->
+
 ## Purpose
-_Describe the purpose of the pull request. Include background information if necessary._
+<!--
+  Why are you making this change? There is nothing more important
+  to provide to the reviewer and to future readers than the cause
+  that gave rise to this pull request. Be careful to avoid circular
+  statements like "the purpose is to change the font colors." and
+  instead provide an explanation like "the current textual color
+  palette does not provide enough contrast for certain classes of
+  visual impairments"
+
+  The purpose may seem self-evident to you now, but the standard to
+  hold yourself to should be "can a developer parachuting into this
+  project reconstruct the necessary context merely by reading this
+  section"
+ -->
 
 ## Approach
-_How does this change fulfill the purpose?_
+<!--
+ How does this change fulfill the purpose? It's best to talk
+ high-level strategy and avoid code-splaining the commit history.
+
+ Bad:
+  Made a dark color of #333, a medium color of #ccc
+
+ Good:
+   This introduces three abstact contrast levels that deveolpers can
+   use: dark, medium, and light.
+
+ The goal is not only to explain what you did, but help other
+ developers *work* with your solution in the future.
+-->
 
 #### TODOS and Open Questions
+<!-- OPTIONAL
 - [ ] Use GitHub checklists. When solved, check the box and explain the answer.
+-->
 
 ## Learning
-_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
+<!-- OPTIONAL
+  Help out not only your reviewer, but also your fellow developer!
+  Sometimes there are key pieces of information that you used to come up
+  with your solution. Don't let all that hard work go to waste! A
+  pull request is a *perfect opportunity to share the learning that
+  you did. Add links to blog posts, patterns, libraries or addons used
+  to solve this problem.
+-->
 
 ## Screenshots
-_Let's see those sweet visuals!_
+<!-- OPTIONAL
+ One picture is literally worth a thousand words. When the feature is
+ an interaction, an animated GIF is best. Most of the time it helps to
+ include "before" and "after" screenshots to quickly demonstrate the
+ value of the feature.
+
+ Here are some great tools to help you record gifs:
+
+ Windows: https://getsharex.com/
+ Mac: https://gifox.io/
+-->


### PR DESCRIPTION
## Purpose
Our PR template doesn't provide support to folks new to the project, and is instead more geared towards people who have already "drunk the koolaid" so to speak. It provides terse boilerplate that can, ironically, leave you wondering "why am I filling out this template?"

Some specific things I've noticed:

1. It doesn't provide any context as to why each section exists
2. Some sections are optional, yet often people feel obliged to fill
   them out. This will inevitably feel like busy-work and degrade the
   experience of the PR author as well as the PR reader.
3. If someone wants to educate themselves about writing good pull
   request, it doesn't actually provide them with any resources to do
   so.

## Approach
This expands unpacks each section of the pull request and gives a purpose and approach for each section. In this way, it actually mirrors the structure of the PR itself in a small way.

All of the section explanations have been moved into comments. The main reason is so that you don't have to delete them from your PR description, and can refer back to them as you develop it. It's a lot of information, and so this ought to give folks the opportunity to learn as they go and also to refine within the same pull request.

Wherever it makes sense, I'v tried to link appropriate tools and resources to learn about and build good PRs.

Finally, I've marked optional seccions as being optional to cut down on the feeling of busy-work.
