### PR TITLE
UIEH-79 Add coverage statement editing

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -235,13 +235,15 @@ export default function configure() {
       isSelected,
       visibilityData,
       customCoverages,
-      customEmbargoPeriod
+      customEmbargoPeriod,
+      coverageStatement
     } = body.data.attributes;
 
     matchingCustomerResource.update('isSelected', isSelected);
     matchingCustomerResource.update('visibilityData', visibilityData);
     matchingCustomerResource.update('customCoverages', customCoverages);
     matchingCustomerResource.update('customEmbargoPeriod', customEmbargoPeriod);
+    matchingCustomerResource.update('coverageStatement', coverageStatement);
 
     return matchingCustomerResource;
   });

--- a/mirage/factories/customer-resource.js
+++ b/mirage/factories/customer-resource.js
@@ -4,6 +4,7 @@ export default Factory.extend({
   isSelected: false,
   url: () => faker.internet.url(),
   customCoverages: [],
+  coverageStatement: '',
 
   withTitle: trait({
     afterCreate(customerResource, server) {

--- a/src/components/coverage-statement-fields.js
+++ b/src/components/coverage-statement-fields.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import { Field } from 'redux-form';
+
+import TextArea from '@folio/stripes-components/lib/TextArea';
+
+export default class CoverageStatementFields extends Component {
+  render() {
+    return (
+      <div
+        data-test-eholdings-coverage-statement-textarea
+      >
+        <Field
+          name="coverageStatement"
+          component={TextArea}
+          label="Describes the coverage to patrons."
+        />
+      </div>
+    );
+  }
+}
+
+export function validate(values) {
+  const errors = {};
+
+  if (values.coverageStatement && values.coverageStatement.length > 350) {
+    errors.coverageStatement = 'Statement must be 350 characters or less.';
+  }
+
+  return errors;
+}

--- a/src/components/coverage-statement-form/coverage-statement-form.css
+++ b/src/components/coverage-statement-form/coverage-statement-form.css
@@ -1,0 +1,34 @@
+@import '@folio/stripes-components/lib/variables';
+
+.coverage-statement-form {
+  &.is-editing {
+    background: #e6f3ff;
+    padding: 1em;
+  }
+}
+
+.coverage-statement-add-button {
+  margin: 1em 0;
+}
+
+.coverage-statement-display {
+  display: flex;
+  align-items: center;
+}
+
+.coverage-statement {
+  display: flex;
+  align-items: flex-start;
+}
+
+.coverage-statement-action-buttons {
+  border-top: 1px solid var(--minor-divider-color);
+  display: flex;
+  margin-top: 1em;
+  padding-top: 1em;
+  align-items: flex-start;
+}
+
+.coverage-statement-action-button {
+  margin-right: 0.25em;
+}

--- a/src/components/coverage-statement-form/coverage-statement-form.js
+++ b/src/components/coverage-statement-form/coverage-statement-form.js
@@ -1,0 +1,166 @@
+import React, { Component } from 'react';
+import { reduxForm } from 'redux-form';
+import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import isEqual from 'lodash/isEqual';
+
+import Button from '@folio/stripes-components/lib/Button';
+import Icon from '@folio/stripes-components/lib/Icon';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+
+import CoverageStatementFields, { validate as validateCoverageStatement } from '../coverage-statement-fields';
+import styles from './coverage-statement-form.css';
+
+const cx = classNames.bind(styles);
+
+class CoverageStatementForm extends Component {
+  static propTypes = {
+    initialValues: PropTypes.shape({
+      coverageStatement: PropTypes.string
+    }).isRequired,
+    isEditable: PropTypes.bool,
+    onEdit: PropTypes.func,
+    onSubmit: PropTypes.func.isRequired,
+    isPending: PropTypes.bool,
+    handleSubmit: PropTypes.func,
+    initialize: PropTypes.func,
+    pristine: PropTypes.bool
+  };
+
+  state = {
+    isEditing: !!this.props.isEditable
+  };
+
+  componentWillReceiveProps(nextProps) {
+    let wasPending = this.props.isPending && !nextProps.isPending;
+    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+
+    if (wasPending && needsUpdate) {
+      this.toggleEditing(false);
+    }
+  }
+
+  toggleEditing(isEditing = !this.state.isEditing) {
+    if (this.props.onEdit) {
+      this.props.onEdit(isEditing);
+    } else {
+      this.setState({ isEditing });
+    }
+  }
+
+  handleEdit = (e) => {
+    e.preventDefault();
+    this.toggleEditing(true);
+  }
+
+  handleCancel = (e) => {
+    e.preventDefault();
+    this.toggleEditing(false);
+    this.props.initialize(this.props.initialValues);
+  }
+
+  render() {
+    let {
+      pristine,
+      isPending,
+      isEditable = this.state.isEditing,
+      // change,
+      handleSubmit,
+      onSubmit
+    } = this.props;
+    const {
+      coverageStatement
+    } = this.props.initialValues;
+    let contents;
+
+    if (isEditable) {
+      contents = (
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div
+            data-test-eholdings-customer-resource-coverage-statement-form
+            className={styles['coverage-statement-form-editing']}
+          >
+            <CoverageStatementFields />
+            <div className={styles['coverage-statement-action-buttons']}>
+              <div
+                data-test-eholdings-customer-resource-cancel-coverage-statement-button
+                className={styles['coverage-statement-action-button']}
+              >
+                <Button
+                  disabled={isPending}
+                  type="button"
+                  role="button"
+                  onClick={this.handleCancel}
+                  marginBottom0 // gag
+                >
+                  Cancel
+                </Button>
+              </div>
+              <div
+                data-test-eholdings-customer-resource-save-coverage-statement-button
+                className={styles['coverage-statement-action-button']}
+              >
+                <Button
+                  disabled={pristine || isPending}
+                  type="submit"
+                  role="button"
+                  buttonStyle="primary"
+                  marginBottom0 // gag
+                >
+                  {isPending ? 'Saving' : 'Save'}
+                </Button>
+              </div>
+              {isPending && (
+                <Icon icon="spinner-ellipsis" />
+              )}
+            </div>
+          </div>
+        </form>
+      );
+    } else if (coverageStatement) {
+      contents = (
+        <div className={styles['coverage-statement-display']}>
+          <span data-test-eholdings-customer-resource-coverage-statement-display>
+            {coverageStatement}
+          </span>
+          <div data-test-eholdings-customer-resource-edit-coverage-statement-button>
+            <IconButton icon="edit" onClick={this.handleEdit} />
+          </div>
+        </div>
+      );
+    } else {
+      contents = (
+        <div data-test-eholdings-customer-resource-add-coverage-statement-button>
+          <Button
+            type="button"
+            onClick={this.handleEdit}
+          >
+            Set coverage statement
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        data-test-eholdings-embargo-form
+        className={cx(styles['coverage-statement-form'], {
+          'is-editing': isEditable
+        })}
+      >
+        {contents}
+      </div>
+    );
+  }
+}
+
+const validate = (values) => {
+  return validateCoverageStatement(values);
+};
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'CoverageStatement',
+  destroyOnUnmount: false
+})(CoverageStatementForm);

--- a/src/components/coverage-statement-form/coverage-statement-form.js
+++ b/src/components/coverage-statement-form/coverage-statement-form.js
@@ -59,14 +59,92 @@ class CoverageStatementForm extends Component {
     this.props.initialize(this.props.initialValues);
   }
 
-  render() {
+  renderCoverageStatement() {
+    const {
+      coverageStatement
+    } = this.props.initialValues;
+
+    return (
+      <div className={styles['coverage-statement-display']}>
+        <span data-test-eholdings-customer-resource-coverage-statement-display>
+          {coverageStatement}
+        </span>
+        <div data-test-eholdings-customer-resource-edit-coverage-statement-button>
+          <IconButton icon="edit" onClick={this.handleEdit} />
+        </div>
+      </div>
+    );
+  }
+
+  renderEditingForm() {
     let {
       pristine,
       isPending,
-      isEditable = this.state.isEditing,
-      // change,
       handleSubmit,
       onSubmit
+    } = this.props;
+
+    return (
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div
+          data-test-eholdings-customer-resource-coverage-statement-form
+          className={styles['coverage-statement-form-editing']}
+        >
+          <CoverageStatementFields />
+          <div className={styles['coverage-statement-action-buttons']}>
+            <div
+              data-test-eholdings-customer-resource-cancel-coverage-statement-button
+              className={styles['coverage-statement-action-button']}
+            >
+              <Button
+                disabled={isPending}
+                type="button"
+                role="button"
+                onClick={this.handleCancel}
+                marginBottom0 // gag
+              >
+                Cancel
+              </Button>
+            </div>
+            <div
+              data-test-eholdings-customer-resource-save-coverage-statement-button
+              className={styles['coverage-statement-action-button']}
+            >
+              <Button
+                disabled={pristine || isPending}
+                type="submit"
+                role="button"
+                buttonStyle="primary"
+                marginBottom0 // gag
+              >
+                {isPending ? 'Saving' : 'Save'}
+              </Button>
+            </div>
+            {isPending && (
+              <Icon icon="spinner-ellipsis" />
+            )}
+          </div>
+        </div>
+      </form>
+    );
+  }
+
+  renderSetCoverage() {
+    return (
+      <div data-test-eholdings-customer-resource-add-coverage-statement-button>
+        <Button
+          type="button"
+          onClick={this.handleEdit}
+        >
+          Set coverage statement
+        </Button>
+      </div>
+    );
+  }
+
+  render() {
+    let {
+      isEditable = this.state.isEditing
     } = this.props;
     const {
       coverageStatement
@@ -74,71 +152,11 @@ class CoverageStatementForm extends Component {
     let contents;
 
     if (isEditable) {
-      contents = (
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <div
-            data-test-eholdings-customer-resource-coverage-statement-form
-            className={styles['coverage-statement-form-editing']}
-          >
-            <CoverageStatementFields />
-            <div className={styles['coverage-statement-action-buttons']}>
-              <div
-                data-test-eholdings-customer-resource-cancel-coverage-statement-button
-                className={styles['coverage-statement-action-button']}
-              >
-                <Button
-                  disabled={isPending}
-                  type="button"
-                  role="button"
-                  onClick={this.handleCancel}
-                  marginBottom0 // gag
-                >
-                  Cancel
-                </Button>
-              </div>
-              <div
-                data-test-eholdings-customer-resource-save-coverage-statement-button
-                className={styles['coverage-statement-action-button']}
-              >
-                <Button
-                  disabled={pristine || isPending}
-                  type="submit"
-                  role="button"
-                  buttonStyle="primary"
-                  marginBottom0 // gag
-                >
-                  {isPending ? 'Saving' : 'Save'}
-                </Button>
-              </div>
-              {isPending && (
-                <Icon icon="spinner-ellipsis" />
-              )}
-            </div>
-          </div>
-        </form>
-      );
+      contents = this.renderEditingForm();
     } else if (coverageStatement) {
-      contents = (
-        <div className={styles['coverage-statement-display']}>
-          <span data-test-eholdings-customer-resource-coverage-statement-display>
-            {coverageStatement}
-          </span>
-          <div data-test-eholdings-customer-resource-edit-coverage-statement-button>
-            <IconButton icon="edit" onClick={this.handleEdit} />
-          </div>
-        </div>
-      );
+      contents = this.renderCoverageStatement();
     } else {
-      contents = (
-        <div data-test-eholdings-customer-resource-add-coverage-statement-button>
-          <Button
-            type="button"
-            onClick={this.handleEdit}
-          >
-            Set coverage statement
-          </Button>
-        </div>
-      );
+      contents = this.renderSetCoverage();
     }
 
     return (

--- a/src/components/coverage-statement-form/index.js
+++ b/src/components/coverage-statement-form/index.js
@@ -1,0 +1,1 @@
+export { default } from './coverage-statement-form';

--- a/src/components/customer-resource-edit/customer-resource-edit.css
+++ b/src/components/customer-resource-edit/customer-resource-edit.css
@@ -1,0 +1,12 @@
+@import '@folio/stripes-components/lib/variables';
+
+.customer-resource-edit-action-buttons {
+  align-items: flex-start;
+  border-top: 1px solid var(--minor-divider-color);
+  display: flex;
+  padding-top: 1em;
+
+  & button {
+    margin-right: 0.25em;
+  }
+}

--- a/src/components/customer-resource-edit/customer-resource-edit.js
+++ b/src/components/customer-resource-edit/customer-resource-edit.js
@@ -1,0 +1,120 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+import isEqual from 'lodash/isEqual';
+
+import Button from '@folio/stripes-components/lib/Button';
+import Icon from '@folio/stripes-components/lib/Icon';
+
+import DetailsView from '../details-view';
+import CoverageStatementFields, { validate as validateCoverageStatement } from '../coverage-statement-fields';
+import DetailsViewSection from '../details-view-section';
+import NavigationModal from '../navigation-modal';
+import styles from './customer-resource-edit.css';
+
+class CustomerResourceEdit extends Component {
+  static propTypes = {
+    model: PropTypes.object.isRequired,
+    initialValues: PropTypes.object.isRequired,
+    handleSubmit: PropTypes.func,
+    onSubmit: PropTypes.func.isRequired,
+    pristine: PropTypes.bool
+  };
+
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
+  componentWillReceiveProps(nextProps) {
+    let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
+    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+
+    if (wasPending && needsUpdate) {
+      this.context.router.history.push(`/eholdings/customer-resources/${this.props.model.id}`);
+    }
+  }
+
+  handleCancel = () => {
+    this.context.router.history.push(`/eholdings/customer-resources/${this.props.model.id}`);
+  }
+
+  render() {
+    let {
+      model,
+      handleSubmit,
+      onSubmit,
+      pristine
+    } = this.props;
+
+    let actionMenuItems = [
+      {
+        label: 'Cancel Editing',
+        to: `/eholdings/customer-resources/${model.id}`
+      }
+    ];
+
+    return (
+      <DetailsView
+        type="resource"
+        model={model}
+        paneTitle={model.name}
+        paneSub={model.packageName}
+        actionMenuItems={actionMenuItems}
+        bodyContent={(
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <DetailsViewSection
+              label="Coverage statement"
+            >
+              <CoverageStatementFields />
+            </DetailsViewSection>
+            <div className={styles['customer-resource-edit-action-buttons']}>
+              <div
+                data-test-eholdings-customer-resource-save-button
+              >
+                <Button
+                  disabled={model.update.isPending}
+                  type="button"
+                  role="button"
+                  onClick={this.handleCancel}
+                >
+                  Cancel
+                </Button>
+              </div>
+              <div
+                data-test-eholdings-customer-resource-cancel-button
+              >
+                <Button
+                  disabled={pristine || model.update.isPending}
+                  type="submit"
+                  role="button"
+                  buttonStyle="primary"
+                >
+                  {model.update.isPending ? 'Saving' : 'Save'}
+                </Button>
+              </div>
+              {model.update.isPending && (
+                <Icon icon="spinner-ellipsis" />
+              )}
+            </div>
+            <NavigationModal when={!pristine && !model.update.isPending} />
+          </form>
+        )}
+      />
+    );
+  }
+}
+
+const validate = (values) => {
+  return validateCoverageStatement(values);
+};
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'CustomerResourceEdit',
+  destroyOnUnmount: false,
+})(CustomerResourceEdit);

--- a/src/components/customer-resource-edit/index.js
+++ b/src/components/customer-resource-edit/index.js
@@ -1,0 +1,1 @@
+export { default } from './customer-resource-edit';

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -12,8 +12,9 @@ import ToggleSwitch from './toggle-switch';
 import CoverageDateList from './coverage-date-list';
 import { isBookPublicationType, isValidCoverageList } from './utilities';
 import Modal from './modal';
-import CustomEmbargoForm from './custom-embargo';
 import CustomerResourceCoverage from './customer-resource-coverage';
+import CustomEmbargoForm from './custom-embargo';
+import CoverageStatementForm from './coverage-statement-form';
 import NavigationModal from './navigation-modal';
 import DetailsViewSection from './details-view-section';
 
@@ -23,7 +24,8 @@ export default class CustomerResourceShow extends Component {
     toggleSelected: PropTypes.func.isRequired,
     toggleHidden: PropTypes.func.isRequired,
     customEmbargoSubmitted: PropTypes.func.isRequired,
-    coverageSubmitted: PropTypes.func.isRequired
+    coverageSubmitted: PropTypes.func.isRequired,
+    coverageStatementSubmitted: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -36,7 +38,8 @@ export default class CustomerResourceShow extends Component {
     resourceSelected: this.props.model.isSelected,
     resourceHidden: this.props.model.visibilityData.isHidden,
     isCoverageEditable: false,
-    isEmbargoEditable: false
+    isEmbargoEditable: false,
+    isCoverageStatementEditable: false
   };
 
   componentWillReceiveProps({ model }) {
@@ -77,15 +80,20 @@ export default class CustomerResourceShow extends Component {
     this.setState({ isEmbargoEditable });
   };
 
+  handleCoverageStatementEdit = (isCoverageStatementEditable) => {
+    this.setState({ isCoverageStatementEditable });
+  };
+
   render() {
-    let { model, customEmbargoSubmitted, coverageSubmitted } = this.props;
+    let { model, customEmbargoSubmitted, coverageSubmitted, coverageStatementSubmitted } = this.props;
     let { locale, intl } = this.context;
     let {
       showSelectionModal,
       resourceSelected,
       resourceHidden,
       isCoverageEditable,
-      isEmbargoEditable
+      isEmbargoEditable,
+      isCoverageStatementEditable
     } = this.state;
 
     let hasManagedCoverages = model.managedCoverages.length > 0 &&
@@ -110,6 +118,13 @@ export default class CustomerResourceShow extends Component {
       }];
     }
 
+    let actionMenuItems = [
+      {
+        label: 'Edit',
+        to: `/eholdings/customer-resources/${model.id}/edit`
+      }
+    ];
+
     return (
       <div>
         <DetailsView
@@ -117,6 +132,7 @@ export default class CustomerResourceShow extends Component {
           model={model}
           paneTitle={model.name}
           paneSub={model.packageName}
+          actionMenuItems={actionMenuItems}
           bodyContent={(
             <div>
               <DetailsViewSection label="Holding status">
@@ -225,6 +241,25 @@ export default class CustomerResourceShow extends Component {
 
                 {!hasManagedEmbargoPeriod && !resourceSelected && (
                   <p>Add the resource to holdings to set an custom embargo period.</p>
+                )}
+
+              </DetailsViewSection>
+
+              <DetailsViewSection
+                label="Coverage statement"
+              >
+                {resourceSelected && (
+                  <CoverageStatementForm
+                    initialValues={{ coverageStatement: model.coverageStatement }}
+                    isEditable={isCoverageStatementEditable}
+                    onEdit={this.handleCoverageStatementEdit}
+                    onSubmit={coverageStatementSubmitted}
+                    isPending={model.update.isPending && 'coverageStatement' in model.update.changedAttributes}
+                  />
+                )}
+
+                {!hasManagedEmbargoPeriod && !resourceSelected && (
+                  <p>Add the resource to holdings to set a coverage statement.</p>
                 )}
 
               </DetailsViewSection>
@@ -341,7 +376,7 @@ export default class CustomerResourceShow extends Component {
           }
         </Modal>
 
-        <NavigationModal when={isCoverageEditable || isEmbargoEditable} />
+        <NavigationModal when={isCoverageEditable || isEmbargoEditable || isCoverageStatementEditable} />
       </div>
     );
   }

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -38,7 +38,8 @@ export default class DetailsView extends Component {
     paneSub: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
     bodyContent: PropTypes.node.isRequired,
     listType: PropTypes.string,
-    renderList: PropTypes.func
+    renderList: PropTypes.func,
+    actionMenuItems: PropTypes.array
   };
 
   static contextTypes = {
@@ -149,7 +150,8 @@ export default class DetailsView extends Component {
       listType,
       renderList,
       paneTitle,
-      paneSub
+      paneSub,
+      actionMenuItems
     } = this.props;
 
     let {
@@ -191,6 +193,7 @@ export default class DetailsView extends Component {
           paneSub={(
             <span data-test-eholdings-details-view-pane-sub>{paneSub}</span>
           )}
+          actionMenuItems={actionMenuItems}
         />
 
         <div

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import ProviderShow from './routes/provider-show';
 import PackageShow from './routes/package-show';
 import TitleShow from './routes/title-show';
 import CustomerResourceShow from './routes/customer-resource-show';
+import CustomerResourceEdit from './routes/customer-resource-edit';
 
 import SettingsRoute from './routes/settings';
 
@@ -63,6 +64,7 @@ export default class EHoldings extends Component {
             <Route path={`${rootPath}/packages/:packageId`} exact component={PackageShow} />
             <Route path={`${rootPath}/titles/:titleId`} exact component={TitleShow} />
             <Route path={`${rootPath}/customer-resources/:id`} exact component={CustomerResourceShow} />
+            <Route path={`${rootPath}/customer-resources/:id/edit`} exact component={CustomerResourceEdit} />
             <Route render={() => (<Redirect to={`${rootPath}?searchType=providers`} />)} />
           </Switch>
         </Route>

--- a/src/redux/customer-resource.js
+++ b/src/redux/customer-resource.js
@@ -21,6 +21,7 @@ class CustomerResource {
   managedEmbargoPeriod = {};
   customEmbargoPeriod = {};
   visibilityData = {};
+  coverageStatement = '';
 }
 
 export default model({

--- a/src/routes/customer-resource-edit.js
+++ b/src/routes/customer-resource-edit.js
@@ -1,0 +1,62 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { createResolver } from '../redux';
+import CustomerResource from '../redux/customer-resource';
+import View from '../components/customer-resource-edit';
+
+class CustomerResourceEditRoute extends Component {
+  static propTypes = {
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        id: PropTypes.string.isRequired
+      }).isRequired
+    }).isRequired,
+    model: PropTypes.object.isRequired,
+    getCustomerResource: PropTypes.func.isRequired,
+    updateResource: PropTypes.func.isRequired
+  };
+
+  componentWillMount() {
+    let { match, getCustomerResource } = this.props;
+    let { id } = match.params;
+    getCustomerResource(id);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    let { match, getCustomerResource } = nextProps;
+    let { id } = match.params;
+
+    if (id !== this.props.match.params.id) {
+      getCustomerResource(id);
+    }
+  }
+
+  resourceEditSubmitted = (values) => {
+    let { model, updateResource } = this.props;
+    model.coverageStatement = values.coverageStatement;
+    updateResource(model);
+  }
+
+  render() {
+    return (
+      <View
+        model={this.props.model}
+        onSubmit={this.resourceEditSubmitted}
+        initialValues={{
+          coverageStatement: this.props.model.coverageStatement
+        }}
+      />
+    );
+  }
+}
+
+export default connect(
+  ({ eholdings: { data } }, { match }) => ({
+    model: createResolver(data).find('customerResources', match.params.id)
+  }), {
+    getCustomerResource: id => CustomerResource.find(id, { include: 'package' }),
+    updateResource: model => CustomerResource.save(model)
+  }
+)(CustomerResourceEditRoute);

--- a/src/routes/customer-resource-show.js
+++ b/src/routes/customer-resource-show.js
@@ -78,6 +78,12 @@ class CustomerResourceShowRoute extends Component {
     updateResource(model);
   }
 
+  coverageStatementSubmitted = (values) => {
+    let { model, updateResource } = this.props;
+    model.coverageStatement = values.coverageStatement;
+    updateResource(model);
+  }
+
   render() {
     return (
       <View
@@ -86,6 +92,7 @@ class CustomerResourceShowRoute extends Component {
         toggleHidden={this.toggleHidden}
         customEmbargoSubmitted={this.customEmbargoSubmitted}
         coverageSubmitted={this.coverageSubmitted}
+        coverageStatementSubmitted={this.coverageStatementSubmitted}
       />
     );
   }

--- a/tests/customer-resource-coverage-statement-test.js
+++ b/tests/customer-resource-coverage-statement-test.js
@@ -1,0 +1,257 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import CustomerResourceShowPage from './pages/bigtest/customer-resource-show';
+
+describeApplication('CustomerResourceCoverageStatement', () => {
+  let pkg,
+    title,
+    resource;
+
+  beforeEach(function () {
+    pkg = this.server.create('package', 'withProvider');
+    title = this.server.create('title');
+    resource = this.server.create('customer-resource', {
+      package: pkg,
+      title,
+      isSelected: true
+    });
+  });
+
+  describe('visiting the customer resource show page with a coverage statement', () => {
+    beforeEach(function () {
+      resource.coverageStatement = 'Only 90s kids would understand.';
+      resource.save();
+
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the coverage statement', () => {
+      expect(CustomerResourceShowPage.coverageStatement).to.equal('Only 90s kids would understand.');
+    });
+  });
+
+  describe('visiting the customer resource show page without a coverage statement', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it.always('does not display the coverage statement', () => {
+      expect(CustomerResourceShowPage.hasCoverageStatement).to.be.false;
+    });
+
+    it('displays a button to add coverage statement', () => {
+      expect(CustomerResourceShowPage.hasCoverageStatementAddButton).to.be.true;
+    });
+
+    describe('clicking on the add coverage statement button', () => {
+      beforeEach(() => {
+        return CustomerResourceShowPage.clickCoverageStatementAddButton();
+      });
+
+      it('should remove the add coverage statement button', () => {
+        expect(CustomerResourceShowPage.hasCoverageStatementAddButton).to.be.false;
+      });
+
+      it('displays the coverage statement form', () => {
+        expect(CustomerResourceShowPage.hasCoverageStatementForm).to.be.true;
+      });
+
+      describe('then trying to navigate away', () => {
+        beforeEach(() => {
+          return CustomerResourceShowPage.clickPackage();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(CustomerResourceShowPage.navigationModal.$root).to.exist;
+        });
+
+        it.always('does not navigate away', function () {
+          expect(this.app.history.location.pathname)
+            .to.equal(`/eholdings/customer-resources/${resource.id}`);
+        });
+      });
+
+      describe('entering valid coverage statement', () => {
+        beforeEach(() => {
+          return CustomerResourceShowPage.inputCoverageStatement('Use this one weird trick to get access.');
+        });
+
+        it('accepts valid coverage statement', () => {
+          expect(CustomerResourceShowPage.coverageStatementFieldValue).to.equal('Use this one weird trick to get access.');
+        });
+
+        it('save button is present', () => {
+          expect(CustomerResourceShowPage.hasCoverageStatementSaveButton).to.be.true;
+        });
+
+        it('save button is enabled', () => {
+          expect(CustomerResourceShowPage.isCoverageStatementSaveDisabled).to.be.false;
+        });
+
+        it('cancel button is present', () => {
+          expect(CustomerResourceShowPage.hasCoverageStatementCancelButton).to.be.true;
+        });
+
+        it('cancel button is enabled', () => {
+          expect(CustomerResourceShowPage.isCoverageStatementCancelDisabled).to.be.false;
+        });
+
+        describe('saving updated coverage statement', () => {
+          beforeEach(() => {
+            return CustomerResourceShowPage.clickCoverageStatementSaveButton();
+          });
+
+          it('displays new coverage statement period', () => {
+            expect(CustomerResourceShowPage.coverageStatement).to.equal('Use this one weird trick to get access.');
+          });
+
+          it('does not display button to add coverage statement', () => {
+            expect(CustomerResourceShowPage.hasCoverageStatementAddButton).to.be.false;
+          });
+
+          it('removes the coverage statement form', () => {
+            expect(CustomerResourceShowPage.hasCoverageStatementForm).to.be.false;
+          });
+        });
+
+        describe('cancelling updated coverage statement', () => {
+          beforeEach(() => {
+            return CustomerResourceShowPage.clickCoverageStatementCancelButton();
+          });
+
+          it('displays existing coverage statement period (none)', () => {
+            expect(CustomerResourceShowPage.hasCoverageStatement).to.be.false;
+          });
+
+          it('removes the coverage statement form', () => {
+            expect(CustomerResourceShowPage.hasCoverageStatementForm).to.be.false;
+          });
+
+          it('displays the button to add coverage statement', () => {
+            expect(CustomerResourceShowPage.hasCoverageStatementAddButton).to.be.true;
+          });
+        });
+
+        describe('entering a coverage statement with too many characters', () => {
+          beforeEach(() => {
+            return CustomerResourceShowPage
+              .inputCoverageStatement(`Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+                Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+                dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,
+                pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
+                fringilla vel, aliquet nec, vulputate e`)
+              .clickCoverageStatementSaveButton();
+          });
+
+          it('highlights the textarea with an error state', () => {
+            expect(CustomerResourceShowPage.coverageStatementHasError).to.be.true;
+          });
+
+          it('displays a validation error message', () => {
+            expect(CustomerResourceShowPage.validationErrorOnCoverageStatement).to.equal('Statement must be 350 characters or less.');
+          });
+        });
+      });
+    });
+  });
+
+  describe('visiting the customer resource show page with no coverage statement', () => {
+    beforeEach(function () {
+      resource.coverageStatement = null;
+      resource.save();
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it.always('does not display the coverage statement section', () => {
+      expect(CustomerResourceShowPage.hasCoverageStatement).to.be.false;
+    });
+  });
+
+  describe('visiting the customer resource show page with title package not selected', () => {
+    beforeEach(function () {
+      resource.isSelected = false;
+      resource.save();
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it.always('does not display the coverage statement section', () => {
+      expect(CustomerResourceShowPage.hasCoverageStatement).to.be.false;
+    });
+  });
+
+  describe('visiting the customer resource show page with title package selected', () => {
+    beforeEach(function () {
+      resource.coverageStatement = 'Refinance your home loans.';
+      resource.save();
+      return this.visit(`/eholdings/customer-resources/${resource.id}`, () => {
+        expect(CustomerResourceShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the coverage statement section', () => {
+      expect(CustomerResourceShowPage.coverageStatement).to.equal('Refinance your home loans.');
+    });
+
+    it('displays the edit button in the coverage statement section', () => {
+      expect(CustomerResourceShowPage.hasCoverageStatementEditButton).to.be.true;
+    });
+
+    it('does not display the add coverage statement button', () => {
+      expect(CustomerResourceShowPage.hasCoverageStatementAddButton).to.be.false;
+    });
+
+    it('displays whether the title package is selected', () => {
+      expect(CustomerResourceShowPage.isSelected).to.equal(true);
+    });
+
+    describe('toggling to deselect a title package', () => {
+      beforeEach(() => {
+        return CustomerResourceShowPage.toggleIsSelected();
+      });
+
+      describe('and confirming deselection', () => {
+        beforeEach(() => {
+          return CustomerResourceShowPage.deselectionModal.confirmDeselection();
+        });
+
+        it('removes coverage statement', () => {
+          expect(CustomerResourceShowPage.hasCoverageStatement).to.be.false;
+        });
+      });
+
+      describe('and canceling deselection', () => {
+        beforeEach(() => {
+          return CustomerResourceShowPage.deselectionModal.cancelDeselection();
+        });
+
+        it('does not remove coverage statement', () => {
+          expect(CustomerResourceShowPage.coverageStatement).to.equal('Refinance your home loans.');
+        });
+
+        it('displays the edit button in the coverage statement section', () => {
+          expect(CustomerResourceShowPage.hasCoverageStatementEditButton).to.be.true;
+        });
+      });
+    });
+
+    describe('clicking the edit button', () => {
+      beforeEach(() => {
+        return CustomerResourceShowPage.clickCoverageStatementEditButton();
+      });
+
+      it('displays the coverage statement form', () => {
+        expect(CustomerResourceShowPage.hasCoverageStatementForm).to.be.true;
+      });
+    });
+  });
+});

--- a/tests/customer-resource-edit-test.js
+++ b/tests/customer-resource-edit-test.js
@@ -1,0 +1,212 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+
+import { describeApplication } from './helpers';
+import ResourceShowPage from './pages/bigtest/customer-resource-show';
+import ResourceEditPage from './pages/bigtest/customer-resource-edit';
+
+describeApplication('CustomerResourceEdit', () => {
+  let provider,
+    providerPackage,
+    resource;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create('package', 'withTitles', {
+      provider,
+      name: 'Cool Package',
+      contentType: 'E-Book',
+      titleCount: 5
+    });
+
+    let title = this.server.create('title', {
+      name: 'Best Title Ever',
+      publicationType: 'Streaming Video',
+      publisherName: 'Amazing Publisher'
+    });
+
+    title.save();
+
+    resource = this.server.create('customer-resource', {
+      package: providerPackage,
+      isSelected: true,
+      title,
+      url: 'frontside.io'
+    });
+  });
+
+  describe('visiting the customer resource edit page without a coverage statement', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/customer-resources/${resource.titleId}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('shows a form with coverage statement', () => {
+      expect(ResourceEditPage.coverageStatement).to.equal('');
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return ResourceEditPage.clickCancel();
+      });
+
+      it('goes to the customer resource show page', () => {
+        expect(ResourceShowPage.$root).to.exist;
+      });
+    });
+
+    describe('entering invalid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .inputCoverageStatement(`Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+            Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+            dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,
+            pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
+            fringilla vel, aliquet nec, vulputate e`)
+          .clickSave();
+      });
+
+      it('highlights the textarea with an error state', () => {
+        expect(ResourceEditPage.coverageStatementHasError).to.be.true;
+      });
+
+      it('displays a validation error message', () => {
+        expect(ResourceEditPage.validationErrorOnCoverageStatement).to.equal('Statement must be 350 characters or less.');
+      });
+    });
+
+    describe('entering valid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage.inputCoverageStatement('Only 90s kids would understand.');
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickCancel();
+        });
+
+        it.skip('shows a navigation confirmation modal', () => {
+          expect(ResourceEditPage.navigationModal.$root).to.exist;
+        });
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('goes to the customer resource show page', () => {
+          expect(ResourceShowPage.$root).to.exist;
+        });
+
+        it('shows the new statement value', () => {
+          expect(ResourceShowPage.coverageStatement).to.equal('Only 90s kids would understand.');
+        });
+      });
+    });
+  });
+
+  describe('visiting the customer resource edit page with an existing coverage statement', () => {
+    beforeEach(function () {
+      resource.coverageStatement = 'Use this one weird trick to get access.';
+
+      return this.visit(`/eholdings/customer-resources/${resource.titleId}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('shows a form with the coverage field', () => {
+      expect(ResourceEditPage.coverageStatement).to.equal('Use this one weird trick to get access.');
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return ResourceEditPage.clickCancel();
+      });
+
+      it('goes to the customer resource show page', () => {
+        expect(ResourceShowPage.$root).to.exist;
+      });
+    });
+
+    describe('entering invalid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .inputCoverageStatement(`Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+            Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+            dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,
+            pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
+            fringilla vel, aliquet nec, vulputate e`)
+          .clickSave();
+      });
+
+      it('highlights the textarea with an error state', () => {
+        expect(ResourceEditPage.coverageStatementHasError).to.be.true;
+      });
+
+      it('displays a validation error message', () => {
+        expect(ResourceEditPage.validationErrorOnCoverageStatement).to.equal('Statement must be 350 characters or less.');
+      });
+    });
+
+    describe('entering valid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage.inputCoverageStatement('Refinance your home loans.');
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickCancel();
+        });
+
+        it.skip('shows a navigation confirmation modal', () => {
+          expect(ResourceEditPage.navigationModal.$root).to.exist;
+        });
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('goes to the customer resource show page', () => {
+          expect(ResourceShowPage.$root).to.exist;
+        });
+
+        it('shows the new statement value', () => {
+          expect(ResourceShowPage.coverageStatement).to.equal('Refinance your home loans.');
+        });
+      });
+    });
+  });
+
+  describe('encountering a server error', () => {
+    beforeEach(function () {
+      this.server.get('/customer-resources/:id', {
+        errors: [{
+          title: 'There was an error'
+        }]
+      }, 500);
+
+      return this.visit(`/eholdings/customer-resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('dies with dignity', () => {
+      expect(ResourceEditPage.hasErrors).to.be.true;
+    });
+  });
+});

--- a/tests/pages/bigtest/customer-resource-edit.js
+++ b/tests/pages/bigtest/customer-resource-edit.js
@@ -1,0 +1,36 @@
+import {
+  blurrable,
+  clickable,
+  fillable,
+  isPresent,
+  page,
+  property,
+  text,
+  value
+} from '@bigtest/interaction';
+import { hasClassBeginningWith } from '../helpers';
+
+@page class CustomerResourceEditNavigationModal {}
+
+@page class CustomerResourceEditPage {
+  navigationModal = new CustomerResourceEditNavigationModal('#navigation-modal');
+
+  clickCancel = clickable('[data-test-eholdings-customer-resource-cancel-button] button');
+  clickSave = clickable('[data-test-eholdings-customer-resource-cancel-button] button');
+  isSaveDisabled = property('disabled', '[data-test-eholdings-customer-resource-cancel-button] button');
+  hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
+
+  coverageStatement = value('[data-test-eholdings-coverage-statement-textarea] textarea');
+  fillCoverageStatement = fillable('[data-test-eholdings-coverage-statement-textarea] textarea');
+  blurCoverageStatement = blurrable('[data-test-eholdings-coverage-statement-textarea] textarea');
+  coverageStatementHasError = hasClassBeginningWith('feedbackError--', '[data-test-eholdings-coverage-statement-textarea] textarea');
+  validationErrorOnCoverageStatement = text('[data-test-eholdings-coverage-statement-textarea] [class^="feedbackError--"]');
+
+  inputCoverageStatement(statement) {
+    return this
+      .fillCoverageStatement(statement)
+      .blurCoverageStatement();
+  }
+}
+
+export default new CustomerResourceEditPage('[data-test-eholdings-details-view="resource"]');

--- a/tests/pages/bigtest/customer-resource-show.js
+++ b/tests/pages/bigtest/customer-resource-show.js
@@ -1,4 +1,5 @@
 import {
+  blurrable,
   clickable,
   collection,
   fillable,
@@ -70,6 +71,31 @@ import { isRootPresent, hasClassBeginningWith } from '../helpers';
   validationErrorOnTextField = text('[data-test-eholdings-customer-resource-custom-embargo-textfield] [class^="feedbackError--"]');
   validationErrorOnSelect = text('[data-test-eholdings-customer-resource-custom-embargo-select] [class^="feedbackError--"]');
   clickCustomEmbargoEditButton = clickable('[data-test-eholdings-customer-resource-edit-custom-embargo-button] button');
+
+  coverageStatement = text('[data-test-eholdings-customer-resource-coverage-statement-display]');
+  hasCoverageStatement = isPresent('[data-test-eholdings-customer-resource-coverage-statement-display]');
+  hasCoverageStatementAddButton = isPresent('[data-test-eholdings-customer-resource-add-coverage-statement-button] button');
+  clickCoverageStatementAddButton = clickable('[data-test-eholdings-customer-resource-add-coverage-statement-button] button');
+  hasCoverageStatementForm = isPresent('[data-test-eholdings-customer-resource-coverage-statement-form]');
+  coverageStatementFieldValue = value('[data-test-eholdings-coverage-statement-textarea] textarea');
+  clickCoverageStatementEditButton = clickable('[data-test-eholdings-customer-resource-edit-coverage-statement-button] button');
+  hasCoverageStatementEditButton = isPresent('[data-test-eholdings-customer-resource-edit-coverage-statement-button] button');
+  clickCoverageStatementSaveButton = clickable('[data-test-eholdings-customer-resource-save-coverage-statement-button] button');
+  hasCoverageStatementSaveButton = isPresent('[data-test-eholdings-customer-resource-save-coverage-statement-button] button');
+  isCoverageStatementSaveDisabled = property('disabled', '[data-test-eholdings-customer-resource-save-coverage-statement-button] button');
+  clickCoverageStatementCancelButton = clickable('[data-test-eholdings-customer-resource-cancel-coverage-statement-button] button');
+  hasCoverageStatementCancelButton = isPresent('[data-test-eholdings-customer-resource-cancel-coverage-statement-button] button');
+  isCoverageStatementCancelDisabled = property('disabled', '[data-test-eholdings-customer-resource-cancel-coverage-statement-button] button');
+  fillCoverageStatement = fillable('[data-test-eholdings-coverage-statement-textarea] textarea');
+  blurCoverageStatement = blurrable('[data-test-eholdings-coverage-statement-textarea] textarea');
+  coverageStatementHasError = hasClassBeginningWith('feedbackError--', '[data-test-eholdings-coverage-statement-textarea] textarea');
+  validationErrorOnCoverageStatement = text('[data-test-eholdings-coverage-statement-textarea] [class^="feedbackError--"]');
+
+  inputCoverageStatement(statement) {
+    return this
+      .fillCoverageStatement(statement)
+      .blurCoverageStatement();
+  }
 
   identifiersList = collection('[data-test-eholdings-identifiers-list-item]', {
     text: text()


### PR DESCRIPTION
## Purpose
When a package-title is selected, a user can customize it by setting a coverage statement.

Resolves https://issues.folio.org/browse/UIEH-79

## Approach
This will be the first example of a set of `redux-form` fields being shared in two places, the customer resource edit and show routes. Eventually we'll want embargo and coverage dates to work the same way.

A lot of the page objects and event handling could be done more elegantly, but in the interests of time, we've got a bulky-but-working version.

## Screenshots
![2018-03-22 10 39 47](https://user-images.githubusercontent.com/230597/37780881-a8dc0c3a-2dbd-11e8-83d6-68c5b516f5f6.gif)