### PR TITLE
Create right-clickability for search results items

### DIFF
--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -13,7 +13,8 @@ export default function PackageListItem({
   active,
   showTitleCount,
   showProviderName,
-  packageName
+  packageName,
+  onClick
 }, {
   intl
 }) {
@@ -31,6 +32,12 @@ export default function PackageListItem({
       className={cx('item', {
         'is-selected': active
       })}
+      onClick={(e) => {
+        if (onClick) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
     >
       <h5 data-test-eholdings-package-list-item-name>
         {packageName || item.name}
@@ -88,7 +95,8 @@ PackageListItem.propTypes = {
   active: PropTypes.bool,
   showTitleCount: PropTypes.bool,
   showProviderName: PropTypes.bool,
-  packageName: PropTypes.string
+  packageName: PropTypes.string,
+  onClick: PropTypes.func
 };
 
 PackageListItem.contextTypes = {

--- a/src/components/package-search-list.js
+++ b/src/components/package-search-list.js
@@ -28,10 +28,14 @@ export default function PackageSearchList({
           showProviderName
           item={item.content}
           link={item.content && {
-            pathname: `/eholdings/packages/${item.content.id}`,
-            search: location.search
+            pathname: `/eholdings/packages/${item.content.id}`
           }}
           active={item.content && isPackagePage && routeParams.id === item.content.id}
+          onClick={() => {
+            router.history.push(
+              `/eholdings/packages/${item.content.id}${location.search}`
+            );
+          }}
         />
       )}
     />

--- a/src/components/provider-list-item/provider-list-item.js
+++ b/src/components/provider-list-item/provider-list-item.js
@@ -7,7 +7,7 @@ import Link from '../link';
 
 const cx = classNames.bind(styles);
 
-export default function ProviderListItem({ item, link, active }, { intl }) {
+export default function ProviderListItem({ item, link, active, onClick }, { intl }) {
   return !item ? (
     <div className={styles.skeleton} />
   ) : (
@@ -17,6 +17,12 @@ export default function ProviderListItem({ item, link, active }, { intl }) {
       className={cx('item', {
         'is-selected': active
       })}
+      onClick={(e) => {
+        if (onClick) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
     >
       <h5 data-test-eholdings-provider-list-item-name>
         {item.name}
@@ -48,6 +54,7 @@ ProviderListItem.propTypes = {
     PropTypes.object
   ]),
   active: PropTypes.bool,
+  onClick: PropTypes.func
 };
 
 ProviderListItem.contextTypes = {

--- a/src/components/provider-search-list.js
+++ b/src/components/provider-search-list.js
@@ -27,10 +27,14 @@ export default function ProviderSearchList({
         <ProviderListItem
           item={item.content}
           link={item.content && {
-            pathname: `/eholdings/providers/${item.content.id}`,
-            search: location.search
+            pathname: `/eholdings/providers/${item.content.id}`
           }}
           active={item.content && isProviderPage && routeParams.id === item.content.id}
+          onClick={() => {
+            router.history.push(
+              `/eholdings/providers/${item.content.id}${location.search}`
+            );
+          }}
         />
       )}
     />

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -12,7 +12,8 @@ export default function TitleListItem({
   link,
   active,
   showSelected,
-  showPublisherAndType
+  showPublisherAndType,
+  onClick
 }) {
   return !item ? (
     <div
@@ -28,6 +29,12 @@ export default function TitleListItem({
       className={cx('item', {
         'is-selected': active
       })}
+      onClick={(e) => {
+        if (onClick) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
     >
       <h5 data-test-eholdings-title-list-item-title-name>
         {item.name}
@@ -75,5 +82,6 @@ TitleListItem.propTypes = {
   ]),
   active: PropTypes.bool,
   showSelected: PropTypes.bool,
-  showPublisherAndType: PropTypes.bool
+  showPublisherAndType: PropTypes.bool,
+  onClick: PropTypes.func
 };

--- a/src/components/title-search-list.js
+++ b/src/components/title-search-list.js
@@ -28,10 +28,14 @@ export default function TitleSearchList({
           showPublisherAndType
           item={item.content}
           link={item.content && {
-            pathname: `/eholdings/titles/${item.content.id}`,
-            search: location.search
+            pathname: `/eholdings/titles/${item.content.id}`
           }}
           active={item.content && isTitlePage && routeParams.id === item.content.id}
+          onClick={() => {
+            router.history.push(
+              `/eholdings/titles/${item.content.id}${location.search}`
+            );
+          }}
         />
       )}
     />


### PR DESCRIPTION
## Purpose
Right now, if you open a native context menu from a search results item and select "Open Link in New Tab" or "Open Link in New Window", it will link to the full search results layout with that record's preview pane open.

## Approach
We can default to the href of the record by itself, but capture that click and add the search parameters to stay within the search results context.