### PR TITLE
Update labels for allow kb to add new titles

### DIFF
--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -172,8 +172,8 @@ export default class PackageShow extends Component {
                       <div>
                         <h4>
                           {packageAllowedToAddTitles
-                            ? 'Allow KB to add new titles'
-                            : 'Do not allow KB to add new titles'}
+                            ? 'Automatically select new titles'
+                            : 'Do not automatically select new titles'}
                         </h4>
                         <ToggleSwitch
                           onChange={this.props.toggleAllowKbToAddTitles}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-191, labels for "allow KB to add new titles" should be updated to "Automatically select new titles"

## Approach
- Update only the labels and do not modify names of props or state because they still hold the meaning of this toggle

## Screenshots
![updatelabels](https://user-images.githubusercontent.com/33662516/37118385-0e6f1ada-2222-11e8-9def-70c730df04f4.gif)

