### PR TITLE
Upgrade @bigtest/mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint ./"
   },
   "devDependencies": {
+    "@bigtest/convergence": "^0.4.0",
     "@bigtest/interaction": "^0.1.0",
     "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@bigtest/interaction": "^0.1.0",
     "@bigtest/mirage": "^0.0.1",
-    "@bigtest/mocha": "^0.2.1",
+    "@bigtest/mocha": "^0.3.1",
     "@folio/eslint-config-stripes": "^1.1.0",
     "@folio/stripes-cli": "^1.0.0",
     "babel-plugin-istanbul": "^4.1.5",

--- a/tests/backend-configuration-test.js
+++ b/tests/backend-configuration-test.js
@@ -120,7 +120,7 @@ describeApplication('With valid backend configuration', () => {
       expect(SettingsPage.apiKeyInputType).to.equal('password');
     });
 
-    it.always.skip('does not have visible form action buttons', () => {
+    it.always('does not have visible form action buttons', () => {
       expect(SettingsPage.hasVisibleActions).to.be.false;
     });
 
@@ -187,7 +187,7 @@ describeApplication('With valid backend configuration', () => {
           return SettingsPage.save();
         });
 
-        it.always.skip('shows the form action buttons', () => {
+        it.always('shows the form action buttons', () => {
           expect(SettingsPage.hasVisibleActions).to.be.true;
         });
 

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -138,7 +138,7 @@ describeApplication('CustomerResourceShow', () => {
       expect(ResourcePage.isSelected).to.equal(false);
     });
 
-    it.always.skip('should not display the back button', () => {
+    it.always('should not display the back button', () => {
       expect(ResourcePage.hasBackButton).to.be.false;
     });
   });
@@ -188,11 +188,11 @@ describeApplication('CustomerResourceShow', () => {
       expect(ResourcePage.titleName).to.equal('Best Title Ever');
     });
 
-    it.always.skip('does not display a content type', () => {
+    it.always('does not display a content type', () => {
       expect(ResourcePage.hasContentType).to.be.false;
     });
 
-    it.always.skip('does not display a publication type', () => {
+    it.always('does not display a publication type', () => {
       expect(ResourcePage.hasPublicationType).to.be.false;
     });
   });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -5,7 +5,7 @@ import chai from 'chai';
 import chaiJquery from 'chai-jquery';
 import $ from 'jquery';
 import { render, unmountComponentAtNode } from 'react-dom';
-import { convergeOn } from './it-will';
+import Convergence from '@bigtest/convergence';
 import startMirage from '../mirage/start';
 import TestHarness from './harness';
 
@@ -45,7 +45,6 @@ export function describeApplication(name, setup, describe = window.describe) {
       this.app = render(<TestHarness />, rootElement);
 
       this.visit = visit.bind(null, this); // eslint-disable-line no-use-before-define
-      this.goBack = goBack.bind(null, this); // eslint-disable-line no-use-before-define
     });
 
     afterEach(function () {
@@ -93,35 +92,9 @@ describeApplication.only = function (name, setup) {
  * @return {Promise} resolved when navigation is complete.
  */
 function visit(context, path, convergenceCheck) {
-  if (context.app) {
-    context.app.visit(path);
-  }
-
-  return convergeOn.call(context, convergenceCheck);
-}
-
-/**
- * Triggers navigating back through the history, and ensures thiat it
- * happens correctly.
- *
- * @param {Object} context - a mocha test context.
- * @param {Function} convergenceCheck - assertion to run to ensure
- * that the navigation worked.
- * @returns {Promise} resolved when navigation is complete
- */
-function goBack(context, convergenceCheck) {
-  if (context.app) {
-    context.app.history.goBack();
-  }
-
-  return convergeOn.call(context, convergenceCheck);
-}
-
-/**
- * Returns a promise that doesn't resolve to make the test wait forever
- */
-window.pauseTest = pauseTest; // eslint-disable-line no-use-before-define
-export function pauseTest(context) {
-  if (context) context.timeout(0);
-  return new Promise(() => {});
+  return new Convergence()
+    .do(() => context.app.visit(path))
+    .once(convergenceCheck)
+    .timeout(context.timeout())
+    .run();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,6 +75,10 @@
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.3.0.tgz#c69a8219e5c6f3b092651117debd3990610118c8"
 
+"@bigtest/convergence@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.4.0.tgz#dc4caa274e4d8e91e5a63eefa8bb76b422e2c7f2"
+
 "@bigtest/interaction@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@bigtest/interaction/-/interaction-0.1.0.tgz#5fe97b50f78d541cce81205785995602d09a2b03"
@@ -90,11 +94,11 @@
     lodash "^4.17.4"
     pretender "^2.0.0"
 
-"@bigtest/mocha@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@bigtest/mocha/-/mocha-0.2.1.tgz#280f9c1168641c87df3444a6a3602a53b7bfd13b"
+"@bigtest/mocha@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@bigtest/mocha/-/mocha-0.3.1.tgz#740011dbe72c9744de37f8862094bb511fdf3168"
   dependencies:
-    "@bigtest/convergence" "^0.3.0"
+    "@bigtest/convergence" "^0.4.0"
 
 "@folio/developer@^1.3.0":
   version "1.3.100011"


### PR DESCRIPTION
## Purpose
Upgrades `@bigtest/mocha` to fix mocha timeout errors

## Approach
- Upgrade `@bigtest/mocha` to `^0.3.0` which removes mocha timeouts
- Unskipped the `it.always` tests that were previously flakey
- Use `@bigtest/convergence` for the `visit` helper
- Also removed `goBack` since it's never used
- And removed `window.pauseTest` since we now have `it.pause`