### PR TITLE
Refactor datepicker page objects

### DIFF
--- a/tests/package-custom-coverage-test.js
+++ b/tests/package-custom-coverage-test.js
@@ -91,8 +91,8 @@ describeApplication('PackageCustomCoverage', () => {
       });
 
       it('displays the date input fields', () => {
-        expect(PackageShowPage.dateFields.hasBeginDateField).to.be.true;
-        expect(PackageShowPage.dateFields.hasEndDateField).to.be.true;
+        expect(PackageShowPage.beginDate.exists).to.be.true;
+        expect(PackageShowPage.endDate.exists).to.be.true;
       });
     });
   });
@@ -129,24 +129,22 @@ describeApplication('PackageCustomCoverage', () => {
       });
 
       it('displays custom coverage date inputs', () => {
-        expect(PackageShowPage.dateFields.hasBeginDateField).to.be.true;
-        expect(PackageShowPage.dateFields.hasEndDateField).to.be.true;
+        expect(PackageShowPage.beginDate.exists).to.be.true;
+        expect(PackageShowPage.endDate.exists).to.be.true;
       });
 
       describe('entering valid coverage', () => {
         describe('with begin date and end date', () => {
           beforeEach(() => {
-            return PackageShowPage.dateFields
-              .fillBeginDate('12/16/2018')
-              .fillEndDate('12/24/2018');
+            return PackageShowPage.fillDates('12/16/2018', '12/24/2018');
           });
 
           it('accepts valid begin date', () => {
-            expect(PackageShowPage.dateFields.beginDateValue).to.equal('12/16/2018');
+            expect(PackageShowPage.beginDate.value).to.equal('12/16/2018');
           });
 
           it('accepts valid end date', () => {
-            expect(PackageShowPage.dateFields.endDateValue).to.equal('12/24/2018');
+            expect(PackageShowPage.endDate.value).to.equal('12/24/2018');
           });
 
           it('save button is enabled', () => {
@@ -163,8 +161,8 @@ describeApplication('PackageCustomCoverage', () => {
             });
 
             it('removes the custom coverage input fields', () => {
-              expect(PackageShowPage.$beginDateField).to.not.exist;
-              expect(PackageShowPage.$endDateField).to.not.exist;
+              expect(PackageShowPage.beginDate.exists).to.be.false;
+              expect(PackageShowPage.endDate.exists).to.be.false;
             });
 
             it('does not display the button to add custom coverage', () => {
@@ -175,11 +173,11 @@ describeApplication('PackageCustomCoverage', () => {
 
         describe('with begin date and no end date', () => {
           beforeEach(() => {
-            return PackageShowPage.dateFields.fillBeginDate('12/16/2018');
+            return PackageShowPage.beginDate.fillAndBlur('12/16/2018');
           });
 
           it('accepts valid begin date', () => {
-            expect(PackageShowPage.dateFields.beginDateValue).to.equal('12/16/2018');
+            expect(PackageShowPage.beginDate.value).to.equal('12/16/2018');
           });
 
           it('save button is enabled', () => {
@@ -196,8 +194,8 @@ describeApplication('PackageCustomCoverage', () => {
             });
 
             it('removes the custom coverage input fields', () => {
-              expect(PackageShowPage.dateFields.hasBeginDateField).to.be.false;
-              expect(PackageShowPage.dateFields.hasEndDateField).to.be.false;
+              expect(PackageShowPage.beginDate.exists).to.be.false;
+              expect(PackageShowPage.endDate.exists).to.be.false;
             });
 
             it('does not display the button to add custom coverage', () => {
@@ -210,7 +208,7 @@ describeApplication('PackageCustomCoverage', () => {
       describe('entering invalid coverage', () => {
         describe('with no begin date', () => {
           beforeEach(() => {
-            return PackageShowPage.dateFields.enterAndClearBeginDate('12/16/2018');
+            return PackageShowPage.beginDate.fillAndClear('12/16/2018');
           });
 
           it('rejects invalid begin date', () => {
@@ -220,8 +218,7 @@ describeApplication('PackageCustomCoverage', () => {
 
         describe('with begin date after end date', () => {
           beforeEach(() => {
-            return PackageShowPage.dateFields
-              .enterBeginDateAfterEndDate('12/24/2018', '12/16/2018');
+            return PackageShowPage.fillDates('12/24/2018', '12/16/2018');
           });
 
 
@@ -238,8 +235,8 @@ describeApplication('PackageCustomCoverage', () => {
         });
 
         it('removes the custom coverage input fields', () => {
-          expect(PackageShowPage.dateFields.hasBeginDateField).to.be.false;
-          expect(PackageShowPage.dateFields.hasEndDateField).to.be.false;
+          expect(PackageShowPage.beginDate.exists).to.be.false;
+          expect(PackageShowPage.endDate.exists).to.be.false;
         });
 
         it('displays the button to add custom coverage', () => {

--- a/tests/pages/bigtest/package-show.js
+++ b/tests/pages/bigtest/package-show.js
@@ -8,68 +8,41 @@ import {
   value,
   fillable,
   triggerable,
-  blurrable,
-  action
+  blurrable
 } from '@bigtest/interaction';
+import { isRootPresent } from '../helpers';
 
 @page class PackageShowModal {
   confirmDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-yes]');
   cancelDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-no]');
 }
 
-@page class PackageDatePickers {
-  hasBeginDateField = isPresent('[data-test-eholdings-custom-coverage-date-range-begin] input')
-  hasEndDateField = isPresent('[data-test-eholdings-custom-coverage-date-range-end] input')
-
-  beginDateValue = value('[data-test-eholdings-custom-coverage-date-range-begin] input')
-  endDateValue = value('[data-test-eholdings-custom-coverage-date-range-end] input')
-
-  fillBeginDate = fillable('[data-test-eholdings-custom-coverage-date-range-begin] input')
-  fillEndDate = fillable('[data-test-eholdings-custom-coverage-date-range-end] input')
-
-  clickBeginDateField = clickable('[data-test-eholdings-custom-coverage-date-range-begin] input')
-  clickEndDateField = clickable('[data-test-eholdings-custom-coverage-date-range-end] input')
-
-  pressEnterBeginDate = triggerable('keydown', '[data-test-eholdings-custom-coverage-date-range-begin] input', {
+@page class Datepicker {
+  exists = isRootPresent();
+  value = value('input');
+  clickInput = clickable('input');
+  fillInput = fillable('input');
+  blurInput = blurrable('input');
+  clearInput = clickable('button[id^=datepicker-clear-button]');
+  pressEnter = triggerable('keydown', 'input', {
     bubbles: true,
     cancelable: true,
     keyCode: 13
-  })
-  pressEnterEndDate = triggerable('keydown', '[data-test-eholdings-custom-coverage-date-range-end] input', {
-    bubbles: true,
-    cancelable: true,
-    keyCode: 13
-  })
-
-  clearBeginDate = clickable('[data-test-eholdings-custom-coverage-date-range-begin] button[id^=datepicker-clear-button]')
-  clearEndDate = clickable('[data-test-eholdings-custom-coverage-date-range-end] button[id^=datepicker-clear-button]')
-
-  blurBeginDate = blurrable('[data-test-eholdings-custom-coverage-date-range-begin] input')
-  blurEndDate = blurrable('[data-test-eholdings-custom-coverage-date-range-end] input')
-
-  fillBeginDateField = action(function (date) {
-    return this.clickBeginDateField()
-      .fillBeginDate(date)
-      .pressEnterBeginDate()
-      .blurBeginDate();
   });
 
-  fillEndDateField = action(function (date) {
-    return this.clickEndDateField()
-      .fillEndDate(date)
-      .pressEnterEndDate()
-      .blurEndDate();
-  });
-
-  enterAndClearBeginDate(date) {
-    return this.fillBeginDateField(date)
-      .clearBeginDate()
-      .blurBeginDate();
+  fillAndBlur(date) {
+    return this
+      .clickInput()
+      .fillInput(date)
+      .pressEnter()
+      .blurInput();
   }
 
-  enterBeginDateAfterEndDate(beginDate, endDate) {
-    return this.fillBeginDateField(beginDate)
-      .fillEndDateField(endDate);
+  fillAndClear(date) {
+    return this
+      .fillAndBlur(date)
+      .clearInput()
+      .blurInput();
   }
 }
 
@@ -104,7 +77,13 @@ import {
   isCustomCoverageDisabled = property('disabled', '[data-test-eholdings-package-details-save-custom-coverage-button] button')
   validationError = text('[data-test-eholdings-custom-coverage-date-range-begin] [class^="feedbackError"]')
 
-  dateFields = new PackageDatePickers('[data-test-eholdings-custom-coverage-form]')
+  beginDate = new Datepicker('[data-test-eholdings-custom-coverage-date-range-begin]');
+  endDate = new Datepicker('[data-test-eholdings-custom-coverage-date-range-end]');
+
+  fillDates(beginDate, endDate) {
+    return this.beginDate.fillAndBlur(beginDate)
+      .append(this.endDate.fillAndBlur(endDate));
+  }
 
   deselectAndConfirmPackage() {
     return this.toggleIsSelected().append(this.modal.confirmDeselection());


### PR DESCRIPTION
## Purpose
We weren't using the full power of page objects when it came to the datepickers on package pages.

## Approach
Create a Datepicker page object to DRY things up.

## Next Steps
- Apply the same pattern to the datepickers on customer resource pages.