### PR TITLE
UIEH-196: Refactor customer-resource-custom-coverage test to use BigTest

### DIFF
--- a/tests/customer-resource-custom-coverage-test.js
+++ b/tests/customer-resource-custom-coverage-test.js
@@ -1,10 +1,8 @@
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
-
 import { describeApplication } from './helpers';
-import ResourcePage from './pages/customer-resource-show';
-import CustomerResourceCoverage from './pages/customer-resource-coverage';
+import ResourcePage from './pages/bigtest/customer-resource-show';
+import CustomerResourceCoverage from './pages/bigtest/customer-resource-custom-coverage';
 
 describeApplication('CustomerResourceCustomCoverage', () => {
   let pkg,
@@ -39,7 +37,7 @@ describeApplication('CustomerResourceCustomCoverage', () => {
     });
 
     it('does not display coverage', () => {
-      expect(CustomerResourceCoverage.$root).to.not.exist;
+      expect(CustomerResourceCoverage.exists).to.be.false;
     });
   });
 
@@ -54,49 +52,45 @@ describeApplication('CustomerResourceCustomCoverage', () => {
     });
 
     it('displays an add custom coverage button', () => {
-      expect(CustomerResourceCoverage.$addButton).to.exist;
+      expect(CustomerResourceCoverage.hasAddButton).to.be.true;
     });
 
     describe('clicking the add custom coverage button', () => {
       beforeEach(() => {
-        CustomerResourceCoverage.clickAddButton();
+        return CustomerResourceCoverage.clickAddButton();
       });
 
       it('reveals the custom coverage form', () => {
-        expect(CustomerResourceCoverage.$form).to.exist;
+        expect(CustomerResourceCoverage.hasForm).to.be.true;
       });
 
       it('reveals a cancel button', () => {
-        expect(CustomerResourceCoverage.$cancelButton).to.exist;
+        expect(CustomerResourceCoverage.hasCancelButton).to.be.true;
       });
 
       it('shows a single row of inputs', () => {
-        expect(CustomerResourceCoverage.dateRangeRowList.length).to.equal(1);
+        expect(CustomerResourceCoverage.dateRangeRowList().length).to.equal(1);
       });
 
       it('reveals a save button', () => {
-        expect(CustomerResourceCoverage.$saveButton).to.exist;
+        expect(CustomerResourceCoverage.hasSaveButton).to.be.true;
       });
 
       it('disables the save button', () => {
-        expect(CustomerResourceCoverage.isSaveButtonEnabled).to.be.false;
+        expect(CustomerResourceCoverage.isSaveButtonDisabled).to.be.true;
       });
 
       it('hides the add custom coverage button', () => {
-        expect(CustomerResourceCoverage.$addButton).to.not.exist;
+        expect(CustomerResourceCoverage.hasAddButton).to.be.false;
       });
 
       describe('then trying to navigate away', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            expect(ResourcePage.isEditingCoverage).to.be.true;
-          }).then(() => (
-            ResourcePage.clickPackage()
-          ));
+          return ResourcePage.clickPackage();
         });
 
         it('shows a navigation confirmation modal', () => {
-          expect(ResourcePage.$navigationModal).to.exist;
+          expect(ResourcePage.navigationModal.exists).to.be.true;
         });
 
         it.always('does not navigate away', function () {
@@ -107,77 +101,60 @@ describeApplication('CustomerResourceCustomCoverage', () => {
 
       describe('clicking cancel', () => {
         beforeEach(() => {
-          CustomerResourceCoverage.clickCancelButton();
+          return CustomerResourceCoverage.clickCancelButton();
         });
 
         it('hides the custom coverage form', () => {
-          expect(CustomerResourceCoverage.$form).to.not.exist;
+          expect(CustomerResourceCoverage.hasForm).to.be.false;
         });
 
         it('displays an add custom coverage button', () => {
-          expect(CustomerResourceCoverage.$addButton).to.exist;
+          expect(CustomerResourceCoverage.hasAddButton).to.exist;
         });
       });
 
       describe('clicking the add row button', () => {
         beforeEach(() => {
-          CustomerResourceCoverage.clickAddRowButton();
+          return CustomerResourceCoverage.clickAddRowButton();
         });
 
         it('adds another row of date inputs', () => {
-          expect(CustomerResourceCoverage.dateRangeRowList.length).to.equal(2);
+          expect(CustomerResourceCoverage.dateRangeRowList().length).to.equal(2);
         });
 
         it('does not put any values in the new inputs', () => {
-          expect(CustomerResourceCoverage.dateRangeRowList[1].beginCoverageValue).equal('');
-          expect(CustomerResourceCoverage.dateRangeRowList[1].endCoverageValue).equal('');
+          expect(CustomerResourceCoverage.dateRangeRowList(1).beginCoverageValue).to.equal('');
+          expect(CustomerResourceCoverage.dateRangeRowList(1).endCoverageValue).to.equal('');
         });
 
         describe('clicking the clear row button', () => {
           beforeEach(() => {
-            return convergeOn(() => {
-              expect(CustomerResourceCoverage.dateRangeRowList.length).to.equal(2);
-            }).then(() => {
-              CustomerResourceCoverage.dateRangeRowList[1].clickRemoveRowButton();
-            });
+            return CustomerResourceCoverage.dateRangeRowList(1).clickRemoveRowButton();
           });
 
           it('removes the new row', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList.length).to.equal(1);
+            expect(CustomerResourceCoverage.dateRangeRowList().length).to.equal(1);
           });
         });
       });
 
       describe('entering a valid date range', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].$beginCoverageField).to.exist;
-            expect(CustomerResourceCoverage.dateRangeRowList[0].$endCoverageField).to.exist;
-          }).then(() => {
-            CustomerResourceCoverage.dateRangeRowList[0].$beginCoverageField.click();
-            CustomerResourceCoverage.dateRangeRowList[0].inputBeginDate('12/16/2018');
-            CustomerResourceCoverage.dateRangeRowList[0].pressEnterBeginDate();
-            CustomerResourceCoverage.dateRangeRowList[0].$endCoverageField.click();
-            CustomerResourceCoverage.dateRangeRowList[0].inputEndDate('12/18/2018');
-            CustomerResourceCoverage.dateRangeRowList[0].pressEnterEndDate();
-          });
-        });
-
-        it('enables the save button', () => {
-          expect(CustomerResourceCoverage.isSaveButtonEnabled).to.be.true;
+          return CustomerResourceCoverage.dateRangeRowList(0)
+            .fillInDateRange('12/16/2018', '12/18/2018');
         });
 
         it('shows the input as valid', () => {
-          expect(CustomerResourceCoverage.dateRangeRowList[0].beginCoverageFieldIsValid).to.be.true;
+          expect(CustomerResourceCoverage.dateRangeRowList(0).beginCoverageFieldIsValid).to.be.true;
         });
 
         it('enables the save button', () => {
-          expect(CustomerResourceCoverage.isSaveButtonEnabled).to.be.true;
+          expect(CustomerResourceCoverage.isSaveButtonDisabled).to.be.false;
         });
 
         describe('successfully submitting the form', () => {
           beforeEach(() => {
-            CustomerResourceCoverage.clickSaveButton();
+            return CustomerResourceCoverage.clickSaveButton();
           });
 
           it('displays the saved date range', () => {
@@ -185,33 +162,25 @@ describeApplication('CustomerResourceCustomCoverage', () => {
           });
 
           it('displays an edit button', () => {
-            expect(CustomerResourceCoverage.$editButton).to.exist;
+            expect(CustomerResourceCoverage.hasEditButton).to.be.true;
           });
         });
       });
 
       describe('entering an invalid date range', () => {
-        beforeEach(() => {
-          return convergeOn(() => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].$beginCoverageField).to.exist;
-            expect(CustomerResourceCoverage.dateRangeRowList[0].$endCoverageField).to.exist;
-          });
-        });
-
         describe('entering an invalid begin date format', () => {
           beforeEach(() => {
-            CustomerResourceCoverage.dateRangeRowList[0].$beginCoverageField.click();
-            CustomerResourceCoverage.dateRangeRowList[0].inputBeginDate('12/16/2018');
-            CustomerResourceCoverage.dateRangeRowList[0].pressEnterBeginDate();
-            CustomerResourceCoverage.dateRangeRowList[0].clearBeginDate();
+            return CustomerResourceCoverage.dateRangeRowList(0)
+              .fillInDateRange('16/12/2018', '')
+              .append(CustomerResourceCoverage.dateRangeRowList(0).clearBeginDate());
           });
 
           it('indicates validation error on begin date', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].beginCoverageFieldIsInvalid).to.be.true;
+            expect(CustomerResourceCoverage.dateRangeRowList(0).beginCoverageFieldIsInvalid).to.be.true;
           });
 
           it('displays messaging that date is invalid format', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].beginCoverageFieldValidationError).to.eq(
+            expect(CustomerResourceCoverage.dateRangeRowList(0).beginCoverageFieldValidationError).to.eq(
               'Enter date in MM/DD/YYYY format.'
             );
           });
@@ -219,88 +188,74 @@ describeApplication('CustomerResourceCustomCoverage', () => {
 
         describe('entering an end date before a start date', () => {
           beforeEach(() => {
-            CustomerResourceCoverage.dateRangeRowList[0].$beginCoverageField.click();
-            CustomerResourceCoverage.dateRangeRowList[0].inputBeginDate('12/16/2018');
-            CustomerResourceCoverage.dateRangeRowList[0].pressEnterBeginDate();
-            CustomerResourceCoverage.dateRangeRowList[0].$endCoverageField.click();
-            CustomerResourceCoverage.dateRangeRowList[0].inputEndDate('12/14/2018');
-            CustomerResourceCoverage.dateRangeRowList[0].pressEnterEndDate();
+            return CustomerResourceCoverage.dateRangeRowList(0)
+              .fillInDateRange('12/18/2018', '12/16/2018');
           });
 
           it('indicates validation error on begin date', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].beginCoverageFieldIsInvalid).to.be.true;
+            expect(CustomerResourceCoverage.dateRangeRowList(0).beginCoverageFieldIsInvalid).to.be.true;
           });
 
           it('displays messaging that end date is before start date', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].beginCoverageFieldValidationError).to.eq(
+            expect(CustomerResourceCoverage.dateRangeRowList(0).beginCoverageFieldValidationError).to.eq(
               'Start date must be before end date'
             );
           });
         });
 
-        describe('entering overlapping ranges', () => {
+        describe('add row', () => {
           beforeEach(() => {
-            CustomerResourceCoverage.dateRangeRowList[0].$beginCoverageField.click();
-            CustomerResourceCoverage.dateRangeRowList[0].inputBeginDate('12/16/2018');
-            CustomerResourceCoverage.dateRangeRowList[0].pressEnterBeginDate();
-            CustomerResourceCoverage.dateRangeRowList[0].$endCoverageField.click();
-            CustomerResourceCoverage.dateRangeRowList[0].inputEndDate('12/20/2018');
-            CustomerResourceCoverage.dateRangeRowList[0].pressEnterEndDate();
+            return CustomerResourceCoverage.clickAddRowButton();
+          });
 
-            CustomerResourceCoverage.clickAddRowButton();
+          it('adds another row of date inputs', () => {
+            expect(CustomerResourceCoverage.dateRangeRowList().length).to.equal(2);
+          });
 
-            return convergeOn(() => {
-              expect(CustomerResourceCoverage.dateRangeRowList[1].$beginCoverageField).to.exist;
-              expect(CustomerResourceCoverage.dateRangeRowList[1].$endCoverageField).to.exist;
-            }).then(() => {
-              CustomerResourceCoverage.dateRangeRowList[1].$beginCoverageField.click();
-              CustomerResourceCoverage.dateRangeRowList[1].inputBeginDate('12/18/2018');
-              CustomerResourceCoverage.dateRangeRowList[1].pressEnterBeginDate();
-              CustomerResourceCoverage.dateRangeRowList[1].$endCoverageField.click();
-              CustomerResourceCoverage.dateRangeRowList[1].inputEndDate('12/19/2018');
-              CustomerResourceCoverage.dateRangeRowList[1].pressEnterEndDate();
+          describe('entering overlapping ranges', () => {
+            beforeEach(() => {
+              return CustomerResourceCoverage.dateRangeRowList(0).fillInDateRange('12/16/2018', '12/20/2018')
+                .append(CustomerResourceCoverage.dateRangeRowList(1).fillInDateRange('12/18/2018', '12/19/2018'));
             });
-          });
 
-          it('indicates validation error on begin dates', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].beginCoverageFieldIsInvalid).to.be.true;
-            expect(CustomerResourceCoverage.dateRangeRowList[1].beginCoverageFieldIsInvalid).to.be.true;
-          });
+            it('indicates validation error on begin dates', () => {
+              expect(CustomerResourceCoverage.dateRangeRowList(0).beginCoverageFieldIsInvalid).to.be.true;
+              expect(CustomerResourceCoverage.dateRangeRowList(1).beginCoverageFieldIsInvalid).to.be.true;
+            });
 
-          it('has messaging that dates overlap', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].beginCoverageFieldValidationError).to.eq(
-              'Date range overlaps with 12/18/2018 - 12/19/2018'
-            );
-            expect(CustomerResourceCoverage.dateRangeRowList[1].beginCoverageFieldValidationError).to.eq(
-              'Date range overlaps with 12/16/2018 - 12/20/2018'
-            );
+            it('has messaging that dates overlap', () => {
+              expect(CustomerResourceCoverage.dateRangeRowList(0).beginCoverageFieldValidationError).to.eq(
+                'Date range overlaps with 12/18/2018 - 12/19/2018'
+              );
+              expect(CustomerResourceCoverage.dateRangeRowList(1).beginCoverageFieldValidationError).to.eq(
+                'Date range overlaps with 12/16/2018 - 12/20/2018'
+              );
+            });
           });
         });
 
         describe('entering a date range outside of package coverage range', () => {
           beforeEach(() => {
-            CustomerResourceCoverage.dateRangeRowList[0].$beginCoverageField.click();
-            CustomerResourceCoverage.dateRangeRowList[0].inputBeginDate('11/16/2018');
-            CustomerResourceCoverage.dateRangeRowList[0].pressEnterBeginDate();
-            CustomerResourceCoverage.dateRangeRowList[0].$endCoverageField.click();
-            CustomerResourceCoverage.dateRangeRowList[0].inputEndDate('01/14/2019');
-            CustomerResourceCoverage.dateRangeRowList[0].pressEnterEndDate();
+            return CustomerResourceCoverage.dateRangeRowList(0)
+              .fillInDateRange('11/16/2018', '01/14/2019');
           });
 
           it('indicates validation error on begin date', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].beginCoverageFieldIsInvalid).to.be.true;
+            expect(CustomerResourceCoverage.dateRangeRowList(0).beginCoverageFieldIsInvalid).to.be.true;
           });
+
           it('indicates validation error on end date', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].endCoverageFieldIsInvalid).to.be.true;
+            expect(CustomerResourceCoverage.dateRangeRowList(0).endCoverageFieldIsInvalid).to.be.true;
           });
 
           it('displays messaging that begin date is outside of package coverage range', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].beginCoverageFieldValidationError).to.eq(
+            expect(CustomerResourceCoverage.dateRangeRowList(0).beginCoverageFieldValidationError).to.eq(
               "Dates must be within package's date range (12/1/2018 - 12/31/2018)."
             );
           });
+
           it('displays messaging that end date is outside of package coverage range', () => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].endCoverageFieldValidationError).to.eq(
+            expect(CustomerResourceCoverage.dateRangeRowList(0).endCoverageFieldValidationError).to.eq(
               "Dates must be within package's date range (12/1/2018 - 12/31/2018)."
             );
           });
@@ -331,80 +286,69 @@ describeApplication('CustomerResourceCustomCoverage', () => {
     });
 
     it('displays an edit button', () => {
-      expect(CustomerResourceCoverage.$editButton).to.exist;
+      expect(CustomerResourceCoverage.hasEditButton).to.be.true;
     });
 
     it('does not display an add custom coverage button', () => {
-      expect(CustomerResourceCoverage.$addButton).to.not.exist;
+      expect(CustomerResourceCoverage.hasAddButton).to.be.false;
     });
 
     describe('clicking the edit button', () => {
       beforeEach(() => {
-        CustomerResourceCoverage.clickEditButton();
+        return CustomerResourceCoverage.clickEditButton();
       });
 
       it('reveals the custom coverage form', () => {
-        expect(CustomerResourceCoverage.$form).to.exist;
+        expect(CustomerResourceCoverage.hasForm).to.be.true;
       });
 
       it('reveals a cancel button', () => {
-        expect(CustomerResourceCoverage.$cancelButton).to.exist;
+        expect(CustomerResourceCoverage.hasCancelButton).to.be.true;
       });
 
       it('shows a single row of inputs', () => {
-        expect(CustomerResourceCoverage.dateRangeRowList.length).to.equal(1);
+        expect(CustomerResourceCoverage.dateRangeRowList().length).to.equal(1);
       });
 
       it('reveals a save button', () => {
-        expect(CustomerResourceCoverage.$saveButton).to.exist;
+        expect(CustomerResourceCoverage.hasSaveButton).to.be.true;
       });
 
       it('disables the save button', () => {
-        expect(CustomerResourceCoverage.isSaveButtonEnabled).to.be.false;
+        expect(CustomerResourceCoverage.isSaveButtonDisabled).to.be.true;
       });
 
       describe('editing one of the fields', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            expect(CustomerResourceCoverage.dateRangeRowList[0].$beginCoverageField).to.exist;
-            expect(CustomerResourceCoverage.dateRangeRowList[0].$endCoverageField).to.exist;
-          }).then(() => {
-            CustomerResourceCoverage.dateRangeRowList[0].$endCoverageField.click();
-            CustomerResourceCoverage.dateRangeRowList[0].inputEndDate('12/16/2018');
-            CustomerResourceCoverage.dateRangeRowList[0].pressEnterEndDate();
-            CustomerResourceCoverage.dateRangeRowList[0].clearEndDate();
-          });
+          return CustomerResourceCoverage.dateRangeRowList(0)
+            .fillInDateRange('', '12/16/2018');
         });
 
         it('enables the save button', () => {
-          expect(CustomerResourceCoverage.isSaveButtonEnabled).to.be.true;
+          expect(CustomerResourceCoverage.isSaveButtonDisabled).to.be.false;
         });
       });
 
       describe('removing the only row', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            expect(CustomerResourceCoverage.dateRangeRowList.length).to.equal(1);
-          }).then(() => {
-            CustomerResourceCoverage.dateRangeRowList[0].clickRemoveRowButton();
-          });
+          return CustomerResourceCoverage.dateRangeRowList(0).clickRemoveRowButton();
         });
 
         it('displays the no rows left message', () => {
-          expect(CustomerResourceCoverage.$noRowsLeftMessage).to.exist;
+          expect(CustomerResourceCoverage.hasNoRowsLeftMessage).to.be.true;
         });
 
         it('enables the save button', () => {
-          expect(CustomerResourceCoverage.isSaveButtonEnabled).to.be.true;
+          expect(CustomerResourceCoverage.isSaveButtonDisabled).to.be.false;
         });
 
         describe('successfully submitting the form', () => {
           beforeEach(() => {
-            CustomerResourceCoverage.clickSaveButton();
+            return CustomerResourceCoverage.clickSaveButton();
           });
 
           it('displays an add custom coverage button', () => {
-            expect(CustomerResourceCoverage.$addButton).to.exist;
+            expect(CustomerResourceCoverage.hasAddButton).to.be.true;
           });
         });
       });

--- a/tests/pages/bigtest/customer-resource-custom-coverage.js
+++ b/tests/pages/bigtest/customer-resource-custom-coverage.js
@@ -1,0 +1,81 @@
+import {
+  blurrable,
+  clickable,
+  collection,
+  computed,
+  fillable,
+  isPresent,
+  page,
+  property,
+  text,
+  triggerable
+} from '@bigtest/interaction';
+import { isRootPresent } from '../helpers';
+
+let hasClassBeginningWith = (className, selector) => {
+  return computed(function () {
+    return this.$(selector).className.includes(className);
+  });
+};
+
+@page class CustomerResourceCustomCoveragePage {
+  exists = isRootPresent();
+  clickAddButton = clickable('[data-test-eholdings-coverage-form-add-button] button');
+  hasForm = isPresent('[data-test-eholdings-coverage-form] form');
+  clickCancelButton = clickable('[data-test-eholdings-coverage-form-cancel-button] button');
+  clickSaveButton = clickable('[data-test-eholdings-coverage-form-save-button] button');
+  clickEditButton = clickable('[data-test-eholdings-coverage-form-edit-button] button')
+  hasCancelButton = isPresent('[data-test-eholdings-coverage-form-cancel-button] button');
+  isSaveButtonDisabled = property('disabled', '[data-test-eholdings-coverage-form-save-button] button');
+  hasSaveButton = isPresent('[data-test-eholdings-coverage-form-save-button] button');
+  hasAddButton = isPresent('[data-test-eholdings-coverage-form-add-button] button');
+  hasEditButton = isPresent('[data-test-eholdings-coverage-form-edit-button]');
+  clickAddRowButton = clickable('[data-test-eholdings-coverage-form-add-row-button] button');
+  displayText = text('[data-test-eholdings-coverage-form-display]');
+  hasNoRowsLeftMessage = isPresent('[data-test-eholdings-coverage-form-no-rows-left]');
+
+  dateRangeRowList = collection('[data-test-eholdings-coverage-form-date-range-row]', {
+    clickBeginCoverage: clickable('[data-test-eholdings-coverage-form-date-range-begin] input'),
+    hasBeginCoverage: isPresent('[data-test-eholdings-coverage-form-date-range-begin] input'),
+    beginCoverageValue: text('[data-test-eholdings-coverage-form-date-range-begin] input'),
+    beginCoverageFieldIsValid: hasClassBeginningWith('feedbackValid--', '[data-test-eholdings-coverage-form-date-range-begin] input'),
+    beginCoverageFieldIsInvalid: hasClassBeginningWith('feedbackError--', '[data-test-eholdings-coverage-form-date-range-begin] input'),
+    beginCoverageFieldValidationError: text('[data-test-eholdings-coverage-form-date-range-begin] div[class^=feedback]'),
+    inputBeginDate: fillable('[data-test-eholdings-coverage-form-date-range-begin] input'),
+    blurBeginDate: blurrable('[data-test-eholdings-coverage-form-date-range-begin] input'),
+    clearBeginDate: clickable('[data-test-eholdings-coverage-form-date-range-begin] button[id^=datepicker-clear-button]'),
+    pressEnterBeginDate: triggerable('keydown', '[data-test-eholdings-coverage-form-date-range-begin] input', {
+      bubbles: true,
+      cancelable: true,
+      keyCode: 13
+    }),
+    hasEndCoverage: isPresent('[data-test-eholdings-coverage-form-date-range-end] input'),
+    endCoverageValue: text('[data-test-eholdings-coverage-form-date-range-end] input'),
+    endCoverageFieldIsValid: hasClassBeginningWith('feedbackValid--', '[data-test-eholdings-coverage-form-date-range-end] input'),
+    endCoverageFieldIsInvalid: hasClassBeginningWith('feedbackError--', '[data-test-eholdings-coverage-form-date-range-end] input'),
+    endCoverageFieldValidationError: text('[data-test-eholdings-coverage-form-date-range-end] div[class^=feedback]'),
+    clickRemoveRowButton: clickable('[data-test-eholdings-coverage-form-remove-row-button] button'),
+    clickEndCoverage: clickable('[data-test-eholdings-coverage-form-date-range-end] input'),
+    inputEndDate: fillable('[data-test-eholdings-coverage-form-date-range-end] input'),
+    blurEndDate: blurrable('[data-test-eholdings-coverage-form-date-range-end] input'),
+    clearEndDate: clickable('[data-test-eholdings-coverage-form-date-range-end] button[id^=datepicker-clear-button]'),
+    pressEnterEndDate: triggerable('keydown', '[data-test-eholdings-coverage-form-date-range-end] input', {
+      bubbles: true,
+      cancelable: true,
+      keyCode: 13
+    }),
+    fillInDateRange(beginDate, endDate) {
+      return this
+        .clickBeginCoverage()
+        .inputBeginDate(beginDate)
+        .pressEnterBeginDate()
+        .blurBeginDate()
+        .clickEndCoverage()
+        .inputEndDate(endDate)
+        .pressEnterEndDate()
+        .blurEndDate();
+    },
+  });
+}
+
+export default new CustomerResourceCustomCoveragePage('[data-test-eholdings-coverage-form]');

--- a/tests/pages/bigtest/customer-resource-show.js
+++ b/tests/pages/bigtest/customer-resource-show.js
@@ -8,13 +8,17 @@ import {
   text,
   value
 } from '@bigtest/interaction';
+import { isRootPresent } from '../helpers';
+
 
 @page class CustomerResourceShowDeselectionModal {
   confirmDeselection = clickable('[data-test-eholdings-customer-resource-deselection-confirmation-modal-yes]');
   cancelDeselection = clickable('[data-test-eholdings-customer-resource-deselection-confirmation-modal-no]');
 }
 
-@page class CustomerResourceShowNavigationModal {}
+@page class CustomerResourceShowNavigationModal {
+  exists = isRootPresent();
+}
 
 @page class CustomerResourceShowPage {
   titleName = text('[data-test-eholdings-details-view-name="resource"]');

--- a/tests/pages/helpers.js
+++ b/tests/pages/helpers.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import { expect } from 'chai';
 import { convergeOn } from '@bigtest/convergence';
+import { computed } from '@bigtest/interaction';
 
 /* Only used for datepicker component */
 export function advancedFillIn(el, value) {
@@ -60,3 +61,13 @@ export function pressEnter(el) {
     throw new Error('Node does not exist.');
   }
 }
+
+export const isRootPresent = () => {
+  return computed(function () {
+    try {
+      return !!this.$root;
+    } catch (e) {
+      return false;
+    }
+  });
+};


### PR DESCRIPTION
## Purpose
Ref [UIEH-196](https://issues.folio.org/browse/UIEH-196). 

Change `customer-resource-custom-coverage` to use `BigTest` page objects.

### ToDo
- [ ] The page object could use some refactoring to dry up some of the begin/end date properties.