### PR TITLE
Fix visit helper

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -94,7 +94,5 @@ describeApplication.only = function (name, setup) {
 function visit(context, path, convergenceCheck) {
   return new Convergence()
     .do(() => context.app.visit(path))
-    .once(convergenceCheck)
-    .timeout(context.timeout())
-    .run();
+    .once(convergenceCheck);
 }


### PR DESCRIPTION
## Purpose

Now that we've fully migrated over to bigtest and we can return convergences from our hooks, this `.timeout().run()` is no longer necessary since bigtest/mocha does that for us.

This will hopefully squelch some timeout errors we're seeing when running our tests in Firefox (#315)
