### PR TITLE
Update logic for search/filter panel visibility on smaller screens +style for disabled search button

### DIFF
--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -73,6 +73,17 @@
   &:hover {
     background-color: color(var(--primary) shade(8%));
   }
+
+  &[disabled] {
+    background-color: #ccc;
+    border-color: #ccc;
+    color: #888;
+
+    &:hover {
+      cursor: initial;
+      opacity: 1;
+    }
+  }
 }
 
 .search-results-list {

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -5,12 +5,11 @@ import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import IconButton from '@folio/stripes-components/lib/IconButton';
 import Button from '@folio/stripes-components/lib/Button';
 import capitalize from 'lodash/capitalize';
-
+import { qs } from '../utilities';
 import SearchPane from '../search-pane';
 import ResultsPane from '../results-pane';
 import PreviewPane from '../preview-pane';
 import SearchPaneVignette from '../search-pane-vignette';
-
 import styles from './search-paneset.css';
 
 export default class SearchPaneset extends React.Component {
@@ -22,7 +21,10 @@ export default class SearchPaneset extends React.Component {
     detailsView: PropTypes.node,
     totalResults: PropTypes.number,
     isLoading: PropTypes.bool,
-    location: PropTypes.object
+    location: PropTypes.shape({
+      pathname: PropTypes.string.isRequired,
+      search: PropTypes.string.isRequired
+    }).isRequired
   };
 
   static defaultProps = {
@@ -40,11 +42,24 @@ export default class SearchPaneset extends React.Component {
     hideFilters: this.props.hideFilters
   };
 
-  componentWillReceiveProps({ hideFilters, resultsType }) {
-    let isSameSearchType = resultsType === this.props.resultsType;
+  componentWillReceiveProps({ resultsType, location }) {
+    let isSameLocation = location.search === this.props.location.search;
 
-    if (isSameSearchType && hideFilters !== this.state.hideFilters) {
-      this.setState({ hideFilters });
+    if (!isSameLocation) {
+      let isSameSearchType = resultsType === this.props.resultsType;
+
+      if (isSameSearchType) {
+        let { ...nextSearchParams } = qs.parse(location.search);
+        let { ...searchParams } = qs.parse(this.props.location.search);
+
+        let searchTermChanged = nextSearchParams.q !== searchParams.q;
+
+        if (searchTermChanged) {
+          this.setState({ hideFilters: true });
+        } else {
+          this.setState({ hideFilters: false });
+        }
+      }
     }
   }
 

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -148,6 +148,7 @@ class SearchRoute extends Component {
    */
   updateURLParams(params) {
     let { location, history } = this.props;
+
     // if the new query is different from our location, update the location
     if (qs.stringify(params) !== qs.stringify(this.state.params)) {
       let url = this.buildSearchUrl(location.pathname, params);
@@ -156,6 +157,7 @@ class SearchRoute extends Component {
       if (params.q !== this.state.params.q) {
         url = this.buildSearchUrl('/eholdings', params);
       }
+
       // if only the filters have changed, just replace the current location
       if (params.q === this.state.params.q) {
         history.replace(url);

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -31,6 +31,10 @@ describeApplication('PackageSearch', () => {
     expect(PackageSearchPage.$searchField).to.exist;
   });
 
+  it('has disabled search button', () => {
+    expect(PackageSearchPage.isSearchButtonEnabled).to.equal(false);
+  });
+
   describe('searching for a package', () => {
     beforeEach(() => {
       PackageSearchPage.search('Package');
@@ -54,6 +58,10 @@ describeApplication('PackageSearch', () => {
 
     it('displays the total number of search results', () => {
       expect(PackageSearchPage.totalResults).to.equal('3 search results');
+    });
+
+    it('hides search filters on smaller screen sizes (due to new search term)', () => {
+      expect(PackageSearchPage.isSearchVignetteHidden).to.equal(true);
     });
 
     describe('clicking a search results list item', () => {
@@ -90,6 +98,10 @@ describeApplication('PackageSearch', () => {
           // to the history. Ensuring the back button works as expected
           let history = this.app.history;
           expect(history.entries[history.index - 1].search).to.include('q=Package');
+        });
+
+        it('hides search filters on smaller screen sizes (due to new search term)', () => {
+          expect(PackageSearchPage.isSearchVignetteHidden).to.equal(true);
         });
       });
 
@@ -158,6 +170,10 @@ describeApplication('PackageSearch', () => {
 
       it('reflects the filter in the URL query params', function () {
         expect(this.app.history.location.search).to.include('filter[type]=ebook');
+      });
+
+      it('shows search filters on smaller screen sizes (due to filter change only)', () => {
+        expect(PackageSearchPage.isSearchVignetteHidden).to.equal(false);
       });
 
       describe('clearing the filters', () => {
@@ -457,6 +473,19 @@ describeApplication('PackageSearch', () => {
         expect(PackageSearchPage.packageList[0].name).to.equal('Academic ASAP');
         expect(PackageSearchPage.packageList[1].name).to.equal('Academic Search Elite');
         expect(PackageSearchPage.packageList[2].name).to.equal('Academic Search Premier');
+      });
+    });
+
+    describe('clearing the search field', () => {
+      beforeEach(() => {
+        return convergeOn(() => {
+          expect(PackageSearchPage.$searchResultsItems).to.have.lengthOf(0);
+        }).then(() => (
+          PackageSearchPage.clearSearch()
+        ));
+      });
+      it('has disabled search button', () => {
+        expect(PackageSearchPage.isSearchButtonEnabled).to.equal(false);
       });
     });
   });

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -74,6 +74,14 @@ export default {
     return $('[data-test-search-form-type-switcher] a[class^="is-active--"]');
   },
 
+  get isSearchButtonEnabled() {
+    return $('[data-test-search-submit]').prop('disabled') === false;
+  },
+
+  get isSearchVignetteHidden() {
+    return $('[data-test-search-vignette]').attr('class').indexOf('is-hidden--') !== -1;
+  },
+
   clickSearchVignette() {
     return $('[data-test-search-vignette]').trigger('click');
   },
@@ -86,6 +94,14 @@ export default {
       expect($input).to.have.value(query);
     }).then(() => {
       $('[data-test-search-submit]').trigger('click');
+    });
+  },
+
+  clearSearch() {
+    let $input = $('[data-test-search-field]').find('input[name="search"]').val('');
+    triggerChange($input.get(0));
+    return convergeOn(() => {
+      expect($input).to.have.value('');
     });
   },
 

--- a/tests/pages/provider-search.js
+++ b/tests/pages/provider-search.js
@@ -84,6 +84,14 @@ export default {
     return $('[data-test-search-form-type-switcher] a[class^="is-active--"]');
   },
 
+  get isSearchButtonEnabled() {
+    return $('[data-test-search-submit]').prop('disabled') === false;
+  },
+
+  get isSearchVignetteHidden() {
+    return $('[data-test-search-vignette]').attr('class').indexOf('is-hidden--') !== -1;
+  },
+
   clickSearchVignette() {
     return $('[data-test-search-vignette]').trigger('click');
   },
@@ -96,6 +104,14 @@ export default {
       expect($input).to.have.value(query);
     }).then(() => {
       $('[data-test-search-submit]').trigger('click');
+    });
+  },
+
+  clearSearch() {
+    let $input = $('[data-test-search-field]').find('input[name="search"]').val('');
+    triggerChange($input.get(0));
+    return convergeOn(() => {
+      expect($input).to.have.value('');
     });
   },
 

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -72,6 +72,14 @@ export default {
     return $('[data-test-search-form-type-switcher] a[class^="is-active--"]');
   },
 
+  get isSearchButtonEnabled() {
+    return $('[data-test-search-submit]').prop('disabled') === false;
+  },
+
+  get isSearchVignetteHidden() {
+    return $('[data-test-search-vignette]').attr('class').indexOf('is-hidden--') !== -1;
+  },
+
   clickSearchVignette() {
     return $('[data-test-search-vignette]').trigger('click');
   },
@@ -83,6 +91,13 @@ export default {
       expect($input).to.have.value(query);
     }).then(() => {
       $('[data-test-search-submit]').trigger('click');
+    });
+  },
+  clearSearch() {
+    let $input = $('[data-test-title-search-field]').find('input[name="search"]').val('');
+    triggerChange($input.get(0));
+    return convergeOn(() => {
+      expect($input).to.have.value('');
     });
   },
   get $searchFieldSelect() {

--- a/tests/provider-search-test.js
+++ b/tests/provider-search-test.js
@@ -26,6 +26,10 @@ describeApplication('ProviderSearch', () => {
     expect(ProviderSearchPage.$searchField).to.exist;
   });
 
+  it('has disabled search button', () => {
+    expect(ProviderSearchPage.isSearchButtonEnabled).to.equal(false);
+  });
+
   describe('searching for a provider', () => {
     beforeEach(() => {
       ProviderSearchPage.search('Provider');
@@ -53,6 +57,10 @@ describeApplication('ProviderSearch', () => {
 
     it('displays the total number of search results', () => {
       expect(ProviderSearchPage.totalResults).to.equal('3 search results');
+    });
+
+    it('hides search filters on smaller screen sizes (due to new search term)', () => {
+      expect(ProviderSearchPage.isSearchVignetteHidden).to.equal(true);
     });
 
     describe('clicking a search results list item', () => {
@@ -89,6 +97,10 @@ describeApplication('ProviderSearch', () => {
           // to the history. Ensuring the back button works as expected
           let history = this.app.history;
           expect(history.entries[history.index - 1].search).to.include('q=Provider');
+        });
+
+        it('hides search filters on smaller screen sizes (due to new search term)', () => {
+          expect(ProviderSearchPage.isSearchVignetteHidden).to.equal(true);
         });
       });
 
@@ -233,6 +245,10 @@ describeApplication('ProviderSearch', () => {
         expect(this.app.history.location.search).to.not.include('sort=relevance');
       });
 
+      it('hides search filters on smaller screen sizes (due to new search term)', () => {
+        expect(ProviderSearchPage.isSearchVignetteHidden).to.equal(true);
+      });
+
       describe('then filtering by sort options', () => {
         beforeEach(() => {
           return convergeOn(() => {
@@ -257,6 +273,10 @@ describeApplication('ProviderSearch', () => {
           expect(this.app.history.location.search).to.include('sort=name');
         });
 
+        it('shows search filters on smaller screen sizes (due to filter change only)', () => {
+          expect(ProviderSearchPage.isSearchVignetteHidden).to.equal(false);
+        });
+
         describe('then searching for other providers', () => {
           beforeEach(() => {
             ProviderSearchPage.search('analytics');
@@ -274,6 +294,10 @@ describeApplication('ProviderSearch', () => {
 
           it('shows the sort filter of name in the search form', () => {
             expect(ProviderSearchPage.getFilter('sort')).to.equal('name');
+          });
+
+          it('hides search filters on smaller screen sizes (due to new search term)', () => {
+            expect(ProviderSearchPage.isSearchVignetteHidden).to.equal(true);
           });
 
           describe('then clicking another search type', () => {
@@ -336,6 +360,19 @@ describeApplication('ProviderSearch', () => {
         expect(ProviderSearchPage.providerList[0].name).to.equal('Health Associations');
         expect(ProviderSearchPage.providerList[1].name).to.equal('My Health Analytics 2');
         expect(ProviderSearchPage.providerList[2].name).to.equal('My Health Analytics 10');
+      });
+    });
+
+    describe('clearing the search field', () => {
+      beforeEach(() => {
+        return convergeOn(() => {
+          expect(ProviderSearchPage.$searchResultsItems).to.have.lengthOf(0);
+        }).then(() => (
+          ProviderSearchPage.clearSearch()
+        ));
+      });
+      it('has disabled search button', () => {
+        expect(ProviderSearchPage.isSearchButtonEnabled).to.equal(false);
       });
     });
   });

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -67,9 +67,17 @@ describeApplication('TitleSearch', () => {
     expect(TitleSearchPage.$searchFilters).to.exist;
   });
 
+  it('has disabled search button', () => {
+    expect(TitleSearchPage.isSearchButtonEnabled).to.equal(false);
+  });
+
   describe('searching for a title', () => {
     beforeEach(() => {
       TitleSearchPage.search('Title');
+    });
+
+    it('has enabled search button', () => {
+      expect(TitleSearchPage.isSearchButtonEnabled).to.equal(true);
     });
 
     it("displays title entries related to 'Title'", () => {
@@ -94,6 +102,10 @@ describeApplication('TitleSearch', () => {
 
     it('displays the total number of search results', () => {
       expect(TitleSearchPage.totalResults).to.equal('3 search results');
+    });
+
+    it('hides search filters on smaller screen sizes (due to new search term)', () => {
+      expect(TitleSearchPage.isSearchVignetteHidden).to.equal(true);
     });
 
     describe('clicking a search results list item', () => {
@@ -130,6 +142,10 @@ describeApplication('TitleSearch', () => {
           // to the history. Ensuring the back button works as expected
           let history = this.app.history;
           expect(history.entries[history.index - 1].search).to.include('q=Title');
+        });
+
+        it('hides search filters on smaller screen sizes (due to new search term)', () => {
+          expect(TitleSearchPage.isSearchVignetteHidden).to.equal(true);
         });
       });
 
@@ -182,6 +198,10 @@ describeApplication('TitleSearch', () => {
         expect(TitleSearchPage.titleList[0].publicationType).to.equal('book');
       });
 
+      it('shows search filters on smaller screen sizes (due to filter change only)', () => {
+        expect(TitleSearchPage.isSearchVignetteHidden).to.equal(false);
+      });
+
       it('reflects the filter in the URL query params', function () {
         expect(this.app.history.location.search).to.include('filter[type]=book');
       });
@@ -197,6 +217,10 @@ describeApplication('TitleSearch', () => {
 
         it.always('removes the filter from the URL query params', function () {
           expect(this.app.history.location.search).to.not.include('filter[type]');
+        });
+
+        it('shows search filters on smaller screen sizes (due to filter change only)', () => {
+          expect(TitleSearchPage.isSearchVignetteHidden).to.equal(false);
         });
       });
 
@@ -219,6 +243,10 @@ describeApplication('TitleSearch', () => {
           expect(TitleSearchPage.titleList).to.have.lengthOf(2);
           expect(TitleSearchPage.titleList[0].publicationType).to.equal('journal');
         });
+
+        it('shows search filters on smaller screen sizes (due to filter change only)', () => {
+          expect(TitleSearchPage.isSearchVignetteHidden).to.equal(false);
+        });
       });
     });
 
@@ -239,6 +267,10 @@ describeApplication('TitleSearch', () => {
         expect(this.app.history.location.search).to.include('filter[selected]=true');
       });
 
+      it('shows search filters on smaller screen sizes (due to filter change only)', () => {
+        expect(TitleSearchPage.isSearchVignetteHidden).to.equal(false);
+      });
+
       describe('clearing the filters', () => {
         beforeEach(() => {
           return convergeOn(() => {
@@ -250,6 +282,10 @@ describeApplication('TitleSearch', () => {
 
         it.always('removes the filter from the URL query params', function () {
           expect(this.app.history.location.search).to.not.include('filter[selected]');
+        });
+
+        it('shows search filters on smaller screen sizes (due to filter change only)', () => {
+          expect(TitleSearchPage.isSearchVignetteHidden).to.equal(false);
         });
       });
 
@@ -270,6 +306,10 @@ describeApplication('TitleSearch', () => {
 
         it('only shows results for non-selected titles', () => {
           expect(TitleSearchPage.titleList).to.have.lengthOf(1);
+        });
+
+        it('shows search filters on smaller screen sizes (due to filter change only)', () => {
+          expect(TitleSearchPage.isSearchVignetteHidden).to.equal(false);
         });
       });
     });
@@ -293,6 +333,10 @@ describeApplication('TitleSearch', () => {
       it('reflects the publisher searchfield in the URL query params', function () {
         expect(this.app.history.location.search).to.include('searchfield=publisher');
       });
+
+      it('hides search filters on smaller screen sizes (due to new search term)', () => {
+        expect(TitleSearchPage.isSearchVignetteHidden).to.equal(true);
+      });
     });
 
     describe('selecting a subject search field', () => {
@@ -313,6 +357,10 @@ describeApplication('TitleSearch', () => {
       it('reflects the subject searchfield in the URL query params', function () {
         expect(this.app.history.location.search).to.include('searchfield=subject');
       });
+
+      it('hides search filters on smaller screen sizes (due to new search term)', () => {
+        expect(TitleSearchPage.isSearchVignetteHidden).to.equal(true);
+      });
     });
 
     describe('selecting an isxn search field', () => {
@@ -332,6 +380,10 @@ describeApplication('TitleSearch', () => {
 
       it('reflects the isxn searchfield in the URL query params', function () {
         expect(this.app.history.location.search).to.include('searchfield=isxn');
+      });
+
+      it('hides search filters on smaller screen sizes (due to new search term)', () => {
+        expect(TitleSearchPage.isSearchVignetteHidden).to.equal(true);
       });
     });
 
@@ -427,6 +479,10 @@ describeApplication('TitleSearch', () => {
         it('shows the preview pane', () => {
           expect(TitleSearchPage.previewPaneIsVisible('titles')).to.be.true;
         });
+
+        it('hides search filters on smaller screen sizes (due to new search term)', () => {
+          expect(TitleSearchPage.isSearchVignetteHidden).to.equal(true);
+        });
       });
     });
 
@@ -485,6 +541,19 @@ describeApplication('TitleSearch', () => {
             expect(this.app.history.location.search).to.not.include('filter[isxn]');
           });
         });
+      });
+    });
+
+    describe('clearing the search field', () => {
+      beforeEach(() => {
+        return convergeOn(() => {
+          expect(TitleSearchPage.$searchResultsItems).to.have.lengthOf(3);
+        }).then(() => (
+          TitleSearchPage.clearSearch()
+        ));
+      });
+      it('has disabled search button', () => {
+        expect(TitleSearchPage.isSearchButtonEnabled).to.equal(false);
       });
     });
   });


### PR DESCRIPTION
## Purpose
Close out remaining functionality for Filter Behavior and result list update as described at:
_[UIEH-157](https://issues.folio.org/browse/UIEH-157)_
Prior pull request - https://github.com/folio-org/ui-eholdings/pull/251 addressed filter selection (without requiring click of search button).
 
The following 2 items are addressed by this PR
- When the search box is empty the search button is currently disabled and remains disabled until text is entered in the search box. There was no visual indication that the button is disabled. Added styling to the button so this is more apparent. (this is done instead of displaying a message about an empty search)
- Updated behavior of search/filter panel visibility on small screens. Rules as follows:
1. Hide Panel if the user enters a new search term
2. Show Panel if the user changes filtering or sort options (but the search term remains the same)

## Approach
Moved logic to detect new search (either new search term or new parameters) from search routes component into search-paneset (based on feedback from Wil). Compared locations as well as details of search in componentWillReceiveProps
~~Similar to caching of queries, keep track of whether a search term has changed or the filters only have changed (in search routes). These statuses are updated when performing a search and read when rendering results.~~

#### TODOS and Open Questions
- [ ] ~~Would like to understand if the way I am storing this stateful information is recommended in  SearchRoute. `this.searchChanged` and `this.filtersOnlyChanged` Making determination based on current search compared to prior search. Is there a better approach?~~
- [ ] Confirm understanding of behavior for when panel is visible/hidden
- [ ] Added majority of tests to title search and some basic tests to provider and package - trying to avoid redundancy

## Learning
- https://developmentarc.gitbooks.io/react-indepth/content/life_cycle/update/component_will_receive_props.html
- https://reactjs.org/blog/2016/01/08/A-implies-B-does-not-imply-B-implies-A.html
Used chrome responsive web designer, also using developer tools in chrome (with smaller screen widths) provides similar behavior.


## Screenshots
![filter-behavior-search-button](https://user-images.githubusercontent.com/19415226/37431840-b9754f8c-27ac-11e8-8112-d353b8698056.gif)
