### PR TITLE
UIEH-223 Copy coverage date editing to full page package edit route

### DIFF
--- a/src/components/coverage-statement-form/coverage-statement-form.js
+++ b/src/components/coverage-statement-form/coverage-statement-form.js
@@ -101,7 +101,6 @@ class CoverageStatementForm extends Component {
               <Button
                 disabled={isPending}
                 type="button"
-                role="button"
                 onClick={this.handleCancel}
                 marginBottom0 // gag
               >
@@ -115,7 +114,6 @@ class CoverageStatementForm extends Component {
               <Button
                 disabled={pristine || isPending}
                 type="submit"
-                role="button"
                 buttonStyle="primary"
                 marginBottom0 // gag
               >

--- a/src/components/custom-embargo-form/custom-embargo-form.js
+++ b/src/components/custom-embargo-form/custom-embargo-form.js
@@ -95,7 +95,6 @@ class CustomEmbargoForm extends Component {
                 <Button
                   disabled={isPending}
                   type="button"
-                  role="button"
                   onClick={this.handleCancelCustomEmbargo}
                   marginBottom0 // gag
                 >
@@ -109,7 +108,6 @@ class CustomEmbargoForm extends Component {
                 <Button
                   disabled={pristine || isPending}
                   type="submit"
-                  role="button"
                   buttonStyle="primary"
                   marginBottom0 // gag
                 >

--- a/src/components/customer-resource-coverage-fields/customer-resource-coverage-fields.js
+++ b/src/components/customer-resource-coverage-fields/customer-resource-coverage-fields.js
@@ -80,7 +80,6 @@ export default class CustomerResourceCoverageFields extends Component {
         >
           <Button
             type="button"
-            role="button"
             onClick={() => fields.push({})}
           >
             + Add date range

--- a/src/components/customer-resource-coverage/customer-resource-coverage.js
+++ b/src/components/customer-resource-coverage/customer-resource-coverage.js
@@ -86,7 +86,6 @@ class CustomerResourceCoverage extends Component {
             <Button
               disabled={isPending}
               type="button"
-              role="button"
               onClick={this.handleCancel}
               marginBottom0 // gag
             >
@@ -100,7 +99,6 @@ class CustomerResourceCoverage extends Component {
             <Button
               disabled={pristine || isPending}
               type="submit"
-              role="button"
               buttonStyle="primary"
               marginBottom0 // gag
             >

--- a/src/components/customer-resource-edit/customer-resource-edit.js
+++ b/src/components/customer-resource-edit/customer-resource-edit.js
@@ -92,7 +92,6 @@ class CustomerResourceEdit extends Component {
                 <Button
                   disabled={model.update.isPending}
                   type="button"
-                  role="button"
                   onClick={this.handleCancel}
                 >
                   Cancel
@@ -104,7 +103,6 @@ class CustomerResourceEdit extends Component {
                 <Button
                   disabled={pristine || model.update.isPending}
                   type="submit"
-                  role="button"
                   buttonStyle="primary"
                 >
                   {model.update.isPending ? 'Saving' : 'Save'}

--- a/src/components/customer-resource-edit/customer-resource-edit.js
+++ b/src/components/customer-resource-edit/customer-resource-edit.js
@@ -39,12 +39,18 @@ class CustomerResourceEdit extends Component {
     let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
 
     if (wasPending && needsUpdate) {
-      this.context.router.history.push(`/eholdings/customer-resources/${this.props.model.id}`);
+      this.context.router.history.push(
+        `/eholdings/customer-resources/${this.props.model.id}`,
+        { eholdings: true }
+      );
     }
   }
 
   handleCancel = () => {
-    this.context.router.history.push(`/eholdings/customer-resources/${this.props.model.id}`);
+    this.context.router.history.push(
+      `/eholdings/customer-resources/${this.props.model.id}`,
+      { eholdings: true }
+    );
   }
 
   render() {
@@ -56,20 +62,12 @@ class CustomerResourceEdit extends Component {
       change
     } = this.props;
 
-    let actionMenuItems = [
-      {
-        label: 'Cancel Editing',
-        to: `/eholdings/customer-resources/${model.id}`
-      }
-    ];
-
     return (
       <DetailsView
         type="resource"
         model={model}
         paneTitle={model.name}
         paneSub={model.packageName}
-        actionMenuItems={actionMenuItems}
         bodyContent={(
           <form onSubmit={handleSubmit(onSubmit)}>
             <DetailsViewSection

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 
 import {
   Button,
-  KeyValue
+  IconButton,
+  KeyValue,
+  PaneMenu
 } from '@folio/stripes-components';
 
 import DetailsView from './details-view';
@@ -127,13 +129,6 @@ export default class CustomerResourceShow extends Component {
       }];
     }
 
-    let actionMenuItems = [
-      {
-        label: 'Edit',
-        to: `/eholdings/customer-resources/${model.id}/edit`
-      }
-    ];
-
     return (
       <div>
         <Toaster toasts={errors} position="bottom" />
@@ -143,7 +138,13 @@ export default class CustomerResourceShow extends Component {
           model={model}
           paneTitle={model.name}
           paneSub={model.packageName}
-          actionMenuItems={actionMenuItems}
+          lastMenu={(
+            <PaneMenu>
+              <Link to={`/eholdings/customer-resources/${model.id}/edit`}>
+                <IconButton icon="edit" />
+              </Link>
+            </PaneMenu>
+          )}
           bodyContent={(
             <div>
               <DetailsViewSection label="Holding status">

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -140,9 +140,10 @@ export default class CustomerResourceShow extends Component {
           paneSub={model.packageName}
           lastMenu={(
             <PaneMenu>
-              <Link to={`/eholdings/customer-resources/${model.id}/edit`}>
-                <IconButton icon="edit" />
-              </Link>
+              <IconButton
+                icon="edit"
+                href={`/eholdings/customer-resources/${model.id}/edit`}
+              />
             </PaneMenu>
           )}
           bodyContent={(

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import capitalize from 'lodash/capitalize';
-import { Link } from 'react-router-dom';
 
 import {
   Icon,
@@ -178,9 +177,10 @@ export default class DetailsView extends Component {
           firstMenu={queryParams.searchType ? (
             <PaneMenu>
               <div data-test-eholdings-details-view-close-button>
-                <Link to={{ pathname: '/eholdings', search: router.route.location.search }}>
-                  <IconButton icon="closeX" />
-                </Link>
+                <IconButton
+                  icon="closeX"
+                  href={`/eholdings${router.route.location.search}`}
+                />
               </div>
             </PaneMenu>
           ) : historyState && historyState.eholdings && (

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -40,7 +40,8 @@ export default class DetailsView extends Component {
     bodyContent: PropTypes.node.isRequired,
     listType: PropTypes.string,
     renderList: PropTypes.func,
-    actionMenuItems: PropTypes.array
+    actionMenuItems: PropTypes.array,
+    lastMenu: PropTypes.node
   };
 
   static contextTypes = {
@@ -152,7 +153,8 @@ export default class DetailsView extends Component {
       renderList,
       paneTitle,
       paneSub,
-      actionMenuItems
+      actionMenuItems,
+      lastMenu
     } = this.props;
 
     let {
@@ -195,6 +197,7 @@ export default class DetailsView extends Component {
             <span data-test-eholdings-details-view-pane-sub>{paneSub}</span>
           )}
           actionMenuItems={actionMenuItems}
+          lastMenu={lastMenu}
         />
 
         <div

--- a/src/components/package-coverage-fields/index.js
+++ b/src/components/package-coverage-fields/index.js
@@ -1,0 +1,1 @@
+export { default, validate } from './package-coverage-fields';

--- a/src/components/package-coverage-fields/package-coverage-fields.css
+++ b/src/components/package-coverage-fields/package-coverage-fields.css
@@ -1,0 +1,31 @@
+@import '@folio/stripes-components/lib/variables';
+
+.coverage-fields {
+  max-width: 50em;
+}
+
+.coverage-fields-date-range-rows {
+  list-style-type: none;
+  padding: 0;
+}
+
+.coverage-fields-date-range-row {
+  display: flex;
+  align-items: flex-start;
+}
+
+.coverage-fields-datepicker {
+  align-self: flex-start;
+  flex: 1 1 200px;
+  margin-right: 1em;
+}
+
+.coverage-fields-date-range-clear-row {
+  flex: 0 0 3em;
+  margin-top: 2.25em;
+  text-align: center;
+
+  @media (--mediumUp) {
+    margin-top: 1.5em;
+  }
+}

--- a/src/components/package-coverage-fields/package-coverage-fields.js
+++ b/src/components/package-coverage-fields/package-coverage-fields.js
@@ -1,0 +1,116 @@
+import React, { Component } from 'react';
+import { Field, FieldArray } from 'redux-form';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+import Datepicker from '@folio/stripes-components/lib/Datepicker';
+import Button from '@folio/stripes-components/lib/Button';
+import IconButton from '@folio/stripes-components/lib/IconButton';
+
+import styles from './package-coverage-fields.css';
+
+export default class PackageCoverageFields extends Component {
+  static propTypes = {
+    packageCoverage: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
+    locale: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
+    intl: PropTypes.object // eslint-disable-line react/no-unused-prop-types
+  };
+
+  renderCoverageFields = ({ fields }) => {
+    return (
+      <div className={styles['coverage-fields']}>
+        {fields.length === 0 ? (
+          <div>
+            <p data-test-eholdings-coverage-fields-no-rows-left>
+              No date range set. Saving will remove custom coverage.
+            </p>
+            <div
+              className={styles['coverage-fields-add-row-button']}
+              data-test-eholdings-coverage-fields-add-row-button
+            >
+              <Button
+                type="button"
+                role="button"
+                onClick={() => fields.push({})}
+              >
+                + Add date range
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <ul className={styles['coverage-fields-date-range-rows']}>
+            {fields.map((dateRange, index) => (
+              <li
+                data-test-eholdings-coverage-fields-date-range-row
+                key={index}
+                className={styles['coverage-fields-date-range-row']}
+              >
+                <div
+                  data-test-eholdings-coverage-fields-date-range-begin
+                  className={styles['coverage-fields-datepicker']}
+                >
+                  <Field
+                    name={`${dateRange}.beginCoverage`}
+                    type="text"
+                    component={Datepicker}
+                    label="Start date"
+                  />
+                </div>
+                <div
+                  data-test-eholdings-coverage-fields-date-range-end
+                  className={styles['coverage-fields-datepicker']}
+                >
+                  <Field
+                    name={`${dateRange}.endCoverage`}
+                    type="text"
+                    component={Datepicker}
+                    label="End date"
+                  />
+                </div>
+
+                <div
+                  data-test-eholdings-coverage-fields-remove-row-button
+                  className={styles['coverage-fields-date-range-clear-row']}
+                >
+                  <IconButton
+                    icon="hollowX"
+                    onClick={() => fields.remove(index)}
+                    size="small"
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  };
+
+  render() {
+    return (
+      <FieldArray name="customCoverages" component={this.renderCoverageFields} />
+    );
+  }
+}
+
+export function validate(values, props) {
+  moment.locale(props.locale);
+  let dateFormat = moment.localeData()._longDateFormat.L;
+  const errors = {};
+
+  values.customCoverages.forEach((dateRange, index) => {
+    let dateRangeErrors = {};
+
+    if (!dateRange.beginCoverage || !moment(dateRange.beginCoverage).isValid()) {
+      dateRangeErrors.beginCoverage = `Enter date in ${dateFormat} format.`;
+    }
+
+    if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
+      dateRangeErrors.beginCoverage = 'Start date must be before end date.';
+    }
+
+    errors[index] = dateRangeErrors;
+  });
+
+  return { customCoverages: errors };
+}

--- a/src/components/package-coverage-fields/package-coverage-fields.js
+++ b/src/components/package-coverage-fields/package-coverage-fields.js
@@ -30,7 +30,6 @@ export default class PackageCoverageFields extends Component {
             >
               <Button
                 type="button"
-                role="button"
                 onClick={() => fields.push({})}
               >
                 + Add date range

--- a/src/components/package-custom-coverage/package-custom-coverage.js
+++ b/src/components/package-custom-coverage/package-custom-coverage.js
@@ -83,7 +83,6 @@ class PackageCustomCoverage extends Component {
             <Button
               disabled={isPending}
               type="button"
-              role="button"
               onClick={this.handleCancelCustomCoverage}
               marginBottom0 // gag
             >
@@ -98,7 +97,6 @@ class PackageCustomCoverage extends Component {
               disabled={pristine || isPending}
               type="submit"
               buttonStyle="primary"
-              role="button"
               marginBottom0 // gag
             >
               {isPending ? 'Saving' : 'Save' }

--- a/src/components/package-edit/index.js
+++ b/src/components/package-edit/index.js
@@ -1,0 +1,1 @@
+export { default } from './package-edit';

--- a/src/components/package-edit/package-edit.css
+++ b/src/components/package-edit/package-edit.css
@@ -1,0 +1,12 @@
+@import '@folio/stripes-components/lib/variables';
+
+.package-edit-action-buttons {
+  align-items: flex-start;
+  border-top: 1px solid var(--minor-divider-color);
+  display: flex;
+  padding-top: 1em;
+
+  & button {
+    margin-right: 0.25em;
+  }
+}

--- a/src/components/package-edit/package-edit.js
+++ b/src/components/package-edit/package-edit.js
@@ -75,7 +75,6 @@ class PackageEdit extends Component {
                 <Button
                   disabled={model.update.isPending}
                   type="button"
-                  role="button"
                   onClick={this.handleCancel}
                 >
                   Cancel
@@ -87,7 +86,6 @@ class PackageEdit extends Component {
                 <Button
                   disabled={pristine || model.update.isPending}
                   type="submit"
-                  role="button"
                   buttonStyle="primary"
                 >
                   {model.update.isPending ? 'Saving' : 'Save'}

--- a/src/components/package-edit/package-edit.js
+++ b/src/components/package-edit/package-edit.js
@@ -34,12 +34,18 @@ class PackageEdit extends Component {
     let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
 
     if (wasPending && needsUpdate) {
-      this.context.router.history.push(`/eholdings/packages/${this.props.model.id}`);
+      this.context.router.history.push(
+        `/eholdings/packages/${this.props.model.id}${this.context.router.route.location.search}`,
+        { eholdings: true }
+      );
     }
   }
 
   handleCancel = () => {
-    this.context.router.history.push(`/eholdings/packages/${this.props.model.id}`);
+    this.context.router.history.push(
+      `/eholdings/packages/${this.props.model.id}${this.context.router.route.location.search}`,
+      { eholdings: true }
+    );
   }
 
   render() {
@@ -50,19 +56,11 @@ class PackageEdit extends Component {
       pristine
     } = this.props;
 
-    let actionMenuItems = [
-      {
-        label: 'Cancel Editing',
-        to: `/eholdings/packages/${model.id}`
-      }
-    ];
-
     return (
       <DetailsView
         type="package"
         model={model}
         paneTitle={model.name}
-        actionMenuItems={actionMenuItems}
         bodyContent={(
           <form onSubmit={handleSubmit(onSubmit)}>
             <DetailsViewSection

--- a/src/components/package-edit/package-edit.js
+++ b/src/components/package-edit/package-edit.js
@@ -1,0 +1,119 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+import isEqual from 'lodash/isEqual';
+
+import Button from '@folio/stripes-components/lib/Button';
+import Icon from '@folio/stripes-components/lib/Icon';
+
+import DetailsView from '../details-view';
+import PackageCoverageFields, { validate as validateCoverageDates } from '../package-coverage-fields';
+import DetailsViewSection from '../details-view-section';
+import NavigationModal from '../navigation-modal';
+import styles from './package-edit.css';
+
+class PackageEdit extends Component {
+  static propTypes = {
+    model: PropTypes.object.isRequired,
+    initialValues: PropTypes.object.isRequired,
+    handleSubmit: PropTypes.func,
+    onSubmit: PropTypes.func.isRequired,
+    pristine: PropTypes.bool
+  };
+
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
+  componentWillReceiveProps(nextProps) {
+    let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
+    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+
+    if (wasPending && needsUpdate) {
+      this.context.router.history.push(`/eholdings/packages/${this.props.model.id}`);
+    }
+  }
+
+  handleCancel = () => {
+    this.context.router.history.push(`/eholdings/packages/${this.props.model.id}`);
+  }
+
+  render() {
+    let {
+      model,
+      handleSubmit,
+      onSubmit,
+      pristine
+    } = this.props;
+
+    let actionMenuItems = [
+      {
+        label: 'Cancel Editing',
+        to: `/eholdings/packages/${model.id}`
+      }
+    ];
+
+    return (
+      <DetailsView
+        type="package"
+        model={model}
+        paneTitle={model.name}
+        actionMenuItems={actionMenuItems}
+        bodyContent={(
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <DetailsViewSection
+              label="Coverage dates"
+            >
+              <PackageCoverageFields />
+            </DetailsViewSection>
+            <div className={styles['package-edit-action-buttons']}>
+              <div
+                data-test-eholdings-package-cancel-button
+              >
+                <Button
+                  disabled={model.update.isPending}
+                  type="button"
+                  role="button"
+                  onClick={this.handleCancel}
+                >
+                  Cancel
+                </Button>
+              </div>
+              <div
+                data-test-eholdings-package-save-button
+              >
+                <Button
+                  disabled={pristine || model.update.isPending}
+                  type="submit"
+                  role="button"
+                  buttonStyle="primary"
+                >
+                  {model.update.isPending ? 'Saving' : 'Save'}
+                </Button>
+              </div>
+              {model.update.isPending && (
+                <Icon icon="spinner-ellipsis" />
+              )}
+            </div>
+            <NavigationModal when={!pristine && !model.update.isPending} />
+          </form>
+        )}
+      />
+    );
+  }
+}
+
+const validate = (values, props) => {
+  return validateCoverageDates(values, props);
+};
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'PackageEdit',
+  destroyOnUnmount: false,
+})(PackageEdit);

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -4,7 +4,9 @@ import PropTypes from 'prop-types';
 import {
   Button,
   Icon,
-  KeyValue
+  IconButton,
+  KeyValue,
+  PaneMenu
 } from '@folio/stripes-components';
 
 import DetailsView from './details-view';
@@ -88,13 +90,6 @@ export default class PackageShow extends Component {
       endCoverage: model.customCoverage.endCoverage
     }];
 
-    let actionMenuItems = [
-      {
-        label: 'Edit',
-        to: { pathname: `/eholdings/packages/${model.id}/edit`, search: router.route.location.search }
-      }
-    ];
-
     return (
       <div>
         <Toaster toasts={errors} position="bottom" />
@@ -102,7 +97,13 @@ export default class PackageShow extends Component {
           type="package"
           model={model}
           paneTitle={model.name}
-          actionMenuItems={actionMenuItems}
+          lastMenu={(
+            <PaneMenu>
+              <Link to={{ pathname: `/eholdings/packages/${model.id}/edit`, search: router.route.location.search }}>
+                <IconButton icon="edit" />
+              </Link>
+            </PaneMenu>
+          )}
           bodyContent={(
             <div>
               <DetailsViewSection label="Holding status">

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -99,9 +99,10 @@ export default class PackageShow extends Component {
           paneTitle={model.name}
           lastMenu={(
             <PaneMenu>
-              <Link to={{ pathname: `/eholdings/packages/${model.id}/edit`, search: router.route.location.search }}>
-                <IconButton icon="edit" />
-              </Link>
+              <IconButton
+                icon="edit"
+                href={`/eholdings/packages/${model.id}/edit${router.route.location.search}`}
+              />
             </PaneMenu>
           )}
           bodyContent={(

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -80,13 +80,20 @@ export default class PackageShow extends Component {
       type: 'error',
       id: `error-${model.update.timestamp}-${index}`
     })) : [];
-    let { intl } = this.context;
+    let { intl, router } = this.context;
     let { showSelectionModal, packageSelected, packageHidden, packageAllowedToAddTitles } = this.state;
 
     let customCoverages = [{
       beginCoverage: model.customCoverage.beginCoverage,
       endCoverage: model.customCoverage.endCoverage
     }];
+
+    let actionMenuItems = [
+      {
+        label: 'Edit',
+        to: { pathname: `/eholdings/packages/${model.id}/edit`, search: router.route.location.search }
+      }
+    ];
 
     return (
       <div>
@@ -95,6 +102,7 @@ export default class PackageShow extends Component {
           type="package"
           model={model}
           paneTitle={model.name}
+          actionMenuItems={actionMenuItems}
           bodyContent={(
             <div>
               <DetailsViewSection label="Holding status">

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import Link from 'react-router-dom/Link';
 import {
   IconButton,
   Pane
@@ -104,7 +103,12 @@ export default class Settings extends Component {
         defaultWidth="fill"
         paneTitle="eHoldings"
         firstMenu={(
-          <Link to="/settings" className={styles['eholdings-settings-back-button']}><IconButton icon="left-arrow" /></Link>
+          <div className={styles['eholdings-settings-back-button']}>
+            <IconButton
+              icon="left-arrow"
+              href="/settings"
+            />
+          </div>
         )}
       >
         <div

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import ApplicationRoute from './routes/application';
 import SearchRoute from './routes/search';
 import ProviderShow from './routes/provider-show';
 import PackageShow from './routes/package-show';
+import PackageEdit from './routes/package-edit';
 import TitleShow from './routes/title-show';
 import CustomerResourceShow from './routes/customer-resource-show';
 import CustomerResourceEdit from './routes/customer-resource-edit';
@@ -62,6 +63,7 @@ export default class EHoldings extends Component {
           <Switch>
             <Route path={`${rootPath}/providers/:providerId`} exact component={ProviderShow} />
             <Route path={`${rootPath}/packages/:packageId`} exact component={PackageShow} />
+            <Route path={`${rootPath}/packages/:packageId/edit`} exact component={PackageEdit} />
             <Route path={`${rootPath}/titles/:titleId`} exact component={TitleShow} />
             <Route path={`${rootPath}/customer-resources/:id`} exact component={CustomerResourceShow} />
             <Route path={`${rootPath}/customer-resources/:id/edit`} exact component={CustomerResourceEdit} />

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -1,0 +1,85 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import moment from 'moment';
+
+import { createResolver } from '../redux';
+import Package from '../redux/package';
+import CustomerResource from '../redux/customer-resource';
+
+import View from '../components/package-edit';
+
+class PackageEditRoute extends Component {
+  static propTypes = {
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        packageId: PropTypes.string.isRequired
+      }).isRequired
+    }).isRequired,
+    model: PropTypes.object.isRequired,
+    getPackage: PropTypes.func.isRequired,
+    unloadCustomerResources: PropTypes.func.isRequired,
+    updatePackage: PropTypes.func.isRequired
+  };
+
+  componentWillMount() {
+    let { packageId } = this.props.match.params;
+    this.props.getPackage(packageId);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    let { model: next, match, getPackage, unloadCustomerResources } = nextProps;
+    let { model: old, match: oldMatch } = this.props;
+    let { packageId } = match.params;
+
+    if (packageId !== oldMatch.params.packageId) {
+      getPackage(packageId);
+
+    // if an update just resolved, unfetch the package titles
+    } else if (next.update.isResolved && old.update.isPending) {
+      unloadCustomerResources(next.customerResources);
+    }
+  }
+
+  packageEditSubmitted = (values) => {
+    let { model, updatePackage } = this.props;
+    let beginCoverage = '';
+    let endCoverage = '';
+
+    if (values.customCoverages[0]) {
+      beginCoverage = !values.customCoverages[0].beginCoverage ? '' : moment(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD');
+      endCoverage = !values.customCoverages[0].endCoverage ? '' : moment(values.customCoverages[0].endCoverage).format('YYYY-MM-DD');
+    }
+
+    model.customCoverage = {
+      beginCoverage,
+      endCoverage
+    };
+    updatePackage(model);
+  };
+
+  render() {
+    return (
+      <View
+        model={this.props.model}
+        onSubmit={this.packageEditSubmitted}
+        initialValues={{
+          customCoverages: [{
+            beginCoverage: this.props.model.customCoverage.beginCoverage,
+            endCoverage: this.props.model.customCoverage.endCoverage
+          }]
+        }}
+      />
+    );
+  }
+}
+
+export default connect(
+  ({ eholdings: { data } }, { match }) => ({
+    model: createResolver(data).find('packages', match.params.packageId)
+  }), {
+    getPackage: id => Package.find(id),
+    unloadCustomerResources: collection => CustomerResource.unload(collection),
+    updatePackage: model => Package.save(model)
+  }
+)(PackageEditRoute);

--- a/tests/package-edit-test.js
+++ b/tests/package-edit-test.js
@@ -1,0 +1,185 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+
+import { describeApplication } from './helpers';
+import PackageShowPage from './pages/package-show';
+import PackageEditPage from './pages/package-edit';
+
+describeApplication('PackageEdit', () => {
+  let provider,
+    providerPackage;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create('package', {
+      provider,
+      name: 'Cool Package',
+      contentType: 'E-Book',
+      isSelected: true
+    });
+  });
+
+  describe('visiting the package edit page without coverage dates', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/packages/${providerPackage.id}/edit`, () => {
+        expect(PackageEditPage.$root).to.exist;
+      });
+    });
+
+    it('shows blank datepicker fields', () => {
+      expect(PackageEditPage.dateRangeRowList(0).beginDate.value).to.equal('');
+      expect(PackageEditPage.dateRangeRowList(0).endDate.value).to.equal('');
+    });
+
+    it('disables the save button', () => {
+      expect(PackageEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return PackageEditPage.clickCancel();
+      });
+
+      it('goes to the package show page', () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    describe('entering invalid data', () => {
+      beforeEach(() => {
+        return PackageEditPage.interaction
+          .once(() => PackageEditPage.dateRangeRowList().length > 0)
+          .do(() => {
+            return PackageEditPage.interaction
+              .append(PackageEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
+              .clickSave();
+          });
+      });
+
+      it('displays a validation error for coverage', () => {
+        expect(PackageEditPage.dateRangeRowList(0).beginDate.isInvalid).to.be.true;
+      });
+    });
+
+    describe('entering valid data', () => {
+      beforeEach(() => {
+        return PackageEditPage.interaction
+          .once(() => PackageEditPage.dateRangeRowList().length > 0)
+          .do(() => {
+            return PackageEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018');
+          });
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return PackageEditPage.clickCancel();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(PackageEditPage.navigationModal.$root).to.exist;
+        });
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return PackageEditPage.clickSave();
+        });
+
+        it('goes to the package show page', () => {
+          expect(PackageShowPage.$root).to.exist;
+        });
+
+        it('displays the new coverage dates', () => {
+          expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
+        });
+      });
+    });
+  });
+
+  describe('visiting the package edit page with coverage dates', () => {
+    beforeEach(function () {
+      providerPackage.update('customCoverage', {
+        beginCoverage: '1969-07-16',
+        endCoverage: '1972-12-19'
+      });
+      providerPackage.save();
+
+      return this.visit(`/eholdings/packages/${providerPackage.id}/edit`, () => {
+        expect(PackageEditPage.$root).to.exist;
+      });
+    });
+
+    it('disables the save button', () => {
+      expect(PackageEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return PackageEditPage.clickCancel();
+      });
+
+      it('goes to the package show page', () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    describe('entering invalid data', () => {
+      beforeEach(() => {
+        return PackageEditPage.interaction
+          .append(PackageEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
+          .clickSave();
+      });
+
+      it('displays a validation error for coverage', () => {
+        expect(PackageEditPage.dateRangeRowList(0).beginDate.isInvalid).to.be.true;
+      });
+    });
+
+    describe('entering valid data', () => {
+      beforeEach(() => {
+        return PackageEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018');
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return PackageEditPage.clickCancel();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(PackageEditPage.navigationModal.$root).to.exist;
+        });
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return PackageEditPage.clickSave();
+        });
+
+        it('goes to the package show page', () => {
+          expect(PackageShowPage.$root).to.exist;
+        });
+      });
+    });
+  });
+
+  describe('encountering a server error', () => {
+    beforeEach(function () {
+      this.server.get('/packages/:id', {
+        errors: [{
+          title: 'There was an error'
+        }]
+      }, 500);
+
+      return this.visit(`/eholdings/packages/${providerPackage.id}/edit`, () => {
+        expect(PackageEditPage.$root).to.exist;
+      });
+    });
+
+    it('dies with dignity', () => {
+      expect(PackageEditPage.hasErrors).to.be.true;
+    });
+  });
+});

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -1,0 +1,31 @@
+import {
+  clickable,
+  collection,
+  isPresent,
+  page,
+  property
+} from '@bigtest/interaction';
+import Datepicker from './datepicker';
+
+@page class PackageEditNavigationModal {}
+
+@page class PackageEditPage {
+  navigationModal = new PackageEditNavigationModal('#navigation-modal');
+
+  clickCancel = clickable('[data-test-eholdings-package-cancel-button] button');
+  clickSave = clickable('[data-test-eholdings-package-save-button] button');
+  isSaveDisabled = property('disabled', '[data-test-eholdings-package-save-button] button');
+  hasErrors = isPresent('[data-test-eholdings-details-view-error="package"]');
+
+  dateRangeRowList = collection('[data-test-eholdings-coverage-fields-date-range-row]', {
+    beginDate: new Datepicker('[data-test-eholdings-coverage-fields-date-range-begin]'),
+    endDate: new Datepicker('[data-test-eholdings-coverage-fields-date-range-end]'),
+    clickRemoveRowButton: clickable('[data-test-eholdings-coverage-fields-remove-row-button] button'),
+    fillDates(beginDate, endDate) {
+      return this.beginDate.fillAndBlur(beginDate)
+        .append(this.endDate.fillAndBlur(endDate));
+    }
+  });
+}
+
+export default new PackageEditPage('[data-test-eholdings-details-view="package"]');

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -33,7 +33,7 @@ import { isRootPresent } from './helpers';
   noResultsMessage = text('[data-test-query-list-not-found="packages"]');
   selectedSearchType = collection('[data-test-search-form-type-switcher] a[class^="is-active--"]');
   sortBy = value('[data-test-eholdings-search-filters="packages"] input[name="sort"]:checked');
-  clickCloseButton = clickable('[data-test-eholdings-details-view-close-button] button');
+  clickCloseButton = clickable('[data-test-eholdings-details-view-close-button] a');
 
   hasLoaded = computed(function () {
     return this.packageList().length > 0;

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -107,10 +107,10 @@ import Toast from './toast';
   clickCustomCoverageEditButton = clickable('[data-test-eholdings-package-details-edit-custom-coverage-button] button');
   clickCustomCoverageSaveButton = clickable('[data-test-eholdings-package-details-save-custom-coverage-button] button');
   isCustomCoverageDisabled = property('disabled', '[data-test-eholdings-package-details-save-custom-coverage-button] button');
-  validationError = text('[data-test-eholdings-custom-coverage-date-range-begin] [class^="feedbackError"]');
+  validationError = text('[data-test-eholdings-coverage-fields-date-range-begin] [class^="feedbackError"]');
 
-  beginDate = new Datepicker('[data-test-eholdings-custom-coverage-date-range-begin]');
-  endDate = new Datepicker('[data-test-eholdings-custom-coverage-date-range-end]');
+  beginDate = new Datepicker('[data-test-eholdings-coverage-fields-date-range-begin]');
+  endDate = new Datepicker('[data-test-eholdings-coverage-fields-date-range-end]');
 
   toast = Toast
 

--- a/tests/pages/provider-search.js
+++ b/tests/pages/provider-search.js
@@ -33,7 +33,7 @@ import { isRootPresent, hasClassBeginningWith } from './helpers';
   sortBy = value('[data-test-eholdings-search-filters="providers"] input[name="sort"]:checked');
   isSearchButtonDisabled = property('disabled', '[data-test-search-submit]');
   isSearchVignetteHidden = hasClassBeginningWith('is-hidden---', '[data-test-search-vignette]');
-  clickCloseButton = clickable('[data-test-eholdings-details-view-close-button] button');
+  clickCloseButton = clickable('[data-test-eholdings-details-view-close-button] a');
 
   hasLoaded = computed(function () {
     return this.providerList().length > 0;

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -35,7 +35,7 @@ import { isRootPresent, hasClassBeginningWith } from './helpers';
   noResultsMessage = text('[data-test-query-list-not-found="titles"]');
   selectedSearchType = collection('[data-test-search-form-type-switcher] a[class^="is-active--"]');
   isSearchVignetteHidden = hasClassBeginningWith('is-hidden--', '[data-test-search-vignette]');
-  clickCloseButton = clickable('[data-test-eholdings-details-view-close-button] button');
+  clickCloseButton = clickable('[data-test-eholdings-details-view-close-button] a');
 
   hasLoaded = computed(function () {
     return this.titleList().length > 0;


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UIEH-223
A package's attributes should be editable from a "full-page" view, not just an "inline" form. 

## Approach
I used the same patterns established in https://github.com/folio-org/ui-eholdings/pull/305 and https://github.com/folio-org/ui-eholdings/pull/317.

I had to avoid using the pane header dropdown because of the lack of z-index management in FOLIO. When there's an active search query, the pane header dropdown isn’t visible, because the z-indices we’re using for eHoldings layout are higher than anything in `stripes-core` or `stripes-components` (but there aren’t enough integers between those used in Stripes and zero for the things we’re doing). Instead I just put a pencil icon in the top right, which is what other FOLIO apps have at the moment anyway. I updated the customer resource edit to work the same way.

## Next Steps
- Create an `InlineForm` component to handle a lot of the shared interactions and styles.

## Screenshots
![2018-03-27 16 32 10](https://user-images.githubusercontent.com/230597/37996191-73e3b564-31dc-11e8-89fc-a027ba652aea.gif)