### PR TITLE
Remove unused blur() helper

### DIFF
--- a/tests/pages/helpers.js
+++ b/tests/pages/helpers.js
@@ -40,23 +40,6 @@ export function advancedFillIn(el, value) {
   });
 }
 
-export function blur(el) {
-  let node = $(el).get(0);
-
-  // the error should not be reported for passing tests
-  /* istanbul ignore else */
-  if (node) {
-    node.dispatchEvent(
-      new MouseEvent('blur', {
-        bubbles: true,
-        cancelable: true
-      })
-    );
-  } else {
-    throw new Error('Blur node does not exist.');
-  }
-}
-
 export function pressEnter(el) {
   let $node = $(el).get(0);
 


### PR DESCRIPTION
As part of moving to BigTest page objects, the old prototype `blur()` helper is no longer in use.