### PR TITLE
Add style imports to test harness

### DIFF
--- a/tests/harness.js
+++ b/tests/harness.js
@@ -10,6 +10,10 @@ import { discoverServices } from '@folio/stripes-core/src/discoverServices';
 import gatherActions from '@folio/stripes-core/src/gatherActions';
 import { setOkapiReady } from '@folio/stripes-core/src/okapiActions';
 
+// load these in our tests
+import 'typeface-source-sans-pro';
+import '@folio/stripes-components/lib/global.css';
+
 import Root from '@folio/stripes-core/src/components/Root';
 
 const actionNames = gatherActions();

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -36,6 +36,7 @@ export function describeApplication(name, setup, describe = window.describe) {
     beforeEach(function () {
       rootElement = document.createElement('div');
       rootElement.id = 'react-testing';
+      rootElement.style.height = '100%';
       document.body.appendChild(rootElement);
 
       this.server = startMirage(setup.scenarios);


### PR DESCRIPTION
## Purpose
Replaces #232

These imports are normally found in the webpack config used by stripes-core, but when running tests using karma-webpack the entry field is discarded. By adding them to our test harness, we can ensure they will be included in our tests as well.

## Approach
Import the missing style assets directly into our test harness and set the `#react-testing` div's height to `100%` to align with the `100%` height given to the typical root element.

## Screenshots
![image](https://user-images.githubusercontent.com/5005153/37169887-d4d7f6f4-22ce-11e8-8cd5-43b19c29a8ed.png)

