### PR TITLE
[WIP] UIEH-130 Create z-index management solution

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-  extends: 'stylelint-config-standard'
+  extends: 'stylelint-config-standard',
+  rules: {
+    "function-name-case": null
+  }
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@bigtest/mocha": "^0.3.3",
     "@folio/eslint-config-stripes": "^1.1.0",
     "@folio/stripes-cli": "^1.0.0",
+    "@folio/stripes-components": "git+https://git@github.com/thefrontside/stripes-components.git#jc/stripeszindex",
+    "@folio/stripes-core": "git+https://git@github.com/thefrontside/stripes-core.git#jc/stripeszindex",
     "babel-plugin-istanbul": "^4.1.5",
     "babel-plugin-remove-jsx-attributes": "^0.0.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -9,7 +9,7 @@
   right: 0;
   align-items: center;
   position: absolute;
-  z-index: 12;
+  z-index: stripesZIndex('modal');
 }
 
 .modal {

--- a/src/components/preview-pane/preview-pane.css
+++ b/src/components/preview-pane/preview-pane.css
@@ -10,7 +10,7 @@
   position: absolute;
   right: 0;
   top: 0;
-  z-index: 11;
+  z-index: stripesZIndex('searchPreviewPane');
   background-color: white;
 }
 

--- a/src/components/results-pane/results-pane.css
+++ b/src/components/results-pane/results-pane.css
@@ -5,5 +5,5 @@
   height: 100%;
   overflow: hidden;
   position: relative;
-  z-index: 10;
+  z-index: stripesZIndex('searchResultsPane');
 }

--- a/src/components/search-pane-vignette/search-pane-vignette.css
+++ b/src/components/search-pane-vignette/search-pane-vignette.css
@@ -2,7 +2,7 @@
 
 .search-pane-vignette {
   height: 100%;
-  z-index: 11;
+  z-index: stripesZIndex('searchPaneVignette');
   position: absolute;
   top: 0;
   bottom: 0;

--- a/src/components/search-pane/search-pane.css
+++ b/src/components/search-pane/search-pane.css
@@ -7,7 +7,7 @@
   position: absolute;
   top: 0;
   width: 100%;
-  z-index: 12;
+  z-index: stripesZIndex('searchFiltersPane');
 
   &:only-child {
     display: block;

--- a/src/components/toaster/style.css
+++ b/src/components/toaster/style.css
@@ -2,7 +2,7 @@
 
 .container {
   position: fixed;
-  z-index: 13;
+  z-index: stripesZIndex('toast');
   pointer-events: none;
   right: 0;
   padding: 1em;

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,6 +195,32 @@
     redux-form "^7.0.3"
     typeface-source-sans-pro "^0.0.44"
 
+"@folio/stripes-components@git+https://git@github.com/thefrontside/stripes-components.git#jc/stripeszindex":
+  version "2.0.8"
+  resolved "git+https://git@github.com/thefrontside/stripes-components.git#a9d2d764413da03818e3793b63dae92b9ba63c73"
+  dependencies:
+    "@folio/stripes-form" "^0.8.2"
+    "@folio/stripes-react-hotkeys" "^1.0.0"
+    classnames "^2.2.5"
+    create-react-class "^15.5.3"
+    dom-helpers "^3.2.1"
+    file-loader "^1.1.5"
+    lodash "^4.17.4"
+    moment "^2.17.1"
+    moment-range "^3.0.3"
+    mousetrap "^1.6.1"
+    normalize.css "^7.0.0"
+    prop-types "^15.5.10"
+    prop-types-extra "^1.0.1"
+    react-flexbox-grid "1.1.3"
+    react-highlighter "^0.4.2"
+    react-overlays "^0.8.3"
+    react-router-dom "^4.1.1"
+    react-tether "^0.6.1"
+    react-transition-group "^2.2.1"
+    redux-form "^7.0.3"
+    typeface-source-sans-pro "^0.0.44"
+
 "@folio/stripes-connect@^3.1.0":
   version "3.1.100036"
   resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-connect/-/stripes-connect-3.1.100036.tgz#5589b6836feac597bf340b06f90d66a2afbbb031"
@@ -253,6 +279,87 @@
     postcss-color-function "^4.0.0"
     postcss-custom-media "^6.0.0"
     postcss-custom-properties "^6.1.0"
+    postcss-import "^10.0.0"
+    postcss-loader "^2.0.6"
+    postcss-media-minmax "^3.0.0"
+    postcss-nesting "^4.0.1"
+    postcss-url "^7.0.0"
+    prop-types "^15.5.10"
+    query-string "^5.0.0"
+    react "^16.3.0"
+    react-apollo "^2.0.1"
+    react-cookie "^2.1.4"
+    react-dom "^16.3.0"
+    react-intl "^2.3.0"
+    react-overlays "^0.8.3"
+    react-redux "^5.0.2"
+    react-router "^4.0.0"
+    react-router-dom "^4.0.0"
+    react-transform-catch-errors "^1.0.2"
+    redux "^3.6.0"
+    redux-form "^7.0.3"
+    redux-logger "^3.0.6"
+    redux-observable "^0.15.0"
+    redux-thunk "^2.1.0"
+    rimraf "^2.5.4"
+    rxjs "^5.4.3"
+    serialize-javascript "^1.4.0"
+    style-loader "^0.18.2"
+    typeface-source-sans-pro "0.0.43"
+    uglify-es "3.3.9"
+    uglifyjs-webpack-plugin "^1.1.8"
+    uuid "^3.0.0"
+    webpack "^3.4.1"
+    webpack-dev-middleware "^2.0.4"
+    webpack-hot-middleware "^2.16.1"
+    webpack-virtual-modules "^0.1.8"
+
+"@folio/stripes-core@git+https://git@github.com/thefrontside/stripes-core.git#jc/stripeszindex":
+  version "2.9.4"
+  resolved "git+https://git@github.com/thefrontside/stripes-core.git#4de1dbb8adde26c1863d54395108fe1831500e29"
+  dependencies:
+    "@folio/stripes-components" "git+https://git@github.com/thefrontside/stripes-components.git#jc/stripeszindex"
+    "@folio/stripes-connect" "^3.1.0"
+    "@folio/stripes-logger" "^0.0.2"
+    apollo-cache-inmemory "^1.1.1"
+    apollo-client "^2.0.3"
+    apollo-link-http "^1.2.0"
+    autoprefixer "^7.1.1"
+    babel-core "^6.23.1"
+    babel-eslint "^8.2.2"
+    babel-loader "^7.0.0"
+    babel-plugin-react-transform "^2.0.2"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.6.0"
+    babel-preset-react "^6.16.0"
+    babel-preset-react-hmre "^1.1.1"
+    babel-preset-stage-2 "^6.16.0"
+    classnames "^2.2.5"
+    commander "^2.9.0"
+    connect-history-api-fallback "^1.3.0"
+    css-loader "^0.28.4"
+    duplicate-package-checker-webpack-plugin "^1.2.6"
+    express "^4.14.0"
+    extract-text-webpack-plugin "^3.0.0"
+    file-loader "^1.1.5"
+    graphql "^0.11.7"
+    hard-source-webpack-plugin "^0.4.4"
+    history "^4.6.3"
+    html-webpack-plugin "^2.30.1"
+    isomorphic-fetch "^2.2.1"
+    json-loader "^0.5.4"
+    localforage "^1.5.6"
+    lodash "^4.16.4"
+    moment "^2.19.1"
+    moment-timezone "^0.5.14"
+    node-object-hash "^1.2.0"
+    optimize-css-assets-webpack-plugin "^3.2.0"
+    postcss "^6.0.2"
+    postcss-calc "^6.0.0"
+    postcss-color-function "^4.0.0"
+    postcss-custom-media "^6.0.0"
+    postcss-custom-properties "^6.1.0"
+    postcss-functions "^3.0.0"
     postcss-import "^10.0.0"
     postcss-loader "^2.0.6"
     postcss-media-minmax "^3.0.0"
@@ -4334,14 +4441,13 @@ html-entities@^1.2.0:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
 html-minifier@^3.2.3:
-  version "3.5.12"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.12.tgz#6bfad4d0327f5b8d2b62f5854654ac3703b9b031"
+  version "3.5.13"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.13.tgz#6bca6d533a7f18a476dc6aeb3d113071ab5c165e"
   dependencies:
     camel-case "3.0.x"
     clean-css "4.1.x"
     commander "2.15.x"
     he "1.1.x"
-    ncname "1.0.x"
     param-case "2.1.x"
     relateurl "0.2.x"
     uglify-js "3.3.x"
@@ -5452,8 +5558,8 @@ loader-utils@^1.0.2, loader-utils@^1.1.0:
     json5 "^0.5.0"
 
 localforage@^1.5.6:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.7.0.tgz#c6ee88fdb213d9ca14df530fd3be6a8198deb74a"
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.7.1.tgz#e4927e042302b864db30f3211f13b5c6f0de965d"
   dependencies:
     lie "3.1.1"
 
@@ -5995,8 +6101,8 @@ moment-timezone@^0.5.14:
     moment ">= 2.9.0"
 
 "moment@>= 2.9.0", moment@^2.17.1, moment@^2.19.1:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 
 mousetrap@^1.5.2, mousetrap@^1.6.1:
   version "1.6.1"
@@ -6070,12 +6176,6 @@ natives@^1.1.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-
-ncname@1.0.x:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
-  dependencies:
-    xml-char-classes "^1.0.0"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -6767,6 +6867,15 @@ postcss-filter-plugins@^2.0.0:
     postcss "^5.0.4"
     uniqid "^4.0.0"
 
+postcss-functions@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-functions/-/postcss-functions-3.0.0.tgz#0e94d01444700a481de20de4d55fb2640564250e"
+  dependencies:
+    glob "^7.1.2"
+    object-assign "^4.1.1"
+    postcss "^6.0.9"
+    postcss-value-parser "^3.3.0"
+
 postcss-html@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/postcss-html/-/postcss-html-0.12.0.tgz#39b6adb4005dfc5464df7999c0f81c95bced7e50"
@@ -6997,10 +7106,10 @@ postcss-sass@^0.2.0:
     postcss "^6.0.6"
 
 postcss-scss@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-1.0.4.tgz#6310fe1a15be418707a2cfd77f21dd4a06d1e09d"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-1.0.5.tgz#40a10cfd03766accf0a3cf8e65a8af887b2bf6c4"
   dependencies:
-    postcss "^6.0.19"
+    postcss "^6.0.21"
 
 postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.2.2:
   version "2.2.3"
@@ -7066,7 +7175,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.14, postcss@^6.0.17, postcss@^6.0.18, postcss@^6.0.19, postcss@^6.0.2, postcss@^6.0.6, postcss@^6.0.8:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.14, postcss@^6.0.17, postcss@^6.0.18, postcss@^6.0.2, postcss@^6.0.21, postcss@^6.0.6, postcss@^6.0.8, postcss@^6.0.9:
   version "6.0.21"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.21.tgz#8265662694eddf9e9a5960db6da33c39e4cd069d"
   dependencies:
@@ -9040,8 +9149,8 @@ uglify-es@3.3.9, uglify-es@^3.3.4:
     source-map "~0.6.1"
 
 uglify-js@3.3.x:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.16.tgz#23ba13efa27aa00885be7417819e8a9787f94028"
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.18.tgz#e16df66d71638df3c9bc61cce827e46f24bdac02"
   dependencies:
     commander "~2.15.0"
     source-map "~0.6.1"
@@ -9633,10 +9742,6 @@ x-is-string@^0.1.0:
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
-
-xml-char-classes@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
 
 xmlbuilder@8.2.2:
   version "8.2.2"


### PR DESCRIPTION
## Purpose
`ui-eholdings` uses `z-index` to manage layering of its search layout. The dropdown menu from the header avatar ends up underneath the third pane: https://issues.folio.org/browse/UIEH-130

Handling `z-index` can be notoriously finicky. The solution to a problem is frequently "set it to a very high number," but with many layers happening, that can get messy real quick.

## Approach
See https://github.com/folio-org/stripes-components/pull/314 and https://github.com/folio-org/stripes-core/pull/257

#### TODOS and Open Questions
- [ ] Merge `stripes-components` PR.
- [ ] Merge `stripes-core` PR.
- [ ] Remove commit pointing to PR branches.

## Learning
The inspiration for this solution: https://www.smashingmagazine.com/2014/06/sassy-z-index-management-for-complex-layouts/

## Screenshots
### Before
Ignore the incorrect pane title CSS, that's addressed in another PR.
![2018-04-02 09 48 04](https://user-images.githubusercontent.com/230597/38200785-48681424-365b-11e8-8a79-fee96c89eced.gif)

### After
![2018-04-02 09 48 17](https://user-images.githubusercontent.com/230597/38200793-4d7ec296-365b-11e8-9a14-4b823b1981ab.gif)