### PR TITLE
Use BigTest for custom embargo test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist/*
 .vscode
+artifacts
 coverage
 .DS_STORE

--- a/mirage/factories/package.js
+++ b/mirage/factories/package.js
@@ -39,6 +39,7 @@ export default Factory.extend({
       }
     }
   }),
+
   withProvider: trait({
     afterCreate(packageObj, server) {
       let provider = server.create('provider');
@@ -56,6 +57,7 @@ export default Factory.extend({
       packageObj.update('visibilityData', visibilityData.toJSON());
     }
   }),
+
   isHiddenWithoutReason: trait({
     afterCreate(packageObj, server) {
       let visibilityData = server.create('visibility-data', {
@@ -66,18 +68,12 @@ export default Factory.extend({
     }
   }),
 
-  // this trait is currently not used, by removing it we
-  // can increase the code coverage of this file by 50%
-
-  // withCustomCoverage: trait({
-  //   afterCreate(packageObj, server) {
-  //     let customCoverage = server.create('custom-coverage', {
-  //       beginCoverage: () => faker.date.past().toISOString().substring(0, 10),
-  //       endCoverage: () => faker.date.future().toISOString().substring(0, 10)
-  //     });
-  //     packageObj.update('customCoverage', customCoverage.toJSON());
-  //   }
-  // }),
+  withCustomCoverage: trait({
+    afterCreate(packageObj, server) {
+      let customCoverage = server.create('custom-coverage');
+      packageObj.update('customCoverage', customCoverage.toJSON());
+    }
+  }),
 
   afterCreate(packageObj, server) {
     if (!packageObj.visibilityData) {

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -291,6 +291,7 @@ export default class CustomerResourceShow extends Component {
           size="small"
           label="Remove resource from holdings?"
           scope="root"
+          id="eholdings-customer-resource-deselection-confirmation-modal"
           footer={(
             <div>
               <Button

--- a/tests/customer-resource-embargo-test.js
+++ b/tests/customer-resource-embargo-test.js
@@ -1,9 +1,8 @@
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
 
 import { describeApplication } from './helpers';
-import CustomerResourceShowPage from './pages/customer-resource-show';
+import CustomerResourceShowPage from './pages/bigtest/customer-resource-show';
 
 describeApplication('CustomerResourceEmbargo', () => {
   let pkg,
@@ -56,41 +55,37 @@ describeApplication('CustomerResourceEmbargo', () => {
     });
 
     it.always('does not display the managed embargo section', () => {
-      expect(CustomerResourceShowPage.managedEmbargoPeriod).to.equal('');
+      expect(CustomerResourceShowPage.hasManagedEmbargoPeriod).to.be.false;
     });
 
     it.always('does not display the custom embargo period', () => {
-      expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+      expect(CustomerResourceShowPage.hasCustomEmbargoPeriod).to.be.false;
     });
 
     it('displays a button to add custom embargo', () => {
-      expect(CustomerResourceShowPage.$customEmbargoAddButton).to.exist;
+      expect(CustomerResourceShowPage.hasCustomEmbargoAddButton).to.be.true;
     });
 
     describe('clicking on the add custom embargo button', () => {
       beforeEach(() => {
-        CustomerResourceShowPage.clickCustomEmbargoAddButton();
+        return CustomerResourceShowPage.clickCustomEmbargoAddButton();
       });
 
       it('should remove the add custom embargo button', () => {
-        expect(CustomerResourceShowPage.$customEmbargoAddButton).to.not.exist;
+        expect(CustomerResourceShowPage.hasCustomEmbargoAddButton).to.be.false;
       });
 
       it('displays the custom embargo form', () => {
-        expect(CustomerResourceShowPage.$customEmbargoForm).to.exist;
+        expect(CustomerResourceShowPage.hasCustomEmbargoForm).to.be.true;
       });
 
       describe('then trying to navigate away', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            expect(CustomerResourceShowPage.isEditingCustomEmbargo).to.be.true;
-          }).then(() => (
-            CustomerResourceShowPage.clickPackage()
-          ));
+          return CustomerResourceShowPage.clickPackage();
         });
 
         it('shows a navigation confirmation modal', () => {
-          expect(CustomerResourceShowPage.$navigationModal).to.exist;
+          expect(CustomerResourceShowPage.navigationModal.$root).to.exist;
         });
 
         it.always('does not navigate away', function () {
@@ -100,46 +95,40 @@ describeApplication('CustomerResourceEmbargo', () => {
       });
 
       describe('entering valid custom embargo value and selecting unit', () => {
-        beforeEach(() => {
-          return convergeOn(() => {
-            expect(CustomerResourceShowPage.$customEmbargoTextField).to.exist;
-            expect(CustomerResourceShowPage.$customEmbargoSelect).to.exist;
-          });
-        });
-
         describe('with valid embargo value and unit', () => {
           beforeEach(() => {
-            CustomerResourceShowPage.inputEmbargoValue('30');
-            CustomerResourceShowPage.selectEmbargoUnit('Weeks');
+            return CustomerResourceShowPage
+              .inputEmbargoValue('30')
+              .selectEmbargoUnit('Weeks');
           });
 
           it('accepts valid custom embargo value', () => {
-            expect(CustomerResourceShowPage.$customEmbargoTextField.value).to.equal('30');
+            expect(CustomerResourceShowPage.customEmbargoTextFieldValue).to.equal('30');
           });
 
           it('accepts valid custom embargo unit selection', () => {
-            expect(CustomerResourceShowPage.$customEmbargoSelect.value).to.equal('Weeks');
+            expect(CustomerResourceShowPage.customEmbargoSelectValue).to.equal('Weeks');
           });
 
           it('save button is present', () => {
-            expect(CustomerResourceShowPage.$customEmbargoSaveButton).to.exist;
+            expect(CustomerResourceShowPage.hasCustomEmbargoSaveButton).to.be.true;
           });
 
           it('save button is enabled', () => {
-            expect(CustomerResourceShowPage.isCustomEmbargoSavable).to.be.true;
+            expect(CustomerResourceShowPage.isCustomEmbargoSaveDisabled).to.be.false;
           });
 
           it('cancel button is present', () => {
-            expect(CustomerResourceShowPage.$customEmbargoCancelButton).to.exist;
+            expect(CustomerResourceShowPage.hasCustomEmbargoCancelButton).to.be.true;
           });
 
           it('cancel button is enabled', () => {
-            expect(CustomerResourceShowPage.isCustomEmbargoCancellable).to.be.true;
+            expect(CustomerResourceShowPage.isCustomEmbargoCancelDisabled).to.be.false;
           });
 
           describe('saving updated custom embargo', () => {
             beforeEach(() => {
-              CustomerResourceShowPage.clickCustomEmbargoSaveButton();
+              return CustomerResourceShowPage.clickCustomEmbargoSaveButton();
             });
 
             it('displays new custom embargo period', () => {
@@ -147,101 +136,95 @@ describeApplication('CustomerResourceEmbargo', () => {
             });
 
             it('does not display button to add custom embargo', () => {
-              expect(CustomerResourceShowPage.$customEmbargoAddButton).to.not.exist;
+              expect(CustomerResourceShowPage.hasCustomEmbargoAddButton).to.be.false;
             });
 
             it('removes the custom embargo form', () => {
-              expect(CustomerResourceShowPage.$customEmbargoForm).to.not.exist;
+              expect(CustomerResourceShowPage.hasCustomEmbargoForm).to.be.false;
             });
           });
 
           describe('cancelling updated custom embargo', () => {
             beforeEach(() => {
-              CustomerResourceShowPage.clickCustomEmbargoCancelButton();
+              return CustomerResourceShowPage.clickCustomEmbargoCancelButton();
             });
 
             it('displays existing custom embargo period (none)', () => {
-              expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+              expect(CustomerResourceShowPage.hasCustomEmbargoPeriod).to.be.false;
             });
 
             it('removes the custom embargo form', () => {
-              expect(CustomerResourceShowPage.$customEmbargoForm).to.not.exist;
+              expect(CustomerResourceShowPage.hasCustomEmbargoForm).to.be.false;
             });
 
             it('displays the button to add custom embargo', () => {
-              expect(CustomerResourceShowPage.$customEmbargoAddButton).to.exist;
+              expect(CustomerResourceShowPage.hasCustomEmbargoAddButton).to.be.true;
             });
           });
 
           describe('selecting none as custom embargo unit should update value to zero', () => {
             beforeEach(() => {
-              CustomerResourceShowPage.inputEmbargoValue(50);
-              CustomerResourceShowPage.selectEmbargoUnit('None');
-              CustomerResourceShowPage.clickCustomEmbargoSaveButton();
+              return CustomerResourceShowPage
+                .inputEmbargoValue('50')
+                .selectEmbargoUnit('None')
+                .clickCustomEmbargoSaveButton();
             });
 
             it('displays new custom embargo period', () => {
-              expect(CustomerResourceShowPage.$customEmbargoTextField.value).to.equal('0');
+              expect(CustomerResourceShowPage.customEmbargoTextFieldValue).to.equal('0');
             });
           });
 
           describe('custom embargo value as zero and unit as not None should throw validation error', () => {
             beforeEach(() => {
-              CustomerResourceShowPage.inputEmbargoValue(0);
-              CustomerResourceShowPage.selectEmbargoUnit('Months');
+              return CustomerResourceShowPage
+                .inputEmbargoValue(0)
+                .selectEmbargoUnit('Months')
+                .clickCustomEmbargoSaveButton();
             });
 
             it('rejects embargo value', () => {
-              convergeOn(() => {
-                expect(CustomerResourceShowPage.validationErrorOnTextField).to.exist;
-              }).then(() => {
-                expect(CustomerResourceShowPage.validationErrorOnTextField).to.equal('Enter value greater than 0');
-              });
+              expect(CustomerResourceShowPage.validationErrorOnTextField).to.equal('Enter value greater than 0');
             });
           });
 
           describe('custom embargo value that cannot be parsed as number should throw validation error', () => {
             beforeEach(() => {
-              CustomerResourceShowPage.inputEmbargoValue('abcdef');
-              CustomerResourceShowPage.selectEmbargoUnit('Months');
+              return CustomerResourceShowPage
+                .inputEmbargoValue('abcdef')
+                .selectEmbargoUnit('Months')
+                .clickCustomEmbargoSaveButton();
             });
 
             it('rejects embargo value', () => {
-              convergeOn(() => {
-                expect(CustomerResourceShowPage.validationErrorOnTextField).to.exist;
-              }).then(() => {
-                expect(CustomerResourceShowPage.validationErrorOnTextField).to.equal('Must be a number');
-              });
+              expect(CustomerResourceShowPage.customEmbargoTextFieldValue).to.equal('');
+              expect(CustomerResourceShowPage.validationErrorOnTextField).to.equal('Value cannot be null');
             });
           });
 
           describe('blank custom embargo value should throw validation error', () => {
             beforeEach(() => {
-              CustomerResourceShowPage.inputEmbargoValue('');
-              CustomerResourceShowPage.selectEmbargoUnit('Months');
+              return CustomerResourceShowPage
+                .inputEmbargoValue('')
+                .selectEmbargoUnit('Months')
+                .clickCustomEmbargoSaveButton();
             });
 
             it('rejects embargo value', () => {
-              convergeOn(() => {
-                expect(CustomerResourceShowPage.validationErrorOnTextField).to.exist;
-              }).then(() => {
-                expect(CustomerResourceShowPage.validationErrorOnTextField).to.equal('Value cannot be null');
-              });
+              expect(CustomerResourceShowPage.validationErrorOnTextField).to.equal('Value cannot be null');
             });
           });
 
           describe('custom embargo value greater than zero and unit as None should throw validation error', () => {
             beforeEach(() => {
-              CustomerResourceShowPage.inputEmbargoValue(50);
-              CustomerResourceShowPage.selectEmbargoUnit('None');
+              return CustomerResourceShowPage
+                .selectEmbargoUnit('None')
+                .inputEmbargoValue('50')
+                .clickCustomEmbargoSaveButton();
             });
 
             it('rejects embargo value', () => {
-              convergeOn(() => {
-                expect(CustomerResourceShowPage.validationErrorOnSelect).to.exist;
-              }).then(() => {
-                expect(CustomerResourceShowPage.validationErrorOnSelect).to.equal('Select a valid unit');
-              });
+              expect(CustomerResourceShowPage.validationErrorOnSelect).to.equal('Select a valid unit');
             });
           });
         });
@@ -268,11 +251,11 @@ describeApplication('CustomerResourceEmbargo', () => {
     });
 
     it.always('does not display the managed embargo section', () => {
-      expect(CustomerResourceShowPage.managedEmbargoPeriod).to.equal('');
+      expect(CustomerResourceShowPage.hasManagedEmbargoPeriod).to.be.false;
     });
 
     it.always('does not display the custom embargo section', () => {
-      expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+      expect(CustomerResourceShowPage.hasCustomEmbargoPeriod).to.be.false;
     });
   });
 
@@ -288,11 +271,11 @@ describeApplication('CustomerResourceEmbargo', () => {
     });
 
     it.always('does not display the managed embargo section', () => {
-      expect(CustomerResourceShowPage.managedEmbargoPeriod).to.equal('');
+      expect(CustomerResourceShowPage.hasManagedEmbargoPeriod).to.be.false;
     });
 
     it.always('does not display the custom embargo section', () => {
-      expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+      expect(CustomerResourceShowPage.hasCustomEmbargoPeriod).to.be.false;
     });
   });
 
@@ -311,7 +294,7 @@ describeApplication('CustomerResourceEmbargo', () => {
     });
 
     it.always('does not display the custom embargo section', () => {
-      expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
+      expect(CustomerResourceShowPage.hasCustomEmbargoPeriod).to.be.false;
     });
   });
 
@@ -333,42 +316,44 @@ describeApplication('CustomerResourceEmbargo', () => {
     });
 
     it('displays the edit button in the custom embargo section', () => {
-      expect(CustomerResourceShowPage.$customEmbargoEditButton).to.exist;
+      expect(CustomerResourceShowPage.hasCustomEmbargoEditButton).to.be.true;
     });
 
     it('does not display the add custom embargo button', () => {
-      expect(CustomerResourceShowPage.$customEmbargoAddButton).to.not.exist;
+      expect(CustomerResourceShowPage.hasCustomEmbargoAddButton).to.be.false;
     });
 
     it('displays whether the title package is selected', () => {
       expect(CustomerResourceShowPage.isSelected).to.equal(true);
     });
 
-    describe('toggling to deselect a title package and confirming deselection', () => {
+    describe('toggling to deselect a title package', () => {
       beforeEach(() => {
-        return CustomerResourceShowPage.toggleIsSelected().then(() => {
-          return CustomerResourceShowPage.confirmDeselection();
+        return CustomerResourceShowPage.toggleIsSelected();
+      });
+
+      describe('and confirming deselection', () => {
+        beforeEach(() => {
+          return CustomerResourceShowPage.deselectionModal.confirmDeselection();
+        });
+
+        it('removes custom embargo', () => {
+          expect(CustomerResourceShowPage.hasCustomEmbargoPeriod).to.be.false;
         });
       });
 
-      it('removes custom embargo', () => {
-        expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('');
-      });
-    });
-
-    describe('toggling to deselect a title package and canceling deselection', () => {
-      beforeEach(() => {
-        return CustomerResourceShowPage.toggleIsSelected().then(() => {
-          return CustomerResourceShowPage.cancelDeselection();
+      describe('and canceling deselection', () => {
+        beforeEach(() => {
+          return CustomerResourceShowPage.deselectionModal.cancelDeselection();
         });
-      });
 
-      it('does not remove custom embargo', () => {
-        expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('10 Weeks');
-      });
+        it('does not remove custom embargo', () => {
+          expect(CustomerResourceShowPage.customEmbargoPeriod).to.equal('10 Weeks');
+        });
 
-      it('displays the edit button in the custom embargo section', () => {
-        expect(CustomerResourceShowPage.$customEmbargoEditButton).to.exist;
+        it('displays the edit button in the custom embargo section', () => {
+          expect(CustomerResourceShowPage.hasCustomEmbargoEditButton).to.be.true;
+        });
       });
     });
 
@@ -378,7 +363,7 @@ describeApplication('CustomerResourceEmbargo', () => {
       });
 
       it('displays the custom embargo form', () => {
-        expect(CustomerResourceShowPage.$customEmbargoForm).to.exist;
+        expect(CustomerResourceShowPage.hasCustomEmbargoForm).to.be.true;
       });
     });
   });

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -15,7 +15,7 @@ describeApplication('PackageShow', () => {
       name: 'Cool Provider'
     });
 
-    providerPackage = this.server.create('package', 'withTitles', {
+    providerPackage = this.server.create('package', 'withTitles', 'withCustomCoverage', {
       provider,
       name: 'Cool Package',
       contentType: 'E-Book',

--- a/tests/pages/bigtest/customer-resource-show.js
+++ b/tests/pages/bigtest/customer-resource-show.js
@@ -1,11 +1,20 @@
 import {
+  clickable,
   collection,
+  fillable,
   isPresent,
   page,
   property,
   text,
-  clickable
+  value
 } from '@bigtest/interaction';
+
+@page class CustomerResourceShowDeselectionModal {
+  confirmDeselection = clickable('[data-test-eholdings-customer-resource-deselection-confirmation-modal-yes]');
+  cancelDeselection = clickable('[data-test-eholdings-customer-resource-deselection-confirmation-modal-no]');
+}
+
+@page class CustomerResourceShowNavigationModal {}
 
 @page class CustomerResourceShowPage {
   titleName = text('[data-test-eholdings-details-view-name="resource"]');
@@ -26,6 +35,33 @@ import {
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   paneSub = text('[data-test-eholdings-details-view-pane-sub]');
+  toggleIsSelected = clickable('[data-test-eholdings-customer-resource-show-selected] input');
+  isEditingCustomEmbargo = isPresent('[data-test-eholdings-embargo-form] form');
+  clickPackage = clickable('[data-test-eholdings-customer-resource-show-package-name] a');
+  deselectionModal = new CustomerResourceShowDeselectionModal('#eholdings-customer-resource-deselection-confirmation-modal');
+  navigationModal = new CustomerResourceShowNavigationModal('#navigation-modal');
+
+  managedEmbargoPeriod = text('[data-test-eholdings-customer-resource-show-managed-embargo-period]');
+  hasManagedEmbargoPeriod = isPresent('[data-test-eholdings-customer-resource-show-managed-embargo-period]');
+  customEmbargoPeriod = text('[data-test-eholdings-customer-resource-custom-embargo-display]');
+  hasCustomEmbargoPeriod = isPresent('[data-test-eholdings-customer-resource-custom-embargo-display]');
+  hasCustomEmbargoAddButton = isPresent('[data-test-eholdings-customer-resource-add-custom-embargo-button] button');
+  hasCustomEmbargoEditButton = isPresent('[data-test-eholdings-customer-resource-edit-custom-embargo-button] button');
+  clickCustomEmbargoAddButton = clickable('[data-test-eholdings-customer-resource-add-custom-embargo-button] button');
+  hasCustomEmbargoForm = isPresent('[data-test-eholdings-customer-resource-custom-embargo-form]');
+  customEmbargoTextFieldValue = value('[data-test-eholdings-customer-resource-custom-embargo-textfield] input');
+  inputEmbargoValue = fillable('[data-test-eholdings-customer-resource-custom-embargo-textfield] input');
+  customEmbargoSelectValue = value('[data-test-eholdings-customer-resource-custom-embargo-select] select');
+  selectEmbargoUnit = fillable('[data-test-eholdings-customer-resource-custom-embargo-select] select');
+  clickCustomEmbargoSaveButton = clickable('[data-test-eholdings-customer-resource-save-custom-embargo-button] button');
+  hasCustomEmbargoSaveButton = isPresent('[data-test-eholdings-customer-resource-save-custom-embargo-button] button');
+  isCustomEmbargoSaveDisabled = property('disabled', '[data-test-eholdings-customer-resource-save-custom-embargo-button] button');
+  clickCustomEmbargoCancelButton = clickable('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button');
+  hasCustomEmbargoCancelButton = isPresent('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button');
+  isCustomEmbargoCancelDisabled = property('disabled', '[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button');
+  validationErrorOnTextField = text('[data-test-eholdings-customer-resource-custom-embargo-textfield] [class^="error-message--"]');
+  validationErrorOnSelect = text('[data-test-eholdings-customer-resource-custom-embargo-select] [class^="error-message--"]');
+  clickCustomEmbargoEditButton = clickable('[data-test-eholdings-customer-resource-edit-custom-embargo-button] button');
 
   identifiersList = collection('[data-test-eholdings-identifiers-list-item]', {
     text: text()

--- a/tests/pages/customer-resource-show.js
+++ b/tests/pages/customer-resource-show.js
@@ -1,60 +1,18 @@
 import $ from 'jquery';
 import { expect } from 'chai';
 import { convergeOn } from '@bigtest/convergence';
-import { advancedFillIn } from './helpers';
-import { triggerChange } from '../helpers';
 
 export default {
   get $root() {
     return $('[data-test-eholdings-details-view="resource"]');
   },
 
-  get titleName() {
-    return $('[data-test-eholdings-details-view-name="resource"]').text();
-  },
-
-  get publisherName() {
-    return $('[data-test-eholdings-customer-resource-show-publisher-name]').text();
-  },
-
-  get publicationType() {
-    return $('[data-test-eholdings-customer-resource-show-publication-type]').text();
-  },
-
-  get providerName() {
-    return $('[data-test-eholdings-customer-resource-show-provider-name]').text();
-  },
-
-  get packageName() {
-    return $('[data-test-eholdings-customer-resource-show-package-name]').text();
-  },
-
   clickPackage() {
     return $('[data-test-eholdings-customer-resource-show-package-name] a').get(0).click();
   },
 
-  get contentType() {
-    return $('[data-test-eholdings-customer-resource-show-content-type]').text();
-  },
-
-  get managedUrl() {
-    return $('[data-test-eholdings-customer-resource-show-managed-url]').text();
-  },
-
-  get subjectsList() {
-    return $('[data-test-eholdings-customer-resource-show-subjects-list]').text();
-  },
-
-  get hasErrors() {
-    return $('[data-test-eholdings-details-view-error="resource"]').length > 0;
-  },
-
   get isSelected() {
     return $('[data-test-eholdings-customer-resource-show-selected] input').prop('checked');
-  },
-
-  get $visibilitySection() {
-    return $('[data-test-eholdings-customer-resource-toggle-hidden]');
   },
 
   toggleIsSelected() {
@@ -75,10 +33,6 @@ export default {
 
   get isSelectedToggleable() {
     return $('[data-test-eholdings-customer-resource-show-selected] input[type=checkbox]').prop('disabled') === false;
-  },
-
-  get flashError() {
-    return '';
   },
 
   get isHidden() {
@@ -109,10 +63,6 @@ export default {
     return $('[data-test-eholdings-customer-resource-toggle-hidden] input[type=checkbox]').prop('disabled') === false;
   },
 
-  get managedEmbargoPeriod() {
-    return $('[data-test-eholdings-customer-resource-show-managed-embargo-period]').text();
-  },
-
   get managedCoverageList() {
     return $('[data-test-eholdings-customer-resource-show-managed-coverage-list]').text();
   },
@@ -123,22 +73,6 @@ export default {
 
   get customEmbargoPeriod() {
     return $('[data-test-eholdings-customer-resource-custom-embargo-display]').text();
-  },
-
-  get isEditingCustomEmbargo() {
-    return $('[data-test-eholdings-embargo-form] form').length === 1;
-  },
-
-  get identifiersList() {
-    return $('[data-test-eholdings-identifiers-list-item]').toArray().map(item => $(item).text());
-  },
-
-  get contributorsList() {
-    return $('[data-test-eholdings-contributors-list-item]').toArray().map(item => $(item).text());
-  },
-
-  get $backButton() {
-    return $('[data-test-eholdings-details-view-back-button] button');
   },
 
   get $deselectTitleWarning() {
@@ -155,103 +89,6 @@ export default {
 
   cancelDeselection() {
     return $('[data-test-eholdings-customer-resource-deselection-confirmation-modal-no]').trigger('click');
-  },
-
-  clickManagedURL() {
-    return $('[data-test-eholdings-customer-resource-show-managed-url]').trigger('click');
-  },
-
-  get $customEmbargoAddButton() {
-    return $('[data-test-eholdings-customer-resource-add-custom-embargo-button] button');
-  },
-
-  get $customEmbargoEditButton() {
-    return $('[data-test-eholdings-customer-resource-edit-custom-embargo-button]');
-  },
-
-  clickCustomEmbargoEditButton() {
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-customer-resource-edit-custom-embargo-button]')).to.exist;
-    }).then(() => (
-      $('[data-test-eholdings-customer-resource-edit-custom-embargo-button] button').click()
-    ));
-  },
-
-  get $customEmbargoForm() {
-    return $('[data-test-eholdings-customer-resource-custom-embargo-form]');
-  },
-
-  clickCustomEmbargoAddButton() {
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-customer-resource-add-custom-embargo-button]')).to.exist;
-    }).then(() => (
-      $('[data-test-eholdings-customer-resource-add-custom-embargo-button] button').click()
-    ));
-  },
-
-  get $customEmbargoTextField() {
-    return $('[data-test-eholdings-customer-resource-custom-embargo-textfield]').find('input[name="customEmbargoValue"]')[0];
-  },
-
-  get $customEmbargoSelect() {
-    return $('[data-test-eholdings-customer-resource-custom-embargo-select]').find('select[name="customEmbargoUnit"]')[0];
-  },
-
-  get $customEmbargoFormCancelButton() {
-    return $('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button');
-  },
-
-  get $customEmbargoFormSaveButton() {
-    return $('[data-test-eholdings-customer-resource-save-custom-embargo-button] button');
-  },
-
-  inputEmbargoValue(customEmbargoValue) {
-    return advancedFillIn(this.$customEmbargoTextField, customEmbargoValue);
-  },
-
-  selectEmbargoUnit(customEmbargoUnit) {
-    let $input = $('[data-test-eholdings-customer-resource-custom-embargo-select]').find('select[name="customEmbargoUnit"]').val(customEmbargoUnit);
-    return triggerChange($input.get(0));
-  },
-
-  get isCustomEmbargoSavable() {
-    return $('[data-test-eholdings-customer-resource-save-custom-embargo-button] button').prop('disabled') === false;
-  },
-
-  get isCustomEmbargoCancellable() {
-    return $('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button').prop('disabled') === false;
-  },
-
-  get $customEmbargoCancelButton() {
-    return $('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button');
-  },
-
-  get $customEmbargoSaveButton() {
-    return $('[data-test-eholdings-customer-resource-save-custom-embargo-button] button');
-  },
-
-  clickCustomEmbargoSaveButton() {
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-customer-resource-save-custom-embargo-button]')).to.exist;
-    }).then(() => {
-      return $('[data-test-eholdings-customer-resource-save-custom-embargo-button] button').click();
-    });
-  },
-
-  clickCustomEmbargoCancelButton() {
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-customer-resource-cancel-custom-embargo-button]')).to.exist;
-    }).then(() => {
-      return $('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button').click();
-    });
-  },
-
-  get validationErrorOnTextField() {
-    return $('[data-test-eholdings-customer-resource-custom-embargo-textfield] [class^="feedbackError"]').text();
-  },
-
-  get validationErrorOnSelect() {
-    return $('[data-test-eholdings-customer-resource-custom-embargo-select] [class^="feedbackError"]').text();
   },
 
   get $navigationModal() {


### PR DESCRIPTION
## Purpose
BigTest page objects are nice. Let's use them.

## Approach
Now the custom embargo test doesn't need to use bigtest/convergence directly.

Removes the need for some chicanery in https://github.com/folio-org/ui-eholdings/pull/268

## Learning
Copied the modal-in-page-object pattern from https://github.com/folio-org/ui-eholdings/pull/253