### PR TITLE
UIEH-199 Persist Relationship Data in Store

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "funcadelic": "^0.4.0",
     "impagination": "^1.0.0-alpha.3",
     "inflected": "^2.0.3",
     "isomorphic-fetch": "^2.2.1",

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -365,6 +365,27 @@ const handlers = {
       }
     }));
 
+    // helper function to merge relationship data without losing
+    // information.  if a record has `data` populated in its
+    // `relationships` key, we want to persist that even if
+    // a more recent request resolves without that relationship data
+    // included.
+    let mergeRelationships = (existing, incoming) => {
+      if (!incoming) { return existing; }
+
+      let mergedRelationships = {};
+
+      for (let recordType in incoming) {
+        if (incoming[recordType] && incoming[recordType].data) {
+          mergedRelationships[recordType] = incoming[recordType];
+        } else {
+          mergedRelationships[recordType] = existing[recordType] || {};
+        }
+      }
+
+      return mergedRelationships;
+    };
+
     // then we reduce each record in the set of records
     next = records.reduce((next, record) => { // eslint-disable-line no-shadow
       return reduceData(record.type, next, (store) => {
@@ -376,7 +397,7 @@ const handlers = {
             [record.id]: {
               ...recordState,
               attributes: record.attributes || {},
-              relationships: record.relationships || {},
+              relationships: mergeRelationships(recordState.relationships, record.relationships),
               isSaving: false,
               isLoading: false,
               isLoaded: true

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -5,6 +5,7 @@ import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 
 import { qs } from '../components/utilities';
+import { mergeRelationships } from './helpers';
 
 // actions
 export const actionTypes = {
@@ -364,27 +365,6 @@ const handlers = {
         }
       }
     }));
-
-    // helper function to merge relationship data without losing
-    // information.  if a record has `data` populated in its
-    // `relationships` key, we want to persist that even if
-    // a more recent request resolves without that relationship data
-    // included.
-    let mergeRelationships = (existing, incoming) => {
-      if (!incoming) { return existing; }
-
-      let mergedRelationships = {};
-
-      for (let recordType in incoming) {
-        if (incoming[recordType] && incoming[recordType].data) {
-          mergedRelationships[recordType] = incoming[recordType];
-        } else {
-          mergedRelationships[recordType] = existing[recordType] || {};
-        }
-      }
-
-      return mergedRelationships;
-    };
 
     // then we reduce each record in the set of records
     next = records.reduce((next, record) => { // eslint-disable-line no-shadow

--- a/src/redux/helpers.js
+++ b/src/redux/helpers.js
@@ -1,0 +1,25 @@
+/**
+ * Helper to merge incoming `relationship` information non-
+ * destructively.  Relationship data held in the store will not
+ * be overwritten with empty data: only by new data.
+ * @param {Object} existing - `relationship` data from a record in the store
+ * @param {Object} incoming - `relationship` data from an incoming request
+ * @returns {Object} safely merged relationship data fit to be persisted
+ */
+
+// eslint-disable-next-line import/prefer-default-export
+export function mergeRelationships(existing, incoming) {
+  if (!incoming) { return existing; }
+
+  let mergedRelationships = {};
+
+  for (let recordType in incoming) {
+    if (incoming[recordType] && incoming[recordType].data) {
+      mergedRelationships[recordType] = incoming[recordType];
+    } else {
+      mergedRelationships[recordType] = existing[recordType] || {};
+    }
+  }
+
+  return mergedRelationships;
+}

--- a/src/redux/helpers.js
+++ b/src/redux/helpers.js
@@ -1,7 +1,18 @@
+import { foldl, append } from 'funcadelic';
+
 /**
  * Helper to merge incoming `relationship` information non-
  * destructively.  Relationship data held in the store will not
  * be overwritten with empty data: only by new data.
+ *
+ * NOTE: for now, this is specific to `relationship` keys in the store, and so
+ * it may seem strange that it lives in a generic 'helpers' file all by itself.
+ * I do not make cuts before they're required, but it seems imminent that this
+ * pattern will be applied to other areas of the store.  Pulling in the FP
+ * power of Funcadelic here will allow us to extract common logical operations like
+ * this one and genericize them to work against complex data structures like
+ * the store.
+ *
  * @param {Object} existing - `relationship` data from a record in the store
  * @param {Object} incoming - `relationship` data from an incoming request
  * @returns {Object} safely merged relationship data fit to be persisted
@@ -11,15 +22,11 @@
 export function mergeRelationships(existing, incoming) {
   if (!incoming) { return existing; }
 
-  let mergedRelationships = {};
-
-  for (let recordType in incoming) {
-    if (incoming[recordType] && incoming[recordType].data) {
-      mergedRelationships[recordType] = incoming[recordType];
+  return foldl((relationships, { key: recordType, value: relationshipData }) => {
+    if (relationshipData && relationshipData.data) {
+      return append(relationships, { [recordType]: relationshipData });
     } else {
-      mergedRelationships[recordType] = existing[recordType] || {};
+      return append(relationships, { [recordType]: existing[recordType] || {} });
     }
-  }
-
-  return mergedRelationships;
+  }, {}, incoming);
 }

--- a/tests/unit/redux-merge-relationships-test.js
+++ b/tests/unit/redux-merge-relationships-test.js
@@ -1,0 +1,44 @@
+/* global describe, beforeEach, it */
+import { expect } from 'chai';
+import { mergeRelationships } from '../../src/redux/helpers';
+
+describe('mergeRelationships', () => {
+  let existing;
+  let incoming;
+
+  const lazy = {
+    get merged() { return mergeRelationships; }
+  };
+
+  beforeEach(() => {
+    existing = {
+      providers: { data: 'data' }
+    };
+  });
+
+  describe('merging existing data with incomplete incoming data', () => {
+    beforeEach(() => {
+      incoming = {
+        providers: { meta: false }
+      };
+    });
+
+    it('does not overwrite populated keys with empty incoming data', () => {
+      let result = lazy.merged(existing, incoming);
+      expect(result.providers.data).to.equal('data');
+    });
+  });
+
+  describe('merging existing data with incoming data', () => {
+    beforeEach(() => {
+      incoming = {
+        providers: { data: 'no, this data' }
+      };
+    });
+
+    it('replaces existing data with incoming data', () => {
+      let result = lazy.merged(existing, incoming);
+      expect(result.providers.data).to.equal('no, this data');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,6 +987,12 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-external-helpers@6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-istanbul@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
@@ -3097,7 +3103,7 @@ error-stack-parser@^1.3.6:
   dependencies:
     stackframe "^0.3.1"
 
-es-abstract@^1.7.0:
+es-abstract@^1.5.1, es-abstract@^1.7.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
   dependencies:
@@ -3893,6 +3899,14 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+funcadelic@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/funcadelic/-/funcadelic-0.4.0.tgz#1df7519310aab04da050060af839769a16e74daf"
+  dependencies:
+    babel-plugin-external-helpers "6.22.0"
+    lodash.curry "4.1.1"
+    object.getownpropertydescriptors "2.0.3"
 
 function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
@@ -5537,6 +5551,10 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.curry@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
+
 lodash.deburr@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-3.2.0.tgz#6da8f54334a366a7cf4c4c76ef8d80aa1b365ed5"
@@ -6321,6 +6339,13 @@ object-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
+
+object.getownpropertydescriptors@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.1"
 
 object.omit@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Purpose
As we navigate through the eholdings app, data from resolved requests is persisted in the redux store.  When we're loading a search route with a selected detail record, one request is fired off for the list of search records and one is fired off for the singleton detail record.  If the search request resolves after the detail request, the detail page's related records are overwritten by the "newer" request, which contains no relationship data.  

The result in the UI is the list of related records on a detail page flickering and disappearing (see [UIEH-199](https://issues.folio.org/browse/UIEH-199)).  This was particularly evident in the Title Details pane, because Title searches take longer than any other RMAPI resource to resolve, and frequently resolved after the detail pane request.  Although the bug was discovered here, theoretically it could affect any view where both a `query` and a `find` request are fired at the same time.

## Approach
This fix introduces a helper method to intelligently merge relationship data.  Once a relationship is established in the store, only updates to that data are accepted.  If a newer request returns with no relationship data whatsoever, the older data is preferred.

Big thanks to @wwilsman for `redux/data` wisdom and direction on where to make the fix.

## Screenshots
**Before:**
![before](http://g.recordit.co/jpKyWAxhEX.gif)

**After:**
![after](http://g.recordit.co/ntxoJWfsbZ.gif)
