### PR TITLE
Run Firefox tests directly on Circle container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           at: ~/
       - run:
           name: Run tests
-          command: yarn test --karma.singleRun --coverage
+          command: yarn test --karma.singleRun --karma.browsers=Chrome --coverage
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:
@@ -74,13 +74,13 @@ jobs:
 
   test-firefox:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:latest-browsers
     steps:
       - attach_workspace:
           at: ~/
       - run:
           name: Run tests
-          command: yarn test --karma.singleRun --karma.browsers=bs_firefox_mac || true
+          command: yarn test --karma.singleRun --karma.browsers=Firefox || true
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,15 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Install the latest Firefox
+          command: |
+            sudo apt-get remove firefox-mozilla-build &&
+            sudo sh -c "echo 'deb http://ftp.hr.debian.org/debian sid main' >> /etc/apt/sources.list" &&
+            sudo apt-get update &&
+            sudo apt-get remove binutils
+            sudo apt-get install -t sid firefox &&
+            firefox --version
+      - run:
           name: Run tests
           command: yarn test --karma.singleRun --karma.browsers=Firefox || true
       - store_test_results:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,6 +49,7 @@ module.exports = (config) => {
 
     plugins: [
       'karma-chrome-launcher',
+      'karma-firefox-launcher',
       'karma-browserstack-launcher',
       'karma-mocha',
       'karma-webpack',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "jquery": "^3.2.1",
     "karma-browserstack-launcher": "^1.3.0",
     "karma-coverage": "^1.1.1",
+    "karma-firefox-launcher": "^1.1.0",
     "karma-junit-reporter": "^1.2.0",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4790,6 +4790,10 @@ karma-coverage@^1.1.1:
     minimatch "^3.0.0"
     source-map "^0.5.1"
 
+karma-firefox-launcher@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz#2c47030452f04531eb7d13d4fc7669630bb93339"
+
 karma-junit-reporter@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz#4f9c40cedfb1a395f8aef876abf96189917c6396"


### PR DESCRIPTION
## Purpose
We're bumping against rate limits on BrowserStack, and Firefox is frequently running very slowly: https://www.browserstack.com/question/670

## Approach
We can run Firefox tests in Linux directly on the Circle container instead of trying to run them on macOS through BrowserStack. That should help cut down the BrowserStack usage and avoid its Firefox problems.