### PR TITLE
Add ariaLabel to search field in absence of label markup

### DIFF
--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -154,6 +154,7 @@ export default class SearchForm extends Component {
                 onClear={this.handleClearSearch}
                 value={searchString}
                 placeholder={`Search ${searchType}...`}
+                ariaLabel={`Search ${searchType}`}
                 loading={isLoading}
               />
             </div>
@@ -165,6 +166,7 @@ export default class SearchForm extends Component {
                 onClear={this.handleClearSearch}
                 value={searchString}
                 placeholder={`Search ${searchType}...`}
+                ariaLabel={`Search ${searchType}`}
                 loading={isLoading}
               />
             </div>


### PR DESCRIPTION
Another quick win. Although it didn't change VoiceOver's behavior, it satisfied axe-devtools to add an `ariaLabel` to the search field.