### PR TITLE
Simplify redux-form render components

### DIFF
--- a/src/components/custom-embargo/custom-embargo.js
+++ b/src/components/custom-embargo/custom-embargo.js
@@ -62,35 +62,6 @@ class CustomEmbargoForm extends Component {
     this.props.initialize(this.props.initialValues);
   }
 
-  renderTextField = ({ input, meta: { touched, error } }) => {
-    return (
-      <div>
-        <TextField
-          {...input}
-        />
-        {touched && ((error && <span className={styles['error-message']}>{error}</span>))}
-      </div>
-    );
-  }
-
-  renderDropDown = ({ input, meta: { touched, error } }) => {
-    return (
-      <div>
-        <Select
-          {...input}
-          dataOptions={[
-            { value: '', label: 'None' },
-            { value: 'Days', label: 'Days' },
-            { value: 'Weeks', label: 'Weeks' },
-            { value: 'Months', label: 'Months' },
-            { value: 'Years', label: 'Years' }
-          ]}
-        />
-        {touched && ((error && <span className={styles['error-message']}>{error}</span>))}
-      </div>
-    );
-  }
-
   render() {
     let {
       pristine,
@@ -117,18 +88,24 @@ class CustomEmbargoForm extends Component {
               <div className={styles['custom-embargo-component-width']}>
                 <div data-test-eholdings-customer-resource-custom-embargo-textfield className={styles['custom-embargo-text-field']}>
                   <Field
-                    name='customEmbargoValue'
-                    type="number"
+                    name="customEmbargoValue"
                     parse={value => (!value ? null : (Number.isNaN(Number(value)) ? '' : Number(value)))}
-                    component={this.renderTextField}
+                    component={TextField}
                   />
                 </div>
               </div>
               <div className={styles['custom-embargo-component-width']}>
                 <div data-test-eholdings-customer-resource-custom-embargo-select className={styles['flex-item-right-bottom-margin']}>
                   <Field
-                    name='customEmbargoUnit'
-                    component={this.renderDropDown}
+                    name="customEmbargoUnit"
+                    component={Select}
+                    dataOptions={[
+                      { value: '', label: 'None' },
+                      { value: 'Days', label: 'Days' },
+                      { value: 'Weeks', label: 'Weeks' },
+                      { value: 'Months', label: 'Months' },
+                      { value: 'Years', label: 'Years' }
+                    ]}
                     onChange={(event, newValue) => {
                       if (newValue === '') {
                         change('customEmbargoValue', 0);

--- a/src/components/customer-resource-coverage/customer-resource-coverage.js
+++ b/src/components/customer-resource-coverage/customer-resource-coverage.js
@@ -66,17 +66,6 @@ class CustomerResourceCoverage extends Component {
     this.props.initialize(this.props.initialValues);
   }
 
-  renderDatepicker = ({ input, label, meta, id }) => {
-    return (
-      <Datepicker
-        label={label}
-        input={input}
-        meta={meta}
-        id={id}
-      />
-    );
-  }
-
   renderCoverageFields = ({ fields }) => {
     return (
       <div>
@@ -99,7 +88,7 @@ class CustomerResourceCoverage extends Component {
                   <Field
                     name={`${dateRange}.beginCoverage`}
                     type="text"
-                    component={this.renderDatepicker}
+                    component={Datepicker}
                     label="Start date"
                     id="begin-coverage"
                   />
@@ -111,7 +100,7 @@ class CustomerResourceCoverage extends Component {
                   <Field
                     name={`${dateRange}.endCoverage`}
                     type="text"
-                    component={this.renderDatepicker}
+                    component={Datepicker}
                     label="End date"
                     id="end-coverage"
                   />

--- a/src/components/package-custom-coverage/package-custom-coverage.js
+++ b/src/components/package-custom-coverage/package-custom-coverage.js
@@ -45,16 +45,6 @@ class PackageCustomCoverage extends Component {
     }
   }
 
-  renderDatepicker = ({ input, label, meta }) => {
-    return (
-      <Datepicker
-        label={label}
-        input={input}
-        meta={meta}
-      />
-    );
-  }
-
   renderCoverageFields = ({ fields }) => {
     return (
       <div>
@@ -92,7 +82,7 @@ class PackageCustomCoverage extends Component {
                   <Field
                     name={`${dateRange}.beginCoverage`}
                     type="text"
-                    component={this.renderDatepicker}
+                    component={Datepicker}
                     label="Start date"
                   />
                 </div>
@@ -103,7 +93,7 @@ class PackageCustomCoverage extends Component {
                   <Field
                     name={`${dateRange}.endCoverage`}
                     type="text"
-                    component={this.renderDatepicker}
+                    component={Datepicker}
                     label="End date"
                   />
                 </div>

--- a/tests/pages/bigtest/customer-resource-show.js
+++ b/tests/pages/bigtest/customer-resource-show.js
@@ -59,8 +59,8 @@ import {
   clickCustomEmbargoCancelButton = clickable('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button');
   hasCustomEmbargoCancelButton = isPresent('[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button');
   isCustomEmbargoCancelDisabled = property('disabled', '[data-test-eholdings-customer-resource-cancel-custom-embargo-button] button');
-  validationErrorOnTextField = text('[data-test-eholdings-customer-resource-custom-embargo-textfield] [class^="error-message--"]');
-  validationErrorOnSelect = text('[data-test-eholdings-customer-resource-custom-embargo-select] [class^="error-message--"]');
+  validationErrorOnTextField = text('[data-test-eholdings-customer-resource-custom-embargo-textfield] [class^="feedbackError--"]');
+  validationErrorOnSelect = text('[data-test-eholdings-customer-resource-custom-embargo-select] [class^="feedbackError--"]');
   clickCustomEmbargoEditButton = clickable('[data-test-eholdings-customer-resource-edit-custom-embargo-button] button');
 
   identifiersList = collection('[data-test-eholdings-identifiers-list-item]', {


### PR DESCRIPTION
## Purpose
A few times when using `<Field>` from `redux-form`, we've defined an extra method to render the relevant component. Ex: `renderDatepicker`.

## Approach
Since the `stripes-components` `Datepicker`, `TextField`, and `Select` are all designed to work with `redux-form` and have all the errors UI built into them, we can pass them in directly to `Field`s without any extra processing or ornamentation.