### PR TITLE
UIEH-237 Move metadata for records to top of detail view

### DIFF
--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -142,6 +142,68 @@ export default class CustomerResourceShow extends Component {
           )}
           bodyContent={(
             <div>
+              <DetailsViewSection label="Resource information">
+
+                <ContributorsList data={model.contributors} />
+
+                <KeyValue label="Publisher">
+                  <div data-test-eholdings-customer-resource-show-publisher-name>
+                    {model.publisherName}
+                  </div>
+                </KeyValue>
+
+                {model.publicationType && (
+                  <KeyValue label="Publication type">
+                    <div data-test-eholdings-customer-resource-show-publication-type>
+                      {model.publicationType}
+                    </div>
+                  </KeyValue>
+                )}
+
+                <IdentifiersList data={model.identifiers} />
+
+                {model.subjects.length > 0 && (
+                  <KeyValue label="Subjects">
+                    <div data-test-eholdings-customer-resource-show-subjects-list>
+                      {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
+                    </div>
+                  </KeyValue>
+                )}
+
+                <KeyValue label="Provider">
+                  <div data-test-eholdings-customer-resource-show-provider-name>
+                    <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
+                  </div>
+                </KeyValue>
+
+                <KeyValue label="Package">
+                  <div data-test-eholdings-customer-resource-show-package-name>
+                    <Link to={`/eholdings/packages/${model.packageId}`}>{model.packageName}</Link>
+                  </div>
+                </KeyValue>
+
+                <KeyValue label="Other packages">
+                  <Link to={`/eholdings/titles/${model.titleId}`}>
+                    View all packages that include this title
+                  </Link>
+                </KeyValue>
+
+                {model.contentType && (
+                  <KeyValue label="Content type">
+                    <div data-test-eholdings-customer-resource-show-content-type>
+                      {model.contentType}
+                    </div>
+                  </KeyValue>
+                )}
+
+                {model.url && (
+                  <KeyValue label="Managed URL">
+                    <div data-test-eholdings-customer-resource-show-managed-url>
+                      <a href={model.url} target="_blank">{model.url}</a>
+                    </div>
+                  </KeyValue>
+                )}
+              </DetailsViewSection>
               <DetailsViewSection label="Holding status">
                 <label
                   data-test-eholdings-customer-resource-show-selected
@@ -270,69 +332,6 @@ export default class CustomerResourceShow extends Component {
                   <p>Add the resource to holdings to set an custom embargo period.</p>
                 )}
 
-              </DetailsViewSection>
-
-              <DetailsViewSection label="Resource information">
-
-                <ContributorsList data={model.contributors} />
-
-                <KeyValue label="Publisher">
-                  <div data-test-eholdings-customer-resource-show-publisher-name>
-                    {model.publisherName}
-                  </div>
-                </KeyValue>
-
-                {model.publicationType && (
-                  <KeyValue label="Publication type">
-                    <div data-test-eholdings-customer-resource-show-publication-type>
-                      {model.publicationType}
-                    </div>
-                  </KeyValue>
-                )}
-
-                <IdentifiersList data={model.identifiers} />
-
-                {model.subjects.length > 0 && (
-                  <KeyValue label="Subjects">
-                    <div data-test-eholdings-customer-resource-show-subjects-list>
-                      {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
-                    </div>
-                  </KeyValue>
-                )}
-
-                <KeyValue label="Provider">
-                  <div data-test-eholdings-customer-resource-show-provider-name>
-                    <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
-                  </div>
-                </KeyValue>
-
-                <KeyValue label="Package">
-                  <div data-test-eholdings-customer-resource-show-package-name>
-                    <Link to={`/eholdings/packages/${model.packageId}`}>{model.packageName}</Link>
-                  </div>
-                </KeyValue>
-
-                <KeyValue label="Other packages">
-                  <Link to={`/eholdings/titles/${model.titleId}`}>
-                    View all packages that include this title
-                  </Link>
-                </KeyValue>
-
-                {model.contentType && (
-                  <KeyValue label="Content type">
-                    <div data-test-eholdings-customer-resource-show-content-type>
-                      {model.contentType}
-                    </div>
-                  </KeyValue>
-                )}
-
-                {model.url && (
-                  <KeyValue label="Managed URL">
-                    <div data-test-eholdings-customer-resource-show-managed-url>
-                      <a href={model.url} target="_blank">{model.url}</a>
-                    </div>
-                  </KeyValue>
-                )}
               </DetailsViewSection>
             </div>
           )}

--- a/src/components/package-show.js
+++ b/src/components/package-show.js
@@ -114,6 +114,33 @@ export default class PackageShow extends Component {
           )}
           bodyContent={(
             <div>
+              <DetailsViewSection label="Package information">
+                <KeyValue label="Provider">
+                  <div data-test-eholdings-package-details-provider>
+                    <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
+                  </div>
+                </KeyValue>
+
+                {model.contentType && (
+                  <KeyValue label="Content type">
+                    <div data-test-eholdings-package-details-content-type>
+                      {model.contentType}
+                    </div>
+                  </KeyValue>
+                )}
+
+                <KeyValue label="Titles selected">
+                  <div data-test-eholdings-package-details-titles-selected>
+                    {intl.formatNumber(model.selectedCount)}
+                  </div>
+                </KeyValue>
+
+                <KeyValue label="Total titles">
+                  <div data-test-eholdings-package-details-titles-total>
+                    {intl.formatNumber(model.titleCount)}
+                  </div>
+                </KeyValue>
+              </DetailsViewSection>
               <DetailsViewSection label="Holding status">
                 <label
                   data-test-eholdings-package-details-selected
@@ -214,33 +241,6 @@ export default class PackageShow extends Component {
                 ) : (
                   <p>Add the package to holdings to set custom coverage dates.</p>
                 )}
-              </DetailsViewSection>
-              <DetailsViewSection label="Package information">
-                <KeyValue label="Provider">
-                  <div data-test-eholdings-package-details-provider>
-                    <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
-                  </div>
-                </KeyValue>
-
-                {model.contentType && (
-                  <KeyValue label="Content type">
-                    <div data-test-eholdings-package-details-content-type>
-                      {model.contentType}
-                    </div>
-                  </KeyValue>
-                )}
-
-                <KeyValue label="Titles selected">
-                  <div data-test-eholdings-package-details-titles-selected>
-                    {intl.formatNumber(model.selectedCount)}
-                  </div>
-                </KeyValue>
-
-                <KeyValue label="Total titles">
-                  <div data-test-eholdings-package-details-titles-total>
-                    {intl.formatNumber(model.titleCount)}
-                  </div>
-                </KeyValue>
               </DetailsViewSection>
             </div>
           )}


### PR DESCRIPTION
Resolves https://issues.folio.org/browse/UIEH-237.

I had moved the "package information" and "resource information" sections lower.

![localhost_3000_eholdings_customer-resources_590-4220-12291861 iphone 5_se](https://user-images.githubusercontent.com/230597/38272792-ec188b86-374f-11e8-9453-0598c0ec628a.png)
