### PR TITLE
Add action menu items to pane headers

### DIFF
--- a/src/components/customer-resource-edit/customer-resource-edit.js
+++ b/src/components/customer-resource-edit/customer-resource-edit.js
@@ -62,12 +62,23 @@ class CustomerResourceEdit extends Component {
       change
     } = this.props;
 
+    let actionMenuItems = [
+      {
+        label: 'Cancel editing',
+        to: {
+          pathname: `/eholdings/customer-resources/${model.id}`,
+          state: { eholdings: true }
+        }
+      }
+    ];
+
     return (
       <DetailsView
         type="resource"
         model={model}
         paneTitle={model.name}
         paneSub={model.packageName}
+        actionMenuItems={actionMenuItems}
         bodyContent={(
           <form onSubmit={handleSubmit(onSubmit)}>
             <DetailsViewSection

--- a/src/components/customer-resource-show.js
+++ b/src/components/customer-resource-show.js
@@ -123,6 +123,16 @@ export default class CustomerResourceShow extends Component {
       }];
     }
 
+    let actionMenuItems = [
+      {
+        label: 'Edit',
+        to: {
+          pathname: `/eholdings/customer-resources/${model.id}/edit`,
+          state: { eholdings: true }
+        }
+      }
+    ];
+
     return (
       <div>
         <Toaster toasts={processErrors(model)} position="bottom" />
@@ -132,6 +142,7 @@ export default class CustomerResourceShow extends Component {
           model={model}
           paneTitle={model.name}
           paneSub={model.packageName}
+          actionMenuItems={actionMenuItems}
           lastMenu={(
             <PaneMenu>
               <IconButton

--- a/src/components/package-edit/package-edit.js
+++ b/src/components/package-edit/package-edit.js
@@ -26,7 +26,8 @@ class PackageEdit extends Component {
       history: PropTypes.shape({
         push: PropTypes.func.isRequired
       }).isRequired
-    }).isRequired
+    }).isRequired,
+    queryParams: PropTypes.object
   };
 
   componentWillReceiveProps(nextProps) {
@@ -56,11 +57,31 @@ class PackageEdit extends Component {
       pristine
     } = this.props;
 
+    let {
+      queryParams,
+      router
+    } = this.context;
+
+    let actionMenuItems = [
+      {
+        label: 'Cancel editing',
+        to: `/eholdings/packages/${model.id}${router.route.location.search}`
+      }
+    ];
+
+    if (queryParams) {
+      actionMenuItems.push({
+        label: 'Maximize',
+        to: `/eholdings/packages/${model.id}/edit`
+      });
+    }
+
     return (
       <DetailsView
         type="package"
         model={model}
         paneTitle={model.name}
+        actionMenuItems={actionMenuItems}
         bodyContent={(
           <form onSubmit={handleSubmit(onSubmit)}>
             <DetailsViewSection

--- a/src/components/package-show/index.js
+++ b/src/components/package-show/index.js
@@ -1,0 +1,1 @@
+export { default } from './package-show';

--- a/src/components/package-show/package-show.css
+++ b/src/components/package-show/package-show.css
@@ -1,0 +1,9 @@
+@import '@folio/stripes-components/lib/variables';
+
+.full-view-link {
+  display: none;
+
+  @media (--mediumUp) {
+    display: block;
+  }
+}

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -8,18 +8,20 @@ import {
   KeyValue,
   PaneMenu
 } from '@folio/stripes-components';
-import { processErrors } from './utilities';
+import { processErrors } from '../utilities';
 
-import DetailsView from './details-view';
-import QueryList from './query-list';
-import Link from './link';
-import TitleListItem from './title-list-item';
-import ToggleSwitch from './toggle-switch';
-import Modal from './modal';
-import PackageCustomCoverage from './package-custom-coverage';
-import NavigationModal from './navigation-modal';
-import DetailsViewSection from './details-view-section';
-import Toaster from './toaster';
+import DetailsView from '../details-view';
+import QueryList from '../query-list';
+import Link from '../link';
+import TitleListItem from '../title-list-item';
+import ToggleSwitch from '../toggle-switch';
+import Modal from '../modal';
+import PackageCustomCoverage from '../package-custom-coverage';
+import NavigationModal from '../navigation-modal';
+import DetailsViewSection from '../details-view-section';
+import Toaster from '../toaster';
+
+import styles from './package-show.css';
 
 export default class PackageShow extends Component {
   static propTypes = {
@@ -83,7 +85,7 @@ export default class PackageShow extends Component {
 
   render() {
     let { model, fetchPackageTitles, customCoverageSubmitted } = this.props;
-    let { intl, router } = this.context;
+    let { intl, router, queryParams } = this.context;
     let {
       showSelectionModal,
       packageSelected,
@@ -97,6 +99,27 @@ export default class PackageShow extends Component {
       endCoverage: model.customCoverage.endCoverage
     }];
 
+    let actionMenuItems = [
+      {
+        label: 'Edit',
+        to: {
+          pathname: `/eholdings/packages/${model.id}/edit`,
+          state: { eholdings: true }
+        }
+      }
+    ];
+
+    if (queryParams.searchType) {
+      actionMenuItems.push({
+        label: 'Full view',
+        to: {
+          pathname: `/eholdings/packages/${model.id}`,
+          state: { eholdings: true }
+        },
+        className: styles['full-view-link']
+      });
+    }
+
     return (
       <div>
         <Toaster toasts={processErrors(model)} position="bottom" />
@@ -104,6 +127,7 @@ export default class PackageShow extends Component {
           type="package"
           model={model}
           paneTitle={model.name}
+          actionMenuItems={actionMenuItems}
           lastMenu={(
             <PaneMenu>
               <IconButton

--- a/src/components/provider-show/index.js
+++ b/src/components/provider-show/index.js
@@ -1,0 +1,1 @@
+export { default } from './provider-show';

--- a/src/components/provider-show/provider-show.css
+++ b/src/components/provider-show/provider-show.css
@@ -1,0 +1,9 @@
+@import '@folio/stripes-components/lib/variables';
+
+.full-view-link {
+  display: none;
+
+  @media (--mediumUp) {
+    display: block;
+  }
+}

--- a/src/components/provider-show/provider-show.js
+++ b/src/components/provider-show/provider-show.js
@@ -2,19 +2,34 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { KeyValue } from '@folio/stripes-components';
 
-import { processErrors } from './utilities';
-import DetailsView from './details-view';
-import QueryList from './query-list';
-import PackageListItem from './package-list-item';
-import DetailsViewSection from './details-view-section';
-import Toaster from './toaster';
+import { processErrors } from '../utilities';
+import DetailsView from '../details-view';
+import QueryList from '../query-list';
+import PackageListItem from '../package-list-item';
+import DetailsViewSection from '../details-view-section';
+import Toaster from '../toaster';
+import styles from './provider-show.css';
 
 export default function ProviderShow({
   model,
   fetchPackages
 }, {
-  intl
+  intl,
+  queryParams
 }) {
+  let actionMenuItems = [];
+
+  if (queryParams.searchType) {
+    actionMenuItems.push({
+      label: 'Full view',
+      to: {
+        pathname: `/eholdings/providers/${model.id}`,
+        state: { eholdings: true }
+      },
+      className: styles['full-view-link']
+    });
+  }
+
   return (
     <div>
       <Toaster toasts={processErrors(model)} position="bottom" />
@@ -23,6 +38,7 @@ export default function ProviderShow({
         type="provider"
         model={model}
         paneTitle={model.name}
+        actionMenuItems={actionMenuItems}
         bodyContent={(
           <DetailsViewSection label="Provider information">
             <KeyValue label="Packages selected">

--- a/src/components/title-show/index.js
+++ b/src/components/title-show/index.js
@@ -1,0 +1,1 @@
+export { default } from './title-show';

--- a/src/components/title-show/title-show.css
+++ b/src/components/title-show/title-show.css
@@ -1,0 +1,9 @@
+@import '@folio/stripes-components/lib/variables';
+
+.full-view-link {
+  display: none;
+
+  @media (--mediumUp) {
+    display: block;
+  }
+}

--- a/src/components/title-show/title-show.js
+++ b/src/components/title-show/title-show.js
@@ -2,16 +2,30 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { KeyValue } from '@folio/stripes-components';
 
-import { processErrors } from './utilities';
-import DetailsView from './details-view';
-import ScrollView from './scroll-view';
-import PackageListItem from './package-list-item';
-import IdentifiersList from './identifiers-list';
-import ContributorsList from './contributors-list';
-import DetailsViewSection from './details-view-section';
-import Toaster from './toaster';
+import { processErrors } from '../utilities';
+import DetailsView from '../details-view';
+import ScrollView from '../scroll-view';
+import PackageListItem from '../package-list-item';
+import IdentifiersList from '../identifiers-list';
+import ContributorsList from '../contributors-list';
+import DetailsViewSection from '../details-view-section';
+import Toaster from '../toaster';
+import styles from './title-show.css';
 
-export default function TitleShow({ model }) {
+export default function TitleShow({ model }, { queryParams }) {
+  let actionMenuItems = [];
+
+  if (queryParams.searchType) {
+    actionMenuItems.push({
+      label: 'Full view',
+      to: {
+        pathname: `/eholdings/titles/${model.id}`,
+        state: { eholdings: true }
+      },
+      className: styles['full-view-link']
+    });
+  }
+
   return (
     <div>
       <Toaster toasts={processErrors(model)} position="bottom" />
@@ -20,6 +34,7 @@ export default function TitleShow({ model }) {
         type="title"
         model={model}
         paneTitle={model.name}
+        actionMenuItems={actionMenuItems}
         bodyContent={(
           <DetailsViewSection label="Title information">
             <ContributorsList data={model.contributors} />


### PR DESCRIPTION
## Purpose
Evolution of https://issues.folio.org/browse/STCOM-194

When a user is looking at a three-pane search layout, we want to give them the option to see the third pane by itself.

## Approach
The "Full view" link kicks the user out to a new page that shows the record without any search query.

Media queries hide the "Full view" link at high browser zoom or small screen width, since at those sizes the third pane is already full-width. That means the action menu is empty for providers and titles at small sizes, but I imagine there will very soon be more items in the menu to make that less strange.

## Screenshots
![2018-04-04 11 56 11](https://user-images.githubusercontent.com/230597/38322317-aa4ef31a-37ff-11e8-8daf-be039cc37dcb.gif)