### PR TITLE
Refactor KB auth form to use redux-form

### DIFF
--- a/src/components/settings-knowledge-base/settings-knowledge-base.css
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.css
@@ -1,80 +1,16 @@
 @import '@folio/stripes-components/lib/variables';
 
+.settings-kb-form {
+  max-width: 50em;
+}
+
 .settings-kb-form-actions {
-  @media (--mediumUp) {
-    display: flex;
-    flex-direction: row-reverse;
-  }
+  align-items: flex-start;
+  border-top: 1px solid var(--minor-divider-color);
+  display: flex;
+  padding-top: 1em;
 
   & button {
-    background: #fff;
-    border: 1px solid var(--primary);
-    border-radius: 0.4em;
-    color: var(--primary);
-    margin: 0.5em 0;
-    padding: 0.57em;
-    text-align: center;
-    text-decoration: none;
-    user-select: none;
-    vertical-align: middle;
-    white-space: nowrap;
-    width: 100%;
-
-    @media (--mediumUp) {
-      display: inline-block;
-      margin: 0.5em;
-      padding: 0.36em 0.57em;
-      width: auto;
-    }
-  }
-
-  & button[type=submit] {
-    background: var(--primary);
-    color: #fff;
-  }
-}
-
-.settings-kb-field {
-  margin-bottom: var(--controlMarginBottom);
-
-  & label {
-    display: block;
-    font-size: 0.8em;
-    font-weight: bold;
-    margin-bottom: 4px;
-    text-transform: Uppercase;
-    color: var(--labelColor);
-  }
-
-  & input {
-    height: var(--controlHeight);
-    min-height: var(--controlHeight);
-    margin-bottom: var(--controlMarginBottom);
-    padding: 4px;
-    border: 1px solid var(--inputBorderColor);
-    width: 100%;
-  }
-
-  &.has-error {
-    & label {
-      color: #900;
-    }
-
-    & input {
-      border-color: #900;
-    }
-  }
-}
-
-.settings-kb-save-error {
-  display: flex;
-  align-items: center;
-  flex-grow: 1;
-  color: var(--error);
-}
-
-.settings-kb-back-button {
-  @media (--mediumUp) {
-    display: none;
+    margin-right: 0.25em;
   }
 }

--- a/src/components/settings-knowledge-base/settings-knowledge-base.js
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.js
@@ -1,168 +1,99 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames/bind';
-import { Icon } from '@folio/stripes-components';
+import { reduxForm, Field } from 'redux-form';
+import {
+  Button,
+  Icon,
+  TextField
+} from '@folio/stripes-components';
 import SettingsDetailPane from '../settings-detail-pane';
-
+import { processErrors } from '../utilities';
+import Toaster from '../toaster';
 import styles from './settings-knowledge-base.css';
 
-const cx = classNames.bind(styles);
-
-export default class SettingsKnowledgeBase extends Component {
+class SettingsKnowledgeBase extends Component {
   static propTypes = {
-    settings: PropTypes.object.isRequired,
-    onSubmit: PropTypes.func.isRequired
-  };
-
-  state = {
-    customerId: this.props.settings.customerId || '',
-    apiKey: this.props.settings.apiKey || '',
-    invalidCustomerId: false,
-    invalidApiKey: false
-  };
-
-  componentWillReceiveProps(nextProps) {
-    let { customerId, apiKey } = this.state;
-    let { settings: old } = this.props;
-    let { settings: next } = nextProps;
-
-    let isDirty = customerId !== next.customerId || apiKey !== next.apiKey;
-    let hasUpdated = old.update.isPending && next.update.isResolved;
-    let hasFinishedLoading = old.isLoading && next.isLoaded;
-
-    if (hasFinishedLoading || (hasUpdated && isDirty)) {
-      this.setState({
-        customerId: next.customerId,
-        apiKey: next.apiKey
-      });
-    }
-  }
-
-  handleSubmit = (e) => {
-    let { customerId, apiKey } = this.state;
-
-    e.preventDefault();
-
-    this.props.onSubmit({
-      customerId,
-      apiKey
-    });
-  };
-
-  handleClear = (e) => {
-    let settings = this.props.settings;
-
-    e.preventDefault();
-
-    this.setState({
-      customerId: settings.customerId,
-      apiKey: settings.apiKey,
-      invalidCustomerId: false,
-      invalidApiKey: false
-    });
-  };
-
-  updateCustomerId = (e) => {
-    this.validateCustomerId(e);
-    this.setState({ customerId: e.target.value });
-  };
-
-  updateApiKey = (e) => {
-    this.validateApiKey(e);
-    this.setState({ apiKey: e.target.value });
-  };
-
-  validateCustomerId = (e) => {
-    if (e.target.value.length > 0) {
-      this.setState({ invalidCustomerId: false });
-    } else {
-      this.setState({ invalidCustomerId: true });
-    }
-  };
-
-  validateApiKey = (e) => {
-    if (e.target.value.length > 0) {
-      this.setState({ invalidApiKey: false });
-    } else {
-      this.setState({ invalidApiKey: true });
-    }
+    model: PropTypes.object.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    handleSubmit: PropTypes.func,
+    pristine: PropTypes.bool,
+    reset: PropTypes.func,
+    invalid: PropTypes.bool
   };
 
   render() {
-    let { customerId, apiKey, invalidCustomerId, invalidApiKey } = this.state;
-    let { settings } = this.props;
-
-    let isFresh = !customerId && !apiKey;
-    let isDirty = customerId !== settings.customerId || apiKey !== settings.apiKey;
-    let isValid = customerId && apiKey;
+    let {
+      model,
+      handleSubmit,
+      onSubmit,
+      pristine,
+      reset,
+      invalid
+    } = this.props;
 
     return (
       <SettingsDetailPane
         paneTitle="Knowledge base"
       >
-        <h4
-          className={styles['setttings-kb-headline']}
-        >
-          EBSCO RM API credentials
-        </h4>
+        <Toaster toasts={processErrors(model)} position="bottom" />
 
-        {settings.isLoading ? (
+        <h3>EBSCO RM API credentials</h3>
+
+        {model.isLoading ? (
           <Icon icon="spinner-ellipsis" />
         ) : (
           <form
-            onSubmit={this.handleSubmit}
+            onSubmit={handleSubmit(onSubmit)}
             data-test-eholdings-settings
             className={styles['settings-kb-form']}
           >
-            {settings.request.isRejected && (
-              <p data-test-eholdings-settings-error>
-                {settings.request.errors[0].title}
-              </p>
-            )}
-
             <div
               data-test-eholdings-settings-customerid
-              className={cx(styles['settings-kb-field'], {
-                'has-error': invalidCustomerId
-              })}
             >
-              <label htmlFor="eholdings-settings-kb-customerid">Customer ID</label>
-              <input
+              <Field
                 id="eholdings-settings-kb-customerid"
+                label="Customer ID"
+                name="customerId"
+                component={TextField}
                 type="text"
                 autoComplete="off"
-                value={customerId}
-                onChange={this.updateCustomerId}
-                onBlur={this.validateCustomerId}
               />
             </div>
 
             <div
               data-test-eholdings-settings-apikey
-              className={cx(styles['settings-kb-field'], {
-                'has-error': invalidApiKey
-              })}
             >
-              <label htmlFor="eholdings-settings-kb-apikey">API key</label>
-              <input
+              <Field
                 id="eholdings-settings-kb-apikey"
+                label="API key"
+                name="apiKey"
+                component={TextField}
                 type="password"
                 autoComplete="off"
-                value={apiKey}
-                onChange={this.updateApiKey}
-                onBlur={this.validateApiKey}
               />
             </div>
 
-            {(isFresh || isDirty) && (
-              <div className={styles['settings-kb-form-actions']} data-test-eholdings-settings-actions>
-                <button type="submit" disabled={!isValid || settings.isSaving}>Save</button>
-                <button type="reset" onClick={this.handleClear}>Cancel</button>
-
-                {settings.update.isRejected && (
-                  <div className={styles['settings-kb-save-error']} data-test-eholdings-settings-error>
-                    {settings.update.errors[0].title}
-                  </div>
+            {(!pristine || (!model.customerId && !model.apiKey)) && (
+              <div
+                className={styles['settings-kb-form-actions']}
+                data-test-eholdings-settings-kb-actions
+              >
+                <Button
+                  disabled={model.update.isPending}
+                  type="reset"
+                  onClick={reset}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  disabled={model.update.isPending || invalid}
+                  type="submit"
+                  buttonStyle="primary"
+                >
+                  {model.update.isPending ? 'Saving' : 'Save'}
+                </Button>
+                {model.update.isPending && (
+                  <Icon icon="spinner-ellipsis" />
                 )}
               </div>
             )}
@@ -172,3 +103,24 @@ export default class SettingsKnowledgeBase extends Component {
     );
   }
 }
+
+const validate = (values) => {
+  let errors = {};
+
+  if (values.customerId.length <= 0) {
+    errors.customerId = 'Customer ID cannot be blank.';
+  }
+
+  if (values.apiKey.length <= 0) {
+    errors.apiKey = 'API key cannot be blank.';
+  }
+
+  return errors;
+};
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'SettingsKnowledgeBase',
+  destroyOnUnmount: false,
+})(SettingsKnowledgeBase);

--- a/src/routes/settings-knowledge-base.js
+++ b/src/routes/settings-knowledge-base.js
@@ -32,8 +32,12 @@ class SettingsKnowledgeBaseRoute extends Component {
 
     return (
       <View
-        settings={config}
+        model={config}
         onSubmit={this.updateConfig}
+        initialValues={{
+          customerId: config.customerId,
+          apiKey: config.apiKey
+        }}
       />
     );
   }

--- a/tests/backend-configuration-test.js
+++ b/tests/backend-configuration-test.js
@@ -52,7 +52,7 @@ describeApplication('With unconfigured backend', {
       });
     });
 
-    describe('when visiting settings', () => {
+    describe('when visiting the KB auth form', () => {
       beforeEach(function () {
         return this.visit('/settings/eholdings/knowledge-base', () => expect(SettingsPage.$root).to.exist);
       });
@@ -99,7 +99,7 @@ describeApplication('With unconfigured backend', {
 });
 
 describeApplication('With valid backend configuration', () => {
-  describe('when visiting settings', () => {
+  describe('when visiting the KB auth form', () => {
     beforeEach(function () {
       return this.visit('/settings/eholdings/knowledge-base', () => expect(SettingsPage.$root).to.exist);
     });
@@ -137,7 +137,7 @@ describeApplication('With valid backend configuration', () => {
       });
 
       it('reports the error to the interface', () => {
-        expect(SettingsPage.errorText).to.equal('RM-API credentials are invalid');
+        expect(SettingsPage.toast.errorText).to.equal('RM-API credentials are invalid');
       });
     });
 
@@ -192,7 +192,7 @@ describeApplication('With valid backend configuration', () => {
         });
 
         it('shows an error message', () => {
-          expect(SettingsPage.errorText).to.equal('an error has occurred');
+          expect(SettingsPage.toast.errorText).to.equal('an error has occurred');
         });
       });
 

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -6,9 +6,9 @@ import {
   isPresent,
   page,
   property,
-  text,
   value
 } from '@bigtest/interaction';
+import Toast from './toast';
 
 import { hasClassBeginningWith } from './helpers';
 
@@ -19,14 +19,15 @@ import { hasClassBeginningWith } from './helpers';
   fillApiKey = fillable('[data-test-eholdings-settings-apikey] input');
   blurCustomerId = blurrable('[data-test-eholdings-settings-customerid] input');
   blurApiKey = blurrable('[data-test-eholdings-settings-apikey] input');
-  hasVisibleActions = isPresent('[data-test-eholdings-settings-actions]');
-  customerIdFieldIsInvalid = hasClassBeginningWith('has-error--', '[data-test-eholdings-settings-customerid]');
-  apiKeyFieldIsInvalid = hasClassBeginningWith('has-error--', '[data-test-eholdings-settings-apikey]');
-  errorText = text('[data-test-eholdings-settings-error]');
-  save = clickable('[data-test-eholdings-settings-actions] [type="submit"]');
-  saveButtonDisabled = property('disabled', '[data-test-eholdings-settings-actions] [type="submit"]');
-  cancel = clickable('[data-test-eholdings-settings-actions] [type="reset"]');
+  hasVisibleActions = isPresent('[data-test-eholdings-settings-kb-actions]');
+  customerIdFieldIsInvalid = hasClassBeginningWith('feedbackError--', '[data-test-eholdings-settings-customerid] input');
+  apiKeyFieldIsInvalid = hasClassBeginningWith('feedbackError--', '[data-test-eholdings-settings-apikey] input');
+  save = clickable('[data-test-eholdings-settings-kb-actions] [type="submit"]');
+  saveButtonDisabled = property('disabled', '[data-test-eholdings-settings-kb-actions] [type="submit"]');
+  cancel = clickable('[data-test-eholdings-settings-kb-actions] [type="reset"]');
   apiKeyInputType = attribute('type', '[data-test-eholdings-settings-apikey] input');
+
+  toast = Toast;
 }
 
 export default new SettingsPage('[data-test-eholdings-settings]');


### PR DESCRIPTION
## Purpose
The knowledge base settings form wasn't using `stripes-components` text inputs, or the `redux-form` patterns established in the rest of `ui-eholdings`. For consistency, we should handle this form the same way.

## Approach
Also now uses `Toast`s when an error occurs.

## Screenshots
### Before

![folio frontside io_ ipad 1](https://user-images.githubusercontent.com/230597/38377534-c34a97ea-38c0-11e8-8f2a-a4a502361651.png)

### After

![localhost_3000_settings_eholdings_knowledge-base ipad](https://user-images.githubusercontent.com/230597/38377526-bf9f95a0-38c0-11e8-9b52-005f89c1634f.png)
