### PR TITLE
UIEH-71: Display GET errors

### DIFF
--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -14,7 +14,7 @@ import IdentifiersList from './identifiers-list';
 import ContributorsList from './contributors-list';
 import ToggleSwitch from './toggle-switch';
 import CoverageDateList from './coverage-date-list';
-import { isBookPublicationType, isValidCoverageList } from './utilities';
+import { isBookPublicationType, isValidCoverageList, processErrors } from './utilities';
 import Modal from './modal';
 import CustomerResourceCoverage from './customer-resource-coverage';
 import CustomEmbargoForm from './custom-embargo-form';
@@ -91,12 +91,6 @@ export default class CustomerResourceShow extends Component {
 
   render() {
     let { model, customEmbargoSubmitted, coverageSubmitted, coverageStatementSubmitted } = this.props;
-    let hasErrors = model.update.isRejected;
-    let errors = hasErrors ? model.update.errors.map((error, index) => ({
-      message: error.title,
-      type: 'error',
-      id: `error-${model.update.timestamp}-${index}`
-    })) : [];
     let { locale, intl } = this.context;
     let {
       showSelectionModal,
@@ -131,7 +125,7 @@ export default class CustomerResourceShow extends Component {
 
     return (
       <div>
-        <Toaster toasts={errors} position="bottom" />
+        <Toaster toasts={processErrors(model)} position="bottom" />
 
         <DetailsView
           type="resource"

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -8,6 +8,7 @@ import {
   KeyValue,
   PaneMenu
 } from '@folio/stripes-components';
+import { processErrors } from './utilities';
 
 import DetailsView from './details-view';
 import QueryList from './query-list';
@@ -76,12 +77,6 @@ export default class PackageShow extends Component {
 
   render() {
     let { model, fetchPackageTitles, customCoverageSubmitted } = this.props;
-    let hasErrors = model.update.isRejected;
-    let errors = hasErrors ? model.update.errors.map((error, index) => ({
-      message: error.title,
-      type: 'error',
-      id: `error-${model.update.timestamp}-${index}`
-    })) : [];
     let { intl, router } = this.context;
     let { showSelectionModal, packageSelected, packageHidden, packageAllowedToAddTitles } = this.state;
 
@@ -92,7 +87,7 @@ export default class PackageShow extends Component {
 
     return (
       <div>
-        <Toaster toasts={errors} position="bottom" />
+        <Toaster toasts={processErrors(model)} position="bottom" />
         <DetailsView
           type="package"
           model={model}

--- a/src/components/provider-show.js
+++ b/src/components/provider-show.js
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { KeyValue } from '@folio/stripes-components';
 
+import { processErrors } from './utilities';
 import DetailsView from './details-view';
 import QueryList from './query-list';
 import PackageListItem from './package-list-item';
 import DetailsViewSection from './details-view-section';
+import Toaster from './toaster';
 
 export default function ProviderShow({
   model,
@@ -14,44 +16,48 @@ export default function ProviderShow({
   intl
 }) {
   return (
-    <DetailsView
-      type="provider"
-      model={model}
-      paneTitle={model.name}
-      bodyContent={(
-        <DetailsViewSection label="Provider information">
-          <KeyValue label="Packages selected">
-            <div data-test-eholdings-provider-details-packages-selected>
-              {intl.formatNumber(model.packagesSelected)}
-            </div>
-          </KeyValue>
+    <div>
+      <Toaster toasts={processErrors(model)} position="bottom" />
 
-          <KeyValue label="Total packages">
-            <div data-test-eholdings-provider-details-packages-total>
-              {intl.formatNumber(model.packagesTotal)}
-            </div>
-          </KeyValue>
-        </DetailsViewSection>
-      )}
-      listType="packages"
-      renderList={scrollable => (
-        <QueryList
-          type="provider-packages"
-          fetch={fetchPackages}
-          collection={model.packages}
-          length={model.packagesTotal}
-          scrollable={scrollable}
-          itemHeight={70}
-          renderItem={item => (
-            <PackageListItem
-              link={item.content && `/eholdings/packages/${item.content.id}`}
-              item={item.content}
-              showTitleCount
-            />
-          )}
-        />
-      )}
-    />
+      <DetailsView
+        type="provider"
+        model={model}
+        paneTitle={model.name}
+        bodyContent={(
+          <DetailsViewSection label="Provider information">
+            <KeyValue label="Packages selected">
+              <div data-test-eholdings-provider-details-packages-selected>
+                {intl.formatNumber(model.packagesSelected)}
+              </div>
+            </KeyValue>
+
+            <KeyValue label="Total packages">
+              <div data-test-eholdings-provider-details-packages-total>
+                {intl.formatNumber(model.packagesTotal)}
+              </div>
+            </KeyValue>
+          </DetailsViewSection>
+        )}
+        listType="packages"
+        renderList={scrollable => (
+          <QueryList
+            type="provider-packages"
+            fetch={fetchPackages}
+            collection={model.packages}
+            length={model.packagesTotal}
+            scrollable={scrollable}
+            itemHeight={70}
+            renderItem={item => (
+              <PackageListItem
+                link={item.content && `/eholdings/packages/${item.content.id}`}
+                item={item.content}
+                showTitleCount
+              />
+            )}
+          />
+        )}
+      />
+    </div>
   );
 }
 

--- a/src/components/title-show.js
+++ b/src/components/title-show.js
@@ -2,66 +2,72 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { KeyValue } from '@folio/stripes-components';
 
+import { processErrors } from './utilities';
 import DetailsView from './details-view';
 import ScrollView from './scroll-view';
 import PackageListItem from './package-list-item';
 import IdentifiersList from './identifiers-list';
 import ContributorsList from './contributors-list';
 import DetailsViewSection from './details-view-section';
+import Toaster from './toaster';
 
 export default function TitleShow({ model }) {
   return (
-    <DetailsView
-      type="title"
-      model={model}
-      paneTitle={model.name}
-      bodyContent={(
-        <DetailsViewSection label="Title information">
-          <ContributorsList data={model.contributors} />
+    <div>
+      <Toaster toasts={processErrors(model)} position="bottom" />
 
-          <KeyValue label="Publisher">
-            <div data-test-eholdings-title-show-publisher-name>
-              {model.publisherName}
-            </div>
-          </KeyValue>
+      <DetailsView
+        type="title"
+        model={model}
+        paneTitle={model.name}
+        bodyContent={(
+          <DetailsViewSection label="Title information">
+            <ContributorsList data={model.contributors} />
 
-          {model.publicationType && (
-            <KeyValue label="Publication Type">
-              <div data-test-eholdings-title-show-publication-type>
-                {model.publicationType}
+            <KeyValue label="Publisher">
+              <div data-test-eholdings-title-show-publisher-name>
+                {model.publisherName}
               </div>
             </KeyValue>
-          )}
 
-          <IdentifiersList data={model.identifiers} />
+            {model.publicationType && (
+              <KeyValue label="Publication Type">
+                <div data-test-eholdings-title-show-publication-type>
+                  {model.publicationType}
+                </div>
+              </KeyValue>
+            )}
 
-          {model.subjects.length > 0 && (
-            <KeyValue label="Subjects">
-              <div data-test-eholdings-title-show-subjects-list>
-                {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
-              </div>
-            </KeyValue>
-          )}
-        </DetailsViewSection>
-      )}
-      listType="packages"
-      renderList={scrollable => (
-        <ScrollView
-          itemHeight={70}
-          items={model.customerResources}
-          scrollable={scrollable}
-          data-test-query-list="title-packages"
-        >
-          {item => (
-            <PackageListItem
-              link={`/eholdings/customer-resources/${item.id}`}
-              packageName={item.packageName}
-              item={item}
-            />
-          )}
-        </ScrollView>
-      )}
-    />
+            <IdentifiersList data={model.identifiers} />
+
+            {model.subjects.length > 0 && (
+              <KeyValue label="Subjects">
+                <div data-test-eholdings-title-show-subjects-list>
+                  {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
+                </div>
+              </KeyValue>
+            )}
+          </DetailsViewSection>
+        )}
+        listType="packages"
+        renderList={scrollable => (
+          <ScrollView
+            itemHeight={70}
+            items={model.customerResources}
+            scrollable={scrollable}
+            data-test-query-list="title-packages"
+          >
+            {item => (
+              <PackageListItem
+                link={`/eholdings/customer-resources/${item.id}`}
+                packageName={item.packageName}
+                item={item}
+              />
+            )}
+          </ScrollView>
+        )}
+      />
+    </div>
   );
 }
 

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -65,3 +65,17 @@ export const qs = {
   parse: path => queryString.parse(path, { ignoreQueryPrefix: true }),
   stringify: params => queryString.stringify(params, { encodeValuesOnly: true })
 };
+
+export const processErrors = ({ request, update }) => {
+  let processErrorsSet = ({ errors, timestamp }) => errors.map((error, index) => ({
+    message: error.title,
+    type: 'error',
+    id: `error-${timestamp}-${index}`
+  }));
+
+  let hasErrors = update.isRejected || request.isRejected;
+  let putErrors = hasErrors ? processErrorsSet(update) : [];
+  let getErrors = hasErrors ? processErrorsSet(request) : [];
+
+  return getErrors.concat(putErrors);
+};

--- a/tests/customer-resource-show-test.js
+++ b/tests/customer-resource-show-test.js
@@ -342,6 +342,20 @@ describeApplication('CustomerResourceShow', () => {
       });
     });
 
+    it('displays the correct error text', () => {
+      expect(ResourcePage.toast.errorText).to.equal('There was an error');
+    });
+
+    it('only has one error', () => {
+      expect(ResourcePage.toast.errorToastCount).to.equal(1);
+      expect(ResourcePage.toast.totalToastCount).to.equal(1);
+    });
+
+    it('is positioned to the bottom', () => {
+      expect(ResourcePage.toast.isPositionedBottom).to.be.true;
+      expect(ResourcePage.toast.isPositionedTop).to.be.false;
+    });
+
     it('dies with dignity', () => {
       expect(ResourcePage.hasErrors).to.be.true;
     });

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -180,6 +180,20 @@ describeApplication('PackageShow', () => {
       });
     });
 
+    it('displays the correct error text', () => {
+      expect(PackageShowPage.toast.errorText).to.equal('There was an error');
+    });
+
+    it('only has one error', () => {
+      expect(PackageShowPage.toast.errorToastCount).to.equal(1);
+      expect(PackageShowPage.toast.totalToastCount).to.equal(1);
+    });
+
+    it('is positioned to the bottom', () => {
+      expect(PackageShowPage.toast.isPositionedBottom).to.be.true;
+      expect(PackageShowPage.toast.isPositionedTop).to.be.false;
+    });
+
     it('dies with dignity', () => {
       expect(PackageShowPage.hasErrors).to.be.true;
     });

--- a/tests/pages/provider-show.js
+++ b/tests/pages/provider-show.js
@@ -6,6 +6,7 @@ import {
   page,
   text
 } from '@bigtest/interaction';
+import Toast from './toast';
 
 @page class ProviderShowPage {
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
@@ -15,6 +16,8 @@ import {
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="provider"]');
   errorMessage = text('[data-test-eholdings-details-view-error="provider"]');
+
+  toast = Toast
 
   packageList = collection('[data-test-query-list="provider-packages"] li a', {
     name: text('[data-test-eholdings-package-list-item-name]'),

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -8,6 +8,7 @@ import {
   text
 } from '@bigtest/interaction';
 import { getComputedStyle } from './helpers';
+import Toast from './toast';
 
 @page class TitleShowPage {
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
@@ -24,6 +25,8 @@ import { getComputedStyle } from './helpers';
   detailsPaneScrollsHeight = property('scrollHeight', '[data-test-eholdings-detail-pane-contents]');
   detailsPaneContentsHeight = property('offsetHeight', '[data-test-eholdings-detail-pane-contents]');
   detailsPaneContentsOverFlowY = getComputedStyle('overflow-y', '[data-test-eholdings-detail-pane-contents]');
+
+toast = Toast
 
   detailsPaneScrollTop = action(function (offset) {
     return this.find('[data-test-query-list="package-titles"]')

--- a/tests/provider-show-test.js
+++ b/tests/provider-show-test.js
@@ -149,8 +149,18 @@ describeApplication('ProviderShow', () => {
       expect(ProviderShowPage.hasErrors).to.be.true;
     });
 
-    it('displays the error message returned from the server', () => {
-      expect(ProviderShowPage.errorMessage).to.equal('There was an error');
+    it('displays the correct error text', () => {
+      expect(ProviderShowPage.toast.errorText).to.equal('There was an error');
+    });
+
+    it('only has one error', () => {
+      expect(ProviderShowPage.toast.errorToastCount).to.equal(1);
+      expect(ProviderShowPage.toast.totalToastCount).to.equal(1);
+    });
+
+    it('is positioned to the bottom', () => {
+      expect(ProviderShowPage.toast.isPositionedBottom).to.be.true;
+      expect(ProviderShowPage.toast.isPositionedTop).to.be.false;
     });
   });
 });

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -257,6 +257,20 @@ describeApplication('TitleShow', () => {
       });
     });
 
+    it('displays the correct error text', () => {
+      expect(TitleShowPage.toast.errorText).to.equal('An unknown error occurred');
+    });
+
+    it('only has one error', () => {
+      expect(TitleShowPage.toast.errorToastCount).to.equal(1);
+      expect(TitleShowPage.toast.totalToastCount).to.equal(1);
+    });
+
+    it('is positioned to the bottom', () => {
+      expect(TitleShowPage.toast.isPositionedBottom).to.be.true;
+      expect(TitleShowPage.toast.isPositionedTop).to.be.false;
+    });
+
     it('dies with dignity', () => {
       expect(TitleShowPage.hasErrors).to.be.true;
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,7 +327,7 @@
     react-router-dom "^4.0.0"
     redux-form "^7.0.3"
 
-"@folio/ui-testing@github:folio-org/ui-testing#framework-only":
+"@folio/ui-testing@folio-org/ui-testing#framework-only":
   version "4.0.0"
   resolved "https://codeload.github.com/folio-org/ui-testing/tar.gz/90a425c1a8d12552e04c72dfeec2f623a81af629"
   dependencies:


### PR DESCRIPTION
## Purpose
Re: [UIEH-71](https://issues.folio.org/browse/UIEH-71)
Currently we do not have `GET` errors displaying to the user. This change displays a generic `error` message to users so that they know that the application is listening, but also that something has gone awry.

## Approach
I based my work off of @Robdel12's pull request #301 to add similar functionality to the `GET` errors as the `PUT`s, utilizing the `toast` components written here. To make the code a bit more dry and reusable, I added both the aforementioned `PUT` errors work, as well as my `GET` errors work, into the `utilities` file.

## Screenshots
This is an example of an error that displays with a package that does not exist. Identical to the errors one gets for `PUT`s.
![localhost_3000_eholdings_packages_1](https://user-images.githubusercontent.com/25858667/38206320-99553d62-366f-11e8-86c4-224de2fb4f52.png)