### PR TITLE
UIEH-281 Hide title management section for custom packages

### DIFF
--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -214,42 +214,46 @@ export default class PackageShow extends Component {
                   <p>Not shown to patrons.</p>
                 )}
               </DetailsViewSection>
-              <DetailsViewSection label="Title management">
-                {packageSelected && !model.isCustom ? (
-                  <div>
-                    {packageAllowedToAddTitles != null ? (
-                      <div>
-                        <label
-                          data-test-eholdings-package-details-allow-add-new-titles
-                          htmlFor="package-details-toggle-allow-add-new-titles-switch"
-                        >
-                          <h4>
-                            {packageAllowedToAddTitles
-                            ? 'Automatically select new titles'
-                            : 'Do not automatically select new titles'}
-                          </h4>
-                          <br />
-                          <ToggleSwitch
-                            onChange={this.props.toggleAllowKbToAddTitles}
-                            checked={packageAllowedToAddTitles}
-                            isPending={model.update.isPending && 'allowKbToAddTitles' in model.update.changedAttributes}
-                            id="package-details-toggle-allow-add-new-titles-switch"
-                          />
-                        </label>
-                      </div>
-                      ) : (
-                        <label
-                          data-test-eholdings-package-details-allow-add-new-titles
-                          htmlFor="package-details-toggle-allow-add-new-titles-switch"
-                        >
-                          <Icon icon="spinner-ellipsis" />
-                        </label>
-                      )}
-                  </div>
-                ) : (
-                  <p>Knowledge base does not automatically select titles.</p>
-                )}
-              </DetailsViewSection>
+
+              {!model.isCustom && (
+                <DetailsViewSection label="Title management">
+                  {packageSelected ? (
+                    <div>
+                      {packageAllowedToAddTitles != null ? (
+                        <div>
+                          <label
+                            data-test-eholdings-package-details-allow-add-new-titles
+                            htmlFor="package-details-toggle-allow-add-new-titles-switch"
+                          >
+                            <h4>
+                              {packageAllowedToAddTitles
+                              ? 'Automatically select new titles'
+                              : 'Do not automatically select new titles'}
+                            </h4>
+                            <br />
+                            <ToggleSwitch
+                              onChange={this.props.toggleAllowKbToAddTitles}
+                              checked={packageAllowedToAddTitles}
+                              isPending={model.update.isPending && 'allowKbToAddTitles' in model.update.changedAttributes}
+                              id="package-details-toggle-allow-add-new-titles-switch"
+                            />
+                          </label>
+                        </div>
+                        ) : (
+                          <label
+                            data-test-eholdings-package-details-allow-add-new-titles
+                            htmlFor="package-details-toggle-allow-add-new-titles-switch"
+                          >
+                            <Icon icon="spinner-ellipsis" />
+                          </label>
+                        )}
+                    </div>
+                  ) : (
+                    <p>Knowledge base does not automatically select titles.</p>
+                  )}
+                </DetailsViewSection>
+              )}
+
               <DetailsViewSection
                 label="Coverage dates"
                 closedByDefault={!packageSelected}

--- a/tests/package-selection-test.js
+++ b/tests/package-selection-test.js
@@ -149,6 +149,10 @@ describeApplication('PackageSelection', () => {
             it('is not hideable', () => {
               expect(PackageShowPage.isHiddenTogglePresent).to.equal(false);
             });
+
+            it('does not display the toggle for allowing the KB to add titles', () => {
+              expect(PackageShowPage.hastoggleForAllowKbToAddTitles).to.be.false;
+            });
           });
         });
       });

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -56,6 +56,10 @@ describeApplication('PackageShow', () => {
       expect(PackageShowPage.numTitlesSelected).to.equal(`${providerPackage.selectedCount}`);
     });
 
+    it('does not display the toggle for allowing the KB to add titles', () => {
+      expect(PackageShowPage.hastoggleForAllowKbToAddTitles).to.be.false;
+    });
+
     it('displays a list of titles', () => {
       expect(PackageShowPage.titleList().length).to.equal(5);
     });
@@ -98,6 +102,20 @@ describeApplication('PackageShow', () => {
         expect(PackageShowPage.numTitles).to.equal('2');
         expect(PackageShowPage.titleList(0).name).to.not.equal(customerResources[0].title.name);
       });
+    });
+  });
+
+  describe('viewing a custom package details page', () => {
+    beforeEach(function () {
+      providerPackage.isCustom = true;
+      providerPackage.isSelected = true;
+      return this.visit(`/eholdings/packages/${providerPackage.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('does not display the toggle for allowing the KB to add titles', () => {
+      expect(PackageShowPage.hastoggleForAllowKbToAddTitles).to.be.false;
     });
   });
 

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -27,6 +27,7 @@ import Toast from './toast';
   isSelecting = hasClassBeginningWith('is-pending--', '[data-test-eholdings-package-details-selected] [data-test-toggle-switch]');
   isSelectedToggleDisabled = property('disabled', '[data-test-eholdings-package-details-selected] input[type=checkbox]');
   modal = new PackageShowModal('#eholdings-package-confirmation-modal');
+  hastoggleForAllowKbToAddTitles = isPresent('[data-test-eholdings-package-details-allow-add-new-titles]');
   toggleAllowKbToAddTitles = clickable('[data-test-eholdings-package-details-allow-add-new-titles] input');
   toggleIsSelected = clickable('[data-test-eholdings-package-details-selected] input');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');


### PR DESCRIPTION
## Purpose
Instead of saying "Knowledge base does not automatically select titles.", custom packages shouldn't show a "Title management" section at all.
Resolves https://issues.folio.org/browse/UIEH-281

## Screenshots
![localhost_3000_ iphone 6_7_8](https://user-images.githubusercontent.com/230597/38628999-6c0ed0ba-3d78-11e8-947a-440c1eb0ce42.png)
