### PR TITLE
Lay groundwork for new list search modal

### DIFF
--- a/src/components/details-view/details-view.css
+++ b/src/components/details-view/details-view.css
@@ -6,6 +6,19 @@
     overflow-y: hidden;
   }
 
+  & .list-header {
+    display: flex;
+    border-bottom: 1px solid #dcdcdc;
+    border-top: 1px solid #dcdcdc;
+    justify-content: space-between;
+  }
+
+  &.locked {
+    & .list-header {
+      border-top: 1px solid #fff;
+    }
+  }
+
   & h3 {
     margin: 1em 0 0.5em;
   }
@@ -38,14 +51,13 @@
 
   & h3 {
     padding: 1rem 1rem 0.75rem;
-    border-bottom: 1px solid #dcdcdc;
     margin: 0;
   }
 
   & .list {
     /* the box-model needs _some_ height that is not 'auto' for flexbox to
        be able to fill this element to fit the remaining space */
-    min-height: 0px;
+    min-height: 0;
     flex: 1;
   }
 }

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -38,7 +38,7 @@ export default class DetailsView extends Component {
     paneTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
     paneSub: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
     bodyContent: PropTypes.node.isRequired,
-    listHeader: PropTypes.string,
+    listType: PropTypes.string,
     renderList: PropTypes.func
   };
 
@@ -147,7 +147,7 @@ export default class DetailsView extends Component {
       type,
       model,
       bodyContent,
-      listHeader,
+      listType,
       renderList,
       paneTitle,
       paneSub
@@ -227,7 +227,11 @@ export default class DetailsView extends Component {
               className={styles.sticky}
               data-test-eholdings-details-view-list={type}
             >
-              <h3>{listHeader}</h3>
+              <div className={styles['list-header']}>
+                <h3>
+                  {capitalize(listType)}
+                </h3>
+              </div>
 
               <div ref={(n) => { this.$list = n; }} className={styles.list}>
                 {renderList(isSticky)}

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -112,9 +112,11 @@ const Modal = (props) => {
         <div className={css.modalContent}>
           {props.children}
         </div>
-        <div className={css.modalFooter}>
-          {props.footer}
-        </div>
+        { props.footer &&
+          <div className={css.modalFooter}>
+            {props.footer}
+          </div>
+        }
       </div>
     </OverlayModal>
   );

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -198,11 +198,9 @@ export default class PackageShow extends Component {
                   </div>
                 </div>
               )}
-
-              <hr />
             </div>
           )}
-          listHeader="Titles"
+          listType="titles"
           renderList={scrollable => (
             <QueryList
               type="package-titles"

--- a/src/components/provider-show.js
+++ b/src/components/provider-show.js
@@ -32,7 +32,7 @@ export default function ProviderShow({
           </KeyValueLabel>
         </div>
       )}
-      listHeader="Packages"
+      listType="packages"
       renderList={scrollable => (
         <QueryList
           type="provider-packages"

--- a/src/components/title-show.js
+++ b/src/components/title-show.js
@@ -39,11 +39,9 @@ export default function TitleShow({ model }) {
               </div>
             </KeyValueLabel>
           )}
-
-          <hr />
         </div>
       )}
-      listHeader="Packages"
+      listType="packages"
       renderList={scrollable => (
         <ScrollView
           itemHeight={70}

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -7,12 +7,9 @@ import Provider from '../redux/provider';
 import Package from '../redux/package';
 import Title from '../redux/title';
 
-import ProviderSearchFilters from '../components/provider-search-filters';
 import ProviderSearchList from '../components/provider-search-list';
 import PackageSearchList from '../components/package-search-list';
-import PackageSearchFilters from '../components/package-search-filters';
 import TitleSearchList from '../components/title-search-list';
-import TitleSearchFilters from '../components/title-search-filters';
 import SearchPaneset from '../components/search-paneset';
 import SearchForm from '../components/search-form';
 
@@ -209,24 +206,6 @@ class SearchRoute extends Component {
   };
 
   /**
-   * Returns the component that is responsible for rendering filters
-   * for the current searchType
-   */
-  getFiltersComponent() {
-    let { searchType } = this.state;
-
-    if (searchType === 'titles') {
-      return TitleSearchFilters;
-    } else if (searchType === 'packages') {
-      return PackageSearchFilters;
-    } else if (searchType === 'providers') {
-      return ProviderSearchFilters;
-    }
-
-    return null;
-  }
-
-  /**
    * Renders the search component specific to the current search type
    */
   renderResults() {
@@ -282,7 +261,6 @@ class SearchRoute extends Component {
                 searchfield={params.searchfield}
                 sort={params.sort}
                 searchTypeUrls={this.getSearchTypeUrls()}
-                filtersComponent={this.getFiltersComponent()}
                 onSearch={this.handleSearch}
               />
             )}


### PR DESCRIPTION
## Purpose
Part of https://issues.folio.org/browse/UIEH-143

We'd like to eventually have a way to search lists of related items on detail panes. I created a proof-of-concept that opens a modal containing the search filters for that type of item.

Proof-of-concept (not implemented in this PR):
![dubenpplzl](https://user-images.githubusercontent.com/230597/37124538-52b1e57c-222e-11e8-8bc8-2b84ff4f8f65.gif)

## Approach
This ships some groundwork of that proof-of-concept that's ready for production. The search form needed to be more independent of the search route to be able to render it in a modal in a different place. The list header is also now ready for a right-aligned icon button to be dropped in.

No functionality changes with this PR.