### PR TITLE
UIEH-257  Set up editing for custom titles

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -243,7 +243,8 @@ export default function configure() {
       visibilityData,
       customCoverages,
       customEmbargoPeriod,
-      coverageStatement
+      coverageStatement,
+      name
     } = body.data.attributes;
 
     matchingResource.update('isSelected', isSelected);
@@ -251,6 +252,7 @@ export default function configure() {
     matchingResource.update('customCoverages', customCoverages);
     matchingResource.update('customEmbargoPeriod', customEmbargoPeriod);
     matchingResource.update('coverageStatement', coverageStatement);
+    matchingResource.title.update('name', name);
 
     return matchingResource;
   });

--- a/mirage/factories/resource.js
+++ b/mirage/factories/resource.js
@@ -6,6 +6,7 @@ export default Factory.extend({
   customCoverages: [],
   coverageStatement: '',
   managedCoverages: [],
+  isTitleCustom: false,
 
   withTitle: trait({
     afterCreate(resource, server) {

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -13,11 +13,31 @@ export default function defaultScenario(server) {
   createProvider('Atlanta A&T Library', [
     {
       name: 'Atlanta A&T Drumming Books',
-      contentType: 'Online Reference',
-      titleCount: 3,
+      contentType: 'AggregatedFullText',
       isCustom: true
     },
   ]);
+
+  let customProvider = server.create('provider', {
+    name: 'Atlanta A&T Library'
+  });
+
+  let customPackage = server.create('package', {
+    name: 'Atlanta A&T Drumming Books',
+    contentType: 'AggregatedFullText',
+    isCustom: true,
+    provider: customProvider
+  });
+
+  let customTitle = server.create('title', {
+    name: 'Single, Double, and Triple Paradiddles',
+  });
+
+  server.create('customer-resource', {
+    package: customPackage,
+    title: customTitle,
+    isTitleCustom: true
+  });
 
   createProvider('Economist Intelligence Unit', [
     {

--- a/src/components/custom-resource-edit/custom-resource-edit.css
+++ b/src/components/custom-resource-edit/custom-resource-edit.css
@@ -1,0 +1,12 @@
+@import '@folio/stripes-components/lib/variables';
+
+.resource-edit-action-buttons {
+  align-items: flex-start;
+  border-top: 1px solid var(--minor-divider-color);
+  display: flex;
+  padding-top: 1em;
+
+  & button {
+    margin-right: 0.25em;
+  }
+}

--- a/src/components/custom-resource-edit/custom-resource-edit.js
+++ b/src/components/custom-resource-edit/custom-resource-edit.js
@@ -1,0 +1,140 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+import isEqual from 'lodash/isEqual';
+
+import {
+  Button,
+  Icon
+} from '@folio/stripes-components';
+import { processErrors } from '../utilities';
+
+import DetailsView from '../details-view';
+import ResourceNameField, { validate as validateName } from '../resource-name-field';
+import ResourceCoverageFields, { validate as validateCoverageDates } from '../resource-coverage-fields';
+import DetailsViewSection from '../details-view-section';
+import NavigationModal from '../navigation-modal';
+import Toaster from '../toaster';
+import styles from './custom-resource-edit.css';
+
+class CustomResourceEdit extends Component {
+  static propTypes = {
+    model: PropTypes.object.isRequired,
+    initialValues: PropTypes.object.isRequired,
+    handleSubmit: PropTypes.func,
+    onSubmit: PropTypes.func.isRequired,
+    pristine: PropTypes.bool
+  };
+
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
+  componentWillReceiveProps(nextProps) {
+    let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
+    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+
+    if (wasPending && needsUpdate) {
+      this.context.router.history.push(
+        `/eholdings/resources/${this.props.model.id}`,
+        { eholdings: true }
+      );
+    }
+  }
+
+  handleCancel = () => {
+    this.context.router.history.push(
+      `/eholdings/resources/${this.props.model.id}`,
+      { eholdings: true }
+    );
+  }
+
+  render() {
+    let {
+      model,
+      handleSubmit,
+      onSubmit,
+      pristine,
+    } = this.props;
+
+    let actionMenuItems = [
+      {
+        label: 'Cancel editing',
+        to: {
+          pathname: `/eholdings/resources/${model.id}`,
+          state: { eholdings: true }
+        }
+      }
+    ];
+
+    return (
+      <div>
+        <Toaster toasts={processErrors(model)} position="bottom" />
+        <DetailsView
+          type="resource"
+          model={model}
+          paneTitle={model.name}
+          paneSub={model.packageName}
+          actionMenuItems={actionMenuItems}
+          bodyContent={(
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <DetailsViewSection
+                label="Resource information"
+              >
+                <ResourceNameField />
+              </DetailsViewSection>
+              <DetailsViewSection
+                label="Coverage dates"
+              >
+                <ResourceCoverageFields />
+              </DetailsViewSection>
+              <div className={styles['resource-edit-action-buttons']}>
+                <div
+                  data-test-eholdings-resource-cancel-button
+                >
+                  <Button
+                    disabled={model.update.isPending}
+                    type="button"
+                    onClick={this.handleCancel}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+                <div
+                  data-test-eholdings-resource-save-button
+                >
+                  <Button
+                    disabled={pristine || model.update.isPending}
+                    type="submit"
+                    buttonStyle="primary"
+                  >
+                    {model.update.isPending ? 'Saving' : 'Save'}
+                  </Button>
+                </div>
+                {model.update.isPending && (
+                  <Icon icon="spinner-ellipsis" />
+                )}
+              </div>
+              <NavigationModal when={!pristine && !model.update.isPending} />
+            </form>
+          )}
+        />
+      </div>
+    );
+  }
+}
+
+const validate = (values, props) => {
+  return Object.assign({}, validateName(values), validateCoverageDates(values, props));
+};
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'CustomResourceEdit',
+  destroyOnUnmount: false,
+})(CustomResourceEdit);

--- a/src/components/custom-resource-edit/index.js
+++ b/src/components/custom-resource-edit/index.js
@@ -1,0 +1,1 @@
+export { default } from './custom-resource-edit';

--- a/src/components/managed-resource-edit/index.js
+++ b/src/components/managed-resource-edit/index.js
@@ -1,0 +1,1 @@
+export { default } from './managed-resource-edit';

--- a/src/components/managed-resource-edit/managed-resource-edit.css
+++ b/src/components/managed-resource-edit/managed-resource-edit.css
@@ -1,0 +1,12 @@
+@import '@folio/stripes-components/lib/variables';
+
+.resource-edit-action-buttons {
+  align-items: flex-start;
+  border-top: 1px solid var(--minor-divider-color);
+  display: flex;
+  padding-top: 1em;
+
+  & button {
+    margin-right: 0.25em;
+  }
+}

--- a/src/components/managed-resource-edit/managed-resource-edit.js
+++ b/src/components/managed-resource-edit/managed-resource-edit.js
@@ -1,0 +1,148 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+import isEqual from 'lodash/isEqual';
+
+import {
+  Button,
+  Icon
+} from '@folio/stripes-components';
+import { processErrors } from '../utilities';
+
+import DetailsView from '../details-view';
+import CoverageStatementFields, { validate as validateCoverageStatement } from '../coverage-statement-fields';
+import ResourceCoverageFields, { validate as validateCoverageDates } from '../resource-coverage-fields';
+import CustomEmbargoFields, { validate as validateEmbargo } from '../custom-embargo-fields';
+import DetailsViewSection from '../details-view-section';
+import NavigationModal from '../navigation-modal';
+import Toaster from '../toaster';
+import styles from './managed-resource-edit.css';
+
+class ManagedResourceEdit extends Component {
+  static propTypes = {
+    model: PropTypes.object.isRequired,
+    initialValues: PropTypes.object.isRequired,
+    handleSubmit: PropTypes.func,
+    onSubmit: PropTypes.func.isRequired,
+    pristine: PropTypes.bool,
+    change: PropTypes.func
+  };
+
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
+  componentWillReceiveProps(nextProps) {
+    let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
+    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+
+    if (wasPending && needsUpdate) {
+      this.context.router.history.push(
+        `/eholdings/resources/${this.props.model.id}`,
+        { eholdings: true }
+      );
+    }
+  }
+
+  handleCancel = () => {
+    this.context.router.history.push(
+      `/eholdings/resources/${this.props.model.id}`,
+      { eholdings: true }
+    );
+  }
+
+  render() {
+    let {
+      model,
+      handleSubmit,
+      onSubmit,
+      pristine,
+      change
+    } = this.props;
+
+    let actionMenuItems = [
+      {
+        label: 'Cancel editing',
+        to: {
+          pathname: `/eholdings/resources/${model.id}`,
+          state: { eholdings: true }
+        }
+      }
+    ];
+
+    return (
+      <div>
+        <Toaster toasts={processErrors(model)} position="bottom" />
+        <DetailsView
+          type="resource"
+          model={model}
+          paneTitle={model.name}
+          paneSub={model.packageName}
+          actionMenuItems={actionMenuItems}
+          bodyContent={(
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <DetailsViewSection
+                label="Coverage dates"
+              >
+                <ResourceCoverageFields />
+              </DetailsViewSection>
+              <DetailsViewSection
+                label="Coverage statement"
+              >
+                <CoverageStatementFields />
+              </DetailsViewSection>
+              <DetailsViewSection
+                label="Embargo period"
+              >
+                <CustomEmbargoFields change={change} />
+              </DetailsViewSection>
+              <div className={styles['resource-edit-action-buttons']}>
+                <div
+                  data-test-eholdings-resource-cancel-button
+                >
+                  <Button
+                    disabled={model.update.isPending}
+                    type="button"
+                    onClick={this.handleCancel}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+                <div
+                  data-test-eholdings-resource-save-button
+                >
+                  <Button
+                    disabled={pristine || model.update.isPending}
+                    type="submit"
+                    buttonStyle="primary"
+                  >
+                    {model.update.isPending ? 'Saving' : 'Save'}
+                  </Button>
+                </div>
+                {model.update.isPending && (
+                  <Icon icon="spinner-ellipsis" />
+                )}
+              </div>
+              <NavigationModal when={!pristine && !model.update.isPending} />
+            </form>
+          )}
+        />
+      </div>
+    );
+  }
+}
+
+const validate = (values, props) => {
+  return Object.assign({}, validateCoverageDates(values, props), validateCoverageStatement(values), validateEmbargo(values));
+};
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'ManagedResourceEdit',
+  destroyOnUnmount: false,
+})(ManagedResourceEdit);

--- a/src/components/resource-coverage-fields/resource-coverage-fields.js
+++ b/src/components/resource-coverage-fields/resource-coverage-fields.js
@@ -24,7 +24,7 @@ export default class ResourceCoverageFields extends Component {
       <div className={styles['coverage-fields']}>
         {fields.length === 0 ? (
           <p data-test-eholdings-coverage-fields-no-rows-left>
-            No date ranges set. Saving will remove all custom coverage.
+            No date ranges set.
           </p>
         ) : (
           <ul className={styles['coverage-fields-date-range-rows']}>

--- a/src/components/resource-name-field/index.js
+++ b/src/components/resource-name-field/index.js
@@ -1,0 +1,1 @@
+export { default, validate } from './resource-name-field';

--- a/src/components/resource-name-field/resource-name-field.css
+++ b/src/components/resource-name-field/resource-name-field.css
@@ -1,0 +1,3 @@
+.resource-name-field {
+  max-width: 50em;
+}

--- a/src/components/resource-name-field/resource-name-field.js
+++ b/src/components/resource-name-field/resource-name-field.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+import { Field } from 'redux-form';
+
+import { TextField } from '@folio/stripes-components';
+import styles from './resource-name-field.css';
+
+export default class ResourceNameField extends Component {
+  render() {
+    return (
+      <div
+        data-test-eholdings-resource-name-field
+        className={styles['resource-name-field']}
+      >
+        <Field
+          name="name"
+          type="text"
+          component={TextField}
+          label="Name"
+        />
+      </div>
+    );
+  }
+}
+
+export function validate(values) {
+  let errors = {};
+
+  if (values.name === '') {
+    errors.name = 'Custom titles must have a name.';
+  }
+
+  if (values.name.length >= 400) {
+    errors.name = 'Must be less than 400 characters.';
+  }
+
+  return errors;
+}

--- a/src/components/resource-show.js
+++ b/src/components/resource-show.js
@@ -194,12 +194,6 @@ export default class ResourceShow extends Component {
                   </div>
                 </KeyValue>
 
-                <KeyValue label="Other packages">
-                  <Link to={`/eholdings/titles/${model.titleId}`}>
-                    View all packages that include this title
-                  </Link>
-                </KeyValue>
-
                 {model.contentType && (
                   <KeyValue label="Content type">
                     <div data-test-eholdings-resource-show-content-type>
@@ -207,6 +201,18 @@ export default class ResourceShow extends Component {
                     </div>
                   </KeyValue>
                 )}
+
+                <KeyValue label="Title type">
+                  <div data-test-eholdings-package-details-type>
+                    {model.isTitleCustom ? 'Custom' : 'Managed'}
+                  </div>
+                </KeyValue>
+
+                <KeyValue label="Other packages">
+                  <Link to={`/eholdings/titles/${model.titleId}`}>
+                    View all packages that include this title
+                  </Link>
+                </KeyValue>
 
                 {model.url && (
                   <KeyValue label="Managed URL">

--- a/src/redux/resource.js
+++ b/src/redux/resource.js
@@ -22,6 +22,7 @@ class Resource {
   customEmbargoPeriod = {};
   visibilityData = {};
   coverageStatement = '';
+  isTitleCustom = false;
 }
 
 export default model({

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -5,7 +5,9 @@ import moment from 'moment';
 
 import { createResolver } from '../redux';
 import Resource from '../redux/resource';
-import View from '../components/resource-edit';
+
+import ManagedResourceEdit from '../components/managed-resource-edit';
+import CustomResourceEdit from '../components/custom-resource-edit';
 
 class ResourceEditRoute extends Component {
   static propTypes = {
@@ -50,20 +52,40 @@ class ResourceEditRoute extends Component {
       embargoValue: values.customEmbargoValue,
       embargoUnit: values.customEmbargoUnit
     };
+
+    if ('name' in values) {
+      model.name = values.name;
+    }
+
     updateResource(model);
   }
 
   render() {
+    let { model } = this.props;
+    let initialValues = {};
+    let View;
+
+    if (model.isTitleCustom) {
+      View = CustomResourceEdit;
+      initialValues = {
+        name: model.name,
+        customCoverages: model.customCoverages
+      };
+    } else {
+      View = ManagedResourceEdit;
+      initialValues = {
+        customCoverages: model.customCoverages,
+        coverageStatement: model.coverageStatement,
+        customEmbargoValue: model.customEmbargoPeriod.embargoValue,
+        customEmbargoUnit: model.customEmbargoPeriod.embargoUnit
+      };
+    }
+
     return (
       <View
         model={this.props.model}
         onSubmit={this.resourceEditSubmitted}
-        initialValues={{
-          customCoverages: this.props.model.customCoverages,
-          coverageStatement: this.props.model.coverageStatement,
-          customEmbargoValue: this.props.model.customEmbargoPeriod.embargoValue,
-          customEmbargoUnit: this.props.model.customEmbargoPeriod.embargoUnit
-        }}
+        initialValues={initialValues}
       />
     );
   }

--- a/tests/custom-resource-edit-test.js
+++ b/tests/custom-resource-edit-test.js
@@ -1,0 +1,253 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+
+import { describeApplication } from './helpers';
+import ResourceShowPage from './pages/resource-show';
+import ResourceEditPage from './pages/resource-edit';
+import ResourceCoverage from './pages/resource-custom-coverage';
+
+describeApplication('CustomResourceEdit', () => {
+  let provider,
+    providerPackage,
+    resource;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create('package', 'withTitles', {
+      provider,
+      name: 'Cool Package',
+      contentType: 'E-Book',
+      titleCount: 5
+    });
+
+    let title = this.server.create('title', {
+      name: 'Best Title Ever',
+      publicationType: 'Streaming Video',
+      publisherName: 'Amazing Publisher'
+    });
+
+    title.save();
+
+    resource = this.server.create('resource', {
+      package: providerPackage,
+      isSelected: true,
+      title,
+      url: 'frontside.io',
+      isTitleCustom: true
+    });
+  });
+
+  describe('visiting the resource edit page without coverage dates', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return ResourceEditPage.clickCancel();
+      });
+
+      it('goes to the resource show page', () => {
+        expect(ResourceShowPage.$root).to.exist;
+      });
+    });
+
+    describe('entering invalid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .name('')
+          .clickAddRowButton()
+          .once(() => ResourceEditPage.dateRangeRowList().length > 0)
+          .do(() => {
+            return ResourceEditPage.interaction
+              .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
+              .clickSave();
+          });
+      });
+
+      it('displays a validation error for the name', () => {
+        expect(ResourceEditPage.nameHasError).to.be.true;
+      });
+
+      it('displays a validation error for coverage', () => {
+        expect(ResourceEditPage.dateRangeRowList(0).beginDate.isInvalid).to.be.true;
+      });
+    });
+
+    describe('entering valid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .clickAddRowButton()
+          .once(() => ResourceEditPage.dateRangeRowList().length > 0)
+          .do(() => {
+            return ResourceEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018');
+          });
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickCancel();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(ResourceEditPage.navigationModal.$root).to.exist;
+        });
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('goes to the resource show page', () => {
+          expect(ResourceShowPage.$root).to.exist;
+        });
+
+        it('displays the saved date range', () => {
+          expect(ResourceCoverage.displayText).to.equal('12/16/2018 - 12/18/2018');
+        });
+      });
+    });
+  });
+
+  describe('visiting the resource edit page with coverage dates', () => {
+    beforeEach(function () {
+      let customCoverages = [
+        this.server.create('custom-coverage', {
+          beginCoverage: '1969-07-16',
+          endCoverage: '1972-12-19'
+        })
+      ];
+      resource.update('customCoverages', customCoverages.map(item => item.toJSON()));
+      resource.save();
+
+      return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return ResourceEditPage.clickCancel();
+      });
+
+      it('goes to the resource show page', () => {
+        expect(ResourceShowPage.$root).to.exist;
+      });
+
+      it('displays the original date range', () => {
+        expect(ResourceCoverage.displayText).to.equal('7/16/1969 - 12/19/1972');
+      });
+    });
+
+    describe('entering invalid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .name('')
+          .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
+          .clickSave();
+      });
+
+      it('displays a validation error for the name', () => {
+        expect(ResourceEditPage.nameHasError).to.be.true;
+      });
+
+      it('displays a validation error for coverage', () => {
+        expect(ResourceEditPage.dateRangeRowList(0).beginDate.isInvalid).to.be.true;
+      });
+    });
+
+    describe('entering valid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .name('A Different Name')
+          .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018'));
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickCancel();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(ResourceEditPage.navigationModal.$root).to.exist;
+        });
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('goes to the resource show page', () => {
+          expect(ResourceShowPage.$root).to.exist;
+        });
+
+        it('reflects the new name', () => {
+          expect(ResourceShowPage.titleName).to.equal('A Different Name');
+        });
+
+        it('displays the saved date range', () => {
+          expect(ResourceCoverage.displayText).to.equal('12/16/2018 - 12/18/2018');
+        });
+      });
+    });
+  });
+
+  describe('encountering a server error when GETting', () => {
+    beforeEach(function () {
+      this.server.get('/resources/:id', {
+        errors: [{
+          title: 'There was an error'
+        }]
+      }, 500);
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('dies with dignity', () => {
+      expect(ResourceEditPage.hasErrors).to.be.true;
+    });
+  });
+
+  describe('encountering a server error when PUTting', () => {
+    beforeEach(function () {
+      this.server.put('/resources/:id', {
+        errors: [{
+          title: 'There was an error'
+        }]
+      }, 500);
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    describe('entering valid data and clicking save', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .name('A Different Name')
+          .clickSave();
+      });
+
+      it('pops up an error', () => {
+        expect(ResourceEditPage.toast.errorText).to.equal('There was an error');
+      });
+    });
+  });
+});

--- a/tests/managed-resource-edit-test.js
+++ b/tests/managed-resource-edit-test.js
@@ -1,0 +1,318 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+
+import { describeApplication } from './helpers';
+import ResourceShowPage from './pages/resource-show';
+import ResourceEditPage from './pages/resource-edit';
+
+describeApplication('ManagedResourceEdit', () => {
+  let provider,
+    providerPackage,
+    resource;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create('package', 'withTitles', {
+      provider,
+      name: 'Cool Package',
+      contentType: 'E-Book',
+      titleCount: 5
+    });
+
+    let title = this.server.create('title', {
+      name: 'Best Title Ever',
+      publicationType: 'Streaming Video',
+      publisherName: 'Amazing Publisher'
+    });
+
+    title.save();
+
+    resource = this.server.create('resource', {
+      package: providerPackage,
+      isSelected: true,
+      title,
+      url: 'frontside.io'
+    });
+  });
+
+  describe('visiting the resource edit page without coverage dates, statement, or embargo', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('shows a form with coverage statement', () => {
+      expect(ResourceEditPage.coverageStatement).to.equal('');
+    });
+
+    it('shows a form with embargo fields', () => {
+      expect(ResourceEditPage.customEmbargoTextFieldValue).to.equal('0');
+      expect(ResourceEditPage.customEmbargoSelectValue).to.equal('');
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return ResourceEditPage.clickCancel();
+      });
+
+      it('goes to the resource show page', () => {
+        expect(ResourceShowPage.$root).to.exist;
+      });
+    });
+
+    describe('entering invalid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage.interaction
+          .clickAddRowButton()
+          .once(() => ResourceEditPage.dateRangeRowList().length > 0)
+          .do(() => {
+            return ResourceEditPage
+              .inputCoverageStatement(`Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+                Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+                dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,
+                pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
+                fringilla vel, aliquet nec, vulputate e`)
+              .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
+              .inputEmbargoValue('')
+              .blurEmbargoValue()
+              .selectEmbargoUnit('Weeks')
+              .clickSave();
+          });
+      });
+
+      it('highlights the textarea with an error state', () => {
+        expect(ResourceEditPage.coverageStatementHasError).to.be.true;
+      });
+
+      it('displays a validation error message', () => {
+        expect(ResourceEditPage.validationErrorOnCoverageStatement).to.equal('Statement must be 350 characters or less.');
+      });
+
+      it('displays a validation error for coverage', () => {
+        expect(ResourceEditPage.dateRangeRowList(0).beginDate.isInvalid).to.be.true;
+      });
+
+      it('displays a validation error for embargo', () => {
+        expect(ResourceEditPage.validationErrorOnEmbargoTextField).to.equal('Value cannot be null');
+      });
+    });
+
+    describe('entering valid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage.interaction
+          .clickAddRowButton()
+          .once(() => ResourceEditPage.dateRangeRowList().length > 0)
+          .do(() => {
+            return ResourceEditPage
+              .inputCoverageStatement('Only 90s kids would understand.')
+              .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018'))
+              .inputEmbargoValue('27')
+              .blurEmbargoValue()
+              .selectEmbargoUnit('Weeks')
+              .blurEmbargoUnit();
+          });
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickCancel();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(ResourceEditPage.navigationModal.$root).to.exist;
+        });
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('goes to the resource show page', () => {
+          expect(ResourceShowPage.$root).to.exist;
+        });
+
+        it('shows the new statement value', () => {
+          expect(ResourceShowPage.coverageStatement).to.equal('Only 90s kids would understand.');
+        });
+
+        it('shows the new embargo value', () => {
+          expect(ResourceShowPage.customEmbargoPeriod).to.equal('27 Weeks');
+        });
+      });
+    });
+  });
+
+  describe('visiting the resource edit page with coverage dates, statement, and embargo', () => {
+    beforeEach(function () {
+      resource.coverageStatement = 'Use this one weird trick to get access.';
+      let customCoverages = [
+        this.server.create('custom-coverage', {
+          beginCoverage: '1969-07-16',
+          endCoverage: '1972-12-19'
+        })
+      ];
+      resource.update('customCoverages', customCoverages.map(item => item.toJSON()));
+      resource.customEmbargoPeriod = this.server.create('embargo-period', {
+        embargoUnit: 'Months',
+        embargoValue: 6
+      }).toJSON();
+      resource.save();
+
+      return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('shows a form with the coverage field', () => {
+      expect(ResourceEditPage.coverageStatement).to.equal('Use this one weird trick to get access.');
+    });
+
+    it('shows a form with embargo fields', () => {
+      expect(ResourceEditPage.customEmbargoTextFieldValue).to.equal('6');
+      expect(ResourceEditPage.customEmbargoSelectValue).to.equal('Months');
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return ResourceEditPage.clickCancel();
+      });
+
+      it('goes to the resource show page', () => {
+        expect(ResourceShowPage.$root).to.exist;
+      });
+    });
+
+    describe('entering invalid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .inputCoverageStatement(`Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+            Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+            dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,
+            pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
+            fringilla vel, aliquet nec, vulputate e`)
+          .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
+          .inputEmbargoValue('')
+          .blurEmbargoValue()
+          .selectEmbargoUnit('Weeks')
+          .clickSave();
+      });
+
+      it('highlights the textarea with an error state', () => {
+        expect(ResourceEditPage.coverageStatementHasError).to.be.true;
+      });
+
+      it('displays a validation error for coverage', () => {
+        expect(ResourceEditPage.dateRangeRowList(0).beginDate.isInvalid).to.be.true;
+      });
+
+      it('displays a validation error message for coverage statement', () => {
+        expect(ResourceEditPage.validationErrorOnCoverageStatement).to.equal('Statement must be 350 characters or less.');
+      });
+
+      it('displays a validation error for embargo', () => {
+        expect(ResourceEditPage.validationErrorOnEmbargoTextField).to.equal('Value cannot be null');
+      });
+    });
+
+    describe('entering valid data', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .inputCoverageStatement('Refinance your home loans.')
+          .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018'))
+          .inputEmbargoValue('27')
+          .blurEmbargoValue()
+          .selectEmbargoUnit('Weeks')
+          .blurEmbargoUnit();
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickCancel();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(ResourceEditPage.navigationModal.$root).to.exist;
+        });
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('goes to the resource show page', () => {
+          expect(ResourceShowPage.$root).to.exist;
+        });
+
+        it('shows the new statement value', () => {
+          expect(ResourceShowPage.coverageStatement).to.equal('Refinance your home loans.');
+        });
+
+        it('shows the new embargo value', () => {
+          expect(ResourceShowPage.customEmbargoPeriod).to.equal('27 Weeks');
+        });
+      });
+    });
+  });
+
+  describe('encountering a server error when GETting', () => {
+    beforeEach(function () {
+      this.server.get('/resources/:id', {
+        errors: [{
+          title: 'There was an error'
+        }]
+      }, 500);
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('dies with dignity', () => {
+      expect(ResourceEditPage.hasErrors).to.be.true;
+    });
+  });
+
+  describe('encountering a server error when PUTting', () => {
+    beforeEach(function () {
+      this.server.put('/resources/:id', {
+        errors: [{
+          title: 'There was an error'
+        }]
+      }, 500);
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    describe('entering valid data and clicking save', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .inputCoverageStatement('10 ways to fail at everything')
+          .inputEmbargoValue('27')
+          .blurEmbargoValue()
+          .selectEmbargoUnit('Weeks')
+          .blurEmbargoUnit()
+          .clickSave();
+      });
+
+      it('pops up an error', () => {
+        expect(ResourceEditPage.toast.errorText).to.equal('There was an error');
+      });
+    });
+  });
+});

--- a/tests/pages/resource-edit.js
+++ b/tests/pages/resource-edit.js
@@ -11,6 +11,7 @@ import {
   value
 } from '@bigtest/interaction';
 import { hasClassBeginningWith } from './helpers';
+import Toast from './toast';
 import Datepicker from './datepicker';
 
 @page class ResourceEditNavigationModal {}
@@ -22,6 +23,11 @@ import Datepicker from './datepicker';
   clickSave = clickable('[data-test-eholdings-resource-save-button] button');
   isSaveDisabled = property('disabled', '[data-test-eholdings-resource-save-button] button');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
+
+  toast = Toast
+
+  name = fillable('[data-test-eholdings-resource-name-field] input');
+  nameHasError = hasClassBeginningWith('feedbackError--', '[data-test-eholdings-resource-name-field] input');
 
   clickAddRowButton = clickable('[data-test-eholdings-coverage-fields-add-row-button] button');
 


### PR DESCRIPTION
## Purpose
Sets up editing for the name and coverage dates of a custom title.
Resolves https://issues.folio.org/browse/UIEH-257
Resolves https://issues.folio.org/browse/UIEH-276

## Approach
When hitting eholdings/customer-resources/:id/edit, determine from the resource's isTitleCustom attribute whether to show the managed or custom package edit form.

_Custom title editing currently does not work in production. This PR does not change that, but sets up everything needed in mirage to keep iterating on the UI._

## Screenshots
![2018-04-12 15 55 36](https://user-images.githubusercontent.com/230597/38703977-6a955dba-3e6a-11e8-9141-a60075077dea.gif)
