### PR TITLE
UIEH-278 Search packages within provider details

### DIFF
--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -43,7 +43,8 @@ export default class DetailsView extends Component {
     renderList: PropTypes.func,
     actionMenuItems: PropTypes.array,
     lastMenu: PropTypes.node,
-    enableListSearch: PropTypes.bool
+    enableListSearch: PropTypes.bool,
+    onSearch: PropTypes.func
   };
 
   static contextTypes = {
@@ -164,7 +165,8 @@ export default class DetailsView extends Component {
       paneSub,
       actionMenuItems,
       lastMenu,
-      enableListSearch
+      enableListSearch,
+      onSearch
     } = this.props;
 
     let {
@@ -277,7 +279,7 @@ export default class DetailsView extends Component {
           >
             <SearchForm
               searchType={listType}
-              onSearch={() => {}}
+              onSearch={onSearch}
               displaySearchTypeSwitcher={false}
             />
           </Modal>

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -154,6 +154,14 @@ export default class DetailsView extends Component {
     }
   };
 
+  handleListSearch = (params) => {
+    this.setState({ showSearchModal: false }, () => {
+      if (this.props.onSearch) {
+        this.props.onSearch(params);
+      };
+    });
+  }
+
   render() {
     let {
       type,
@@ -279,7 +287,7 @@ export default class DetailsView extends Component {
           >
             <SearchForm
               searchType={listType}
-              onSearch={onSearch}
+              onSearch={this.handleListSearch}
               displaySearchTypeSwitcher={false}
             />
           </Modal>

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -270,7 +270,9 @@ export default class DetailsView extends Component {
                 <h3>{capitalize(listType)}</h3>
 
                 {enableListSearch && (
-                  <IconButton icon="search" onClick={this.toggleSearchModal} />
+                  <div data-test-eholdings-details-view-search>
+                    <IconButton icon="search" onClick={this.toggleSearchModal} />
+                  </div>
                 )}
               </div>
 
@@ -287,6 +289,7 @@ export default class DetailsView extends Component {
             label={`Filter ${listType}`}
             open={showSearchModal}
             onClose={this.toggleSearchModal}
+            id="eholdings-details-view-search-modal"
             closeOnBackgroundClick
             dismissible
           >

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -9,6 +9,8 @@ import {
   PaneHeader,
   PaneMenu
 } from '@folio/stripes-components';
+import Modal from '../modal';
+import SearchForm from '../search-form';
 import styles from './details-view.css';
 
 const cx = classNames.bind(styles);
@@ -40,7 +42,8 @@ export default class DetailsView extends Component {
     listType: PropTypes.string,
     renderList: PropTypes.func,
     actionMenuItems: PropTypes.array,
-    lastMenu: PropTypes.node
+    lastMenu: PropTypes.node,
+    enableListSearch: PropTypes.bool
   };
 
   static contextTypes = {
@@ -49,7 +52,8 @@ export default class DetailsView extends Component {
   };
 
   state = {
-    isSticky: false
+    isSticky: false,
+    showSearchModal: false
   };
 
   componentDidMount() {
@@ -63,6 +67,12 @@ export default class DetailsView extends Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleLayout);
+  }
+
+  toggleSearchModal = () => {
+    this.setState(({ showSearchModal }) => ({
+      showSearchModal: !showSearchModal
+    }));
   }
 
   /**
@@ -153,7 +163,8 @@ export default class DetailsView extends Component {
       paneTitle,
       paneSub,
       actionMenuItems,
-      lastMenu
+      lastMenu,
+      enableListSearch
     } = this.props;
 
     let {
@@ -162,7 +173,8 @@ export default class DetailsView extends Component {
     } = this.context;
 
     let {
-      isSticky
+      isSticky,
+      showSearchModal
     } = this.state;
 
     let containerClassName = cx('container', {
@@ -240,9 +252,11 @@ export default class DetailsView extends Component {
               data-test-eholdings-details-view-list={type}
             >
               <div className={styles['list-header']}>
-                <h3>
-                  {capitalize(listType)}
-                </h3>
+                <h3>{capitalize(listType)}</h3>
+
+                {enableListSearch && (
+                  <IconButton icon="search" onClick={this.toggleSearchModal}/>
+                )}
               </div>
 
               <div ref={(n) => { this.$list = n; }} className={styles.list}>
@@ -251,6 +265,23 @@ export default class DetailsView extends Component {
             </div>
           )}
         </div>
+
+        {enableListSearch && showSearchModal && (
+          <Modal
+            size="small"
+            label={`Filter ${listType}`}
+            open={showSearchModal}
+            onClose={this.toggleSearchModal}
+            closeOnBackgroundClick
+            dismissible
+          >
+            <SearchForm
+              searchType={listType}
+              onSearch={() => {}}
+              displaySearchTypeSwitcher={false}
+            />
+          </Modal>
+        )}
       </div>
     );
   }

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -44,7 +44,8 @@ export default class DetailsView extends Component {
     actionMenuItems: PropTypes.array,
     lastMenu: PropTypes.node,
     enableListSearch: PropTypes.bool,
-    onSearch: PropTypes.func
+    onSearch: PropTypes.func,
+    searchParams: PropTypes.object
   };
 
   static contextTypes = {
@@ -155,10 +156,14 @@ export default class DetailsView extends Component {
   };
 
   handleListSearch = (params) => {
-    this.setState({ showSearchModal: false }, () => {
-      if (this.props.onSearch) {
-        this.props.onSearch(params);
-      };
+    let { searchParams } = this.props;
+
+    if (params.q && this.props.onSearch) {
+      this.props.onSearch(params);
+    }
+
+    this.setState({
+      showSearchModal: searchParams.q === params.q
     });
   }
 
@@ -174,7 +179,7 @@ export default class DetailsView extends Component {
       actionMenuItems,
       lastMenu,
       enableListSearch,
-      onSearch
+      searchParams
     } = this.props;
 
     let {
@@ -239,9 +244,9 @@ export default class DetailsView extends Component {
               <h2 data-test-eholdings-details-view-name={type}>
                 {paneTitle}
               </h2>
-              {paneSub &&
+              {paneSub && (
                 <p>{paneSub}</p>
-              }
+              )}
             </div>,
 
             <div key="body" className={styles.body}>
@@ -265,7 +270,7 @@ export default class DetailsView extends Component {
                 <h3>{capitalize(listType)}</h3>
 
                 {enableListSearch && (
-                  <IconButton icon="search" onClick={this.toggleSearchModal}/>
+                  <IconButton icon="search" onClick={this.toggleSearchModal} />
                 )}
               </div>
 
@@ -287,6 +292,10 @@ export default class DetailsView extends Component {
           >
             <SearchForm
               searchType={listType}
+              searchString={searchParams.q}
+              filter={searchParams.filter}
+              searchField={searchParams.searchField}
+              sort={searchParams.sort}
               onSearch={this.handleListSearch}
               displaySearchTypeSwitcher={false}
             />

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -28,28 +28,38 @@
 .modalHeader {
   position: relative;
   border-bottom: 1px solid #dedede;
-  padding: 0.5em 1em;
   line-height: 1.15;
+  flex: 0, 0, 42px;
 }
 
 .modalLabel {
-  font-weight: bold;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  min-height: 44px;
   font-size: calc(1.2rem);
-  flex-grow: 1;
-  flex-shrink: 0;
 }
 
 .modalContent {
-  padding: 1rem;
+  padding: var(--major-padding);
   flex: 1 2 auto;
   overflow: auto;
   width: 100%;
-  max-height: calc(100% - 31px - 2rem);
+  max-height: calc(100% - 44px - 2rem);
   line-height: 1.15;
 }
 
 .modalControls {
+  position: absolute;
+  height: 100%;
+  top: 0;
+  left: 0;
+  display: flex;
+  width: 100%;
   pointer-events: none;
+  justify-content: flex-start;
+  align-items: center;
 }
 
 .closeModal {
@@ -65,7 +75,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: rgba(0, 0, 0, 0.2);
 }
 
 .modalFooter {
@@ -85,8 +95,9 @@
 
 @media (--mediumUp) {
   .modal {
-    margin: 0 auto;
-    width: 60%;
+    &.medium {
+      width: 60%;
+    }
 
     &.small {
       width: 40%;

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -7,7 +7,7 @@ import React from 'react';
 import { Modal as OverlayModal } from 'react-overlays';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import { Icon } from '@folio/stripes-components';
+import { IconButton } from '@folio/stripes-components';
 import css from './modal.css';
 
 const propTypes = {
@@ -52,6 +52,7 @@ const defaultProps = {
   dismissible: false,
   open: false,
   showHeader: true,
+  size: 'medium',
 };
 
 const Modal = (props) => {
@@ -97,14 +98,13 @@ const Modal = (props) => {
             </div>
             <div className={css.modalControls}>
               {props.dismissible &&
-                <button
+                <IconButton
                   className={css.closeModal}
                   onClick={props.onClose}
                   title="Dismiss modal"
-                  aria-label="Dismiss modal"
-                >
-                  <Icon icon="closeX" />
-                </button>
+                  ariaLabel="Dismiss modal"
+                  icon="closeX"
+                />
               }
             </div>
           </div>

--- a/src/components/provider-show/provider-show.js
+++ b/src/components/provider-show/provider-show.js
@@ -12,7 +12,9 @@ import styles from './provider-show.css';
 
 export default function ProviderShow({
   model,
-  fetchPackages
+  packages,
+  fetchPackages,
+  searchPackages
 }, {
   intl,
   queryParams
@@ -54,8 +56,9 @@ export default function ProviderShow({
             </KeyValue>
           </DetailsViewSection>
         )}
-        listType="packages"
         enableListSearch
+        listType="packages"
+        onSearch={searchPackages}
         renderList={scrollable => (
           <QueryList
             type="provider-packages"
@@ -81,7 +84,8 @@ export default function ProviderShow({
 
 ProviderShow.propTypes = {
   model: PropTypes.object.isRequired,
-  fetchPackages: PropTypes.func.isRequired
+  fetchPackages: PropTypes.func.isRequired,
+  searchPackages: PropTypes.func.isRequired
 };
 
 ProviderShow.contextTypes = {

--- a/src/components/provider-show/provider-show.js
+++ b/src/components/provider-show/provider-show.js
@@ -14,7 +14,8 @@ export default function ProviderShow({
   model,
   packages,
   fetchPackages,
-  searchPackages
+  searchPackages,
+  searchParams
 }, {
   intl,
   queryParams
@@ -59,12 +60,13 @@ export default function ProviderShow({
         enableListSearch
         listType="packages"
         onSearch={searchPackages}
+        searchParams={searchParams}
         renderList={scrollable => (
           <QueryList
             type="provider-packages"
             fetch={fetchPackages}
-            collection={model.packages}
-            length={model.packagesTotal}
+            collection={packages}
+            length={packages.length}
             scrollable={scrollable}
             itemHeight={70}
             renderItem={item => (
@@ -84,8 +86,10 @@ export default function ProviderShow({
 
 ProviderShow.propTypes = {
   model: PropTypes.object.isRequired,
+  packages: PropTypes.object.isRequired,
   fetchPackages: PropTypes.func.isRequired,
-  searchPackages: PropTypes.func.isRequired
+  searchPackages: PropTypes.func.isRequired,
+  searchParams: PropTypes.object.isRequired
 };
 
 ProviderShow.contextTypes = {

--- a/src/components/provider-show/provider-show.js
+++ b/src/components/provider-show/provider-show.js
@@ -55,6 +55,7 @@ export default function ProviderShow({
           </DetailsViewSection>
         )}
         listType="packages"
+        enableListSearch
         renderList={scrollable => (
           <QueryList
             type="provider-packages"

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -15,6 +15,7 @@ class ProviderShowRoute extends Component {
       }).isRequired
     }).isRequired,
     model: PropTypes.object.isRequired,
+    resolver: PropTypes.object.isRequired,
     getProvider: PropTypes.func.isRequired,
     getPackages: PropTypes.func.isRequired
   };
@@ -68,6 +69,7 @@ class ProviderShowRoute extends Component {
         packages={this.getPkgResults()}
         fetchPackages={this.fetchPackages}
         searchPackages={this.searchPackages}
+        searchParams={this.state.pkgSearchParams}
       />
     );
   }

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -47,8 +47,6 @@ class ProviderShowRoute extends Component {
     let { pkgSearchParams } = this.state;
     let { providerId } = match.params;
 
-    console.log(pkgSearchParams);
-
     return resolver.query('packages', pkgSearchParams, {
       path: `${Provider.pathFor(providerId)}/packages`
     });

--- a/tests/pages/provider-show.js
+++ b/tests/pages/provider-show.js
@@ -4,9 +4,12 @@ import {
   computed,
   isPresent,
   page,
-  text
+  text,
+  clickable
 } from '@bigtest/interaction';
+
 import Toast from './toast';
+import SearchModal from './search-modal';
 
 @page class ProviderShowPage {
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
@@ -16,8 +19,10 @@ import Toast from './toast';
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="provider"]');
   errorMessage = text('[data-test-eholdings-details-view-error="provider"]');
+  clickListSearch = clickable('[data-test-eholdings-details-view-search] button');
 
-  toast = Toast
+  toast = Toast;
+  searchModal = new SearchModal('#eholdings-details-view-search-modal');
 
   packageList = collection('[data-test-query-list="provider-packages"] li a', {
     name: text('[data-test-eholdings-package-list-item-name]'),

--- a/tests/pages/search-modal.js
+++ b/tests/pages/search-modal.js
@@ -1,0 +1,27 @@
+import {
+  page,
+  action,
+  attribute,
+  value,
+} from '@bigtest/interaction';
+import { isRootPresent } from './helpers';
+
+export default @page class SearchModal {
+  exists = isRootPresent();
+  searchType = attribute('data-test-search-form', '[data-test-search-form]')
+  searchFieldValue = value('[data-test-search-field] input[name="search"]');
+
+  clickFilter = action(function (name, val) {
+    return this.click(`[data-test-eholdings-search-filters] input[name="${name}"][value="${val}"]`);
+  });
+
+  getFilter(name) {
+    return this.$(`[data-test-eholdings-search-filters] input[name="${name}"]:checked`).value;
+  }
+
+  search = action(function (query) {
+    return this
+      .fill('[data-test-search-field] input[name="search"]', query)
+      .click('[data-test-search-submit]');
+  });
+}

--- a/tests/provider-show-package-search-test.js
+++ b/tests/provider-show-package-search-test.js
@@ -1,0 +1,127 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import ProviderShowPage from './pages/provider-show';
+
+describeApplication('ProviderShow package search', () => {
+  let provider,
+    packages;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', 'withPackagesAndTitles', {
+      name: 'League of Ordinary Men',
+      packagesTotal: 5
+    });
+
+    packages = this.server.schema.where('package', {
+      providerId: provider.id
+    }).models;
+
+    packages.forEach((p, i) => p.update({
+      name: `Package ${i}`,
+      contentType: 'Print'
+    }));
+
+    packages[2].update({
+      name: 'Ordinary Package',
+      contentType: 'eBook',
+      isSelected: false
+    });
+
+    packages[4].update({
+      name: 'Other Ordinary Package',
+      isSelected: true
+    });
+
+    return this.visit(`/eholdings/providers/${provider.id}`, () => {
+      expect(ProviderShowPage.$root).to.exist;
+    });
+  });
+
+  describe('clicking the search button', () => {
+    beforeEach(() => {
+      return ProviderShowPage.clickListSearch();
+    });
+
+    it('shows the package search modal', () => {
+      expect(ProviderShowPage.searchModal.exists).to.be.true;
+    });
+  });
+
+  describe('searching for specific packages', () => {
+    beforeEach(() => {
+      return ProviderShowPage.clickListSearch()
+        .append(ProviderShowPage.searchModal.search('other ordinary'));
+    });
+
+    it('hides the package search modal', () => {
+      expect(ProviderShowPage.searchModal.exists).to.be.false;
+    });
+
+    it('displays packages matching the search term', () => {
+      expect(ProviderShowPage.packageList()).to.have.lengthOf(2);
+      expect(ProviderShowPage.packageList(0).name).to.equal('Other Ordinary Package');
+      expect(ProviderShowPage.packageList(1).name).to.equal('Ordinary Package');
+    });
+
+    describe('reopening the modal', () => {
+      beforeEach(() => {
+        return ProviderShowPage.clickListSearch();
+      });
+
+      it('shows the previous search term', () => {
+        expect(ProviderShowPage.searchModal.searchFieldValue).to.equal('other ordinary');
+      });
+    });
+
+    describe('then sorting by package name', () => {
+      beforeEach(() => {
+        return ProviderShowPage.clickListSearch()
+          .append(ProviderShowPage.searchModal.clickFilter('sort', 'name'));
+      });
+
+      it.always('leaves the search modal open', () => {
+        expect(ProviderShowPage.searchModal.exists).to.be.true;
+      });
+
+      it('displays packages matching the search term ordered by name', () => {
+        expect(ProviderShowPage.packageList()).to.have.lengthOf(2);
+        expect(ProviderShowPage.packageList(0).name).to.equal('Ordinary Package');
+        expect(ProviderShowPage.packageList(1).name).to.equal('Other Ordinary Package');
+      });
+    });
+
+    describe('then filtering the packages by selection status', () => {
+      beforeEach(() => {
+        return ProviderShowPage.clickListSearch()
+          .append(ProviderShowPage.searchModal.clickFilter('selected', 'true'));
+      });
+
+      it.always('leaves the search modal open', () => {
+        expect(ProviderShowPage.searchModal.exists).to.be.true;
+      });
+
+      it('displays selected packages matching the search term', () => {
+        expect(ProviderShowPage.packageList()).to.have.lengthOf(1);
+        expect(ProviderShowPage.packageList(0).name).to.equal('Other Ordinary Package');
+      });
+    });
+
+    describe('then filtering the packages by content type', () => {
+      beforeEach(() => {
+        return ProviderShowPage.clickListSearch()
+          .append(ProviderShowPage.searchModal.clickFilter('type', 'ebook'));
+      });
+
+      it.always('leaves the search modal open', () => {
+        expect(ProviderShowPage.searchModal.exists).to.be.true;
+      });
+
+      it('displays packages matching the search term and content type', () => {
+        expect(ProviderShowPage.packageList()).to.have.lengthOf(1);
+        expect(ProviderShowPage.packageList(0).name).to.equal('Ordinary Package');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose

Adds a search button and modal to provider details that allows searching the list of packages pertaining to the provider. ([UIEH-278](https://issues.folio.org/browse/UIEH-278))

## Approach

The `SearchForm` component was reused, but within a modal that is displayed when clicking on a search button in the header of the provider's related packages list.

When a new search string is given, the modal will close itself on search. When only the sort or filter options change, the modal remains open but the search is still performed in the background.

#### Future TODOs
- The inner search params are not persisted in the URL. This prevents us from deep linking searches within the details view. The current params are persisted in the route state, and in the future we can make this route use query params instead of it's state without changing any other props or components.
- There is no focus management for modals in stripes. Ideally, we would focus-trap the modal when open and focus back to the list when it is closed.
- There should be some indicator when search filters are active ([UIEH-216](https://issues.folio.org/browse/UIEH-216)), and another indicator showing how many packages are returned from the search ([UIEH-148](https://issues.folio.org/browse/UIEH-148))

## Screenshots
![2018-04-12 15 59 57](https://user-images.githubusercontent.com/5005153/38704309-82331d44-3e6b-11e8-912e-4b13c5bb9cd8.gif)
