### PR TITLE
UIEH-249: Custom Package Content Type

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -163,7 +163,14 @@ export default function configure() {
     });
 
     let body = JSON.parse(request.requestBody);
-    let { isSelected, allowKbToAddTitles, customCoverage, visibilityData, name } = body.data.attributes;
+    let {
+      isSelected,
+      allowKbToAddTitles,
+      customCoverage,
+      visibilityData,
+      name,
+      contentType
+    } = body.data.attributes;
 
     let selectedCount = isSelected ? matchingCustomerResources.length : 0;
 
@@ -175,6 +182,7 @@ export default function configure() {
     matchingPackage.update('visibilityData', visibilityData);
     matchingPackage.update('allowKbToAddTitles', allowKbToAddTitles);
     matchingPackage.update('name', name);
+    matchingPackage.update('contentType', contentType);
 
     return matchingPackage;
   });

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -13,7 +13,7 @@ export default function defaultScenario(server) {
   createProvider('Atlanta A&T Library', [
     {
       name: 'Atlanta A&T Drumming Books',
-      contentType: 'AggregatedFullText',
+      contentType: 'Online Reference',
       titleCount: 3,
       isCustom: true
     },

--- a/src/components/custom-package-edit/custom-package-edit.js
+++ b/src/components/custom-package-edit/custom-package-edit.js
@@ -12,6 +12,7 @@ import { processErrors } from '../utilities';
 import DetailsView from '../details-view';
 import PackageNameField, { validate as validatePackageName } from '../package-name-field';
 import PackageCoverageFields, { validate as validateCoverageDates } from '../package-coverage-fields';
+import PackageContentTypeField from '../package-content-type-field';
 import DetailsViewSection from '../details-view-section';
 import NavigationModal from '../navigation-modal';
 import Toaster from '../toaster';
@@ -95,6 +96,7 @@ class CustomPackageEdit extends Component {
                 label="Custom package information"
               >
                 <PackageNameField />
+                <PackageContentTypeField />
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage dates"

--- a/src/components/package-content-type-field/index.js
+++ b/src/components/package-content-type-field/index.js
@@ -1,0 +1,1 @@
+export { default } from './package-content-type-field';

--- a/src/components/package-content-type-field/package-content-type-field.css
+++ b/src/components/package-content-type-field/package-content-type-field.css
@@ -1,0 +1,3 @@
+.package-content-type-field {
+  max-width: 50em;
+}

--- a/src/components/package-content-type-field/package-content-type-field.js
+++ b/src/components/package-content-type-field/package-content-type-field.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import { Field } from 'redux-form';
+
+import { Select } from '@folio/stripes-components';
+import styles from './package-content-type-field.css';
+
+export default class PackageContentTypeField extends Component {
+  render() {
+    return (
+      <div
+        data-test-eholdings-package-content-type-field
+        className={styles['package-content-type-field']}
+      >
+        <Field
+          name="contentType"
+          component={Select}
+          label="Content type"
+          dataOptions={[
+            { value: 'Aggregated Full Text', label: 'Aggregated Full Text' },
+            { value: 'Abstract and Index', label: 'Abstract and Index' },
+            { value: 'E-Book', label: 'E-Book' },
+            { value: 'E-Journal', label: 'E-Journal' },
+            { value: 'Print', label: 'Print' },
+            { value: 'Online Reference', label: 'Online Reference' },
+            { value: 'Unknown', label: 'Unknown' }
+          ]}
+        />
+      </div>
+    );
+  }
+}

--- a/src/components/package-content-type/index.js
+++ b/src/components/package-content-type/index.js
@@ -1,0 +1,1 @@
+export { default } from './package-content-type';

--- a/src/components/package-content-type/package-content-type.css
+++ b/src/components/package-content-type/package-content-type.css
@@ -1,0 +1,11 @@
+.package-content-type-display {
+  display: flex;
+}
+
+.package-content-type {
+  &.is-editing {
+    background: #e6f3ff;
+    padding: 1em 1em 0;
+    margin-bottom: 1em;
+  }
+}

--- a/src/components/package-content-type/package-content-type.js
+++ b/src/components/package-content-type/package-content-type.js
@@ -1,0 +1,133 @@
+import React, { Component } from 'react';
+import { reduxForm } from 'redux-form';
+import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import isEqual from 'lodash/isEqual';
+
+import {
+  IconButton,
+  KeyValue
+} from '@folio/stripes-components';
+
+import PackageContentTypeField from '../package-content-type-field';
+import InlineForm from '../inline-form';
+import styles from './package-content-type.css';
+
+const cx = classNames.bind(styles);
+
+class PackageContentType extends Component {
+  static propTypes = {
+    initialValues: PropTypes.shape({
+      contentType: PropTypes.string
+    }).isRequired,
+    isEditable: PropTypes.bool,
+    onEdit: PropTypes.func,
+    onSubmit: PropTypes.func.isRequired,
+    isPending: PropTypes.bool,
+    handleSubmit: PropTypes.func,
+    initialize: PropTypes.func,
+    pristine: PropTypes.bool
+  };
+
+  state = {
+    isEditing: !!this.props.isEditable
+  };
+
+  componentWillReceiveProps(nextProps) {
+    let wasPending = this.props.isPending && !nextProps.isPending;
+    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+
+    if (wasPending && needsUpdate) {
+      this.toggleEditing(false);
+    }
+  }
+
+  toggleEditing(isEditing = !this.state.isEditing) {
+    if (this.props.onEdit) {
+      this.props.onEdit(isEditing);
+    } else {
+      this.setState({ isEditing });
+    }
+  }
+
+  handleEdit = (e) => {
+    e.preventDefault();
+    this.toggleEditing(true);
+  }
+
+  handleCancel = (e) => {
+    e.preventDefault();
+    this.toggleEditing(false);
+    this.props.initialize(this.props.initialValues);
+  }
+
+  renderEditingForm() {
+    let {
+      pristine,
+      isPending,
+      handleSubmit,
+      onSubmit
+    } = this.props;
+
+    return (
+      <InlineForm
+        data-test-eholdings-package-content-type-form
+        onSubmit={handleSubmit(onSubmit)}
+        onCancel={this.handleCancel}
+        pristine={pristine}
+        isPending={isPending}
+      >
+        <PackageContentTypeField />
+      </InlineForm>
+    );
+  }
+
+  renderContentType() {
+    const {
+      contentType
+    } = this.props.initialValues;
+
+    return (
+      <div className={styles['package-content-type-display']}>
+        <KeyValue label="Content type">
+          <span data-test-eholdings-package-content-type>
+            {contentType}
+          </span>
+        </KeyValue>
+        <div data-test-eholdings-package-content-type-edit-button>
+          <IconButton icon="edit" onClick={this.handleEdit} />
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    let {
+      isEditable = this.state.isEditing
+    } = this.props;
+    let contents;
+
+    if (isEditable) {
+      contents = this.renderEditingForm();
+    } else {
+      contents = this.renderContentType();
+    }
+
+    return (
+      <div
+        data-test-eholdings-package-content-type
+        className={cx(styles['package-content-type'], {
+          'is-editing': isEditable
+        })}
+      >
+        {contents}
+      </div>
+    );
+  }
+}
+
+export default reduxForm({
+  enableReinitialize: true,
+  form: 'PackageContentType',
+  destroyOnUnmount: false
+})(PackageContentType);

--- a/src/components/package-show/package-show.js
+++ b/src/components/package-show/package-show.js
@@ -17,6 +17,7 @@ import TitleListItem from '../title-list-item';
 import ToggleSwitch from '../toggle-switch';
 import Modal from '../modal';
 import PackageCustomCoverage from '../package-custom-coverage';
+import PackageContentType from '../package-content-type';
 import NavigationModal from '../navigation-modal';
 import DetailsViewSection from '../details-view-section';
 import Toaster from '../toaster';
@@ -30,7 +31,8 @@ export default class PackageShow extends Component {
     toggleSelected: PropTypes.func.isRequired,
     toggleHidden: PropTypes.func.isRequired,
     customCoverageSubmitted: PropTypes.func.isRequired,
-    toggleAllowKbToAddTitles: PropTypes.func.isRequired
+    toggleAllowKbToAddTitles: PropTypes.func.isRequired,
+    packageContentTypeSubmitted: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -81,6 +83,33 @@ export default class PackageShow extends Component {
 
   handleCoverageEdit = (isCoverageEditable) => {
     this.setState({ isCoverageEditable });
+  };
+
+  renderContentType = () => {
+    let { model, packageContentTypeSubmitted } = this.props;
+    let content;
+    if (model.isCustom) {
+      content = (
+        <PackageContentType
+          initialValues={{ contentType: model.contentType }}
+          onSubmit={packageContentTypeSubmitted}
+          isPending={model.update.isPending && 'contentType' in model.update.changedAttributes}
+        />
+      );
+    } else if (model.contentType) {
+      content = (
+        <KeyValue label="Content type">
+          <div data-test-eholdings-package-details-content-type>
+            {model.contentType}
+          </div>
+        </KeyValue>
+      );
+    }
+    return (
+      <div>
+        {content}
+      </div>
+    );
   };
 
   render() {
@@ -146,13 +175,7 @@ export default class PackageShow extends Component {
                   </div>
                 </KeyValue>
 
-                {model.contentType && (
-                  <KeyValue label="Content type">
-                    <div data-test-eholdings-package-details-content-type>
-                      {model.contentType}
-                    </div>
-                  </KeyValue>
-                )}
+                {this.renderContentType()}
 
                 <KeyValue label="Titles selected">
                   <div data-test-eholdings-package-details-titles-selected>

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -61,6 +61,10 @@ class PackageEditRoute extends Component {
       model.name = values.name;
     }
 
+    if ('contentType' in values) {
+      model.contentType = values.contentType;
+    }
+
     updatePackage(model);
   };
 
@@ -73,6 +77,7 @@ class PackageEditRoute extends Component {
       View = CustomPackageEdit;
       initialValues = {
         name: model.name,
+        contentType: model.contentType,
         customCoverages: [{
           beginCoverage: model.customCoverage.beginCoverage,
           endCoverage: model.customCoverage.endCoverage

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -91,6 +91,12 @@ class PackageShowRoute extends Component {
     updatePackage(model);
   };
 
+  packageContentTypeSubmitted = (values) => {
+    let { model, updatePackage } = this.props;
+    model.contentType = values.contentType;
+    updatePackage(model);
+  }
+
   toggleAllowKbToAddTitles = () => {
     let { model, updatePackage } = this.props;
     model.allowKbToAddTitles = !model.allowKbToAddTitles;
@@ -106,6 +112,7 @@ class PackageShowRoute extends Component {
         toggleHidden={this.toggleHidden}
         customCoverageSubmitted={this.customCoverageSubmitted}
         toggleAllowKbToAddTitles={this.toggleAllowKbToAddTitles}
+        packageContentTypeSubmitted={this.packageContentTypeSubmitted}
       />
     );
   }

--- a/tests/custom-package-edit-test.js
+++ b/tests/custom-package-edit-test.js
@@ -100,12 +100,13 @@ describeApplication('CustomPackageEdit', () => {
     });
   });
 
-  describe('visiting the package edit page with coverage dates', () => {
+  describe('visiting the package edit page with coverage dates and content type', () => {
     beforeEach(function () {
       providerPackage.update('customCoverage', {
         beginCoverage: '1969-07-16',
         endCoverage: '1972-12-19'
       });
+      providerPackage.update('contentType', 'E-Book');
       providerPackage.save();
 
       return this.visit(`/eholdings/packages/${providerPackage.id}/edit`, () => {
@@ -148,6 +149,7 @@ describeApplication('CustomPackageEdit', () => {
       beforeEach(() => {
         return PackageEditPage
           .name('A Different Name')
+          .contentType('E-Journal')
           .append(PackageEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018'));
       });
 
@@ -176,6 +178,10 @@ describeApplication('CustomPackageEdit', () => {
 
         it('reflects the new coverage dates', () => {
           expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
+        });
+
+        it('reflects the new content type', () => {
+          expect(PackageShowPage.customContentType).to.equal('E-Journal');
         });
       });
     });

--- a/tests/package-content-type-test.js
+++ b/tests/package-content-type-test.js
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+
+import { describeApplication } from './helpers';
+import PackageShowPage from './pages/package-show';
+
+describeApplication('PackageContentType', () => {
+  let provider,
+    providerPackage;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create('package', {
+      provider,
+      name: 'Cool Package',
+      contentType: 'Unknown',
+      isSelected: true,
+      isCustom: true
+    });
+  });
+
+  describe('visiting the package edit page with an unknown content type', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/packages/${providerPackage.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays with content type of unknown', () => {
+      expect(PackageShowPage.customContentType).to.equal('Unknown');
+    });
+  });
+
+  describe('visiting the package edit page with a known content type', () => {
+    beforeEach(function () {
+      providerPackage.contentType = 'E-Book';
+      return this.visit(`/eholdings/packages/${providerPackage.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays known content type', () => {
+      expect(PackageShowPage.customContentType).to.equal('E-Book');
+    });
+
+
+    describe('clicking the edit icon', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickContentTypeEdit();
+      });
+
+      it('button is disabled with no change', () => {
+        expect(PackageShowPage.isContentTypeSaveDisabled).to.be.true;
+      });
+
+      it('displays the select field', () => {
+        expect(PackageShowPage.hasContentTypeField).to.be.true;
+      });
+
+      describe('changing the value of content type', () => {
+        beforeEach(() => {
+          return PackageShowPage.selectContentType('E-Journal');
+        });
+
+        it('enables the save button', () => {
+          expect(PackageShowPage.isContentTypeSaveDisabled).to.be.false;
+        });
+
+        describe('clicking the cancel button', () => {
+          beforeEach(() => {
+            return PackageShowPage.clickContentTypeCancel();
+          });
+
+          it('removes the select field', () => {
+            expect(PackageShowPage.hasContentTypeField).to.be.false;
+          });
+        });
+        describe('clicking the save button', () => {
+          beforeEach(() => {
+            return PackageShowPage.clickContentTypeSave();
+          });
+
+          it('shows the new content type', () => {
+            expect(PackageShowPage.customContentType).to.equal('E-Journal');
+          });
+
+          it('removes the select field', () => {
+            expect(PackageShowPage.hasContentTypeField).to.be.false;
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -23,6 +23,7 @@ import Datepicker from './datepicker';
   toast = Toast
 
   name = fillable('[data-test-eholdings-package-name-field] input');
+  contentType = fillable('[data-test-eholdings-package-content-type-field] select');
   nameHasError = hasClassBeginningWith('feedbackError--', '[data-test-eholdings-package-name-field] input');
 
   dateRangeRowList = collection('[data-test-eholdings-coverage-fields-date-range-row]', {

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -2,6 +2,7 @@ import {
   clickable,
   collection,
   computed,
+  fillable,
   isPresent,
   page,
   property,
@@ -31,8 +32,8 @@ import Toast from './toast';
   toggleAllowKbToAddTitles = clickable('[data-test-eholdings-package-details-allow-add-new-titles] input');
   toggleIsSelected = clickable('[data-test-eholdings-package-details-selected] input');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
-  name = text('[data-test-eholdings-details-view-name="package"]');
   contentType = text('[data-test-eholdings-package-details-content-type]');
+  name = text('[data-test-eholdings-details-view-name="package"]');
   numTitles = text('[data-test-eholdings-package-details-titles-total]');
   numTitlesSelected = text('[data-test-eholdings-package-details-titles-selected]');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="package"]');
@@ -94,6 +95,14 @@ import Toast from './toast';
         });
       });
   });
+
+  selectContentType = fillable('[data-test-eholdings-package-content-type-field] select');
+  customContentType = text('[data-test-eholdings-package-content-type] span');
+  hasContentTypeField = isPresent('[data-test-eholdings-package-content-type-field] select');
+  clickContentTypeEdit = clickable('[data-test-eholdings-package-content-type-edit-button] button');
+  clickContentTypeCancel = clickable('[data-test-eholdings-inline-form-cancel-button] button');
+  clickContentTypeSave = clickable('[data-test-eholdings-inline-form-save-button] button');
+  isContentTypeSaveDisabled = property('disabled', '[data-test-eholdings-inline-form-save-button] button');
 
   titleContainerHeight = property('offsetHeight', '[data-test-eholdings-details-view-list="package"]');
   detailPaneContentsHeight = property('offsetHeight', '[data-test-eholdings-detail-pane-contents]');

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,7 +328,7 @@
     react-router-dom "^4.0.0"
     redux-form "^7.0.3"
 
-"@folio/ui-testing@github:folio-org/ui-testing#framework-only":
+"@folio/ui-testing@folio-org/ui-testing#framework-only":
   version "4.0.0"
   resolved "https://codeload.github.com/folio-org/ui-testing/tar.gz/90a425c1a8d12552e04c72dfeec2f623a81af629"
   dependencies:


### PR DESCRIPTION
## Purpose
Adds the capability for users to assign a content type to a custom package. We now have the ability to choose a content type on the `custom-edit` page as well as inline on the `package-show` page.
 
Resolves [UIEH-249](https://issues.folio.org/browse/UIEH-249)

## Screenshots
### Inline
![2018-04-12 12 02 33](https://user-images.githubusercontent.com/25858667/38692465-71a6e7f2-3e49-11e8-8053-5d81701b3a94.gif)

### Edit window
![2018-04-12 12 03 39](https://user-images.githubusercontent.com/25858667/38692522-92c5d4ca-3e49-11e8-8db7-3d6dcde7a2e0.gif)