### PR TITLE
Only run linting on Travis, not Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 
 buildNPM {
   publishModDescriptor = 'yes'
-  runLint = 'yes'
+  runLint = 'no'
   runTest = 'no'
-}  
+}


### PR DESCRIPTION
❌  Jenkins only leaves comments in the PR when the lint fails, but does not fail the build.

✅  Travis fails the build with linting errors. 

No need to run lint on Jenkins.