### PR TITLE
UIEH-222 Copy custom coverage editing to full-page view

### DIFF
--- a/src/components/coverage-statement-fields/coverage-statement-fields.css
+++ b/src/components/coverage-statement-fields/coverage-statement-fields.css
@@ -1,0 +1,3 @@
+.coverage-statement-textarea {
+  max-width: 50em;
+}

--- a/src/components/coverage-statement-fields/coverage-statement-fields.js
+++ b/src/components/coverage-statement-fields/coverage-statement-fields.js
@@ -2,12 +2,14 @@ import React, { Component } from 'react';
 import { Field } from 'redux-form';
 
 import TextArea from '@folio/stripes-components/lib/TextArea';
+import styles from './coverage-statement-fields.css';
 
 export default class CoverageStatementFields extends Component {
   render() {
     return (
       <div
         data-test-eholdings-coverage-statement-textarea
+        className={styles['coverage-statement-textarea']}
       >
         <Field
           name="coverageStatement"

--- a/src/components/coverage-statement-fields/index.js
+++ b/src/components/coverage-statement-fields/index.js
@@ -1,0 +1,1 @@
+export { default, validate } from './coverage-statement-fields';

--- a/src/components/custom-embargo/custom-embargo.css
+++ b/src/components/custom-embargo/custom-embargo.css
@@ -44,10 +44,6 @@
   margin-right: 1em;
 }
 
-.custom-embargo-component-width {
-  width: 13em;
-}
-
 .error-message {
   color: var(--error);
 }

--- a/src/components/customer-resource-coverage-fields/customer-resource-coverage-fields.css
+++ b/src/components/customer-resource-coverage-fields/customer-resource-coverage-fields.css
@@ -1,0 +1,31 @@
+@import '@folio/stripes-components/lib/variables';
+
+.coverage-fields {
+  max-width: 50em;
+}
+
+.coverage-fields-date-range-rows {
+  list-style-type: none;
+  padding: 0;
+}
+
+.coverage-fields-date-range-row {
+  display: flex;
+  align-items: flex-start;
+}
+
+.coverage-fields-datepicker {
+  align-self: flex-start;
+  flex: 1 1 200px;
+  margin-right: 1em;
+}
+
+.coverage-fields-date-range-clear-row {
+  flex: 0 0 3em;
+  margin-top: 2.25em;
+  text-align: center;
+
+  @media (--mediumUp) {
+    margin-top: 1.5em;
+  }
+}

--- a/src/components/customer-resource-coverage-fields/customer-resource-coverage-fields.js
+++ b/src/components/customer-resource-coverage-fields/customer-resource-coverage-fields.js
@@ -1,0 +1,243 @@
+import React, { Component } from 'react';
+import { Field, FieldArray } from 'redux-form';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+import Datepicker from '@folio/stripes-components/lib/Datepicker';
+import Button from '@folio/stripes-components/lib/Button';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+
+import styles from './customer-resource-coverage-fields.css';
+import { formatISODateWithoutTime } from '../utilities';
+
+export default class CustomerResourceCoverageFields extends Component {
+  static propTypes = {
+    packageCoverage: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
+    locale: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
+    intl: PropTypes.object // eslint-disable-line react/no-unused-prop-types
+  };
+
+  renderCoverageFields = ({ fields }) => {
+    return (
+      <div className={styles['coverage-fields']}>
+        {fields.length === 0 ? (
+          <p data-test-eholdings-coverage-fields-no-rows-left>
+            No date ranges set. Saving will remove all custom coverage.
+          </p>
+        ) : (
+          <ul className={styles['coverage-fields-date-range-rows']}>
+            {fields.map((dateRange, index) => (
+              <li
+                data-test-eholdings-coverage-fields-date-range-row
+                key={index}
+                className={styles['coverage-fields-date-range-row']}
+              >
+                <div
+                  data-test-eholdings-coverage-fields-date-range-begin
+                  className={styles['coverage-fields-datepicker']}
+                >
+                  <Field
+                    name={`${dateRange}.beginCoverage`}
+                    type="text"
+                    component={Datepicker}
+                    label="Start date"
+                    id="begin-coverage"
+                  />
+                </div>
+                <div
+                  data-test-eholdings-coverage-fields-date-range-end
+                  className={styles['coverage-fields-datepicker']}
+                >
+                  <Field
+                    name={`${dateRange}.endCoverage`}
+                    type="text"
+                    component={Datepicker}
+                    label="End date"
+                    id="end-coverage"
+                  />
+                </div>
+
+                <div
+                  data-test-eholdings-coverage-fields-remove-row-button
+                  className={styles['coverage-fields-date-range-clear-row']}
+                >
+                  <IconButton
+                    icon="hollowX"
+                    onClick={() => fields.remove(index)}
+                    size="small"
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div
+          className={styles['coverage-fields-add-row-button']}
+          data-test-eholdings-coverage-fields-add-row-button
+        >
+          <Button
+            type="button"
+            role="button"
+            onClick={() => fields.push({})}
+          >
+            + Add date range
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  render() {
+    return (
+      <FieldArray name="customCoverages" component={this.renderCoverageFields} />
+    );
+  }
+}
+
+/**
+ * Validator to ensure start date comes before end date chronologically
+ * @param {} dateRange - coverage date range to validate
+ * @returns {} - an error object if errors are found, or `false` otherwise
+ */
+const validateStartDateBeforeEndDate = (dateRange) => {
+  const message = 'Start date must be before end date';
+
+  if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
+    return { beginCoverage: message };
+  }
+
+  return false;
+};
+
+/**
+ * Validator to ensure begin date is present and entered dates are valid
+ * @param {} dateRange - coverage date range to validate
+ * @returns {} - an error object if errors are found, or `false` otherwise
+ */
+const validateDateFormat = (dateRange, locale) => {
+  moment.locale(locale);
+  let dateFormat = moment.localeData()._longDateFormat.L;
+  const message = `Enter date in ${dateFormat} format.`;
+
+  if (!dateRange.beginCoverage || !moment(dateRange.beginCoverage).isValid()) {
+    return { beginCoverage: message };
+  }
+
+  return false;
+};
+
+/**
+ * Validator to ensure all coverage ranges are within the parent package's
+ * custom coverage range if one is present
+ * @param {} dateRange - coverage date range to validate
+ * @param {} packageCoverage - parent package's custom coverage range
+ * @param {} intl - object containing locale-specific data & formatting
+ * @returns {} - an error object if errors are found, or `false` otherwise
+ */
+const validateWithinPackageRange = (dateRange, packageCoverage, intl) => {
+  // javascript/moment has no mechanism for "infinite", so we
+  // use an absurd future date to represent the concept of "present"
+  let present = moment('9999-09-09T05:00:00.000Z');
+
+  if (packageCoverage && packageCoverage.beginCoverage) {
+    let {
+      beginCoverage: packageBeginCoverage,
+      endCoverage: packageEndCoverage
+    } = packageCoverage;
+
+    let beginCoverageDate = moment(dateRange.beginCoverage);
+    let endCoverageDate = dateRange.endCoverage ? moment(dateRange.endCoverage) : present;
+
+    let packageBeginCoverageDate = moment(packageBeginCoverage);
+    let packageEndCoverageDate = packageEndCoverage ? moment(packageEndCoverage) : moment();
+    let packageRange = moment.range(packageBeginCoverageDate, packageEndCoverageDate);
+
+    const message = `Dates must be within package's date range (${
+      formatISODateWithoutTime(packageBeginCoverageDate.format('YYYY-MM-DD'), intl)
+    } - ${
+      packageEndCoverage
+        ? formatISODateWithoutTime(packageEndCoverageDate.format('YYYY-MM-DD'), intl)
+        : 'Present'
+    }).`;
+
+    let beginDateOutOfRange = !packageRange.contains(beginCoverageDate);
+    let endDateOutOfRange = !packageRange.contains(endCoverageDate);
+    if (beginDateOutOfRange || endDateOutOfRange) {
+      return {
+        beginCoverage: beginDateOutOfRange ? message : false,
+        endCoverage: endDateOutOfRange ? message : false
+      };
+    }
+  }
+
+  return false;
+};
+
+
+/**
+ * Validator to check that no date ranges overlap or are identical
+ * @param {} dateRange - coverage date range to validate
+ * @param {} customCoverages - all custom coverage ranges present in edit form
+ * @param {} index - index in the field array indicating which coverage range is
+ * presently being considered
+ * @param {} intl - object containing locale-specific data & formatting
+ * @returns {} - an error object if errors are found, or `false` otherwise
+ */
+const validateNoRangeOverlaps = (dateRange, customCoverages, index, intl) => {
+  let present = moment('9999-09-09T05:00:00.000Z');
+
+  let beginCoverageDate = moment(dateRange.beginCoverage);
+  let endCoverageDate = dateRange.endCoverage ? moment(dateRange.endCoverage) : present;
+  let coverageRange = moment.range(beginCoverageDate, endCoverageDate);
+
+  for (let overlapIndex = 0, len = customCoverages.length; overlapIndex < len; overlapIndex++) {
+    let overlapRange = customCoverages[overlapIndex];
+
+    // don't compare range to itself or to empty rows
+    if (index === overlapIndex || !overlapRange.beginCoverage) {
+      continue; // eslint-disable-line no-continue
+    }
+
+    let overlapCoverageBeginDate = moment(overlapRange.beginCoverage);
+    let overlapCoverageEndDate = overlapRange.endCoverage ? moment(overlapRange.endCoverage) : present;
+    let overlapCoverageRange = moment.range(overlapCoverageBeginDate, overlapCoverageEndDate);
+
+    const message = `Date range overlaps with ${
+      overlapRange.beginCoverage &&
+        formatISODateWithoutTime(overlapCoverageBeginDate.format('YYYY-MM-DD'), intl)
+    } - ${
+      overlapRange.endCoverage
+        ? formatISODateWithoutTime(overlapCoverageEndDate.format('YYYY-MM-DD'), intl)
+        : 'Present'
+    }`;
+
+    if (overlapCoverageRange.overlaps(coverageRange)
+        || overlapCoverageRange.isEqual(coverageRange)
+        || overlapCoverageRange.contains(coverageRange)) {
+      // set endCoverage: true to make box red without message
+      return { beginCoverage: message, endCoverage: true };
+    }
+  }
+
+  return false;
+};
+
+export function validate(values, props) {
+  let errors = [];
+  let { intl, packageCoverage, locale } = props;
+
+  values.customCoverages.forEach((dateRange, index) => {
+    let dateRangeErrors = {};
+
+    dateRangeErrors =
+      validateDateFormat(dateRange, locale) ||
+      validateStartDateBeforeEndDate(dateRange) ||
+      validateNoRangeOverlaps(dateRange, values.customCoverages, index, intl) ||
+      validateWithinPackageRange(dateRange, packageCoverage, intl);
+
+    errors[index] = dateRangeErrors;
+  });
+
+  return { customCoverages: errors };
+}

--- a/src/components/customer-resource-coverage-fields/index.js
+++ b/src/components/customer-resource-coverage-fields/index.js
@@ -1,0 +1,1 @@
+export { default, validate } from './customer-resource-coverage-fields';

--- a/src/components/customer-resource-coverage/customer-resource-coverage.css
+++ b/src/components/customer-resource-coverage/customer-resource-coverage.css
@@ -12,40 +12,6 @@
   align-items: center;
 }
 
-.coverage-form-date-range-rows {
-  list-style-type: none;
-  padding: 0;
-}
-
-.coverage-form-date-range-row {
-  display: flex;
-  align-items: flex-start;
-}
-
-.coverage-form-datepicker {
-  align-self: flex-start;
-  flex: 1 1 200px;
-  margin-right: 1em;
-}
-
-.coverage-form-date-range-clear-row {
-  flex: 0 0 3em;
-  margin-top: 2.25em;
-  text-align: center;
-
-  @media (--mediumUp) {
-    margin-top: 1.5em;
-  }
-}
-
-.coverage-form-add-row-button button {
-  width: 100%;
-
-  @media (--mediumUp) {
-    width: auto;
-  }
-}
-
 .coverage-form-action-buttons {
   border-top: 1px solid var(--minor-divider-color);
   display: flex;

--- a/src/components/customer-resource-coverage/customer-resource-coverage.js
+++ b/src/components/customer-resource-coverage/customer-resource-coverage.js
@@ -1,19 +1,18 @@
 import React, { Component } from 'react';
-import { Field, FieldArray, reduxForm } from 'redux-form';
+import { reduxForm } from 'redux-form';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import moment from 'moment';
 import isEqual from 'lodash/isEqual';
 
-import Datepicker from '@folio/stripes-components/lib/Datepicker';
 import Button from '@folio/stripes-components/lib/Button';
 import Icon from '@folio/stripes-components/lib/Icon';
 import IconButton from '@folio/stripes-components/lib/IconButton';
 import KeyValueLabel from '../key-value-label';
 
 import CoverageDateList from '../coverage-date-list';
+import CustomerResourceCoverageFields, { validate as validateCoverage } from '../customer-resource-coverage-fields';
 import styles from './customer-resource-coverage.css';
-import { formatISODateWithoutTime } from '../utilities';
+
 
 const cx = classNames.bind(styles);
 
@@ -66,160 +65,103 @@ class CustomerResourceCoverage extends Component {
     this.props.initialize(this.props.initialValues);
   }
 
-  renderCoverageFields = ({ fields }) => {
-    return (
-      <div>
-        {fields.length === 0 ? (
-          <p data-test-eholdings-coverage-form-no-rows-left>
-            No date ranges set. Saving will remove all custom coverage.
-          </p>
-        ) : (
-          <ul className={styles['coverage-form-date-range-rows']}>
-            {fields.map((dateRange, index) => (
-              <li
-                data-test-eholdings-coverage-form-date-range-row
-                key={index}
-                className={styles['coverage-form-date-range-row']}
-              >
-                <div
-                  data-test-eholdings-coverage-form-date-range-begin
-                  className={styles['coverage-form-datepicker']}
-                >
-                  <Field
-                    name={`${dateRange}.beginCoverage`}
-                    type="text"
-                    component={Datepicker}
-                    label="Start date"
-                    id="begin-coverage"
-                  />
-                </div>
-                <div
-                  data-test-eholdings-coverage-form-date-range-end
-                  className={styles['coverage-form-datepicker']}
-                >
-                  <Field
-                    name={`${dateRange}.endCoverage`}
-                    type="text"
-                    component={Datepicker}
-                    label="End date"
-                    id="end-coverage"
-                  />
-                </div>
-
-                <div
-                  data-test-eholdings-coverage-form-remove-row-button
-                  className={styles['coverage-form-date-range-clear-row']}
-                >
-                  <IconButton
-                    disabled={this.props.isPending}
-                    icon="hollowX"
-                    onClick={() => fields.remove(index)}
-                    size="small"
-                  />
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-
-        <div
-          className={styles['coverage-form-add-row-button']}
-          data-test-eholdings-coverage-form-add-row-button
-        >
-          <Button
-            disabled={this.props.isPending}
-            type="button"
-            role="button"
-            onClick={() => fields.push({})}
-          >
-            + Add date range
-          </Button>
-        </div>
-      </div>
-    );
-  };
-
-  render() {
+  renderEditingForm() {
     let {
       pristine,
       isPending,
-      isEditable = this.state.isEditing,
       handleSubmit,
       onSubmit
+    } = this.props;
+
+    return (
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <CustomerResourceCoverageFields />
+        <div className={styles['coverage-form-action-buttons']}>
+          <div
+            data-test-eholdings-coverage-form-cancel-button
+            className={styles['coverage-form-action-button']}
+          >
+            <Button
+              disabled={isPending}
+              type="button"
+              role="button"
+              onClick={this.handleCancel}
+              marginBottom0 // gag
+            >
+              Cancel
+            </Button>
+          </div>
+          <div
+            data-test-eholdings-coverage-form-save-button
+            className={styles['coverage-form-action-button']}
+          >
+            <Button
+              disabled={pristine || isPending}
+              type="submit"
+              role="button"
+              buttonStyle="primary"
+              marginBottom0 // gag
+            >
+              {isPending ? 'Saving' : 'Save' }
+            </Button>
+          </div>
+          {isPending && (
+            <Icon icon="spinner-ellipsis" />
+          )}
+        </div>
+      </form>
+    );
+  }
+
+  renderCoverageDates() {
+    let { customCoverages } = this.props.initialValues;
+
+    return (
+      <div
+        className={styles['coverage-form-display']}
+      >
+        <KeyValueLabel label="Custom">
+          <span data-test-eholdings-coverage-form-display>
+            <CoverageDateList
+              coverageArray={customCoverages}
+            />
+          </span>
+        </KeyValueLabel>
+        <div data-test-eholdings-coverage-form-edit-button>
+          <IconButton icon="edit" onClick={this.handleEdit} />
+        </div>
+      </div>
+    );
+  }
+
+  renderSetCoverageDates() {
+    return (
+      <div
+        data-test-eholdings-coverage-form-add-button
+      >
+        <Button
+          type="button"
+          onClick={this.handleEdit}
+        >
+          Set custom coverage dates
+        </Button>
+      </div>
+    );
+  }
+
+  render() {
+    let {
+      isEditable = this.state.isEditing
     } = this.props;
     let { customCoverages } = this.props.initialValues;
     let contents;
 
     if (isEditable) {
-      contents = (
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <FieldArray name="customCoverages" component={this.renderCoverageFields} />
-          <div className={styles['coverage-form-action-buttons']}>
-            <div
-              data-test-eholdings-coverage-form-cancel-button
-              className={styles['coverage-form-action-button']}
-            >
-              <Button
-                disabled={isPending}
-                type="button"
-                role="button"
-                onClick={this.handleCancel}
-                marginBottom0 // gag
-              >
-                Cancel
-              </Button>
-            </div>
-            <div
-              data-test-eholdings-coverage-form-save-button
-              className={styles['coverage-form-action-button']}
-            >
-              <Button
-                disabled={pristine || isPending}
-                type="submit"
-                role="button"
-                buttonStyle="primary"
-                marginBottom0 // gag
-              >
-                {isPending ? 'Saving' : 'Save' }
-              </Button>
-            </div>
-            {isPending && (
-              <Icon icon="spinner-ellipsis" />
-            )}
-          </div>
-        </form>
-      );
+      contents = this.renderEditingForm();
     } else if (customCoverages.length && customCoverages[0].beginCoverage !== '') {
-      contents = (
-        <div
-          className={styles['coverage-form-display']}
-        >
-          <KeyValueLabel label="Custom">
-            <span data-test-eholdings-coverage-form-display>
-              <CoverageDateList
-                coverageArray={customCoverages}
-              />
-            </span>
-          </KeyValueLabel>
-          <div data-test-eholdings-coverage-form-edit-button>
-            <IconButton icon="edit" onClick={this.handleEdit} />
-          </div>
-        </div>
-      );
+      contents = this.renderCoverageDates();
     } else {
-      contents = (
-        <div
-          data-test-eholdings-coverage-form-add-button
-          className={styles['coverage-form-add-button']}
-        >
-          <Button
-            type="button"
-            onClick={this.handleEdit}
-          >
-            Set custom coverage dates
-          </Button>
-        </div>
-      );
+      contents = this.renderSetCoverageDates();
     }
 
     return (
@@ -235,152 +177,8 @@ class CustomerResourceCoverage extends Component {
   }
 }
 
-/**
- * Validator to ensure start date comes before end date chronologically
- * @param {} dateRange - coverage date range to validate
- * @returns {} - an error object if errors are found, or `false` otherwise
- */
-const validateStartDateBeforeEndDate = (dateRange) => {
-  const message = 'Start date must be before end date';
-
-  if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
-    return { beginCoverage: message };
-  }
-
-  return false;
-};
-
-/**
- * Validator to ensure begin date is present and entered dates are valid
- * @param {} dateRange - coverage date range to validate
- * @returns {} - an error object if errors are found, or `false` otherwise
- */
-const validateDateFormat = (dateRange, locale) => {
-  moment.locale(locale);
-  let dateFormat = moment.localeData()._longDateFormat.L;
-  const message = `Enter date in ${dateFormat} format.`;
-
-  if (!dateRange.beginCoverage || !moment(dateRange.beginCoverage).isValid()) {
-    return { beginCoverage: message };
-  }
-
-  return false;
-};
-
-/**
- * Validator to ensure all coverage ranges are within the parent package's
- * custom coverage range if one is present
- * @param {} dateRange - coverage date range to validate
- * @param {} packageCoverage - parent package's custom coverage range
- * @param {} intl - object containing locale-specific data & formatting
- * @returns {} - an error object if errors are found, or `false` otherwise
- */
-const validateWithinPackageRange = (dateRange, packageCoverage, intl) => {
-  // javascript/moment has no mechanism for "infinite", so we
-  // use an absurd future date to represent the concept of "present"
-  let present = moment('9999-09-09T05:00:00.000Z');
-
-  if (packageCoverage && packageCoverage.beginCoverage) {
-    let {
-      beginCoverage: packageBeginCoverage,
-      endCoverage: packageEndCoverage
-    } = packageCoverage;
-
-    let beginCoverageDate = moment(dateRange.beginCoverage);
-    let endCoverageDate = dateRange.endCoverage ? moment(dateRange.endCoverage) : present;
-
-    let packageBeginCoverageDate = moment(packageBeginCoverage);
-    let packageEndCoverageDate = packageEndCoverage ? moment(packageEndCoverage) : moment();
-    let packageRange = moment.range(packageBeginCoverageDate, packageEndCoverageDate);
-
-    const message = `Dates must be within package's date range (${
-      formatISODateWithoutTime(packageBeginCoverageDate.format('YYYY-MM-DD'), intl)
-    } - ${
-      packageEndCoverage
-        ? formatISODateWithoutTime(packageEndCoverageDate.format('YYYY-MM-DD'), intl)
-        : 'Present'
-    }).`;
-
-    let beginDateOutOfRange = !packageRange.contains(beginCoverageDate);
-    let endDateOutOfRange = !packageRange.contains(endCoverageDate);
-    if (beginDateOutOfRange || endDateOutOfRange) {
-      return {
-        beginCoverage: beginDateOutOfRange ? message : false,
-        endCoverage: endDateOutOfRange ? message : false
-      };
-    }
-  }
-
-  return false;
-};
-
-
-/**
- * Validator to check that no date ranges overlap or are identical
- * @param {} dateRange - coverage date range to validate
- * @param {} customCoverages - all custom coverage ranges present in edit form
- * @param {} index - index in the field array indicating which coverage range is
- * presently being considered
- * @param {} intl - object containing locale-specific data & formatting
- * @returns {} - an error object if errors are found, or `false` otherwise
- */
-const validateNoRangeOverlaps = (dateRange, customCoverages, index, intl) => {
-  let present = moment('9999-09-09T05:00:00.000Z');
-
-  let beginCoverageDate = moment(dateRange.beginCoverage);
-  let endCoverageDate = dateRange.endCoverage ? moment(dateRange.endCoverage) : present;
-  let coverageRange = moment.range(beginCoverageDate, endCoverageDate);
-
-  for (let overlapIndex = 0, len = customCoverages.length; overlapIndex < len; overlapIndex++) {
-    let overlapRange = customCoverages[overlapIndex];
-
-    // don't compare range to itself or to empty rows
-    if (index === overlapIndex || !overlapRange.beginCoverage) {
-      continue; // eslint-disable-line no-continue
-    }
-
-    let overlapCoverageBeginDate = moment(overlapRange.beginCoverage);
-    let overlapCoverageEndDate = overlapRange.endCoverage ? moment(overlapRange.endCoverage) : present;
-    let overlapCoverageRange = moment.range(overlapCoverageBeginDate, overlapCoverageEndDate);
-
-    const message = `Date range overlaps with ${
-      overlapRange.beginCoverage &&
-        formatISODateWithoutTime(overlapCoverageBeginDate.format('YYYY-MM-DD'), intl)
-    } - ${
-      overlapRange.endCoverage
-        ? formatISODateWithoutTime(overlapCoverageEndDate.format('YYYY-MM-DD'), intl)
-        : 'Present'
-    }`;
-
-    if (overlapCoverageRange.overlaps(coverageRange)
-        || overlapCoverageRange.isEqual(coverageRange)
-        || overlapCoverageRange.contains(coverageRange)) {
-      // set endCoverage: true to make box red without message
-      return { beginCoverage: message, endCoverage: true };
-    }
-  }
-
-  return false;
-};
-
 const validate = (values, props) => {
-  let errors = [];
-
-  let { intl, packageCoverage, locale } = props;
-
-  values.customCoverages.forEach((dateRange, index) => {
-    let dateRangeErrors = {};
-
-    dateRangeErrors =
-      validateDateFormat(dateRange, locale) ||
-      validateStartDateBeforeEndDate(dateRange) ||
-      validateNoRangeOverlaps(dateRange, values.customCoverages, index, intl) ||
-      validateWithinPackageRange(dateRange, packageCoverage, intl);
-
-    errors[index] = dateRangeErrors;
-  });
-
-  return { customCoverages: errors };
+  return validateCoverage(values, props);
 };
 
 export default reduxForm({

--- a/src/components/customer-resource-edit/customer-resource-edit.js
+++ b/src/components/customer-resource-edit/customer-resource-edit.js
@@ -8,6 +8,7 @@ import Icon from '@folio/stripes-components/lib/Icon';
 
 import DetailsView from '../details-view';
 import CoverageStatementFields, { validate as validateCoverageStatement } from '../coverage-statement-fields';
+import CustomerResourceCoverageFields, { validate as validateCoverageDates } from '../customer-resource-coverage-fields';
 import DetailsViewSection from '../details-view-section';
 import NavigationModal from '../navigation-modal';
 import styles from './customer-resource-edit.css';
@@ -67,13 +68,18 @@ class CustomerResourceEdit extends Component {
         bodyContent={(
           <form onSubmit={handleSubmit(onSubmit)}>
             <DetailsViewSection
+              label="Coverage dates"
+            >
+              <CustomerResourceCoverageFields />
+            </DetailsViewSection>
+            <DetailsViewSection
               label="Coverage statement"
             >
               <CoverageStatementFields />
             </DetailsViewSection>
             <div className={styles['customer-resource-edit-action-buttons']}>
               <div
-                data-test-eholdings-customer-resource-save-button
+                data-test-eholdings-customer-resource-cancel-button
               >
                 <Button
                   disabled={model.update.isPending}
@@ -85,7 +91,7 @@ class CustomerResourceEdit extends Component {
                 </Button>
               </div>
               <div
-                data-test-eholdings-customer-resource-cancel-button
+                data-test-eholdings-customer-resource-save-button
               >
                 <Button
                   disabled={pristine || model.update.isPending}
@@ -108,8 +114,8 @@ class CustomerResourceEdit extends Component {
   }
 }
 
-const validate = (values) => {
-  return validateCoverageStatement(values);
+const validate = (values, props) => {
+  return Object.assign({}, validateCoverageDates(values, props), validateCoverageStatement(values));
 };
 
 export default reduxForm({

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -217,6 +217,26 @@ export default class CustomerResourceShow extends Component {
                 )}
 
               </DetailsViewSection>
+
+              <DetailsViewSection
+                label="Coverage statement"
+              >
+                {resourceSelected && (
+                  <CoverageStatementForm
+                    initialValues={{ coverageStatement: model.coverageStatement }}
+                    isEditable={isCoverageStatementEditable}
+                    onEdit={this.handleCoverageStatementEdit}
+                    onSubmit={coverageStatementSubmitted}
+                    isPending={model.update.isPending && 'coverageStatement' in model.update.changedAttributes}
+                  />
+                )}
+
+                {!hasManagedEmbargoPeriod && !resourceSelected && (
+                  <p>Add the resource to holdings to set a coverage statement.</p>
+                )}
+
+              </DetailsViewSection>
+
               <DetailsViewSection
                 label="Embargo period"
                 closedByDefault={!hasManagedEmbargoPeriod && !resourceSelected}
@@ -241,25 +261,6 @@ export default class CustomerResourceShow extends Component {
 
                 {!hasManagedEmbargoPeriod && !resourceSelected && (
                   <p>Add the resource to holdings to set an custom embargo period.</p>
-                )}
-
-              </DetailsViewSection>
-
-              <DetailsViewSection
-                label="Coverage statement"
-              >
-                {resourceSelected && (
-                  <CoverageStatementForm
-                    initialValues={{ coverageStatement: model.coverageStatement }}
-                    isEditable={isCoverageStatementEditable}
-                    onEdit={this.handleCoverageStatementEdit}
-                    onSubmit={coverageStatementSubmitted}
-                    isPending={model.update.isPending && 'coverageStatement' in model.update.changedAttributes}
-                  />
-                )}
-
-                {!hasManagedEmbargoPeriod && !resourceSelected && (
-                  <p>Add the resource to holdings to set a coverage statement.</p>
                 )}
 
               </DetailsViewSection>

--- a/src/routes/customer-resource-edit.js
+++ b/src/routes/customer-resource-edit.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import moment from 'moment';
 
 import { createResolver } from '../redux';
 import CustomerResource from '../redux/customer-resource';
@@ -35,6 +36,15 @@ class CustomerResourceEditRoute extends Component {
 
   resourceEditSubmitted = (values) => {
     let { model, updateResource } = this.props;
+    model.customCoverages = values.customCoverages.map((dateRange) => {
+      let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).format('YYYY-MM-DD');
+      let endCoverage = !dateRange.endCoverage ? null : moment(dateRange.endCoverage).format('YYYY-MM-DD');
+
+      return {
+        beginCoverage,
+        endCoverage
+      };
+    });
     model.coverageStatement = values.coverageStatement;
     updateResource(model);
   }
@@ -45,6 +55,7 @@ class CustomerResourceEditRoute extends Component {
         model={this.props.model}
         onSubmit={this.resourceEditSubmitted}
         initialValues={{
+          customCoverages: this.props.model.customCoverages,
           coverageStatement: this.props.model.coverageStatement
         }}
       />

--- a/tests/customer-resource-edit-test.js
+++ b/tests/customer-resource-edit-test.js
@@ -38,7 +38,7 @@ describeApplication('CustomerResourceEdit', () => {
     });
   });
 
-  describe('visiting the customer resource edit page without a coverage statement', () => {
+  describe('visiting the customer resource edit page without coverage dates or statement', () => {
     beforeEach(function () {
       return this.visit(`/eholdings/customer-resources/${resource.titleId}/edit`, () => {
         expect(ResourceEditPage.$root).to.exist;
@@ -65,13 +65,19 @@ describeApplication('CustomerResourceEdit', () => {
 
     describe('entering invalid data', () => {
       beforeEach(() => {
-        return ResourceEditPage
-          .inputCoverageStatement(`Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-            Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
-            dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,
-            pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
-            fringilla vel, aliquet nec, vulputate e`)
-          .clickSave();
+        return ResourceEditPage.interaction
+          .clickAddRowButton()
+          .once(() => ResourceEditPage.dateRangeRowList().length > 0)
+          .do(() => {
+            return ResourceEditPage
+              .inputCoverageStatement(`Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+                Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+                dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,
+                pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
+                fringilla vel, aliquet nec, vulputate e`)
+              .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
+              .clickSave();
+          });
       });
 
       it('highlights the textarea with an error state', () => {
@@ -81,11 +87,22 @@ describeApplication('CustomerResourceEdit', () => {
       it('displays a validation error message', () => {
         expect(ResourceEditPage.validationErrorOnCoverageStatement).to.equal('Statement must be 350 characters or less.');
       });
+
+      it('displays a validation error for coverage', () => {
+        expect(ResourceEditPage.dateRangeRowList(0).beginDate.isInvalid).to.be.true;
+      });
     });
 
     describe('entering valid data', () => {
       beforeEach(() => {
-        return ResourceEditPage.inputCoverageStatement('Only 90s kids would understand.');
+        return ResourceEditPage.interaction
+          .clickAddRowButton()
+          .once(() => ResourceEditPage.dateRangeRowList().length > 0)
+          .do(() => {
+            return ResourceEditPage
+              .inputCoverageStatement('Only 90s kids would understand.')
+              .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018'));
+          });
       });
 
       describe('clicking cancel', () => {
@@ -93,7 +110,7 @@ describeApplication('CustomerResourceEdit', () => {
           return ResourceEditPage.clickCancel();
         });
 
-        it.skip('shows a navigation confirmation modal', () => {
+        it('shows a navigation confirmation modal', () => {
           expect(ResourceEditPage.navigationModal.$root).to.exist;
         });
       });
@@ -114,9 +131,17 @@ describeApplication('CustomerResourceEdit', () => {
     });
   });
 
-  describe('visiting the customer resource edit page with an existing coverage statement', () => {
+  describe('visiting the customer resource edit page with coverage dates and statement', () => {
     beforeEach(function () {
       resource.coverageStatement = 'Use this one weird trick to get access.';
+      let customCoverages = [
+        this.server.create('custom-coverage', {
+          beginCoverage: '1969-07-16',
+          endCoverage: '1972-12-19'
+        })
+      ];
+      resource.update('customCoverages', customCoverages.map(item => item.toJSON()));
+      resource.save();
 
       return this.visit(`/eholdings/customer-resources/${resource.titleId}/edit`, () => {
         expect(ResourceEditPage.$root).to.exist;
@@ -149,6 +174,7 @@ describeApplication('CustomerResourceEdit', () => {
             dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,
             pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
             fringilla vel, aliquet nec, vulputate e`)
+          .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
           .clickSave();
       });
 
@@ -159,11 +185,17 @@ describeApplication('CustomerResourceEdit', () => {
       it('displays a validation error message', () => {
         expect(ResourceEditPage.validationErrorOnCoverageStatement).to.equal('Statement must be 350 characters or less.');
       });
+
+      it('displays a validation error for coverage', () => {
+        expect(ResourceEditPage.dateRangeRowList(0).beginDate.isInvalid).to.be.true;
+      });
     });
 
     describe('entering valid data', () => {
       beforeEach(() => {
-        return ResourceEditPage.inputCoverageStatement('Refinance your home loans.');
+        return ResourceEditPage
+          .inputCoverageStatement('Refinance your home loans.')
+          .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018'));
       });
 
       describe('clicking cancel', () => {
@@ -171,7 +203,7 @@ describeApplication('CustomerResourceEdit', () => {
           return ResourceEditPage.clickCancel();
         });
 
-        it.skip('shows a navigation confirmation modal', () => {
+        it('shows a navigation confirmation modal', () => {
           expect(ResourceEditPage.navigationModal.$root).to.exist;
         });
       });

--- a/tests/pages/customer-resource-custom-coverage.js
+++ b/tests/pages/customer-resource-custom-coverage.js
@@ -21,14 +21,14 @@ import Datepicker from './datepicker';
   hasSaveButton = isPresent('[data-test-eholdings-coverage-form-save-button] button');
   hasAddButton = isPresent('[data-test-eholdings-coverage-form-add-button] button');
   hasEditButton = isPresent('[data-test-eholdings-coverage-form-edit-button]');
-  clickAddRowButton = clickable('[data-test-eholdings-coverage-form-add-row-button] button');
+  clickAddRowButton = clickable('[data-test-eholdings-coverage-fields-add-row-button] button');
   displayText = text('[data-test-eholdings-coverage-form-display]');
-  hasNoRowsLeftMessage = isPresent('[data-test-eholdings-coverage-form-no-rows-left]');
+  hasNoRowsLeftMessage = isPresent('[data-test-eholdings-coverage-fields-no-rows-left]');
 
-  dateRangeRowList = collection('[data-test-eholdings-coverage-form-date-range-row]', {
-    beginDate: new Datepicker('[data-test-eholdings-coverage-form-date-range-begin]'),
-    endDate: new Datepicker('[data-test-eholdings-coverage-form-date-range-end]'),
-    clickRemoveRowButton: clickable('[data-test-eholdings-coverage-form-remove-row-button] button'),
+  dateRangeRowList = collection('[data-test-eholdings-coverage-fields-date-range-row]', {
+    beginDate: new Datepicker('[data-test-eholdings-coverage-fields-date-range-begin]'),
+    endDate: new Datepicker('[data-test-eholdings-coverage-fields-date-range-end]'),
+    clickRemoveRowButton: clickable('[data-test-eholdings-coverage-fields-remove-row-button] button'),
     fillDates(beginDate, endDate) {
       return this.beginDate.fillAndBlur(beginDate)
         .append(this.endDate.fillAndBlur(endDate));

--- a/tests/pages/customer-resource-edit.js
+++ b/tests/pages/customer-resource-edit.js
@@ -1,6 +1,8 @@
 import {
+  action,
   blurrable,
   clickable,
+  collection,
   fillable,
   isPresent,
   page,
@@ -9,6 +11,7 @@ import {
   value
 } from '@bigtest/interaction';
 import { hasClassBeginningWith } from './helpers';
+import Datepicker from './datepicker';
 
 @page class CustomerResourceEditNavigationModal {}
 
@@ -16,9 +19,21 @@ import { hasClassBeginningWith } from './helpers';
   navigationModal = new CustomerResourceEditNavigationModal('#navigation-modal');
 
   clickCancel = clickable('[data-test-eholdings-customer-resource-cancel-button] button');
-  clickSave = clickable('[data-test-eholdings-customer-resource-cancel-button] button');
-  isSaveDisabled = property('disabled', '[data-test-eholdings-customer-resource-cancel-button] button');
+  clickSave = clickable('[data-test-eholdings-customer-resource-save-button] button');
+  isSaveDisabled = property('disabled', '[data-test-eholdings-customer-resource-save-button] button');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
+
+  clickAddRowButton = clickable('[data-test-eholdings-coverage-fields-add-row-button] button');
+
+  dateRangeRowList = collection('[data-test-eholdings-coverage-fields-date-range-row]', {
+    beginDate: new Datepicker('[data-test-eholdings-coverage-fields-date-range-begin]'),
+    endDate: new Datepicker('[data-test-eholdings-coverage-fields-date-range-end]'),
+    clickRemoveRowButton: clickable('[data-test-eholdings-coverage-fields-remove-row-button] button'),
+    fillDates(beginDate, endDate) {
+      return this.beginDate.fillAndBlur(beginDate)
+        .append(this.endDate.fillAndBlur(endDate));
+    }
+  });
 
   coverageStatement = value('[data-test-eholdings-coverage-statement-textarea] textarea');
   fillCoverageStatement = fillable('[data-test-eholdings-coverage-statement-textarea] textarea');
@@ -26,11 +41,11 @@ import { hasClassBeginningWith } from './helpers';
   coverageStatementHasError = hasClassBeginningWith('feedbackError--', '[data-test-eholdings-coverage-statement-textarea] textarea');
   validationErrorOnCoverageStatement = text('[data-test-eholdings-coverage-statement-textarea] [class^="feedbackError--"]');
 
-  inputCoverageStatement(statement) {
+  inputCoverageStatement = action(function (statement) {
     return this
       .fillCoverageStatement(statement)
       .blurCoverageStatement();
-  }
+  })
 }
 
 export default new CustomerResourceEditPage('[data-test-eholdings-details-view="resource"]');


### PR DESCRIPTION
## Purpose
Package-title custom coverage dates should be editable both inline and in the full-page edit view.

Resolves https://issues.folio.org/browse/UIEH-222.

## Approach
Abstract out the fields and validations in the `CustomerResourceCoverageFields` component.

## Next Steps
- Copy custom embargo editing the same way (https://issues.folio.org/browse/UIEH-221)
- Create an `InlineForm` component to handle a lot of the shared interactions and styles.

## Screenshots
![2018-03-22 23 00 32](https://user-images.githubusercontent.com/230597/37810937-f72dc59c-2e24-11e8-8d7b-fad04bdb5eff.gif)

