### PR TITLE
Create CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,145 @@
+version: 2.0
+
+jobs:
+  checkout-and-install:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-node-modules-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install dependencies
+          command: yarn install
+      - persist_to_workspace:
+          root: ~/
+          paths: project
+      - save_cache:
+          key: v1-node-modules-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/project/node_modules
+
+  eslint:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Lint JS
+          command: yarn eslint --max-warnings=0
+
+  stylelint:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Lint CSS
+          command: yarn stylelint
+
+  test-chrome:
+    docker:
+      - image: circleci/node:latest-browsers
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run tests
+          command: yarn test --karma.singleRun --coverage
+      - store_test_results:
+          path: ./artifacts/junit
+      - store_artifacts:
+          name: Store junit test report
+          path: ./artifacts/junit
+      - store_artifacts:
+          name: Store code coverage report
+          path: ./artifacts/coverage/lcov.txt
+
+  test-safari:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run tests
+          command: yarn test --karma.singleRun --karma.browsers=bs_safari_11
+      - store_test_results:
+          path: ./artifacts/junit
+      - store_artifacts:
+          name: Store junit test report
+          path: ./artifacts/junit
+
+  test-firefox:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run tests
+          command: yarn test --karma.singleRun --karma.browsers=bs_firefox_mac
+      - store_test_results:
+          path: ./artifacts/junit
+      - store_artifacts:
+          name: Store junit test report
+          path: ./artifacts/junit
+
+  test-edge:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run tests
+          command: yarn test --karma.singleRun --karma.browsers=bs_ieEdge_windows || true
+      - store_test_results:
+          path: ./artifacts/junit
+      - store_artifacts:
+          name: Store junit test report
+          path: ./artifacts/junit
+
+  test-ie:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run tests
+          command: yarn test --karma.singleRun --karma.browsers=bs_ie11_windows || true
+      - store_test_results:
+          path: ./artifacts/junit
+      - store_artifacts:
+          name: Store junit test report
+          path: ./artifacts/junit
+
+workflows:
+  version: 2
+  push:
+    jobs:
+      - checkout-and-install
+      - eslint:
+          requires:
+            - checkout-and-install
+      - stylelint:
+          requires:
+            - checkout-and-install
+      - test-chrome:
+          requires:
+            - checkout-and-install
+      - test-safari:
+          requires:
+            - checkout-and-install
+      - test-firefox:
+          requires:
+            - checkout-and-install
+      - test-edge:
+          requires:
+            - checkout-and-install
+      - test-ie:
+          requires:
+            - checkout-and-install

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -47,14 +47,28 @@ module.exports = (config) => {
       'karma-browserstack-launcher',
       'karma-mocha',
       'karma-webpack',
-      'karma-mocha-reporter'
+      'karma-mocha-reporter',
+      'karma-junit-reporter'
     ]
   };
+
+  // Also run junit reporter on CircleCI
+  if (process.env.CIRCLECI) {
+    configuration.reporters.push('junit');
+    configuration.junitReporter = {
+      outputDir: 'artifacts/junit/Karma'
+    };
+  }
 
   // Turn on coverage reports if --coverage option set
   if (config.coverage) {
     configuration.coverageReporter = {
-      type: 'text',
+      dir: 'artifacts/coverage',
+      subdir: '.',
+      reporters: [
+        { type: 'text' },
+        { type: 'lcovonly', file: 'lcov.txt' }
+      ],
       includeAllSources: true,
       check: {
         global: { // thresholds under which karma will return failure

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "start": "stripes serve demo/stripes.config.js",
     "build": "stripes build demo/stripes.config.js dist",
     "test": "stripes test karma demo/stripes.config.js",
-    "lint": "eslint ./ && stylelint \"src/**/*.css\""
+    "lint": "eslint ./ && stylelint \"src/**/*.css\"",
+    "eslint": "eslint ./",
+    "stylelint": "stylelint \"src/**/*.css\""
   },
   "devDependencies": {
     "@bigtest/convergence": "^0.4.0",
@@ -28,6 +30,7 @@
     "jquery": "^3.2.1",
     "karma-browserstack-launcher": "^1.3.0",
     "karma-coverage": "^1.1.1",
+    "karma-junit-reporter": "^1.2.0",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",
     "qs": "^6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4790,6 +4790,13 @@ karma-coverage@^1.1.1:
     minimatch "^3.0.0"
     source-map "^0.5.1"
 
+karma-junit-reporter@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz#4f9c40cedfb1a395f8aef876abf96189917c6396"
+  dependencies:
+    path-is-absolute "^1.0.0"
+    xmlbuilder "8.2.2"
+
 karma-mocha-reporter@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz#15120095e8ed819186e47a0b012f3cd741895560"
@@ -8937,6 +8944,10 @@ xdg-basedir@^3.0.0:
 xml-char-classes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
+
+xmlbuilder@8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
 
 xmlhttprequest-ssl@1.5.3:
   version "1.5.3"


### PR DESCRIPTION
## Purpose
CircleCI 2.0 has a lot of optimizations over Travis that can improve the speed and reliability of our CI builds.

## Learning
[CircleCI 2.0 Workflows](https://circleci.com/docs/2.0/workflows/)

## Caveats
- Circle doesn't have the nice `allow_failures` option that Travis does, so the IE and Edge jobs just have to report passing, even though those test runs failed.

## Next Steps
- ESLint and Stylelint are not yet reporting their results in JUnit format, which enables Circle to have some nicer UI and reporting.
- We can dry up the YAML a lot with anchors and references.

## Screenshots
![screen shot 2018-03-08 at 4 13 45 pm](https://user-images.githubusercontent.com/230597/37179597-b944d17e-22eb-11e8-80a2-6a026be21419.png)

![screen shot 2018-03-08 at 4 29 50 pm](https://user-images.githubusercontent.com/230597/37180238-f4b06154-22ed-11e8-9f00-cfddcb285c7b.png)
