### PR TITLE
Turn off Firefox tests in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,3 @@ workflows:
       - test-safari:
           requires:
             - checkout-and-install
-      - test-firefox:
-          requires:
-            - checkout-and-install


### PR DESCRIPTION
Tests that haven't been converted to use BigTest page objects are flaking on nearly every build, blocking approved and validated PRs from being merged.

We can turn these back on after the remaining tests have been converted to using BigTest page objects.