### PR TITLE
Use stripes-components Button for search

### DIFF
--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -62,30 +62,6 @@
   }
 }
 
-.search-submit {
-  background-color: var(--primary);
-  border: 1px solid var(--primary);
-  border-radius: 0.4em;
-  color: #fff;
-  line-height: 2;
-  width: 100%;
-
-  &:hover {
-    background-color: color(var(--primary) shade(8%));
-  }
-
-  &[disabled] {
-    background-color: #ccc;
-    border-color: #ccc;
-    color: #888;
-
-    &:hover {
-      cursor: initial;
-      opacity: 1;
-    }
-  }
-}
-
 .search-results-list {
   margin: 1em 0;
   padding-left: 0;

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -4,6 +4,7 @@ import Link from 'react-router-dom/Link';
 import capitalize from 'lodash/capitalize';
 import isEqual from 'lodash/isEqual';
 import SearchField from '@folio/stripes-components/lib/structures/SearchField';
+import Button from '@folio/stripes-components/lib/Button';
 import ProviderSearchFilters from '../provider-search-filters';
 import PackageSearchFilters from '../package-search-filters';
 import TitleSearchFilters from '../title-search-filters';
@@ -166,14 +167,15 @@ export default class SearchForm extends Component {
               />
             </div>
           )}
-          <button
-            className={styles['search-submit']}
+          <Button
             type="submit"
+            buttonStyle="primary"
+            fullWidth
             disabled={!searchString}
             data-test-search-submit
           >
             Search
-          </button>
+          </Button>
 
           {Filters && (
             <div>


### PR DESCRIPTION
There's no longer a compelling reason to use our own button that mimics the upstream styles - we should just use the available `stripes-components` button.

![localhost_3000_eholdings_searchtype titles iphone 5_se](https://user-images.githubusercontent.com/230597/37740181-d678f89e-2d2a-11e8-95b1-8ac2c6399e72.png)
