### PR TITLE
Refine preview pane design with headers

### DIFF
--- a/src/components/custom-embargo/custom-embargo.css
+++ b/src/components/custom-embargo/custom-embargo.css
@@ -1,10 +1,9 @@
 @import '@folio/stripes-components/lib/variables';
 
 .custom-embargo-form {
-  padding: 0.5em 1em 1em;
-
   &.is-editing {
     background: #e6f3ff;
+    padding: 1em;
   }
 }
 

--- a/src/components/custom-embargo/custom-embargo.js
+++ b/src/components/custom-embargo/custom-embargo.js
@@ -207,7 +207,6 @@ class CustomEmbargoForm extends Component {
           'is-editing': isEditable
         })}
       >
-        <h4>Embargo period</h4>
         {contents}
       </div>
     );

--- a/src/components/customer-resource-coverage/customer-resource-coverage.css
+++ b/src/components/customer-resource-coverage/customer-resource-coverage.css
@@ -1,15 +1,10 @@
 @import '@folio/stripes-components/lib/variables';
 
 .coverage-form {
-  padding: 0.5em 1em 1em;
-
   &.is-editing {
     background: #e6f3ff;
+    padding: 1em;
   }
-}
-
-.coverage-form-legend {
-  margin-bottom: 0.5em;
 }
 
 .coverage-form-display {

--- a/src/components/customer-resource-coverage/customer-resource-coverage.js
+++ b/src/components/customer-resource-coverage/customer-resource-coverage.js
@@ -240,7 +240,6 @@ class CustomerResourceCoverage extends Component {
           'is-editing': isEditable
         })}
       >
-        <h4 className={styles['coverage-form-legend']}>Coverage dates</h4>
         {contents}
       </div>
     );

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import Button from '@folio/stripes-components/lib/Button';
-import Layout from '@folio/stripes-components/lib/Layout';
 
 import DetailsView from './details-view';
 import Link from './link';
@@ -13,10 +12,10 @@ import ToggleSwitch from './toggle-switch';
 import CoverageDateList from './coverage-date-list';
 import { isBookPublicationType, isValidCoverageList } from './utilities';
 import Modal from './modal';
-import styles from './styles.css';
 import CustomEmbargoForm from './custom-embargo';
 import CustomerResourceCoverage from './customer-resource-coverage';
 import NavigationModal from './navigation-modal';
+import DetailsViewSection from './details-view-section';
 
 export default class CustomerResourceShow extends Component {
   static propTypes = {
@@ -120,138 +119,70 @@ export default class CustomerResourceShow extends Component {
           paneSub={model.packageName}
           bodyContent={(
             <div>
-              <ContributorsList data={model.contributors} />
+              <DetailsViewSection label="Holding status">
+                <label
+                  data-test-eholdings-customer-resource-show-selected
+                  htmlFor="customer-resource-show-toggle-switch"
+                >
+                  <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
+                  <ToggleSwitch
+                    onChange={this.handleSelectionToggle}
+                    checked={resourceSelected}
+                    isPending={model.update.isPending && 'isSelected' in model.update.changedAttributes}
+                    id="customer-resource-show-toggle-switch"
+                  />
+                </label>
+              </DetailsViewSection>
+              <DetailsViewSection label="Visibility">
+                {resourceSelected ? (
+                  <div>
+                    <label
+                      data-test-eholdings-customer-resource-toggle-hidden
+                      htmlFor="customer-resource-show-hide-toggle-switch"
+                    >
+                      <h4>
+                        {model.visibilityData.isHidden
+                          ? 'Hidden from patrons'
+                          : 'Visible to patrons'}
+                      </h4>
 
-              <KeyValueLabel label="Publisher">
-                <div data-test-eholdings-customer-resource-show-publisher-name>
-                  {model.publisherName}
-                </div>
-              </KeyValueLabel>
+                      <ToggleSwitch
+                        onChange={this.props.toggleHidden}
+                        checked={!resourceHidden}
+                        isPending={model.update.isPending &&
+                          ('visibilityData' in model.update.changedAttributes)}
+                        id="customer-resource-show-hide-toggle-switch"
+                      />
+                    </label>
 
-              {model.publicationType && (
-                <KeyValueLabel label="Publication type">
-                  <div data-test-eholdings-customer-resource-show-publication-type>
-                    {model.publicationType}
-                  </div>
-                </KeyValueLabel>
-              )}
-
-              <IdentifiersList data={model.identifiers} />
-
-              {model.subjects.length > 0 && (
-                <KeyValueLabel label="Subjects">
-                  <div data-test-eholdings-customer-resource-show-subjects-list>
-                    {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
-                  </div>
-                </KeyValueLabel>
-              )}
-
-              <KeyValueLabel label="Package">
-                <div data-test-eholdings-customer-resource-show-package-name>
-                  <Link to={`/eholdings/packages/${model.packageId}`}>{model.packageName}</Link>
-                </div>
-              </KeyValueLabel>
-
-              {model.contentType && (
-                <KeyValueLabel label="Content type">
-                  <div data-test-eholdings-customer-resource-show-content-type>
-                    {model.contentType}
-                  </div>
-                </KeyValueLabel>
-              )}
-
-              <KeyValueLabel label="Provider">
-                <div data-test-eholdings-customer-resource-show-provider-name>
-                  <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
-                </div>
-              </KeyValueLabel>
-
-              {model.url && (
-                <KeyValueLabel label="Managed URL">
-                  <div data-test-eholdings-customer-resource-show-managed-url>
-                    <a href={model.url} target="_blank">{model.url}</a>
-                  </div>
-                </KeyValueLabel>
-              )}
-
-              {hasManagedCoverages && (
-                <KeyValueLabel label="Managed coverage dates">
-                  <div data-test-eholdings-customer-resource-show-managed-coverage-list>
-                    <CoverageDateList
-                      coverageArray={model.managedCoverages}
-                      isYearOnly={isBookPublicationType(model.publicationType)}
-                    />
-                  </div>
-                </KeyValueLabel>
-              )}
-
-              {hasManagedEmbargoPeriod && (
-                <KeyValueLabel label="Managed embargo period">
-                  <div data-test-eholdings-customer-resource-show-managed-embargo-period>
-                    {model.managedEmbargoPeriod.embargoValue} {model.managedEmbargoPeriod.embargoUnit}
-                  </div>
-                </KeyValueLabel>
-              )}
-
-              <hr />
-
-              <label
-                data-test-eholdings-customer-resource-show-selected
-                htmlFor="customer-resource-show-toggle-switch"
-              >
-                <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
-                <ToggleSwitch
-                  onChange={this.handleSelectionToggle}
-                  checked={resourceSelected}
-                  isPending={model.update.isPending && 'isSelected' in model.update.changedAttributes}
-                  id="customer-resource-show-toggle-switch"
-                />
-              </label>
-
-              {resourceSelected && (
-                <div>
-                  <hr />
-                  <label
-                    data-test-eholdings-customer-resource-toggle-hidden
-                    htmlFor="customer-resource-show-hide-toggle-switch"
-                  >
-                    <h4>
-                      {model.visibilityData.isHidden
-                        ? 'Hidden from patrons'
-                        : 'Visible to patrons'}
-                    </h4>
-
-                    <Layout className="flex">
-                      <div className={styles.marginRightHalf}>
-                        {model.package.visibilityData.isHidden ? (
-                          <ToggleSwitch
-                            id="customer-resource-show-hide-toggle-switch"
-                            checked={false}
-                            disabled
-                          />
-                        ) : (
-                          <ToggleSwitch
-                            onChange={this.props.toggleHidden}
-                            checked={!resourceHidden}
-                            isPending={model.update.isPending &&
-                              ('visibilityData' in model.update.changedAttributes)}
-                            id="customer-resource-show-hide-toggle-switch"
-                          />
-                        )}
+                    {model.visibilityData.isHidden && (
+                      <div data-test-eholdings-customer-resource-toggle-hidden-reason>
+                        {model.package.visibilityData.isHidden
+                          ? 'All titles in this package are hidden.'
+                          : model.visibilityData.reason}
                       </div>
+                    )}
+                  </div>
+                ) : (
+                  <p>Not shown to patrons.</p>
+                )}
+              </DetailsViewSection>
+              <DetailsViewSection
+                label="Coverage dates"
+                closedByDefault={!hasManagedCoverages && !resourceSelected}
+              >
+                {hasManagedCoverages && (
+                  <KeyValueLabel label="Managed coverage dates">
+                    <div data-test-eholdings-customer-resource-show-managed-coverage-list>
+                      <CoverageDateList
+                        coverageArray={model.managedCoverages}
+                        isYearOnly={isBookPublicationType(model.publicationType)}
+                      />
+                    </div>
+                  </KeyValueLabel>
+                )}
 
-                      {model.visibilityData.isHidden && (
-                        <div data-test-eholdings-customer-resource-toggle-hidden-reason>
-                          {model.package.visibilityData.isHidden
-                            ? 'All titles in this package are hidden.'
-                            : model.visibilityData.reason}
-                        </div>
-                      )}
-                    </Layout>
-                  </label>
-
-                  <hr />
-
+                {resourceSelected && (
                   <CustomerResourceCoverage
                     initialValues={{ customCoverages }}
                     packageCoverage={model.package.customCoverage}
@@ -262,9 +193,26 @@ export default class CustomerResourceShow extends Component {
                     locale={locale}
                     intl={intl}
                   />
+                )}
 
-                  <hr />
+                {!hasManagedCoverages && !resourceSelected && (
+                  <p>Add the resource to holdings to set custom coverage dates.</p>
+                )}
 
+              </DetailsViewSection>
+              <DetailsViewSection
+                label="Embargo period"
+                closedByDefault={!hasManagedEmbargoPeriod && !resourceSelected}
+              >
+                {hasManagedEmbargoPeriod && (
+                  <KeyValueLabel label="Managed embargo period">
+                    <div data-test-eholdings-customer-resource-show-managed-embargo-period>
+                      {model.managedEmbargoPeriod.embargoValue} {model.managedEmbargoPeriod.embargoUnit}
+                    </div>
+                  </KeyValueLabel>
+                )}
+
+                {resourceSelected && (
                   <CustomEmbargoForm
                     initialValues={{ customEmbargoValue, customEmbargoUnit }}
                     isEditable={isEmbargoEditable}
@@ -272,16 +220,76 @@ export default class CustomerResourceShow extends Component {
                     onSubmit={customEmbargoSubmitted}
                     isPending={model.update.isPending && 'customEmbargoPeriod' in model.update.changedAttributes}
                   />
-                </div>
-              )}
+                )}
 
-              <hr />
+                {!hasManagedEmbargoPeriod && !resourceSelected && (
+                  <p>Add the resource to holdings to set an custom embargo period.</p>
+                )}
 
-              <div>
-                <Link to={`/eholdings/titles/${model.titleId}`}>
-                  View all packages that include this title
-                </Link>
-              </div>
+              </DetailsViewSection>
+
+              <DetailsViewSection label="Resource information">
+
+                <ContributorsList data={model.contributors} />
+
+                <KeyValueLabel label="Publisher">
+                  <div data-test-eholdings-customer-resource-show-publisher-name>
+                    {model.publisherName}
+                  </div>
+                </KeyValueLabel>
+
+                {model.publicationType && (
+                  <KeyValueLabel label="Publication type">
+                    <div data-test-eholdings-customer-resource-show-publication-type>
+                      {model.publicationType}
+                    </div>
+                  </KeyValueLabel>
+                )}
+
+                <IdentifiersList data={model.identifiers} />
+
+                {model.subjects.length > 0 && (
+                  <KeyValueLabel label="Subjects">
+                    <div data-test-eholdings-customer-resource-show-subjects-list>
+                      {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
+                    </div>
+                  </KeyValueLabel>
+                )}
+
+                <KeyValueLabel label="Provider">
+                  <div data-test-eholdings-customer-resource-show-provider-name>
+                    <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
+                  </div>
+                </KeyValueLabel>
+
+                <KeyValueLabel label="Package">
+                  <div data-test-eholdings-customer-resource-show-package-name>
+                    <Link to={`/eholdings/packages/${model.packageId}`}>{model.packageName}</Link>
+                  </div>
+                </KeyValueLabel>
+
+                <KeyValueLabel label="Other packages">
+                  <Link to={`/eholdings/titles/${model.titleId}`}>
+                    View all packages that include this title
+                  </Link>
+                </KeyValueLabel>
+
+                {model.contentType && (
+                  <KeyValueLabel label="Content type">
+                    <div data-test-eholdings-customer-resource-show-content-type>
+                      {model.contentType}
+                    </div>
+                  </KeyValueLabel>
+                )}
+
+                {model.url && (
+                  <KeyValueLabel label="Managed URL">
+                    <div data-test-eholdings-customer-resource-show-managed-url>
+                      <a href={model.url} target="_blank">{model.url}</a>
+                    </div>
+                  </KeyValueLabel>
+                )}
+              </DetailsViewSection>
             </div>
           )}
         />

--- a/src/components/details-view-section/details-view-section.css
+++ b/src/components/details-view-section/details-view-section.css
@@ -1,0 +1,12 @@
+@import '@folio/stripes-components/lib/variables';
+
+.details-view-section {
+  border-top: 1px solid var(--minor-divider-color);
+  padding-bottom: 1em;
+}
+
+.details-view-section-label {
+  color: var(--subLabelColor #999);
+  font-size: 18px;
+  font-weight: 600;
+}

--- a/src/components/details-view-section/details-view-section.js
+++ b/src/components/details-view-section/details-view-section.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './details-view-section.css';
+
+export default function DetailsViewSection(props) {
+  return (
+    <div className={styles['details-view-section']}>
+      <h3 className={styles['details-view-section-label']}>{props.label}</h3>
+      <div className={styles['details-view-section-value']}>
+        {props.children}
+      </div>
+    </div>
+  );
+}
+
+DetailsViewSection.propTypes = {
+  label: PropTypes.string,
+  children: PropTypes.node
+};

--- a/src/components/details-view-section/index.js
+++ b/src/components/details-view-section/index.js
@@ -1,0 +1,1 @@
+export { default } from './details-view-section';

--- a/src/components/details-view/details-view.css
+++ b/src/components/details-view/details-view.css
@@ -1,3 +1,5 @@
+@import '@folio/stripes-components/lib/variables';
+
 .container {
   height: calc(100vh - 90px);
   overflow-y: auto;
@@ -8,8 +10,8 @@
 
   & .list-header {
     display: flex;
-    border-bottom: 1px solid #dcdcdc;
-    border-top: 1px solid #dcdcdc;
+    border-bottom: 1px solid #eee;
+    border-top: 1px solid var(--minor-divider-color);
     justify-content: space-between;
   }
 
@@ -19,11 +21,8 @@
     }
   }
 
-  & h3 {
-    margin: 1em 0 0.5em;
-  }
-
   & h4 {
+    font-size: inherit;
     margin: 0.5em 0;
   }
 }
@@ -32,10 +31,18 @@
   padding: 0 1rem;
   margin: 2rem 0;
 
-  & h1 {
+  & h2 {
     font-size: 2.5em;
     font-weight: 700;
-    margin-top: 0.125em;
+    margin: 0.5em 1em 0 0;
+  }
+
+  & p {
+    color: var(--secondary);
+    font-size: 1.5em;
+    font-weight: 600;
+    margin-bottom: 0;
+    margin-top: 0.25em;
   }
 }
 
@@ -50,6 +57,9 @@
   max-height: 100%;
 
   & h3 {
+    color: var(--subLabelColor #999);
+    font-size: 18px;
+    font-weight: 600;
     padding: 1rem 1rem 0.75rem;
     margin: 0;
   }

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -9,7 +9,6 @@ import IconButton from '@folio/stripes-components/lib/IconButton';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import Link from 'react-router-dom/Link';
 
-import KeyValueLabel from '../key-value-label';
 import styles from './details-view.css';
 
 const cx = classNames.bind(styles);
@@ -203,11 +202,12 @@ export default class DetailsView extends Component {
         >
           {model.isLoaded ? [
             <div key="header" className={styles.header}>
-              <KeyValueLabel label={capitalize(type)}>
-                <h1 data-test-eholdings-details-view-name={type}>
-                  {model.name}
-                </h1>
-              </KeyValueLabel>
+              <h2 data-test-eholdings-details-view-name={type}>
+                {paneTitle}
+              </h2>
+              {paneSub &&
+                <p>{paneSub}</p>
+              }
             </div>,
 
             <div key="body" className={styles.body}>

--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -4,7 +4,7 @@
   padding: 0;
 
   & li {
-    border-bottom: 1px solid #dcdcdc;
+    border-bottom: 1px solid #eee;
     list-style-type: none;
     margin: 0;
 
@@ -19,7 +19,7 @@
       color: #888;
 
       &:hover {
-        background-color: #eee;
+        background-color: #efefef;
       }
 
       & h5 {

--- a/src/components/package-custom-coverage/package-custom-coverage.css
+++ b/src/components/package-custom-coverage/package-custom-coverage.css
@@ -1,10 +1,9 @@
 @import '@folio/stripes-components/lib/variables';
 
 .custom-coverage-form {
-  padding: 0.5em 1em 1em;
-
   &.is-editing {
     background: #e6f3ff;
+    padding: 1em;
   }
 }
 

--- a/src/components/package-custom-coverage/package-custom-coverage.js
+++ b/src/components/package-custom-coverage/package-custom-coverage.js
@@ -218,7 +218,6 @@ class PackageCustomCoverage extends Component {
           'is-editing': this.state.isEditing
         })}
       >
-        <h4>Coverage dates</h4>
         {contents}
       </div>
     );

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import Button from '@folio/stripes-components/lib/Button';
-import Layout from '@folio/stripes-components/lib/Layout';
 import Icon from '@folio/stripes-components/lib/Icon';
 
 import DetailsView from './details-view';
@@ -13,7 +12,7 @@ import TitleListItem from './title-list-item';
 import ToggleSwitch from './toggle-switch';
 import Modal from './modal';
 import PackageCustomCoverage from './package-custom-coverage';
-import styles from './styles.css';
+import DetailsViewSection from './details-view-section';
 
 export default class PackageShow extends Component {
   static propTypes = {
@@ -88,80 +87,54 @@ export default class PackageShow extends Component {
           paneTitle={model.name}
           bodyContent={(
             <div>
-              <KeyValueLabel label="Provider">
-                <div data-test-eholdings-package-details-provider>
-                  <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
-                </div>
-              </KeyValueLabel>
+              <DetailsViewSection label="Holding status">
+                <label
+                  data-test-eholdings-package-details-selected
+                  htmlFor="package-details-toggle-switch"
+                >
+                  <h4>{packageSelected ? 'Selected' : 'Not selected'}</h4>
+                  <ToggleSwitch
+                    onChange={this.handleSelectionToggle}
+                    checked={packageSelected}
+                    isPending={model.update.isPending && 'isSelected' in model.update.changedAttributes}
+                    id="package-details-toggle-switch"
+                  />
+                </label>
+              </DetailsViewSection>
+              <DetailsViewSection label="Visibility">
+                {packageSelected ? (
+                  <div>
+                    <label
+                      data-test-eholdings-package-details-hidden
+                      htmlFor="package-details-toggle-hidden-switch"
+                    >
+                      <h4>
+                        {model.visibilityData.isHidden
+                          ? 'Hidden from patrons'
+                          : 'Visible to patrons'}
+                      </h4>
 
-              {model.contentType && (
-                <KeyValueLabel label="Content type">
-                  <div data-test-eholdings-package-details-content-type>
-                    {model.contentType}
-                  </div>
-                </KeyValueLabel>
-              )}
+                      <ToggleSwitch
+                        onChange={this.props.toggleHidden}
+                        checked={!packageHidden}
+                        isPending={model.update.isPending &&
+                          ('visibilityData' in model.update.changedAttributes)}
+                        id="package-details-toggle-hidden-switch"
+                      />
+                    </label>
 
-              <KeyValueLabel label="Titles selected">
-                <div data-test-eholdings-package-details-titles-selected>
-                  {intl.formatNumber(model.selectedCount)}
-                </div>
-              </KeyValueLabel>
-
-              <KeyValueLabel label="Total titles">
-                <div data-test-eholdings-package-details-titles-total>
-                  {intl.formatNumber(model.titleCount)}
-                </div>
-              </KeyValueLabel>
-
-              <label
-                data-test-eholdings-package-details-selected
-                htmlFor="package-details-toggle-switch"
-              >
-                <h4>{packageSelected ? 'Selected' : 'Not selected'}</h4>
-                <ToggleSwitch
-                  onChange={this.handleSelectionToggle}
-                  checked={packageSelected}
-                  isPending={model.update.isPending && 'isSelected' in model.update.changedAttributes}
-                  id="package-details-toggle-switch"
-                />
-              </label>
-
-              {packageSelected && (
-                <div>
-                  <hr />
-
-                  <label
-                    data-test-eholdings-package-details-hidden
-                    htmlFor="package-details-toggle-hidden-switch"
-                  >
-                    <h4>
-                      {model.visibilityData.isHidden
-                        ? 'Hidden from patrons'
-                        : 'Visible to patrons'}
-                    </h4>
-
-                    <Layout className="flex">
-                      <div className={styles.marginRightHalf}>
-                        <ToggleSwitch
-                          onChange={this.props.toggleHidden}
-                          checked={!packageHidden}
-                          isPending={model.update.isPending &&
-                            ('visibilityData' in model.update.changedAttributes)}
-                          id="package-details-toggle-hidden-switch"
-                        />
+                    {model.visibilityData.isHidden && (
+                      <div data-test-eholdings-package-details-is-hidden>
+                        {model.visibilityData.reason}
                       </div>
-
-                      {model.visibilityData.isHidden && (
-                        <div data-test-eholdings-package-details-is-hidden>
-                          {model.visibilityData.reason}
-                        </div>
-                      )}
-                    </Layout>
-                  </label>
-
-                  <hr />
-
+                    )}
+                  </div>
+                ) : (
+                  <p>Not shown to patrons.</p>
+                )}
+              </DetailsViewSection>
+              <DetailsViewSection label="Title management">
+                {packageSelected ? (
                   <label
                     data-test-eholdings-package-details-allow-add-new-titles
                     htmlFor="package-details-toggle-allow-add-new-titles-switch"
@@ -186,9 +159,15 @@ export default class PackageShow extends Component {
                         <Icon icon="spinner-ellipsis" />
                       )}
                   </label>
-
-                  <hr />
-
+                ) : (
+                  <p>Knowledge base does not automatically select titles.</p>
+                )}
+              </DetailsViewSection>
+              <DetailsViewSection
+                label="Coverage dates"
+                closedByDefault={!packageSelected}
+              >
+                {packageSelected ? (
                   <div data-test-eholdings-package-details-custom-coverage>
                     <PackageCustomCoverage
                       initialValues={{ customCoverages }}
@@ -196,8 +175,37 @@ export default class PackageShow extends Component {
                       isPending={model.update.isPending && 'customCoverage' in model.update.changedAttributes}
                     />
                   </div>
-                </div>
-              )}
+                ) : (
+                  <p>Add the package to holdings to set custom coverage dates.</p>
+                )}
+              </DetailsViewSection>
+              <DetailsViewSection label="Package information">
+                <KeyValueLabel label="Provider">
+                  <div data-test-eholdings-package-details-provider>
+                    <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
+                  </div>
+                </KeyValueLabel>
+
+                {model.contentType && (
+                  <KeyValueLabel label="Content type">
+                    <div data-test-eholdings-package-details-content-type>
+                      {model.contentType}
+                    </div>
+                  </KeyValueLabel>
+                )}
+
+                <KeyValueLabel label="Titles selected">
+                  <div data-test-eholdings-package-details-titles-selected>
+                    {intl.formatNumber(model.selectedCount)}
+                  </div>
+                </KeyValueLabel>
+
+                <KeyValueLabel label="Total titles">
+                  <div data-test-eholdings-package-details-titles-total>
+                    {intl.formatNumber(model.titleCount)}
+                  </div>
+                </KeyValueLabel>
+              </DetailsViewSection>
             </div>
           )}
           listType="titles"

--- a/src/components/provider-show.js
+++ b/src/components/provider-show.js
@@ -5,6 +5,7 @@ import DetailsView from './details-view';
 import KeyValueLabel from './key-value-label';
 import QueryList from './query-list';
 import PackageListItem from './package-list-item';
+import DetailsViewSection from './details-view-section';
 
 export default function ProviderShow({
   model,
@@ -18,7 +19,7 @@ export default function ProviderShow({
       model={model}
       paneTitle={model.name}
       bodyContent={(
-        <div>
+        <DetailsViewSection label="Provider information">
           <KeyValueLabel label="Packages selected">
             <div data-test-eholdings-provider-details-packages-selected>
               {intl.formatNumber(model.packagesSelected)}
@@ -30,7 +31,7 @@ export default function ProviderShow({
               {intl.formatNumber(model.packagesTotal)}
             </div>
           </KeyValueLabel>
-        </div>
+        </DetailsViewSection>
       )}
       listType="packages"
       renderList={scrollable => (

--- a/src/components/title-show.js
+++ b/src/components/title-show.js
@@ -7,6 +7,7 @@ import ScrollView from './scroll-view';
 import PackageListItem from './package-list-item';
 import IdentifiersList from './identifiers-list';
 import ContributorsList from './contributors-list';
+import DetailsViewSection from './details-view-section';
 
 export default function TitleShow({ model }) {
   return (
@@ -15,7 +16,7 @@ export default function TitleShow({ model }) {
       model={model}
       paneTitle={model.name}
       bodyContent={(
-        <div>
+        <DetailsViewSection label="Title information">
           <ContributorsList data={model.contributors} />
 
           <KeyValueLabel label="Publisher">
@@ -39,7 +40,7 @@ export default function TitleShow({ model }) {
               </div>
             </KeyValueLabel>
           )}
-        </div>
+        </DetailsViewSection>
       )}
       listType="packages"
       renderList={scrollable => (


### PR DESCRIPTION
## Purpose
Replaces https://github.com/folio-org/ui-eholdings/pull/272.

## Approach
The main benefit of the accordions was the nice headlines organizing the content. I made a component that mimics the accordion headline styles, minus the accessibility issues.

Detail panes also have the appropriate headline hierarchy now (with the exception of the duplicated title, which will eventually be resolved with https://github.com/folio-org/ui-eholdings/pull/252).

## Screenshots
![lxotwoc5ol](https://user-images.githubusercontent.com/230597/37478738-0d119730-2849-11e8-84ca-8f578043d238.gif)