### PR TITLE
Minimize BrowserStack usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,9 +146,3 @@ workflows:
       - test-firefox:
           requires:
             - checkout-and-install
-      - test-edge:
-          requires:
-            - checkout-and-install
-      - test-ie:
-          requires:
-            - checkout-and-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
             firefox --version
       - run:
           name: Run tests
-          command: yarn test --karma.singleRun --karma.browsers=Firefox || true
+          command: yarn test --karma.singleRun --karma.browsers=Firefox
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ language: node_js
 env:
   - BROWSER=Chrome_travis_ci
   - BROWSER=bs_safari_11
-  - BROWSER=Firefox
+  - BROWSER=bs_firefox_mac
 addons:
   chrome: stable
-  firefox: latest
 before_install:
   - export CHROME_BIN=google-chrome-stable
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,10 @@ language: node_js
 env:
   - BROWSER=Chrome_travis_ci
   - BROWSER=bs_safari_11
-  - BROWSER=bs_firefox_mac
-  - BROWSER=bs_ieEdge_windows
-  - BROWSER=bs_ie11_windows
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: BROWSER=bs_firefox_mac
-    - env: BROWSER=bs_ieEdge_windows
-    - env: BROWSER=bs_ie11_windows
+  - BROWSER=Firefox
 addons:
   chrome: stable
+  firefox: latest
 before_install:
   - export CHROME_BIN=google-chrome-stable
   - export DISPLAY=:99.0


### PR DESCRIPTION
## Purpose
`ui-eholdings` has been rate-limited on BrowserStack lately, causing CI builds to take sometimes 10x longer than they should.

## Approach
- Firefox, now being tested directly on the Linux container, now needs to pass on Circle.
- Travis will now test Firefox directly on its containers instead of BrowserStack.
- Stop running Edge and IE 11 tests. IE can't even begin to run the test suite, and we can revisit Edge with https://issues.folio.org/browse/UIEH-182

## Next Steps
- Only run Travis or Circle, not both.