### PR TITLE
Simplify package and resource edit routing

### DIFF
--- a/src/components/package/edit.js
+++ b/src/components/package/edit.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import EditManaged from './edit-managed';
+import EditCustom from './edit-custom';
+
+export default function PackageEdit({ model, ...props }) {
+  let View = model.isCustom ? EditCustom : EditManaged;
+
+  return (
+    <View
+      model={model}
+      {...props}
+    />
+  );
+}
+
+PackageEdit.propTypes = {
+  model: PropTypes.object.isRequired
+};

--- a/src/components/resource/edit.js
+++ b/src/components/resource/edit.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import EditManaged from './edit-managed';
+import EditCustom from './edit-custom';
+
+export default function ResourceEdit({ model, ...props }) {
+  let View = model.isTitleCustom ? EditCustom : EditManaged;
+
+  return (
+    <View
+      model={model}
+      {...props}
+    />
+  );
+}
+
+ResourceEdit.propTypes = {
+  model: PropTypes.object.isRequired
+};

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -7,8 +7,7 @@ import { createResolver } from '../redux';
 import Package from '../redux/package';
 import Resource from '../redux/resource';
 
-import PackageEditManaged from '../components/package/edit-managed';
-import PackageEditCustom from '../components/package/edit-custom';
+import View from '../components/package/edit';
 
 class PackageEditRoute extends Component {
   static propTypes = {
@@ -70,34 +69,19 @@ class PackageEditRoute extends Component {
 
   render() {
     let { model } = this.props;
-    let initialValues = {};
-    let View;
-
-    if (model.isCustom) {
-      View = PackageEditCustom;
-      initialValues = {
-        name: model.name,
-        contentType: model.contentType,
-        customCoverages: [{
-          beginCoverage: model.customCoverage.beginCoverage,
-          endCoverage: model.customCoverage.endCoverage
-        }]
-      };
-    } else {
-      View = PackageEditManaged;
-      initialValues = {
-        customCoverages: [{
-          beginCoverage: model.customCoverage.beginCoverage,
-          endCoverage: model.customCoverage.endCoverage
-        }]
-      };
-    }
 
     return (
       <View
         model={model}
         onSubmit={this.packageEditSubmitted}
-        initialValues={initialValues}
+        initialValues={{
+          name: model.name,
+          contentType: model.contentType,
+          customCoverages: [{
+            beginCoverage: model.customCoverage.beginCoverage,
+            endCoverage: model.customCoverage.endCoverage
+          }]
+        }}
       />
     );
   }

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -6,8 +6,7 @@ import moment from 'moment';
 import { createResolver } from '../redux';
 import Resource from '../redux/resource';
 
-import ResourceEditManaged from '../components/resource/edit-managed';
-import ResourceEditCustom from '../components/resource/edit-custom';
+import View from '../components/resource/edit';
 
 class ResourceEditRoute extends Component {
   static propTypes = {
@@ -62,34 +61,18 @@ class ResourceEditRoute extends Component {
 
   render() {
     let { model } = this.props;
-    let initialValues = {};
-    let View;
-
-    if (model.isTitleCustom) {
-      View = ResourceEditCustom;
-      initialValues = {
-        name: model.name,
-        customCoverages: model.customCoverages,
-        coverageStatement: this.props.model.coverageStatement,
-        customEmbargoValue: model.customEmbargoPeriod.embargoValue,
-        customEmbargoUnit: model.customEmbargoPeriod.embargoUnit
-
-      };
-    } else {
-      View = ResourceEditManaged;
-      initialValues = {
-        customCoverages: model.customCoverages,
-        coverageStatement: model.coverageStatement,
-        customEmbargoValue: model.customEmbargoPeriod.embargoValue,
-        customEmbargoUnit: model.customEmbargoPeriod.embargoUnit
-      };
-    }
 
     return (
       <View
-        model={this.props.model}
+        model={model}
         onSubmit={this.resourceEditSubmitted}
-        initialValues={initialValues}
+        initialValues={{
+          name: model.name,
+          customCoverages: model.customCoverages,
+          coverageStatement: model.coverageStatement,
+          customEmbargoValue: model.customEmbargoPeriod.embargoValue,
+          customEmbargoUnit: model.customEmbargoPeriod.embargoUnit
+        }}
       />
     );
   }


### PR DESCRIPTION
## Purpose
@cowboyd pointed out that in the `PackageEdit` and `ResourceEdit` routes, the check to see whether we should show the form for a managed or custom object is purely presentational:
```
if (model.isCustom) {
  View = PackageEditCustom;
}
```

## Approach
Moves the `isCustom` and `isTitleCustom` checks to new components out of the route. We can also combine the `initialValues` props for managed/custom. The `initialValues` managed packages/resources/ lack will just be ignored.
