### PR TITLE
 Allow Firefox failures on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           at: ~/
       - run:
           name: Run tests
-          command: yarn test --karma.singleRun --karma.browsers=bs_firefox_mac
+          command: yarn test --karma.singleRun --karma.browsers=bs_firefox_mac || true
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: BROWSER=bs_firefox_mac
     - env: BROWSER=bs_ieEdge_windows
     - env: BROWSER=bs_ie11_windows
 addons:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,6 +2,11 @@ module.exports = (config) => {
   let configuration = {
     reporters: ['mocha', 'BrowserStack'],
 
+    browserDisconnectTimeout: 3e5,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 3e5,
+    captureTimeout: 3e5,
+
     customLaunchers: {
       Chrome_travis_ci: {
         base: 'Chrome',


### PR DESCRIPTION
## Purpose
Last week we were seeing lots of "browser disconnected" messages from BrowserStack. Any disconnection would fail the build on CI. It would happen sometimes with Safari, but much more frequently with Firefox.

## Approach
I tried increasing the disconnection tolerance so the browser would attempt to reconnect x number of times, and that succeeded (https://github.com/karma-runner/karma-browserstack-launcher/issues/61). The side effect was that Firefox would sometimes take 30-40 minutes to complete its test run with BrowserStack. I'm guessing that's because BrowserStack has had a rough time with newer versions of Firefox: https://www.browserstack.com/question/670.

I then tried just running the Firefox tests directly on the CI container, since both Travis and Circle have Firefox available directly on the box. I still had frequent failures with that scenario, since every time at least one of the search UI tests has timed out. Getting the remaining tests moved over to BigTest page objects will probably fix those timeouts.

In the meantime, I recommend allowing failures on Firefox again to improve the build health. Three out of the last five master builds have failed due to hiccups in the connection between Karma and BrowserStack Firefox.