### PR TITLE
Run Firefox ESR in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,13 +79,10 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Install the latest Firefox
+          name: Install the latest Firefox ESR
           command: |
             sudo apt-get remove firefox-mozilla-build &&
-            sudo sh -c "echo 'deb http://ftp.hr.debian.org/debian sid main' >> /etc/apt/sources.list" &&
-            sudo apt-get update &&
-            sudo apt-get remove binutils
-            sudo apt-get install -t sid firefox &&
+            sudo apt install firefox-esr &&
             firefox --version
       - run:
           name: Run tests


### PR DESCRIPTION
## Purpose
Circle's `circleci/node:latest-browsers` image runs Firefox 47. We were trying to install the `sid` version, which didn't always install on the Circle `jessie` boxes.

## Approach
Install Firefox's extended support release instead. Right now it's 52.7.2.