### PR TITLE
UIEH-196 Use BigTest page object for package visibility test

### DIFF
--- a/tests/package-visibility-test.js
+++ b/tests/package-visibility-test.js
@@ -1,8 +1,8 @@
-import { beforeEach, afterEach, describe, it } from '@bigtest/mocha';
+import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
 import { describeApplication } from './helpers';
-import PackageShowPage from './pages/package-show';
+import PackageShowPage from './pages/bigtest/package-show';
 
 describeApplication('PackageVisibility', () => {
   let provider,
@@ -28,8 +28,8 @@ describeApplication('PackageVisibility', () => {
       });
     });
 
-    it('displays an OFF Toggle (Hidden from patrons)', () => {
-      expect(PackageShowPage.isHidden).to.be.true;
+    it('displays an OFF toggle (Hidden from patrons)', () => {
+      expect(PackageShowPage.isVisibleToPatrons).to.be.false;
     });
 
     it('displays the hidden/reason section', () => {
@@ -51,12 +51,12 @@ describeApplication('PackageVisibility', () => {
       });
     });
 
-    it('displays an OFF Toggle (Hidden from patrons)', () => {
-      expect(PackageShowPage.isHidden).to.be.true;
+    it('displays an OFF toggle (Hidden from patrons)', () => {
+      expect(PackageShowPage.isVisibleToPatrons).to.be.false;
     });
 
-    it.always('does not displays the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessage).to.equal('');
+    it('does not display the hidden/reason section', () => {
+      expect(PackageShowPage.isHiddenMessagePresent).to.be.false;
     });
   });
 
@@ -74,12 +74,12 @@ describeApplication('PackageVisibility', () => {
       });
     });
 
-    it('displays an ON Toggle (Visible to patrons)', () => {
-      expect(PackageShowPage.isHidden).to.be.false;
+    it('displays an ON toggle (Visible to patrons)', () => {
+      expect(PackageShowPage.isVisibleToPatrons).to.be.true;
     });
 
     it.always('does not display the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessage).to.equal('');
+      expect(PackageShowPage.isHiddenMessagePresent).to.be.false;
     });
   });
 
@@ -97,16 +97,12 @@ describeApplication('PackageVisibility', () => {
       });
     });
 
-    it('displays an ON Toggle (Visible to patrons)', () => {
-      expect(PackageShowPage.isHidden).to.be.false;
-    });
-
-    it('displays a disabled Toggle', () => {
-      expect(PackageShowPage.isHiddenToggleable).to.be.false;
+    it('does not display a toggle', () => {
+      expect(PackageShowPage.isHiddenTogglePresent).to.be.false;
     });
 
     it.always('does not display the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessage).to.equal('');
+      expect(PackageShowPage.isHiddenMessagePresent).to.be.false;
     });
   });
 
@@ -124,38 +120,34 @@ describeApplication('PackageVisibility', () => {
       });
     });
 
-    it('displays an ON Toggle (Visible to patrons)', () => {
-      expect(PackageShowPage.isHidden).to.be.false;
+    it('displays an ON toggle (Visible to patrons)', () => {
+      expect(PackageShowPage.isVisibleToPatrons).to.be.true;
     });
 
     describe('successfully hiding a package', () => {
-      beforeEach(function () {
-        this.server.timing = 50;
+      beforeEach(() => {
         return PackageShowPage.toggleIsHidden();
       });
 
-      afterEach(function () {
-        this.server.timing = 0;
-      });
       it('reflects the desired state OFF (Hidden from patrons)', () => {
-        expect(PackageShowPage.isHidden).to.equal(true);
+        expect(PackageShowPage.isVisibleToPatrons).to.be.false;
       });
 
       it.skip('cannot be interacted with while the request is in flight', () => {
-        expect(PackageShowPage.isHiddenToggleable).to.equal(false);
+        expect(PackageShowPage.isHiddenToggleDisabled).to.be.true;
       });
 
       describe('when the request succeeds', () => {
         it('reflects the desired state OFF (Hidden from patrons)', () => {
-          expect(PackageShowPage.isHidden).to.equal(true);
+          expect(PackageShowPage.isVisibleToPatrons).to.be.false;
         });
 
         it('indicates it is no longer pending', () => {
-          expect(PackageShowPage.isHiding).to.equal(false);
+          expect(PackageShowPage.isHiding).to.be.false;
         });
 
         it('shows the package titles are all hidden', () => {
-          expect(PackageShowPage.allTitlesHidden).to.equal(true);
+          expect(PackageShowPage.allTitlesHidden).to.be.true;
         });
       });
     });
@@ -176,36 +168,33 @@ describeApplication('PackageVisibility', () => {
     });
 
     it('reflects the desired initial state OFF (Hidden from patrons)', () => {
-      expect(PackageShowPage.isHidden).to.be.true;
+      expect(PackageShowPage.isVisibleToPatrons).to.be.false;
     });
+
     describe('successfully showing a package', () => {
-      beforeEach(function () {
-        this.server.timing = 50;
+      beforeEach(() => {
         return PackageShowPage.toggleIsHidden();
       });
 
-      afterEach(function () {
-        this.server.timing = 0;
-      });
       it('displays an ON Toggle (Visible to patrons)', () => {
-        expect(PackageShowPage.isHidden).to.equal(false);
+        expect(PackageShowPage.isVisibleToPatrons).to.be.true;
       });
 
       it.skip('cannot be interacted with while the request is in flight', () => {
-        expect(PackageShowPage.isHiddenToggleable).to.equal(false);
+        expect(PackageShowPage.isHiddenToggleDisabled).to.be.true;
       });
 
       describe('when the request succeeds', () => {
         it('reflects the desired state as ON Toggle (Visible to patrons)', () => {
-          expect(PackageShowPage.isHidden).to.equal(false);
+          expect(PackageShowPage.isVisibleToPatrons).to.be.true;
         });
 
         it('indicates it is no longer pending', () => {
-          expect(PackageShowPage.isHiding).to.equal(false);
+          expect(PackageShowPage.isHiding).to.be.false;
         });
 
         it('should show the package titles are all not hidden', () => {
-          expect(PackageShowPage.allTitlesHidden).to.equal(false);
+          expect(PackageShowPage.allTitlesHidden).to.be.false;
         });
       });
     });

--- a/tests/pages/bigtest/package-show.js
+++ b/tests/pages/bigtest/package-show.js
@@ -1,12 +1,14 @@
 import {
   clickable,
   collection,
+  computed,
   isPresent,
   page,
   property,
   text
 } from '@bigtest/interaction';
 import Datepicker from './datepicker';
+import { hasClassBeginningWith } from '../helpers';
 
 @page class PackageShowModal {
   confirmDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-yes]');
@@ -30,9 +32,25 @@ import Datepicker from './datepicker';
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button] button');
 
+  isVisibleToPatrons = property('checked', '[data-test-eholdings-package-details-hidden] input');
+  isHiddenMessage = text('[data-test-eholdings-package-details-is-hidden]');
+  isHiddenMessagePresent = isPresent('[data-test-eholdings-package-details-is-hidden]');
+  isHiddenToggleDisabled = property('disabled', '[data-test-eholdings-package-details-hidden] input[type=checkbox]');
+  isHiddenTogglePresent = isPresent('[data-test-eholdings-package-details-hidden] input');
+  isHiding = hasClassBeginningWith('is-pending--', '[data-test-eholdings-package-details-hidden] [data-test-toggle-switch]');
+  allTitlesHidden = computed(function () {
+    return !!this.titleList().length && this.titleList().every(title => title.isHidden);
+  });
+
+  toggleIsHidden = clickable('[data-test-eholdings-package-details-hidden] input');
+
   titleList = collection('[data-test-query-list="package-titles"] li a', {
     name: text('[data-test-eholdings-title-list-item-title-name]'),
-    selectedLabel: text('[data-test-eholdings-title-list-item-title-selected]')
+    selectedLabel: text('[data-test-eholdings-title-list-item-title-selected]'),
+    isHiddenLabel: text('[data-test-eholdings-title-list-item-title-hidden]'),
+    isHidden: computed(function () {
+      return this.isHiddenLabel === 'Hidden';
+    })
   });
 
   hasCustomCoverage = isPresent('[data-test-eholdings-package-details-custom-coverage-display]')

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -9,12 +9,7 @@ function createTitleObject(element) {
   return {
     get isSelected() {
       return $scope.find('[data-test-eholdings-title-list-item-title-selected]').text() === 'Selected';
-    },
-
-    get isHidden() {
-      return $scope.find('[data-test-eholdings-title-list-item-title-hidden]').text() === 'Hidden';
     }
-
   };
 }
 
@@ -79,31 +74,8 @@ export default {
     return $('[data-test-query-list="package-titles"] li a').toArray().map(createTitleObject);
   },
 
-  toggleIsHidden() {
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-package-details-hidden]')).to.exist;
-    }).then(() => (
-      $('[data-test-eholdings-package-details-hidden] input').click()
-    ));
-  },
-
-  get isHiding() {
-    return $('[data-test-eholdings-package-details-hidden] [data-test-toggle-switch]').attr('class').indexOf('is-pending--') !== -1;
-  },
-
-  get isHiddenToggleable() {
-    return $('[data-test-eholdings-package-details-hidden] input[type=checkbox]').prop('disabled') === false;
-  },
-
   get isHidden() {
     return $('[data-test-eholdings-package-details-hidden] input').prop('checked') === false;
-  },
-
-  get allTitlesHidden() {
-    return !!this.titleList.length && this.titleList.every(title => title.isHidden);
-  },
-  get isHiddenMessage() {
-    return $('[data-test-eholdings-package-details-is-hidden]').text();
   },
 
   get customCoverage() {


### PR DESCRIPTION
~~Skipped one assertion using `allTitlesHidden` from the page object. We can revisit that the next time this test gets touched.~~ No skips added.

Someday to-do: figure out how to instrument the mirage server to test loading states.