### PR TITLE
UIEH-196 Refactor customer-resource-deselection to use BigTest

### DIFF
--- a/tests/customer-resource-deselection-test.js
+++ b/tests/customer-resource-deselection-test.js
@@ -1,8 +1,8 @@
-import { beforeEach, afterEach, describe, it } from '@bigtest/mocha';
+import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
 import { describeApplication } from './helpers';
-import ResourcePage from './pages/customer-resource-show';
+import ResourcePage from './pages/bigtest/customer-resource-show';
 
 describeApplication('CustomerResourceDeselection', () => {
   let provider,
@@ -48,11 +48,11 @@ describeApplication('CustomerResourceDeselection', () => {
 
       describe('deselecting', () => {
         beforeEach(() => {
-          ResourcePage.toggleIsSelected();
+          return ResourcePage.toggleIsSelected();
         });
 
         it('warns the user they are deselecting the final title in the package', () => {
-          expect(ResourcePage.$deselectFinalTitleWarning).to.exist;
+          expect(ResourcePage.deselectionModal.hasDeselectFinalTitleWarning).to.be.true;
         });
       });
     });
@@ -77,7 +77,7 @@ describeApplication('CustomerResourceDeselection', () => {
         });
 
         it('warns the user they are deselecting', () => {
-          expect(ResourcePage.$deselectTitleWarning).to.exist;
+          expect(ResourcePage.deselectionModal.hasDeselectTitleWarning).to.be.true;
         });
 
         it('reflects the desired state (not selected)', () => {
@@ -86,7 +86,7 @@ describeApplication('CustomerResourceDeselection', () => {
 
         describe('canceling the deselection', () => {
           beforeEach(() => {
-            return ResourcePage.cancelDeselection();
+            return ResourcePage.deselectionModal.cancelDeselection();
           });
 
           it('reverts back to the selected state', () => {
@@ -95,13 +95,8 @@ describeApplication('CustomerResourceDeselection', () => {
         });
 
         describe('confirming the deselection', () => {
-          beforeEach(function () {
-            this.server.timing = 50;
-            ResourcePage.confirmDeselection();
-          });
-
-          afterEach(function () {
-            this.server.timing = 0;
+          beforeEach(() => {
+            return ResourcePage.deselectionModal.confirmDeselection();
           });
 
           it('reflects the desired state (not selected)', () => {
@@ -113,7 +108,7 @@ describeApplication('CustomerResourceDeselection', () => {
           });
 
           it('cannot be interacted with while the request is in flight', () => {
-            expect(ResourcePage.isSelectedToggleable).to.equal(false);
+            expect(ResourcePage.isSelectedToggleDisabled).to.equal(true);
           });
 
           describe('when the request succeeds', () => {
@@ -126,12 +121,12 @@ describeApplication('CustomerResourceDeselection', () => {
             });
 
             it('removes custom embargo', () => {
-              expect(ResourcePage.customEmbargoPeriod).to.equal('');
+              expect(ResourcePage.hasCustomEmbargoPeriod).to.equal(false);
             });
 
             it('is not hidden', () => {
               expect(resource.visibilityData.isHidden).to.equal(false);
-              expect(ResourcePage.isHidden).to.equal(false);
+              expect(ResourcePage.hasHiddenToggle).to.equal(false);
             });
           });
         });

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -146,7 +146,7 @@ describeApplication('CustomerResourceShow', () => {
     describe('navigating away when editing a field', () => {
       beforeEach(() => {
         return ResourcePage
-          .toggleSelected()
+          .toggleIsSelected()
           .addCoverage()
           .clickProvider();
       });

--- a/tests/pages/bigtest/customer-resource-custom-coverage.js
+++ b/tests/pages/bigtest/customer-resource-custom-coverage.js
@@ -2,7 +2,6 @@ import {
   blurrable,
   clickable,
   collection,
-  computed,
   fillable,
   isPresent,
   page,
@@ -10,13 +9,7 @@ import {
   text,
   triggerable
 } from '@bigtest/interaction';
-import { isRootPresent } from '../helpers';
-
-let hasClassBeginningWith = (className, selector) => {
-  return computed(function () {
-    return this.$(selector).className.includes(className);
-  });
-};
+import { isRootPresent, hasClassBeginningWith } from '../helpers';
 
 @page class CustomerResourceCustomCoveragePage {
   exists = isRootPresent();

--- a/tests/pages/bigtest/customer-resource-show.js
+++ b/tests/pages/bigtest/customer-resource-show.js
@@ -8,12 +8,14 @@ import {
   text,
   value
 } from '@bigtest/interaction';
-import { isRootPresent } from '../helpers';
+import { isRootPresent, hasClassBeginningWith } from '../helpers';
 
 
 @page class CustomerResourceShowDeselectionModal {
   confirmDeselection = clickable('[data-test-eholdings-customer-resource-deselection-confirmation-modal-yes]');
   cancelDeselection = clickable('[data-test-eholdings-customer-resource-deselection-confirmation-modal-no]');
+  hasDeselectTitleWarning = isPresent('[data-test-eholdings-deselect-title-warning]');
+  hasDeselectFinalTitleWarning = isPresent('[data-test-eholdings-deselect-final-title-warning]');
 }
 
 @page class CustomerResourceShowNavigationModal {
@@ -34,16 +36,18 @@ import { isRootPresent } from '../helpers';
   hasContentType = isPresent('[data-test-eholdings-customer-resource-show-content-type]');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
   isSelected = property('checked', '[data-test-eholdings-customer-resource-show-selected] input');
-  toggleSelected = clickable('[data-test-eholdings-customer-resource-show-selected] input');
+  isSelecting = hasClassBeginningWith('is-pending--', '[data-test-eholdings-customer-resource-show-selected] [data-test-toggle-switch]');
   addCoverage = clickable('[data-test-eholdings-coverage-form-add-button] button');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   paneSub = text('[data-test-eholdings-details-view-pane-sub]');
+  isSelectedToggleDisabled = property('disabled', '[data-test-eholdings-customer-resource-show-selected] input[type=checkbox]');
   toggleIsSelected = clickable('[data-test-eholdings-customer-resource-show-selected] input');
   isEditingCustomEmbargo = isPresent('[data-test-eholdings-embargo-form] form');
   clickPackage = clickable('[data-test-eholdings-customer-resource-show-package-name] a');
   deselectionModal = new CustomerResourceShowDeselectionModal('#eholdings-customer-resource-deselection-confirmation-modal');
   navigationModal = new CustomerResourceShowNavigationModal('#navigation-modal');
+  hasHiddenToggle = isPresent('[data-test-eholdings-customer-resource-toggle-hidden] input');
 
   managedEmbargoPeriod = text('[data-test-eholdings-customer-resource-show-managed-embargo-period]');
   hasManagedEmbargoPeriod = isPresent('[data-test-eholdings-customer-resource-show-managed-embargo-period]');

--- a/tests/pages/helpers.js
+++ b/tests/pages/helpers.js
@@ -71,3 +71,9 @@ export const isRootPresent = () => {
     }
   });
 };
+
+export const hasClassBeginningWith = (className, selector) => {
+  return computed(function () {
+    return this.$(selector).className.includes(className);
+  });
+};


### PR DESCRIPTION
## Purpose
Ref [UIEH-196](https://issues.folio.org/browse/UIEH-196)

Convert `customer-resource-deselection` to BigTest to continue ongoing migration efforts.

I also added the `hasClassBeginningWith` into the helpers as I have found myself needing it in multiple places.