### PR TITLE
Blur embargo value for validation tests

### DIFF
--- a/tests/customer-resource-edit-test.js
+++ b/tests/customer-resource-edit-test.js
@@ -82,6 +82,7 @@ describeApplication('CustomerResourceEdit', () => {
                 fringilla vel, aliquet nec, vulputate e`)
               .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
               .inputEmbargoValue('')
+              .blurEmbargoValue()
               .selectEmbargoUnit('Weeks')
               .clickSave();
           });
@@ -204,6 +205,7 @@ describeApplication('CustomerResourceEdit', () => {
             fringilla vel, aliquet nec, vulputate e`)
           .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
           .inputEmbargoValue('')
+          .blurEmbargoValue()
           .selectEmbargoUnit('Weeks')
           .clickSave();
       });


### PR DESCRIPTION
This test has been flaky: https://circleci.com/gh/folio-org/ui-eholdings/1582

Sometimes it can't find the validation message at all, and sometimes it is the wrong message.

My best guess is that the validation isn't being properly triggered, so I explicitly blur the field. That's the approach we've taken on some other inputs.