### PR TITLE
UIEH-212 Create settings subnavigation (alternate implementation)

### DIFF
--- a/src/components/error-screen/invalid-backend.js
+++ b/src/components/error-screen/invalid-backend.js
@@ -10,7 +10,7 @@ export default function InvalidBackendErrorScreen() {
         <h1>Knowledge base not configured</h1>
       </KeyValue>
       <p>The eHoldings application detected the presence of a knowledge base, but the knowledge base does not appear to be configured.</p>
-      <p>Please configure the knowledge base with your credentials in <Link to="/settings/eholdings">Settings/eHoldings</Link>.</p>
+      <p>Please configure the knowledge base with your credentials in <Link to="/settings/eholdings/knowledge-base">Settings/eHoldings</Link>.</p>
     </div>
   );
 }

--- a/src/components/settings-detail-pane/index.js
+++ b/src/components/settings-detail-pane/index.js
@@ -1,0 +1,1 @@
+export { default } from './settings-detail-pane';

--- a/src/components/settings-detail-pane/settings-detail-pane.css
+++ b/src/components/settings-detail-pane/settings-detail-pane.css
@@ -1,0 +1,7 @@
+@import '@folio/stripes-components/lib/variables';
+
+.settings-detail-pane-back-button {
+  @media (--mediumUp) {
+    display: none;
+  }
+}

--- a/src/components/settings-detail-pane/settings-detail-pane.js
+++ b/src/components/settings-detail-pane/settings-detail-pane.js
@@ -22,12 +22,11 @@ export default class SettingsDetailPane extends Component {
         defaultWidth="fill"
         paneTitle={paneTitle}
         firstMenu={(
-          <div className={styles['settings-detail-pane-back-button']}>
-            <IconButton
-              icon="left-arrow"
-              href="/settings/eholdings"
-            />
-          </div>
+          <IconButton
+            icon="left-arrow"
+            href="/settings/eholdings"
+            className={styles['settings-detail-pane-back-button']}
+          />
         )}
       >
         {children}

--- a/src/components/settings-detail-pane/settings-detail-pane.js
+++ b/src/components/settings-detail-pane/settings-detail-pane.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Link from 'react-router-dom/Link';
 import Pane from '@folio/stripes-components/lib/Pane';
 import IconButton from '@folio/stripes-components/lib/IconButton';
 
@@ -23,9 +22,12 @@ export default class SettingsDetailPane extends Component {
         defaultWidth="fill"
         paneTitle={paneTitle}
         firstMenu={(
-          <Link to="/settings/eholdings" className={styles['settings-detail-pane-back-button']}>
-            <IconButton icon="left-arrow" />
-          </Link>
+          <div className={styles['settings-detail-pane-back-button']}>
+            <IconButton
+              icon="left-arrow"
+              href="/settings/eholdings"
+            />
+          </div>
         )}
       >
         {children}

--- a/src/components/settings-detail-pane/settings-detail-pane.js
+++ b/src/components/settings-detail-pane/settings-detail-pane.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Link from 'react-router-dom/Link';
+import Pane from '@folio/stripes-components/lib/Pane';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+
+import styles from './settings-detail-pane.css';
+
+export default class SettingsDetailPane extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    paneTitle: PropTypes.string
+  };
+
+  render() {
+    let {
+      children,
+      paneTitle
+    } = this.props;
+
+    return (
+      <Pane
+        defaultWidth="fill"
+        paneTitle={paneTitle}
+        firstMenu={(
+          <Link to="/settings/eholdings" className={styles['settings-detail-pane-back-button']}>
+            <IconButton icon="left-arrow" />
+          </Link>
+        )}
+      >
+        {children}
+      </Pane>
+    );
+  }
+}

--- a/src/components/settings-knowledge-base/index.js
+++ b/src/components/settings-knowledge-base/index.js
@@ -1,0 +1,1 @@
+export { default } from './settings-knowledge-base';

--- a/src/components/settings-knowledge-base/settings-knowledge-base.css
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.css
@@ -1,19 +1,6 @@
 @import '@folio/stripes-components/lib/variables';
 
-.eholdings-settings {
-  padding: 0 2em;
-  width: 100%;
-
-  & h2 {
-    margin: 0.83em 0;
-  }
-
-  & form {
-    max-width: 40em;
-  }
-}
-
-.eholdings-settings-form-actions {
+.settings-kb-form-actions {
   @media (--mediumUp) {
     display: flex;
     flex-direction: row-reverse;
@@ -47,7 +34,7 @@
   }
 }
 
-.eholdings-settings-field {
+.settings-kb-field {
   margin-bottom: var(--controlMarginBottom);
 
   & label {
@@ -79,14 +66,14 @@
   }
 }
 
-.eholdings-settings-save-error {
+.settings-kb-save-error {
   display: flex;
   align-items: center;
   flex-grow: 1;
   color: var(--error);
 }
 
-.eholdings-settings-back-button {
+.settings-kb-back-button {
   @media (--mediumUp) {
     display: none;
   }

--- a/src/components/settings-knowledge-base/settings-knowledge-base.js
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.js
@@ -1,17 +1,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import {
-  IconButton,
-  Pane
-} from '@folio/stripes-components';
+import { Icon } from '@folio/stripes-components';
+import SettingsDetailPane from '../settings-detail-pane';
 
-
-import styles from './settings.css';
+import styles from './settings-knowledge-base.css';
 
 const cx = classNames.bind(styles);
 
-export default class Settings extends Component {
+export default class SettingsKnowledgeBase extends Component {
   static propTypes = {
     settings: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired
@@ -31,8 +28,9 @@ export default class Settings extends Component {
 
     let isDirty = customerId !== next.customerId || apiKey !== next.apiKey;
     let hasUpdated = old.update.isPending && next.update.isResolved;
+    let hasFinishedLoading = old.isLoading && next.isLoaded;
 
-    if (hasUpdated && isDirty) {
+    if (hasFinishedLoading || (hasUpdated && isDirty)) {
       this.setState({
         customerId: next.customerId,
         apiKey: next.apiKey
@@ -99,26 +97,23 @@ export default class Settings extends Component {
     let isValid = customerId && apiKey;
 
     return (
-      <Pane
-        defaultWidth="fill"
-        paneTitle="eHoldings"
-        firstMenu={(
-          <div className={styles['eholdings-settings-back-button']}>
-            <IconButton
-              icon="left-arrow"
-              href="/settings"
-            />
-          </div>
-        )}
+      <SettingsDetailPane
+        paneTitle="Knowledge base"
       >
-        <div
-          className={styles['eholdings-settings']}
-          data-test-eholdings-settings
+        <h4
+          className={styles['setttings-kb-headline']}
         >
-          <h2 data-test-eholdings-settings-description>
-            EBSCO Knowledge Base
-          </h2>
-          <form onSubmit={this.handleSubmit}>
+          EBSCO RM API credentials
+        </h4>
+
+        {settings.isLoading ? (
+          <Icon icon="spinner-ellipsis" />
+        ) : (
+          <form
+            onSubmit={this.handleSubmit}
+            data-test-eholdings-settings
+            className={styles['settings-kb-form']}
+          >
             {settings.request.isRejected && (
               <p data-test-eholdings-settings-error>
                 {settings.request.errors[0].title}
@@ -127,13 +122,13 @@ export default class Settings extends Component {
 
             <div
               data-test-eholdings-settings-customerid
-              className={cx(styles['eholdings-settings-field'], {
+              className={cx(styles['settings-kb-field'], {
                 'has-error': invalidCustomerId
               })}
             >
-              <label htmlFor="eholdings-settings-customerid">Customer ID</label>
+              <label htmlFor="eholdings-settings-kb-customerid">Customer ID</label>
               <input
-                id="eholdings-settings-customerid"
+                id="eholdings-settings-kb-customerid"
                 type="text"
                 autoComplete="off"
                 value={customerId}
@@ -144,13 +139,13 @@ export default class Settings extends Component {
 
             <div
               data-test-eholdings-settings-apikey
-              className={cx(styles['eholdings-settings-field'], {
+              className={cx(styles['settings-kb-field'], {
                 'has-error': invalidApiKey
               })}
             >
-              <label htmlFor="eholdings-settings-apikey">API key</label>
+              <label htmlFor="eholdings-settings-kb-apikey">API key</label>
               <input
-                id="eholdings-settings-apikey"
+                id="eholdings-settings-kb-apikey"
                 type="password"
                 autoComplete="off"
                 value={apiKey}
@@ -160,20 +155,20 @@ export default class Settings extends Component {
             </div>
 
             {(isFresh || isDirty) && (
-              <div className={styles['eholdings-settings-form-actions']} data-test-eholdings-settings-actions>
+              <div className={styles['settings-kb-form-actions']} data-test-eholdings-settings-actions>
                 <button type="submit" disabled={!isValid || settings.isSaving}>Save</button>
                 <button type="reset" onClick={this.handleClear}>Cancel</button>
 
                 {settings.update.isRejected && (
-                  <div className={styles['eholdings-settings-save-error']} data-test-eholdings-settings-error>
+                  <div className={styles['settings-kb-save-error']} data-test-eholdings-settings-error>
                     {settings.update.errors[0].title}
                   </div>
                 )}
               </div>
             )}
           </form>
-        </div>
-      </Pane>
+        )}
+      </SettingsDetailPane>
     );
   }
 }

--- a/src/components/settings-root-proxy.js
+++ b/src/components/settings-root-proxy.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+import SettingsDetailPane from './settings-detail-pane';
+
+export default class SettingsRootProxy extends Component {
+  render() {
+    return (
+      <SettingsDetailPane
+        paneTitle="Root proxy"
+      >
+        <p>EBSCO KB API customers: please access EBSCOAdmin to setup and maintain proxies.</p>
+
+        <p>Warning: changing the root proxy setting with override the proxy for all link and resources currently set to inherit the root proxy selection.</p>
+      </SettingsDetailPane>
+    );
+  }
+}

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -1,1 +1,0 @@
-export { default } from './settings';

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Route, Switch, Redirect } from './router';
+import Settings from '@folio/stripes-components/lib/Settings';
 
+import { Route, Switch, Redirect } from './router';
 import { reducer, epics } from './redux';
 
 import ApplicationRoute from './routes/application';
@@ -13,7 +14,8 @@ import TitleShow from './routes/title-show';
 import CustomerResourceShow from './routes/customer-resource-show';
 import CustomerResourceEdit from './routes/customer-resource-edit';
 
-import SettingsRoute from './routes/settings';
+import SettingsKnowledgeBaseRoute from './routes/settings-knowledge-base';
+import SettingsRootProxyRoute from './routes/settings-root-proxy';
 
 export default class EHoldings extends Component {
   static propTypes = {
@@ -29,7 +31,8 @@ export default class EHoldings extends Component {
 
   static contextTypes = {
     addReducer: PropTypes.func.isRequired,
-    addEpic: PropTypes.func.isRequired
+    addEpic: PropTypes.func.isRequired,
+    router: PropTypes.object
   };
 
   static childContextTypes = {
@@ -54,9 +57,26 @@ export default class EHoldings extends Component {
       showSettings,
       match: { path: rootPath }
     } = this.props;
+    let { router } = this.context;
 
     return showSettings ? (
-      <Route path={rootPath} component={SettingsRoute} />
+      <Settings
+        {...this.props}
+        pages={[
+          {
+            route: 'knowledge-base',
+            label: 'Knowledge base',
+            component: SettingsKnowledgeBaseRoute
+          },
+          {
+            route: 'root-proxy',
+            label: 'Root proxy',
+            component: SettingsRootProxyRoute
+          }
+        ]}
+        paneTitle="eHoldings"
+        activeLink={router.route.location.pathname}
+      />
     ) : (
       <Route path={rootPath} component={ApplicationRoute}>
         <Route path={`${rootPath}/:type?/:id?`} component={SearchRoute}>

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,8 @@ export default class EHoldings extends Component {
       match: { path: rootPath }
     } = this.props;
 
+    // The settings routes below are passed on to the SettingsRoute, which parses
+    // them into an array and sends them on to the stripes-components <Settings>
     return showSettings ? (
       <Route path={rootPath} component={SettingsRoute}>
         <Route path="knowledge-base" exact component={SettingsKnowledgeBaseRoute} name="Knowledge base" />

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Settings from '@folio/stripes-components/lib/Settings';
 
 import { Route, Switch, Redirect } from './router';
 import { reducer, epics } from './redux';
 
 import ApplicationRoute from './routes/application';
+import SettingsRoute from './routes/settings';
 import SearchRoute from './routes/search';
 import ProviderShow from './routes/provider-show';
 import PackageShow from './routes/package-show';
@@ -57,26 +57,12 @@ export default class EHoldings extends Component {
       showSettings,
       match: { path: rootPath }
     } = this.props;
-    let { router } = this.context;
 
     return showSettings ? (
-      <Settings
-        {...this.props}
-        pages={[
-          {
-            route: 'knowledge-base',
-            label: 'Knowledge base',
-            component: SettingsKnowledgeBaseRoute
-          },
-          {
-            route: 'root-proxy',
-            label: 'Root proxy',
-            component: SettingsRootProxyRoute
-          }
-        ]}
-        paneTitle="eHoldings"
-        activeLink={router.route.location.pathname}
-      />
+      <Route path={rootPath} component={SettingsRoute}>
+        <Route path="knowledge-base" exact component={SettingsKnowledgeBaseRoute} name="Knowledge base" />
+        <Route path="root-proxy" exact component={SettingsRootProxyRoute} name="Root proxy" />
+      </Route>
     ) : (
       <Route path={rootPath} component={ApplicationRoute}>
         <Route path={`${rootPath}/:type?/:id?`} component={SearchRoute}>

--- a/src/routes/settings-knowledge-base.js
+++ b/src/routes/settings-knowledge-base.js
@@ -1,15 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Icon } from '@folio/stripes-components';
 
 import { createResolver } from '../redux';
 import { Configuration } from '../redux/application';
-import View from '../components/settings';
-import ApplicationRoute from './application';
 
-// eslint-disable-next-line no-shadow
-class SettingsRoute extends Component {
+import View from '../components/settings-knowledge-base';
+
+class SettingsKnowledgeBaseRoute extends Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
     getBackendConfig: PropTypes.func.isRequired,
@@ -33,16 +31,10 @@ class SettingsRoute extends Component {
     let { config } = this.props;
 
     return (
-      <ApplicationRoute showSettings>
-        {config.isLoading ? (
-          <Icon icon="spinner-ellipsis" />
-        ) : (
-          <View
-            settings={config}
-            onSubmit={this.updateConfig}
-          />
-        )}
-      </ApplicationRoute>
+      <View
+        settings={config}
+        onSubmit={this.updateConfig}
+      />
     );
   }
 }
@@ -54,4 +46,4 @@ export default connect(
     getBackendConfig: () => Configuration.find('configuration'),
     updateBackendConfig: model => Configuration.save(model)
   }
-)(SettingsRoute);
+)(SettingsKnowledgeBaseRoute);

--- a/src/routes/settings-root-proxy.js
+++ b/src/routes/settings-root-proxy.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react';
+import View from '../components/settings-root-proxy';
+
+class SettingsRootProxyRoute extends Component {
+  render() {
+    return (
+      <View />
+    );
+  }
+}
+
+export default SettingsRootProxyRoute;

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import View from '@folio/stripes-components/lib/Settings';
+import ApplicationRoute from './application';
+
+export default class SettingsRoute extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired
+  };
+
+  static contextTypes = {
+    router: PropTypes.object
+  };
+
+  render() {
+    let { children } = this.props;
+    let { router } = this.context;
+
+    let pages = React.Children.map(children, child => ({
+      route: child.props.path,
+      label: child.props.name,
+      component: child.props.component
+    }));
+
+    return (
+      <ApplicationRoute showSettings>
+        <View
+          paneTitle="eHoldings"
+          activeLink={router.route.location.pathname}
+          match={router.route.match}
+          location={router.route.location}
+          pages={pages}
+        />
+      </ApplicationRoute>
+    );
+  }
+}

--- a/tests/backend-configuration-test.js
+++ b/tests/backend-configuration-test.js
@@ -54,7 +54,7 @@ describeApplication('With unconfigured backend', {
 
     describe('when visiting settings', () => {
       beforeEach(function () {
-        return this.visit('/settings/eholdings', () => expect(SettingsPage.$root).to.exist);
+        return this.visit('/settings/eholdings/knowledge-base', () => expect(SettingsPage.$root).to.exist);
       });
 
       it('shows the form action buttons', () => {
@@ -101,11 +101,7 @@ describeApplication('With unconfigured backend', {
 describeApplication('With valid backend configuration', () => {
   describe('when visiting settings', () => {
     beforeEach(function () {
-      return this.visit('/settings/eholdings', () => expect(SettingsPage.$root).to.exist);
-    });
-
-    it('has a description of itself', () => {
-      expect(SettingsPage.description).to.equal('EBSCO Knowledge Base');
+      return this.visit('/settings/eholdings/knowledge-base', () => expect(SettingsPage.$root).to.exist);
     });
 
     it('has a field for the ebsco customer id', () => {

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -23,7 +23,6 @@ import { hasClassBeginningWith } from './helpers';
   customerIdFieldIsInvalid = hasClassBeginningWith('has-error--', '[data-test-eholdings-settings-customerid]');
   apiKeyFieldIsInvalid = hasClassBeginningWith('has-error--', '[data-test-eholdings-settings-apikey]');
   errorText = text('[data-test-eholdings-settings-error]');
-  description = text('[data-test-eholdings-settings-description]');
   save = clickable('[data-test-eholdings-settings-actions] [type="submit"]');
   saveButtonDisabled = property('disabled', '[data-test-eholdings-settings-actions] [type="submit"]');
   cancel = clickable('[data-test-eholdings-settings-actions] [type="reset"]');


### PR DESCRIPTION
## Purpose
Until now, ui-eholdings has only had one screen of settings. With root proxy settings about to be built and custom labels coming very soon, we needed a way to have more than one screen of settings.

Groundwork for https://issues.folio.org/browse/UIEH-212

## Approach
To compare to https://github.com/folio-org/ui-eholdings/pull/318, this uses the `stripes-components` `Settings` with modifications: https://github.com/folio-org/stripes-components/pull/301

#### TODO
- [x] Remove commit pointing to `stripes-components` fork.

## Screenshots
![2018-03-27 15 16 05](https://user-images.githubusercontent.com/230597/37992853-7ba6eb7c-31d2-11e8-8643-b3f0aef5762b.gif)