### PR TITLE
Only increase heading levels by one

### DIFF
--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -22,8 +22,10 @@
         background-color: #efefef;
       }
 
-      & h5 {
+      & h3,
+      & h4 {
         color: #555;
+        font-size: 1.1rem;
         font-weight: 600;
         margin: 0 0 0.5em;
       }

--- a/src/components/package-list-item/package-list-item.css
+++ b/src/components/package-list-item/package-list-item.css
@@ -9,12 +9,14 @@
       background-color: #555;
     }
 
-    & h5 {
+    & h3,
+    & h4 {
       color: #fff;
     }
   }
 
-  & h5,
+  & h3,
+  & h4,
   & div {
     overflow: hidden;
     white-space: nowrap;

--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -14,10 +14,13 @@ export default function PackageListItem({
   showTitleCount,
   showProviderName,
   packageName,
-  onClick
+  onClick,
+  headingLevel
 }, {
   intl
 }) {
+  let Heading = headingLevel || 'h3';
+
   return !item ? (
     <div
       className={cx('skeleton', {
@@ -39,9 +42,9 @@ export default function PackageListItem({
         }
       }}
     >
-      <h5 data-test-eholdings-package-list-item-name>
+      <Heading data-test-eholdings-package-list-item-name>
         {packageName || item.name}
-      </h5>
+      </Heading>
 
       {showProviderName && (
         <div data-test-eholdings-package-list-item-provider-name>
@@ -96,7 +99,8 @@ PackageListItem.propTypes = {
   showTitleCount: PropTypes.bool,
   showProviderName: PropTypes.bool,
   packageName: PropTypes.string,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  headingLevel: PropTypes.string
 };
 
 PackageListItem.contextTypes = {

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -283,6 +283,7 @@ export default class PackageShow extends Component {
                   item={item.content}
                   link={item.content && `/eholdings/customer-resources/${item.content.id}`}
                   showSelected
+                  headingLevel='h4'
                 />
               )}
             />

--- a/src/components/provider-list-item/provider-list-item.css
+++ b/src/components/provider-list-item/provider-list-item.css
@@ -9,12 +9,14 @@
       background-color: #555;
     }
 
-    & h5 {
+    & h3,
+    & h4 {
       color: #fff;
     }
   }
 
-  & h5,
+  & h3,
+  & h4,
   & div {
     overflow: hidden;
     white-space: nowrap;

--- a/src/components/provider-list-item/provider-list-item.js
+++ b/src/components/provider-list-item/provider-list-item.js
@@ -7,7 +7,9 @@ import Link from '../link';
 
 const cx = classNames.bind(styles);
 
-export default function ProviderListItem({ item, link, active, onClick }, { intl }) {
+export default function ProviderListItem({ item, link, active, onClick, headingLevel }, { intl }) {
+  let Heading = headingLevel || 'h3';
+
   return !item ? (
     <div className={styles.skeleton} />
   ) : (
@@ -24,9 +26,9 @@ export default function ProviderListItem({ item, link, active, onClick }, { intl
         }
       }}
     >
-      <h5 data-test-eholdings-provider-list-item-name>
+      <Heading data-test-eholdings-provider-list-item-name>
         {item.name}
-      </h5>
+      </Heading>
 
       <div data-test-eholdings-provider-list-item-selections>
         <span data-test-eholdings-provider-list-item-num-packages-selected>
@@ -54,7 +56,8 @@ ProviderListItem.propTypes = {
     PropTypes.object
   ]),
   active: PropTypes.bool,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  headingLevel: PropTypes.string
 };
 
 ProviderListItem.contextTypes = {

--- a/src/components/provider-show/provider-show.js
+++ b/src/components/provider-show/provider-show.js
@@ -68,6 +68,7 @@ export default function ProviderShow({
                 link={item.content && `/eholdings/packages/${item.content.id}`}
                 item={item.content}
                 showTitleCount
+                headingLevel='h4'
               />
             )}
           />

--- a/src/components/title-list-item/title-list-item.css
+++ b/src/components/title-list-item/title-list-item.css
@@ -9,12 +9,14 @@
       background-color: #555;
     }
 
-    & h5 {
+    & h3,
+    & h4 {
       color: #fff;
     }
   }
 
-  & h5,
+  & h3,
+  & h4,
   & div {
     overflow: hidden;
     white-space: nowrap;

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -13,8 +13,11 @@ export default function TitleListItem({
   active,
   showSelected,
   showPublisherAndType,
-  onClick
+  onClick,
+  headingLevel
 }) {
+  let Heading = headingLevel || 'h3';
+
   return !item ? (
     <div
       className={cx('skeleton', {
@@ -36,9 +39,9 @@ export default function TitleListItem({
         }
       }}
     >
-      <h5 data-test-eholdings-title-list-item-title-name>
+      <Heading data-test-eholdings-title-list-item-title-name>
         {item.name}
-      </h5>
+      </Heading>
 
       {showPublisherAndType && (
         <div>
@@ -83,5 +86,6 @@ TitleListItem.propTypes = {
   active: PropTypes.bool,
   showSelected: PropTypes.bool,
   showPublisherAndType: PropTypes.bool,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  headingLevel: PropTypes.string
 };

--- a/src/components/title-show/title-show.js
+++ b/src/components/title-show/title-show.js
@@ -77,6 +77,7 @@ export default function TitleShow({ model }, { queryParams }) {
                 link={`/eholdings/customer-resources/${item.id}`}
                 packageName={item.packageName}
                 item={item}
+                headingLevel='h4'
               />
             )}
           </ScrollView>


### PR DESCRIPTION
## Purpose
`h1`/`h2`/`h3`/etc. should only increment by one in the DOM hierarchy.

## Approach
Add a `headingLevel` prop to list item renderers. Defaults to `h3`.

## Learning
https://dequeuniversity.com/rules/axe/3.0/heading-order
