### PR TITLE
[WIP] Replace uses of convergeOn()

### DIFF
--- a/tests/details-view-test.js
+++ b/tests/details-view-test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
+import Convergence from '@bigtest/convergence';
 
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/package-show';
@@ -29,11 +29,10 @@ describeApplication('DetailsView', () => {
     describe('scrolling to the bottom of the container', () => {
       beforeEach(() => {
         // converge on the titles being loaded
-        return convergeOn(() => {
-          expect(PackageShowPage.titleList.length).to.be.gt(0);
-        }).then(() => {
-          PackageShowPage.$detailPaneContents.scrollTop(PackageShowPage.$detailPaneContents.prop('scrollHeight'));
-        });
+        return new Convergence()
+          .once(() => expect(PackageShowPage.titleList.length).to.be.gt(0))
+          .do(() => PackageShowPage.$detailPaneContents.scrollTop(PackageShowPage.$detailPaneContents.prop('scrollHeight')))
+          .run();
       });
 
       it('disables scrolling the container', () => {
@@ -47,11 +46,10 @@ describeApplication('DetailsView', () => {
       describe('scrolling up from the list', () => {
         beforeEach(() => {
           // converge on the previous expected behavior first
-          return convergeOn(() => {
-            expect(PackageShowPage.$detailPaneContents).to.have.css('overflow-y', 'hidden');
-          }).then(() => {
-            PackageShowPage.scrollToTitleOffset(0);
-          });
+          return new Convergence()
+            .once(() => expect(PackageShowPage.$detailPaneContents).to.have.css('overflow-y', 'hidden'))
+            .do(() => PackageShowPage.scrollToTitleOffset(0))
+            .run();
         });
 
         it('enables scrolling the container', () => {
@@ -66,11 +64,10 @@ describeApplication('DetailsView', () => {
       describe('scrolling up from the container', () => {
         beforeEach(() => {
           // converge on the previous expected behavior first
-          return convergeOn(() => {
-            expect(PackageShowPage.$detailPaneContents).to.have.css('overflow-y', 'hidden');
-          }).then(() => {
-            PackageShowPage.$detailPaneContents.scrollTop(10);
-          });
+          return new Convergence()
+            .once(() => expect(PackageShowPage.$detailPaneContents).to.have.css('overflow-y', 'hidden'))
+            .do(() => PackageShowPage.$detailPaneContents.scrollTop(10))
+            .run();
         });
 
         it('enables scrolling the container', () => {
@@ -85,13 +82,14 @@ describeApplication('DetailsView', () => {
       describe('scrolling up with the mousewheel', () => {
         beforeEach(() => {
           // converge on the previous expected behavior first
-          return convergeOn(() => {
-            expect(PackageShowPage.$detailPaneContents).to.have.css('overflow-y', 'hidden');
-          }).then(() => {
-            PackageShowPage.$detailPaneContents.get(0).dispatchEvent(
-              new WheelEvent('wheel', { bubbles: true, deltaY: -1 })
-            );
-          });
+          return new Convergence()
+            .once(() => expect(PackageShowPage.$detailPaneContents).to.have.css('overflow-y', 'hidden'))
+            .do(() => {
+              PackageShowPage.$detailPaneContents.get(0).dispatchEvent(
+                new WheelEvent('wheel', { bubbles: true, deltaY: -1 })
+              );
+            })
+            .run();
         });
 
         it('enables scrolling the container', () => {
@@ -109,13 +107,14 @@ describeApplication('DetailsView', () => {
         let title = this.server.create('title');
 
         // converge on the previous page being loaded first
-        return convergeOn(() => {
-          expect(PackageShowPage.titleList.length).to.be.gt(0);
-        }).then(() => {
-          return this.visit(`/eholdings/titles/${title.id}`, () => {
-            expect(TitleShowPage.$root).to.exist;
-          });
-        });
+        return new Convergence()
+          .once(() => expect(PackageShowPage.titleList.length).to.be.gt(0))
+          .do(() => {
+            return this.visit(`/eholdings/titles/${title.id}`, () => {
+              expect(TitleShowPage.$root).to.exist;
+            });
+          })
+          .run();
       });
 
       it('has a list that does not fill the container', () => {

--- a/tests/package-selection-test.js
+++ b/tests/package-selection-test.js
@@ -1,6 +1,6 @@
 import { beforeEach, afterEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
+import Convergence from '@bigtest/convergence';
 
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/package-show';
@@ -81,10 +81,10 @@ describeApplication('PackageSelection', () => {
 
       describe('and deselecting the package', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            // wait for the package to become toggleable again
-            expect(PackageShowPage.isSelectedToggleable).to.equal(true);
-          }).then(() => PackageShowPage.toggleIsSelected());
+          return new Convergence()
+            .once(() => expect(PackageShowPage.isSelectedToggleable).to.equal(true))
+            .do(() => PackageShowPage.toggleIsSelected())
+            .run();
         });
 
         it('reflects the desired state (not selected)', () => {

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
+import Convergence from '@bigtest/convergence';
 
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/bigtest/package-show';
@@ -82,13 +82,14 @@ describeApplication('PackageShow', () => {
         });
 
         // converge on the previous package loading first
-        return convergeOn(() => {
-          expect(PackageShowPage.titleList.length).to.be.gt(0);
-        }).then(() => (
-          this.visit(`/eholdings/packages/${otherPackage.id}`, () => {
-            expect(PackageShowPage.$root).to.exist;
+        return new Convergence()
+          .once(() => expect(PackageShowPage.titleList.length).to.be.gt(0))
+          .do(() => {
+            this.visit(`/eholdings/packages/${otherPackage.id}`, () => {
+              expect(PackageShowPage.$root).to.exist;
+            });
           })
-        ));
+          .run();
       });
 
       it('displays the different package', () => {
@@ -117,11 +118,10 @@ describeApplication('PackageShow', () => {
 
     describe.skip('scrolling down the list of titles', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(PackageShowPage.titleList.length).to.be.gt(0);
-        }).then(() => {
-          PackageShowPage.scrollToTitleOffset(26);
-        });
+        return new Convergence()
+          .once(() => expect(PackageShowPage.titleList.length).to.be.gt(0))
+          .do(() => PackageShowPage.scrollToTitleOffset(26))
+          .run();
       });
 
       it('should display the next page of related titles', () => {

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
+import Convergence from '@bigtest/convergence';
 
 export default {
   get $root() {
@@ -16,11 +16,10 @@ export default {
      * We don't want to click the element before it exists.  This should
      * probably become a generic 'click' helper once we have more usage.
      */
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-customer-resource-show-selected]')).to.exist;
-    }).then(() => (
-      $('[data-test-eholdings-customer-resource-show-selected] input').click()
-    ));
+    return new Convergence()
+      .once(() => expect($('[data-test-eholdings-customer-resource-show-selected]')).to.exist)
+      .do(() => $('[data-test-eholdings-customer-resource-show-selected] input').click())
+      .run();
   },
 
   get isSelecting() {
@@ -44,11 +43,10 @@ export default {
      * We don't want to click the element before it exists.  This should
      * probably become a generic 'click' helper once we have more usage.
      */
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-customer-resource-toggle-hidden]')).to.exist;
-    }).then(() => (
-      $('[data-test-eholdings-customer-resource-toggle-hidden] input').click()
-    ));
+    return new Convergence()
+      .once(() => expect($('[data-test-eholdings-customer-resource-toggle-hidden]')).to.exist)
+      .do(() => $('[data-test-eholdings-customer-resource-toggle-hidden] input').click())
+      .run();
   },
 
   get isHiding() {

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
+import Convergence from '@bigtest/convergence';
 import { triggerChange } from '../helpers';
 
 function createPackageObject(element) {
@@ -90,19 +90,18 @@ export default {
     let $input = $('[data-test-search-field]').find('input[name="search"]').val(query);
     triggerChange($input.get(0));
 
-    return convergeOn(() => {
-      expect($input).to.have.value(query);
-    }).then(() => {
-      $('[data-test-search-submit]').trigger('click');
-    });
+    return new Convergence()
+      .once(() => expect($input).to.have.value(query))
+      .do(() => $('[data-test-search-submit]').trigger('click'))
+      .run();
   },
 
   clearSearch() {
     let $input = $('[data-test-search-field]').find('input[name="search"]').val('');
     triggerChange($input.get(0));
-    return convergeOn(() => {
-      expect($input).to.have.value('');
-    });
+    return new Convergence()
+      .once(() => expect($input).to.have.value(''))
+      .run();
   },
 
   getFilter(name) {
@@ -112,7 +111,9 @@ export default {
   clickFilter(name, value) {
     let $radio = this.$searchFilters.find(`input[name="${name}"][value="${value}"]`);
     $radio.get(0).click();
-    return convergeOn(() => expect($radio).to.have.prop('checked'));
+    return new Convergence()
+      .once(() => expect($radio).to.have.prop('checked'))
+      .run();
   },
 
   clearFilter(name) {
@@ -124,17 +125,23 @@ export default {
 
   changeSearchType(searchType) {
     $(`[data-test-search-type-button="${searchType}"]`).get(0).click();
-    return convergeOn(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist);
+
+    return new Convergence()
+      .once(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist)
+      .run();
   },
 
   clickTitle(index) {
     let $title = null;
 
     // wait until the item exists before clicking
-    return convergeOn(() => {
-      $title = $('[data-test-query-list="package-titles"] li a');
-      expect($title.eq(index)).to.exist;
-    }).then(() => $title.get(index).click());
+    return new Convergence()
+      .once(() => {
+        $title = $('[data-test-query-list="package-titles"] li a');
+        expect($title.eq(index)).to.exist;
+      })
+      .do(() => $title.get(index).click())
+      .run();
   },
 
   clickBackButton() {

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import { expect } from 'chai';
 
-import { convergeOn } from '@bigtest/convergence';
+import Convergence from '@bigtest/convergence';
 
 function createTitleObject(element) {
   let $scope = $(element);
@@ -40,11 +40,10 @@ export default {
      * We don't want to click the element before it exists.  This should
      * probably become a generic 'click' helper once we have more usage.
      */
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-package-details-selected]')).to.exist;
-    }).then(() => (
-      $('[data-test-eholdings-package-details-selected] input').click()
-    ));
+    return new Convergence()
+      .once(() => expect($('[data-test-eholdings-package-details-selected]')).to.exist)
+      .do(() => $('[data-test-eholdings-package-details-selected] input').click())
+      .run();
   },
 
   get isSelecting() {
@@ -80,11 +79,10 @@ export default {
   },
 
   toggleIsHidden() {
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-package-details-hidden]')).to.exist;
-    }).then(() => (
-      $('[data-test-eholdings-package-details-hidden] input').click()
-    ));
+    return new Convergence()
+      .once(() => expect($('[data-test-eholdings-package-details-hidden]')).to.exist)
+      .do(() => $('[data-test-eholdings-package-details-hidden] input').click())
+      .run();
   },
 
   get isHiding() {

--- a/tests/pages/provider-search.js
+++ b/tests/pages/provider-search.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
+import Convergence from '@bigtest/convergence';
 import { triggerChange } from '../helpers';
 
 function createProviderObject(element) {
@@ -45,7 +45,9 @@ export default {
   clickFilter(name, value) {
     let $radio = this.$searchFilters.find(`input[name="${name}"][value="${value}"]`);
     $radio.get(0).click();
-    return convergeOn(() => expect($radio).to.have.prop('checked'));
+    return new Convergence()
+      .once(() => expect($radio).to.have.prop('checked'))
+      .run();
   },
 
   get $searchResultsItems() {
@@ -100,34 +102,38 @@ export default {
     let $input = $('[data-test-search-field]').find('input[name="search"]').val(query);
     triggerChange($input.get(0));
 
-    return convergeOn(() => {
-      expect($input).to.have.value(query);
-    }).then(() => {
-      $('[data-test-search-submit]').trigger('click');
-    });
+    return new Convergence()
+      .once(() => expect($input).to.have.value(query))
+      .do(() => $('[data-test-search-submit]').trigger('click'))
+      .run();
   },
 
   clearSearch() {
     let $input = $('[data-test-search-field]').find('input[name="search"]').val('');
     triggerChange($input.get(0));
-    return convergeOn(() => {
-      expect($input).to.have.value('');
-    });
+    return new Convergence()
+      .once(() => expect($input).to.have.value(''))
+      .run();
   },
 
   changeSearchType(searchType) {
     $(`[data-test-search-type-button="${searchType}"]`).get(0).click();
-    return convergeOn(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist);
+    return new Convergence()
+      .once(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist)
+      .run();
   },
 
   clickPackage(index) {
     let $pkg = null;
 
     // wait until the item exists before clicking
-    return convergeOn(() => {
-      $pkg = $('[data-test-query-list="provider-packages"] li a');
-      expect($pkg.eq(index)).to.exist;
-    }).then(() => $pkg.get(index).click());
+    return new Convergence()
+      .once(() => {
+        $pkg = $('[data-test-query-list="provider-packages"] li a');
+        expect($pkg.eq(index)).to.exist;
+      })
+      .do(() => $pkg.get(index).click())
+      .run();
   },
 
   clickBackButton() {

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
+import Convergence from '@bigtest/convergence';
 import { triggerChange } from '../helpers';
 
 function createTitleObject(element) {
@@ -87,18 +87,17 @@ export default {
     let $input = $('[data-test-title-search-field]').find('input[name="search"]').val(query);
     triggerChange($input.get(0));
 
-    return convergeOn(() => {
-      expect($input).to.have.value(query);
-    }).then(() => {
-      $('[data-test-search-submit]').trigger('click');
-    });
+    return new Convergence()
+      .once(() => expect($input).to.have.value(query))
+      .do(() => $('[data-test-search-submit]').trigger('click'))
+      .run();
   },
   clearSearch() {
     let $input = $('[data-test-title-search-field]').find('input[name="search"]').val('');
     triggerChange($input.get(0));
-    return convergeOn(() => {
-      expect($input).to.have.value('');
-    });
+    return new Convergence()
+      .once(() => expect($input).to.have.value(''))
+      .run();
   },
   get $searchFieldSelect() {
     return $('[data-test-title-search-field]').find('select')[0];
@@ -115,7 +114,9 @@ export default {
   clickFilter(name, value) {
     let $radio = this.$searchFilters.find(`input[name="${name}"][value="${value}"]`);
     $radio.get(0).click();
-    return convergeOn(() => expect($radio).to.have.prop('checked'));
+    return new Convergence()
+      .once(() => expect($radio).to.have.prop('checked'))
+      .run();
   },
 
   clearFilter(name) {
@@ -127,17 +128,22 @@ export default {
 
   changeSearchType(searchType) {
     $(`[data-test-search-type-button="${searchType}"]`).get(0).click();
-    return convergeOn(() => expect($(`[data-test-search-form="${searchType}"]`)).to.exist);
+    return new Convergence()
+      .once(() => () => expect($(`[data-test-search-form="${searchType}"]`)).to.exist)
+      .run();
   },
 
   clickPackage(index) {
     let $pkg = null;
 
     // wait until the item exists before clicking
-    return convergeOn(() => {
-      $pkg = $('[data-test-query-list="title-packages"] li a');
-      expect($pkg.eq(index)).to.exist;
-    }).then(() => $pkg.get(index).click());
+    return new Convergence()
+      .once(() => {
+        $pkg = $('[data-test-query-list="title-packages"] li a');
+        expect($pkg.eq(index)).to.exist;
+      })
+      .do(() => $pkg.get(index).click())
+      .run();
   },
 
   clickBackButton() {

--- a/tests/provider-show-test.js
+++ b/tests/provider-show-test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
+import Convergence from '@bigtest/convergence';
 
 import { describeApplication } from './helpers';
 import ProviderShowPage from './pages/provider-show';
@@ -81,11 +81,10 @@ describeApplication('ProviderShow', () => {
 
     describe('scrolling down the list of packages', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(ProviderShowPage.packageList.length).to.be.gt(0);
-        }).then(() => {
-          ProviderShowPage.scrollToPackageOffset(26);
-        });
+        return new Convergence()
+          .once(() => expect(ProviderShowPage.packageList.length).to.be.gt(0))
+          .do(() => ProviderShowPage.scrollToPackageOffset(26))
+          .run();
       });
 
       it('should display the next page of related packages', () => {

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
+import Convergence from '@bigtest/convergence';
 
 import { describeApplication } from './helpers';
 import TitleSearchPage from './pages/title-search';
@@ -110,10 +110,11 @@ describeApplication('TitleSearch', () => {
 
     describe('clicking a search results list item', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          // wait for the previous search to complete
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => TitleSearchPage.$searchResultsItems[0].click());
+        // wait for the previous search to complete
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => TitleSearchPage.$searchResultsItems[0].click())
+          .run();
       });
 
       it('clicked item has an active state', () => {
@@ -186,11 +187,10 @@ describeApplication('TitleSearch', () => {
 
     describe('filtering by publication type', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => (
-          TitleSearchPage.clickFilter('type', 'book')
-        ));
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => TitleSearchPage.clickFilter('type', 'book'))
+          .run();
       });
 
       it('only shows results for book publication types', () => {
@@ -208,11 +208,10 @@ describeApplication('TitleSearch', () => {
 
       describe('clearing the filters', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(1);
-          }).then(() => (
-            TitleSearchPage.clearFilter('type')
-          ));
+          return new Convergence()
+            .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(1))
+            .do(() => TitleSearchPage.clearFilter('type'))
+            .run();
         });
 
         it.always('removes the filter from the URL query params', function () {
@@ -226,13 +225,14 @@ describeApplication('TitleSearch', () => {
 
       describe('visiting the page with an existing filter', () => {
         beforeEach(function () {
-          return convergeOn(() => {
-            expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(1);
-          }).then(() => {
-            return this.visit('/eholdings/?searchType=titles&q=Title&filter[type]=journal', () => {
-              expect(TitleSearchPage.$root).to.exist;
-            });
-          });
+          return new Convergence()
+            .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(1))
+            .do(() => {
+              return this.visit('/eholdings/?searchType=titles&q=Title&filter[type]=journal', () => {
+                expect(TitleSearchPage.$root).to.exist;
+              });
+            })
+            .run();
         });
 
         it('shows the existing filter in the search form', () => {
@@ -252,11 +252,10 @@ describeApplication('TitleSearch', () => {
 
     describe('filtering by selection status', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => (
-          TitleSearchPage.clickFilter('selected', 'true')
-        ));
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => TitleSearchPage.clickFilter('selected', 'true'))
+          .run();
       });
 
       it('only shows results for selected titles', () => {
@@ -273,11 +272,10 @@ describeApplication('TitleSearch', () => {
 
       describe('clearing the filters', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(2);
-          }).then(() => (
-            TitleSearchPage.clearFilter('selected')
-          ));
+          return new Convergence()
+            .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(2))
+            .do(() => TitleSearchPage.clearFilter('selected'))
+            .run();
         });
 
         it.always('removes the filter from the URL query params', function () {
@@ -291,13 +289,14 @@ describeApplication('TitleSearch', () => {
 
       describe('visiting the page with an existing filter', () => {
         beforeEach(function () {
-          return convergeOn(() => {
-            expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(2);
-          }).then(() => {
-            return this.visit('/eholdings/?searchType=titles&q=Title&filter[selected]=false', () => {
-              expect(TitleSearchPage.$root).to.exist;
-            });
-          });
+          return new Convergence()
+            .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(2))
+            .do(() => {
+              return this.visit('/eholdings/?searchType=titles&q=Title&filter[selected]=false', () => {
+                expect(TitleSearchPage.$root).to.exist;
+              });
+            })
+            .run();
         });
 
         it('shows the existing filter in the search form', () => {
@@ -316,13 +315,11 @@ describeApplication('TitleSearch', () => {
 
     describe('selecting a publisher search field', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => (
-          TitleSearchPage.selectSearchField('publisher')
-        )).then(() => (
-          TitleSearchPage.search('TestPublisher')
-        ));
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => TitleSearchPage.selectSearchField('publisher'))
+          .do(() => TitleSearchPage.search('TestPublisher'))
+          .run();
       });
 
       it('only shows results having publishers with name including TestPublisher', () => {
@@ -341,13 +338,11 @@ describeApplication('TitleSearch', () => {
 
     describe('selecting a subject search field', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => (
-          TitleSearchPage.selectSearchField('subject')
-        )).then(() => (
-          TitleSearchPage.search('TestSubject')
-        ));
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => TitleSearchPage.selectSearchField('subject'))
+          .do(() => TitleSearchPage.search('TestSubject'))
+          .run();
       });
 
       it('only shows results having subjects including TestSubject', () => {
@@ -365,13 +360,11 @@ describeApplication('TitleSearch', () => {
 
     describe('selecting an isxn search field', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => (
-          TitleSearchPage.selectSearchField('isxn')
-        )).then(() => (
-          TitleSearchPage.search('999-999')
-        ));
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => TitleSearchPage.selectSearchField('isxn'))
+          .do(() => TitleSearchPage.search('999-999'))
+          .run();
       });
 
       it('only shows results having isxn field ', () => {
@@ -389,11 +382,10 @@ describeApplication('TitleSearch', () => {
 
     describe('changing search fields', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => (
-          TitleSearchPage.selectSearchField('subject')
-        ));
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => TitleSearchPage.selectSearchField('subject'))
+          .run();
       });
 
       it('maintains the previous search', () => {
@@ -403,13 +395,14 @@ describeApplication('TitleSearch', () => {
 
     describe('visiting the page with an existing search field', () => {
       beforeEach(function () {
-        return convergeOn(() => {
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => {
-          return this.visit('/eholdings/?searchType=titles&q=TestPublisher&searchfield=publisher', () => {
-            expect(TitleSearchPage.$root).to.exist;
-          });
-        });
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => {
+            return this.visit('/eholdings/?searchType=titles&q=TestPublisher&searchfield=publisher', () => {
+              expect(TitleSearchPage.$root).to.exist;
+            });
+          })
+          .run();
       });
 
       it('displays publisher as searchfield', () => {
@@ -426,11 +419,10 @@ describeApplication('TitleSearch', () => {
     });
     describe('with a more specific query', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => (
-          TitleSearchPage.search('Title1')
-        ));
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => TitleSearchPage.search('Title1'))
+          .run();
       });
 
       it('only shows a single result', () => {
@@ -440,11 +432,14 @@ describeApplication('TitleSearch', () => {
 
     describe('clicking another search type', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          // wait for the previous search to complete
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => TitleSearchPage.$searchResultsItems[0].click())
-          .then(() => TitleSearchPage.changeSearchType('providers'));
+        // wait for the previous search to complete
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => {
+            TitleSearchPage.$searchResultsItems[0].click();
+            TitleSearchPage.changeSearchType('providers');
+          })
+          .run();
       });
 
       it('only shows one search type as selected', () => {
@@ -488,15 +483,12 @@ describeApplication('TitleSearch', () => {
 
     describe('selecting both a search field and a search filter', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => (
-          TitleSearchPage.selectSearchField('isxn')
-        )).then(() => (
-          TitleSearchPage.clickFilter('type', 'book')
-        )).then(() => (
-          TitleSearchPage.search('999-999')
-        ));
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => TitleSearchPage.selectSearchField('isxn'))
+          .do(() => TitleSearchPage.clickFilter('type', 'book'))
+          .do(() => TitleSearchPage.search('999-999'))
+          .run();
       });
       it('only shows results having both isxn and book pub type', () => {
         expect(TitleSearchPage.titleList).to.have.lengthOf(1);
@@ -546,11 +538,10 @@ describeApplication('TitleSearch', () => {
 
     describe('clearing the search field', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
-        }).then(() => (
-          TitleSearchPage.clearSearch()
-        ));
+        return new Convergence()
+          .once(() => expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3))
+          .do(() => TitleSearchPage.clearSearch())
+          .run();
       });
       it('has disabled search button', () => {
         expect(TitleSearchPage.isSearchButtonEnabled).to.equal(false);
@@ -577,11 +568,10 @@ describeApplication('TitleSearch', () => {
 
       describe('and then scrolling down', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            expect(TitleSearchPage.titleList.length).to.be.gt(0);
-          }).then(() => {
-            TitleSearchPage.scrollToOffset(26);
-          });
+          return new Convergence()
+            .once(() => expect(TitleSearchPage.titleList.length).to.be.gt(0))
+            .do(() => TitleSearchPage.scrollToOffset(26))
+            .run();
         });
 
         it('shows the next page of results', () => {
@@ -614,11 +604,10 @@ describeApplication('TitleSearch', () => {
 
       describe('and then scrolling up', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            expect(TitleSearchPage.titleList.length).to.be.gt(0);
-          }).then(() => {
-            TitleSearchPage.scrollToOffset(0);
-          });
+          return new Convergence()
+            .once(() => expect(TitleSearchPage.titleList.length).to.be.gt(0))
+            .do(() => TitleSearchPage.scrollToOffset(0))
+            .run();
         });
 
         // it might take a bit for the next request to be triggered after the scroll

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { describe, beforeEach, it, convergeOn } from '@bigtest/mocha';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import Convergence from '@bigtest/convergence';
 
 import { describeApplication } from './helpers';
 import TitleShowPage from './pages/bigtest/title-show';
@@ -231,11 +232,10 @@ describeApplication('TitleShow', () => {
 
     describe.skip('scrolling down the list of packages', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleShowPage.packageList().length).to.be.gt(0);
-        }).then(() => {
-          TitleShowPage.scrollToPackageOffset(26);
-        });
+        return new Convergence()
+          .once(() => expect(TitleShowPage.packageList().length).to.be.gt(0))
+          .do(() => TitleShowPage.scrollToPackageOffset(26))
+          .run();
       });
 
       it('should display the next page of related packages', () => {


### PR DESCRIPTION
## Purpose
`convergeOn()` is an [intimate API](https://github.com/thefrontside/bigtest/tree/master/packages/convergence#advanced) of bigtest/convergence. We should instead be creating `Convergence` objects.

## Next Steps
- Using BigTest page objects makes most of this refactor irrelevant. Very few of these direct uses of `Convergence` will need to remain.
- I skipped a couple of failing assertions re: custom embargo editing. I'll revisit those when refactoring that test to use BigTest page objects.

## Learning
More on bigtest/convergence: https://github.com/thefrontside/bigtest/tree/master/packages/convergence
