### PR TITLE
UIEH-295: Add coverage statement to edit page

### DIFF
--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -33,7 +33,7 @@ export default function defaultScenario(server) {
     name: 'Single, Double, and Triple Paradiddles',
   });
 
-  server.create('customer-resource', {
+  server.create('resource', {
     package: customPackage,
     title: customTitle,
     isTitleCustom: true

--- a/src/components/custom-resource-edit/custom-resource-edit.js
+++ b/src/components/custom-resource-edit/custom-resource-edit.js
@@ -12,6 +12,7 @@ import { processErrors } from '../utilities';
 import DetailsView from '../details-view';
 import ResourceNameField, { validate as validateName } from '../resource-name-field';
 import ResourceCoverageFields, { validate as validateCoverageDates } from '../resource-coverage-fields';
+import CoverageStatementFields, { validate as validateCoverageStatement } from '../coverage-statement-fields';
 import DetailsViewSection from '../details-view-section';
 import NavigationModal from '../navigation-modal';
 import Toaster from '../toaster';
@@ -92,6 +93,12 @@ class CustomResourceEdit extends Component {
               >
                 <ResourceCoverageFields />
               </DetailsViewSection>
+              <DetailsViewSection
+                label="Coverage statement"
+              >
+                <CoverageStatementFields />
+              </DetailsViewSection>
+
               <div className={styles['resource-edit-action-buttons']}>
                 <div
                   data-test-eholdings-resource-cancel-button
@@ -129,7 +136,7 @@ class CustomResourceEdit extends Component {
 }
 
 const validate = (values, props) => {
-  return Object.assign({}, validateName(values), validateCoverageDates(values, props));
+  return Object.assign({}, validateName(values), validateCoverageDates(values, props), validateCoverageStatement(values));
 };
 
 export default reduxForm({

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -69,7 +69,8 @@ class ResourceEditRoute extends Component {
       View = CustomResourceEdit;
       initialValues = {
         name: model.name,
-        customCoverages: model.customCoverages
+        customCoverages: model.customCoverages,
+        coverageStatement: this.props.model.coverageStatement
       };
     } else {
       View = ManagedResourceEdit;

--- a/tests/custom-resource-edit-test.js
+++ b/tests/custom-resource-edit-test.js
@@ -40,11 +40,15 @@ describeApplication('CustomResourceEdit', () => {
     });
   });
 
-  describe('visiting the resource edit page without coverage dates', () => {
+  describe('visiting the resource edit page without coverage dates or statements', () => {
     beforeEach(function () {
       return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
         expect(ResourceEditPage.$root).to.exist;
       });
+    });
+
+    it('shows a form with coverage statement', () => {
+      expect(ResourceEditPage.coverageStatement).to.equal('');
     });
 
     it('disables the save button', () => {
@@ -89,7 +93,9 @@ describeApplication('CustomResourceEdit', () => {
           .clickAddRowButton()
           .once(() => ResourceEditPage.dateRangeRowList().length > 0)
           .do(() => {
-            return ResourceEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018');
+            return ResourceEditPage
+              .inputCoverageStatement('Only 90s kids would understand.')
+              .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018'));
           });
       });
 
@@ -115,11 +121,14 @@ describeApplication('CustomResourceEdit', () => {
         it('displays the saved date range', () => {
           expect(ResourceCoverage.displayText).to.equal('12/16/2018 - 12/18/2018');
         });
+        it('shows the new statement value', () => {
+          expect(ResourceShowPage.coverageStatement).to.equal('Only 90s kids would understand.');
+        });
       });
     });
   });
 
-  describe('visiting the resource edit page with coverage dates', () => {
+  describe('visiting the resource edit page with coverage dates or statements', () => {
     beforeEach(function () {
       let customCoverages = [
         this.server.create('custom-coverage', {
@@ -156,6 +165,11 @@ describeApplication('CustomResourceEdit', () => {
     describe('entering invalid data', () => {
       beforeEach(() => {
         return ResourceEditPage
+          .inputCoverageStatement(`Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+            Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
+            dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec,
+            pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo,
+            fringilla vel, aliquet nec, vulputate e`)
           .name('')
           .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/18/2018', '12/16/2018'))
           .clickSave();
@@ -168,11 +182,16 @@ describeApplication('CustomResourceEdit', () => {
       it('displays a validation error for coverage', () => {
         expect(ResourceEditPage.dateRangeRowList(0).beginDate.isInvalid).to.be.true;
       });
+
+      it('displays a validation error message for coverage statement', () => {
+        expect(ResourceEditPage.validationErrorOnCoverageStatement).to.equal('Statement must be 350 characters or less.');
+      });
     });
 
     describe('entering valid data', () => {
       beforeEach(() => {
         return ResourceEditPage
+          .inputCoverageStatement('Refinance your home loans.')
           .name('A Different Name')
           .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018'));
       });
@@ -202,6 +221,10 @@ describeApplication('CustomResourceEdit', () => {
 
         it('displays the saved date range', () => {
           expect(ResourceCoverage.displayText).to.equal('12/16/2018 - 12/18/2018');
+        });
+
+        it('shows the new statement value', () => {
+          expect(ResourceShowPage.coverageStatement).to.equal('Refinance your home loans.');
         });
       });
     });
@@ -241,6 +264,7 @@ describeApplication('CustomResourceEdit', () => {
     describe('entering valid data and clicking save', () => {
       beforeEach(() => {
         return ResourceEditPage
+          .inputCoverageStatement('10 ways to fail at everything')
           .name('A Different Name')
           .clickSave();
       });


### PR DESCRIPTION
## Purpose
This adds editing capabilities to the coverage statements in the full page editing view.

This resolves [UIEH-295](https://issues.folio.org/browse/UIEH-295)

## Screenshots
![2018-04-13 12 41 30](https://user-images.githubusercontent.com/25858667/38749935-ead563b8-3f18-11e8-805c-90d7614248ae.gif)
