### PR TITLE
Turn off Safari tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,3 @@ workflows:
       - test-chrome:
           requires:
             - checkout-and-install
-      - test-safari:
-          requires:
-            - checkout-and-install


### PR DESCRIPTION
## Purpose
Sometime in the last few days BrowserStack upgraded the version of Safari used by its tests on High Sierra. It moved from Safari 11.0.3 to 11.1.

Since then, Circle hasn't been able to maintain a consistent connection to BrowserStack. It tries to reconnect a few times, but at around 40 min or so it hits the maximum number of disconnects and fails the run.

Last time Safari tests passed on master: https://circleci.com/gh/folio-org/ui-eholdings/1842
First run when it started failing: https://circleci.com/gh/folio-org/ui-eholdings/1872

## Approach
We can't point to an earlier Safari on High Sierra. I tried Safari 10.1 on Sierra and got ten failures that would be pretty painful to go debug.

I reached out to BrowserStack, but in the meantime, since PR merges are blocked, I recommend just turning off tests for Safari.

