### PR TITLE
UIEH-193: Prevent toggling switch when clicking in label's white space

### DIFF
--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -125,6 +125,7 @@ export default class CustomerResourceShow extends Component {
                   htmlFor="customer-resource-show-toggle-switch"
                 >
                   <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
+                  <br />
                   <ToggleSwitch
                     onChange={this.handleSelectionToggle}
                     checked={resourceSelected}
@@ -145,7 +146,7 @@ export default class CustomerResourceShow extends Component {
                           ? 'Hidden from patrons'
                           : 'Visible to patrons'}
                       </h4>
-
+                      <br />
                       <ToggleSwitch
                         onChange={this.props.toggleHidden}
                         checked={!resourceHidden}

--- a/src/components/details-view/details-view.css
+++ b/src/components/details-view/details-view.css
@@ -25,6 +25,10 @@
     font-size: inherit;
     margin: 0.5em 0;
   }
+
+  & label h4 {
+    display: inline-block;
+  }
 }
 
 .header {

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -93,6 +93,7 @@ export default class PackageShow extends Component {
                   htmlFor="package-details-toggle-switch"
                 >
                   <h4>{packageSelected ? 'Selected' : 'Not selected'}</h4>
+                  <br />
                   <ToggleSwitch
                     onChange={this.handleSelectionToggle}
                     checked={packageSelected}
@@ -113,7 +114,7 @@ export default class PackageShow extends Component {
                           ? 'Hidden from patrons'
                           : 'Visible to patrons'}
                       </h4>
-
+                      <br />
                       <ToggleSwitch
                         onChange={this.props.toggleHidden}
                         checked={!packageHidden}
@@ -135,30 +136,36 @@ export default class PackageShow extends Component {
               </DetailsViewSection>
               <DetailsViewSection label="Title management">
                 {packageSelected ? (
-                  <label
-                    data-test-eholdings-package-details-allow-add-new-titles
-                    htmlFor="package-details-toggle-allow-add-new-titles-switch"
-                  >
-                    {/* The check below for null could be refactored after RM API starts sending this attribute
-                    in list of packages to mod-kb-ebsco */}
+                  <div>
                     {packageAllowedToAddTitles != null ? (
                       <div>
-                        <h4>
-                          {packageAllowedToAddTitles
+                        <label
+                          data-test-eholdings-package-details-allow-add-new-titles
+                          htmlFor="package-details-toggle-allow-add-new-titles-switch"
+                        >
+                          <h4>
+                            {packageAllowedToAddTitles
                             ? 'Automatically select new titles'
                             : 'Do not automatically select new titles'}
-                        </h4>
-                        <ToggleSwitch
-                          onChange={this.props.toggleAllowKbToAddTitles}
-                          checked={packageAllowedToAddTitles}
-                          isPending={model.update.isPending && 'allowKbToAddTitles' in model.update.changedAttributes}
-                          id="package-details-toggle-allow-add-new-titles-switch"
-                        />
+                          </h4>
+                          <br />
+                          <ToggleSwitch
+                            onChange={this.props.toggleAllowKbToAddTitles}
+                            checked={packageAllowedToAddTitles}
+                            isPending={model.update.isPending && 'allowKbToAddTitles' in model.update.changedAttributes}
+                            id="package-details-toggle-allow-add-new-titles-switch"
+                          />
+                        </label>
                       </div>
                       ) : (
-                        <Icon icon="spinner-ellipsis" />
+                        <label
+                          data-test-eholdings-package-details-allow-add-new-titles
+                          htmlFor="package-details-toggle-allow-add-new-titles-switch"
+                        >
+                          <Icon icon="spinner-ellipsis" />
+                        </label>
                       )}
-                  </label>
+                  </div>
                 ) : (
                   <p>Knowledge base does not automatically select titles.</p>
                 )}


### PR DESCRIPTION
## Purpose
Ref [UIEH-193](https://issues.folio.org/browse/UIEH-193)
This change confines the elements inside the label to the length of the label itself, preventing functionality applied to the label from spanning the length of the container.

## Approach
By placing the `ToggleSwitch` and `<h4>` within the label element and styling them within a confined space, we are now only able to click the switch itself to change it's state. As a note, the only way I was able to make the `<h4>` and `ToggleSwitch` remain stacked was by adding a `<br />` between them. 

## Screenshots
# Before
![2018-03-19 17 54 10](https://user-images.githubusercontent.com/25858667/37626628-d153b026-2b9e-11e8-95f9-8f29fe4bee2a.gif)

# After
![2018-03-19 17 41 17](https://user-images.githubusercontent.com/25858667/37626484-397a6a56-2b9e-11e8-8e59-bdf1923ce17c.gif)

