### PR TITLE
UIEH-196 Use BigTest page object for package selection test

### DIFF
--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -48,8 +48,11 @@ export default function TitleListItem({
       )}
 
       {showSelected && (
-        <span data-test-eholdings-title-list-item-title-selected>
-          {item.isSelected ? 'Selected' : 'Not selected'}
+        <span>
+          <span data-test-eholdings-title-list-item-title-selected>
+            {item.isSelected ? 'Selected' : 'Not selected'}
+          </span>
+
           {item.visibilityData.isHidden && (
             <span>
               &nbsp;&bull;&nbsp;

--- a/tests/package-selection-test.js
+++ b/tests/package-selection-test.js
@@ -1,9 +1,8 @@
 import { beforeEach, afterEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
 
 import { describeApplication } from './helpers';
-import PackageShowPage from './pages/package-show';
+import PackageShowPage from './pages/bigtest/package-show';
 
 describeApplication('PackageSelection', () => {
   let provider,
@@ -58,7 +57,7 @@ describeApplication('PackageSelection', () => {
       });
 
       it('cannot be interacted with while the request is in flight', () => {
-        expect(PackageShowPage.isSelectedToggleable).to.equal(false);
+        expect(PackageShowPage.isSelectedToggleDisabled).to.equal(true);
       });
 
       describe('when the request succeeds', () => {
@@ -81,10 +80,9 @@ describeApplication('PackageSelection', () => {
 
       describe('and deselecting the package', () => {
         beforeEach(() => {
-          return convergeOn(() => {
-            // wait for the package to become toggleable again
-            expect(PackageShowPage.isSelectedToggleable).to.equal(true);
-          }).then(() => PackageShowPage.toggleIsSelected());
+          return PackageShowPage.interaction
+            .once(() => !PackageShowPage.isSelectedToggleDisabled)
+            .toggleIsSelected();
         });
 
         it('reflects the desired state (not selected)', () => {
@@ -97,7 +95,7 @@ describeApplication('PackageSelection', () => {
 
         describe('canceling the deselection', () => {
           beforeEach(() => {
-            PackageShowPage.cancelDeselection();
+            return PackageShowPage.modal.cancelDeselection();
           });
 
           it('reverts back to the selected state', () => {
@@ -108,7 +106,7 @@ describeApplication('PackageSelection', () => {
         describe('confirming the deselection', () => {
           beforeEach(function () {
             this.server.timing = 50;
-            PackageShowPage.confirmDeselection();
+            return PackageShowPage.modal.confirmDeselection();
           });
 
           afterEach(function () {
@@ -124,7 +122,7 @@ describeApplication('PackageSelection', () => {
           });
 
           it('cannot be interacted with while the request is in flight', () => {
-            expect(PackageShowPage.isSelectedToggleable).to.equal(false);
+            expect(PackageShowPage.isSelectedToggleDisabled).to.equal(true);
           });
 
           describe('when the request succeeds', () => {
@@ -145,11 +143,11 @@ describeApplication('PackageSelection', () => {
             });
 
             it('removes custom coverage', () => {
-              expect(PackageShowPage.customCoverage).to.equal('');
+              expect(PackageShowPage.hasCustomCoverage).to.equal(false);
             });
 
-            it('is not hidden', () => {
-              expect(PackageShowPage.isHidden).to.equal(false);
+            it('is not hideable', () => {
+              expect(PackageShowPage.isHiddenTogglePresent).to.equal(false);
             });
           });
         });
@@ -181,7 +179,7 @@ describeApplication('PackageSelection', () => {
       });
 
       it('cannot be interacted with while the request is in flight', () => {
-        expect(PackageShowPage.isSelectedToggleable).to.equal(false);
+        expect(PackageShowPage.isSelectedToggleDisabled).to.equal(true);
       });
 
       describe('when the request fails', () => {

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -65,7 +65,7 @@ describeApplication('PackageShow', () => {
     });
 
     it('displays whether the first title is selected', () => {
-      expect(PackageShowPage.titleList(0).selectedLabel).to.equal((customerResources[0].isSelected ? 'Selected' : 'Not selected'));
+      expect(PackageShowPage.titleList(0).isSelectedLabel).to.equal((customerResources[0].isSelected ? 'Selected' : 'Not selected'));
     });
 
     it.always('should not display a back button', () => {

--- a/tests/pages/bigtest/package-show.js
+++ b/tests/pages/bigtest/package-show.js
@@ -20,6 +20,8 @@ import { hasClassBeginningWith } from '../helpers';
   hasAllowKbToAddTitles = isPresent('[data-test-eholdings-package-details-toggle-allow-add-new-titles] input');
   hasAllowKbToAddTitlesToggle = isPresent('[package-details-toggle-allow-add-new-titles-switch]');
   isSelected = property('checked', '[data-test-eholdings-package-details-selected] input');
+  isSelecting = hasClassBeginningWith('is-pending--', '[data-test-eholdings-package-details-selected] [data-test-toggle-switch]');
+  isSelectedToggleDisabled = property('disabled', '[data-test-eholdings-package-details-selected] input[type=checkbox]');
   modal = new PackageShowModal('#eholdings-package-confirmation-modal');
   toggleAllowKbToAddTitles = clickable('[data-test-eholdings-package-details-allow-add-new-titles] input');
   toggleIsSelected = clickable('[data-test-eholdings-package-details-selected] input');
@@ -32,21 +34,28 @@ import { hasClassBeginningWith } from '../helpers';
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button] button');
 
+  toggleIsHidden = clickable('[data-test-eholdings-package-details-hidden] input');
   isVisibleToPatrons = property('checked', '[data-test-eholdings-package-details-hidden] input');
   isHiddenMessage = text('[data-test-eholdings-package-details-is-hidden]');
   isHiddenMessagePresent = isPresent('[data-test-eholdings-package-details-is-hidden]');
   isHiddenToggleDisabled = property('disabled', '[data-test-eholdings-package-details-hidden] input[type=checkbox]');
   isHiddenTogglePresent = isPresent('[data-test-eholdings-package-details-hidden] input');
   isHiding = hasClassBeginningWith('is-pending--', '[data-test-eholdings-package-details-hidden] [data-test-toggle-switch]');
+
   allTitlesHidden = computed(function () {
     return !!this.titleList().length && this.titleList().every(title => title.isHidden);
   });
 
-  toggleIsHidden = clickable('[data-test-eholdings-package-details-hidden] input');
+  allTitlesSelected = computed(function () {
+    return !!this.titleList().length && this.titleList().every(title => title.isSelected);
+  });
 
   titleList = collection('[data-test-query-list="package-titles"] li a', {
     name: text('[data-test-eholdings-title-list-item-title-name]'),
-    selectedLabel: text('[data-test-eholdings-title-list-item-title-selected]'),
+    isSelectedLabel: text('[data-test-eholdings-title-list-item-title-selected]'),
+    isSelected: computed(function () {
+      return this.isSelectedLabel === 'Selected';
+    }),
     isHiddenLabel: text('[data-test-eholdings-title-list-item-title-hidden]'),
     isHidden: computed(function () {
       return this.isHiddenLabel === 'Hidden';

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -1,7 +1,4 @@
 import $ from 'jquery';
-import { expect } from 'chai';
-
-import { convergeOn } from '@bigtest/convergence';
 
 function createTitleObject(element) {
   let $scope = $(element);
@@ -22,46 +19,6 @@ export default {
     return $('[data-test-eholdings-detail-pane-contents]');
   },
 
-  get numTitlesSelected() {
-    return $('[data-test-eholdings-package-details-titles-selected]').text();
-  },
-
-  get isSelected() {
-    return $('[data-test-eholdings-package-details-selected] input').prop('checked');
-  },
-
-  toggleIsSelected() {
-    /*
-     * We don't want to click the element before it exists.  This should
-     * probably become a generic 'click' helper once we have more usage.
-     */
-    return convergeOn(() => {
-      expect($('[data-test-eholdings-package-details-selected]')).to.exist;
-    }).then(() => (
-      $('[data-test-eholdings-package-details-selected] input').click()
-    ));
-  },
-
-  get isSelecting() {
-    return $('[data-test-eholdings-package-details-selected] [data-test-toggle-switch]').attr('class').indexOf('is-pending--') !== -1;
-  },
-
-  get isSelectedToggleable() {
-    return $('[data-test-eholdings-package-details-selected] input[type=checkbox]').prop('disabled') === false;
-  },
-
-  get allTitlesSelected() {
-    return !!this.titleList.length && this.titleList.every(title => title.isSelected);
-  },
-
-  confirmDeselection() {
-    return $('[data-test-eholdings-package-deselection-confirmation-modal-yes]').trigger('click');
-  },
-
-  cancelDeselection() {
-    return $('[data-test-eholdings-package-deselection-confirmation-modal-no]').trigger('click');
-  },
-
   get $titleContainer() {
     return $('[data-test-eholdings-details-view-list="package"]');
   },
@@ -72,14 +29,6 @@ export default {
 
   get titleList() {
     return $('[data-test-query-list="package-titles"] li a').toArray().map(createTitleObject);
-  },
-
-  get isHidden() {
-    return $('[data-test-eholdings-package-details-hidden] input').prop('checked') === false;
-  },
-
-  get customCoverage() {
-    return $('[data-test-eholdings-package-details-custom-coverage-display]').text();
   },
 
   scrollToTitleOffset(readOffset) {


### PR DESCRIPTION
Only three tests left using legacy page objects:
- [x] customer-resource-managed-coverage-test
- [x] customer-resource-visibility-test
- [ ] details-view-test