### PR TITLE
Update Filter Labels on Title and Package Search

### DIFF
--- a/src/components/package-search-filters.js
+++ b/src/components/package-search-filters.js
@@ -31,7 +31,7 @@ export default function PackageSearchFilters(props) {
           { label: 'All', value: 'all' },
           { label: 'Selected', value: 'true' },
           { label: 'Not selected', value: 'false' },
-          { label: 'Selected by EBSCO', value: 'ebsco' }
+          { label: 'Ordered through EBSCO', value: 'ebsco' }
         ]
       }, {
         name: 'type',
@@ -39,12 +39,12 @@ export default function PackageSearchFilters(props) {
         defaultValue: 'all',
         options: [
           { label: 'All', value: 'all' },
-          { label: 'Aggregated full text', value: 'aggregatedfulltext' },
-          { label: 'Abstract and index', value: 'abstractandindex' },
-          { label: 'E-book', value: 'ebook' },
-          { label: 'E-journal', value: 'ejournal' },
+          { label: 'Aggregated Full Text', value: 'aggregatedfulltext' },
+          { label: 'Abstract and Index', value: 'abstractandindex' },
+          { label: 'E-Book', value: 'ebook' },
+          { label: 'E-Journal', value: 'ejournal' },
           { label: 'Print', value: 'print' },
-          { label: 'Online reference', value: 'onlinereference' },
+          { label: 'Online Reference', value: 'onlinereference' },
           { label: 'Unknown', value: 'unknown' }
         ]
       }]}

--- a/src/components/title-search-filters.js
+++ b/src/components/title-search-filters.js
@@ -22,7 +22,7 @@ export default function TitleSearchFilters(props) {
           { label: 'All', value: 'all' },
           { label: 'Selected', value: 'true' },
           { label: 'Not selected', value: 'false' },
-          { label: 'Selected by EBSCO', value: 'ebsco' }
+          { label: 'Ordered through EBSCO', value: 'ebsco' }
         ]
       }, {
         name: 'type',
@@ -30,18 +30,18 @@ export default function TitleSearchFilters(props) {
         defaultValue: 'all',
         options: [
           { label: 'All', value: 'all' },
-          { label: 'Audio book', value: 'audiobook' },
+          { label: 'Audio Book', value: 'audiobook' },
           { label: 'Book', value: 'book' },
-          { label: 'Book series', value: 'bookseries' },
+          { label: 'Book Series', value: 'bookseries' },
           { label: 'Database', value: 'database' },
           { label: 'Journal', value: 'journal' },
           { label: 'Newsletter', value: 'newsletter' },
           { label: 'Newspaper', value: 'newspaper' },
           { label: 'Proceedings', value: 'proceedings' },
           { label: 'Report', value: 'report' },
-          { label: 'Streaming audio', value: 'streamingaudio' },
-          { label: 'Streaming video', value: 'streamingvideo' },
-          { label: 'Thesis & dissertation', value: 'thesisdissertation' },
+          { label: 'Streaming Audio', value: 'streamingaudio' },
+          { label: 'Streaming Video', value: 'streamingvideo' },
+          { label: 'Thesis & Dissertation', value: 'thesisdissertation' },
           { label: 'Website', value: 'website' },
           { label: 'Unspecified', value: 'unspecified' }
         ]


### PR DESCRIPTION
## Purpose
Update selected label from `Selected by EBSCO` to `Ordered through EBSCO` on both Title and Package search as noted https://issues.folio.org/browse/UIEH-154.
Also update Publication Type and Content Type filters from sentence case to title case (noted as part of https://issues.folio.org/browse/UIEH-168)

## Approach
Updated labels - no unit tests involved

#### TODOS and Open Questions
- [ ] As noted in earlier PRs, the filters should eventually come from back end module as configuration 

## Screenshots
![label-changes](https://user-images.githubusercontent.com/19415226/37112598-e501db94-2210-11e8-96dc-c6046a1620ef.gif)

