### PR TITLE
UIEH-196 Replace a few instances of convergeOn()

### DIFF
--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -1,6 +1,5 @@
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { convergeOn } from '@bigtest/convergence';
 
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/bigtest/package-show';
@@ -82,13 +81,13 @@ describeApplication('PackageShow', () => {
         });
 
         // converge on the previous package loading first
-        return convergeOn(() => {
-          expect(PackageShowPage.titleList.length).to.be.gt(0);
-        }).then(() => (
-          this.visit(`/eholdings/packages/${otherPackage.id}`, () => {
-            expect(PackageShowPage.$root).to.exist;
-          })
-        ));
+        return PackageShowPage.interaction
+          .once(() => PackageShowPage.titleList().length > 0)
+          .do(() => {
+            return this.visit(`/eholdings/packages/${otherPackage.id}`, () => {
+              expect(PackageShowPage.$root).to.exist;
+            });
+          });
       });
 
       it('displays the different package', () => {
@@ -117,11 +116,9 @@ describeApplication('PackageShow', () => {
 
     describe.skip('scrolling down the list of titles', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(PackageShowPage.titleList.length).to.be.gt(0);
-        }).then(() => {
-          PackageShowPage.scrollToTitleOffset(26);
-        });
+        return PackageShowPage.interaction
+          .once(() => PackageShowPage.titleList().length > 0)
+          .scrollToTitleOffset(26);
       });
 
       it('should display the next page of related titles', () => {

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { describe, beforeEach, it, convergeOn } from '@bigtest/mocha';
+import { describe, beforeEach, it } from '@bigtest/mocha';
 
 import { describeApplication } from './helpers';
 import TitleShowPage from './pages/bigtest/title-show';
@@ -231,11 +231,9 @@ describeApplication('TitleShow', () => {
 
     describe.skip('scrolling down the list of packages', () => {
       beforeEach(() => {
-        return convergeOn(() => {
-          expect(TitleShowPage.packageList().length).to.be.gt(0);
-        }).then(() => {
-          TitleShowPage.scrollToPackageOffset(26);
-        });
+        return TitleShowPage.interaction
+          .once(() => TitleShowPage.packageList().length > 0)
+          .scrollToPackageOffset(26);
       });
 
       it('should display the next page of related packages', () => {


### PR DESCRIPTION
Using a `.once().do()` is preferable to `convergeOn()`.