### PR TITLE
Adjust custom coverage fields behavior

### DIFF
--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -13,28 +13,39 @@ export default class PackageCoverageFields extends Component {
   static propTypes = {
     packageCoverage: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     locale: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
-    intl: PropTypes.object // eslint-disable-line react/no-unused-prop-types
+    intl: PropTypes.object, // eslint-disable-line react/no-unused-prop-types,
+    initialValue: PropTypes.array
+  };
+
+  static defaultProps = {
+    initialValue: []
   };
 
   renderCoverageFields = ({ fields }) => {
+    let { initialValue } = this.props;
+
     return (
       <div className={styles['coverage-fields']}>
+        {fields.length === 0
+          && initialValue.length > 0
+          && initialValue[0].beginCoverage
+          && (
+          <p data-test-eholdings-package-coverage-fields-saving-will-remove>
+            No date ranges set. Saving will remove custom coverage.
+          </p>
+        )}
+
         {fields.length === 0 ? (
-          <div>
-            <p data-test-eholdings-coverage-fields-no-rows-left>
-              No date range set. Saving will remove custom coverage.
-            </p>
-            <div
-              className={styles['coverage-fields-add-row-button']}
-              data-test-eholdings-coverage-fields-add-row-button
+          <div
+            className={styles['coverage-fields-add-row-button']}
+            data-test-eholdings-coverage-fields-add-row-button
+          >
+            <Button
+              type="button"
+              onClick={() => fields.push({})}
             >
-              <Button
-                type="button"
-                onClick={() => fields.push({})}
-              >
-                + Add date range
-              </Button>
-            </div>
+              + Add date range
+            </Button>
           </div>
         ) : (
           <ul className={styles['coverage-fields-date-range-rows']}>

--- a/src/components/package/_forms/custom-coverage/package-custom-coverage.js
+++ b/src/components/package/_forms/custom-coverage/package-custom-coverage.js
@@ -70,6 +70,7 @@ class PackageCustomCoverage extends Component {
 
   renderEditingForm() {
     let {
+      initialValues,
       handleSubmit,
       onSubmit,
       pristine,
@@ -84,7 +85,9 @@ class PackageCustomCoverage extends Component {
         pristine={pristine}
         isPending={isPending}
       >
-        <CoverageFields />
+        <CoverageFields
+          initialValue={initialValues.customCoverages}
+        />
       </InlineForm>
     );
   }

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -58,6 +58,7 @@ class CustomPackageEdit extends Component {
   render() {
     let {
       model,
+      initialValues,
       handleSubmit,
       onSubmit,
       pristine
@@ -101,7 +102,9 @@ class CustomPackageEdit extends Component {
               <DetailsViewSection
                 label="Coverage dates"
               >
-                <CoverageFields />
+                <CoverageFields
+                  initialValue={initialValues.customCoverages}
+                />
               </DetailsViewSection>
               <div className={styles['package-edit-action-buttons']}>
                 <div

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -56,6 +56,7 @@ class ManagedPackageEdit extends Component {
   render() {
     let {
       model,
+      initialValues,
       handleSubmit,
       onSubmit,
       pristine
@@ -93,7 +94,9 @@ class ManagedPackageEdit extends Component {
               <DetailsViewSection
                 label="Coverage dates"
               >
-                <CoverageFields />
+                <CoverageFields
+                  initialValue={initialValues.customCoverages}
+                />
               </DetailsViewSection>
               <div className={styles['package-edit-action-buttons']}>
                 <div

--- a/src/components/resource/_fields/custom-coverage/resource-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/resource-coverage-fields.js
@@ -16,17 +16,29 @@ export default class ResourceCoverageFields extends Component {
   static propTypes = {
     packageCoverage: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     locale: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
-    intl: PropTypes.object // eslint-disable-line react/no-unused-prop-types
+    intl: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
+    initialValue: PropTypes.array
+  };
+
+  static defaultProps = {
+    initialValue: []
   };
 
   renderCoverageFields = ({ fields }) => {
+    let { initialValue } = this.props;
+
     return (
       <div className={styles['coverage-fields']}>
-        {fields.length === 0 ? (
-          <p data-test-eholdings-coverage-fields-no-rows-left>
-            No date ranges set.
+        {fields.length === 0
+          && initialValue.length > 0
+          && initialValue[0].beginCoverage
+          && (
+          <p data-test-eholdings-coverage-fields-saving-will-remove>
+            No date ranges set. Saving will remove custom coverage.
           </p>
-        ) : (
+        )}
+
+        {fields.length > 0 && (
           <ul className={styles['coverage-fields-date-range-rows']}>
             {fields.map((dateRange, index) => (
               <li

--- a/src/components/resource/_forms/custom-coverage/resource-coverage.js
+++ b/src/components/resource/_forms/custom-coverage/resource-coverage.js
@@ -68,6 +68,7 @@ class ResourceCoverage extends Component {
 
   renderEditingForm() {
     let {
+      initialValues,
       pristine,
       isPending,
       handleSubmit,
@@ -82,7 +83,9 @@ class ResourceCoverage extends Component {
         pristine={pristine}
         isPending={isPending}
       >
-        <CustomCoverageFields />
+        <CustomCoverageFields
+          initialValue={initialValues.customCoverages}
+        />
       </InlineForm>
     );
   }

--- a/src/components/resource/edit-custom/custom-resource-edit.js
+++ b/src/components/resource/edit-custom/custom-resource-edit.js
@@ -59,6 +59,7 @@ class CustomResourceEdit extends Component {
   render() {
     let {
       model,
+      initialValues,
       handleSubmit,
       onSubmit,
       pristine,
@@ -94,7 +95,9 @@ class CustomResourceEdit extends Component {
               <DetailsViewSection
                 label="Coverage dates"
               >
-                <CustomCoverageFields />
+                <CustomCoverageFields
+                  initialValue={initialValues.customCoverages}
+                />
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage statement"

--- a/src/components/resource/edit-managed/managed-resource-edit.js
+++ b/src/components/resource/edit-managed/managed-resource-edit.js
@@ -58,6 +58,7 @@ class ManagedResourceEdit extends Component {
   render() {
     let {
       model,
+      initialValues,
       handleSubmit,
       onSubmit,
       pristine,
@@ -88,7 +89,9 @@ class ManagedResourceEdit extends Component {
               <DetailsViewSection
                 label="Coverage dates"
               >
-                <CustomCoverageFields />
+                <CustomCoverageFields
+                  initialValue={initialValues.customCoverages}
+                />
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage statement"

--- a/tests/pages/resource-custom-coverage.js
+++ b/tests/pages/resource-custom-coverage.js
@@ -23,7 +23,7 @@ import Datepicker from './datepicker';
   hasEditButton = isPresent('[data-test-eholdings-coverage-form-edit-button]');
   clickAddRowButton = clickable('[data-test-eholdings-coverage-fields-add-row-button] button');
   displayText = text('[data-test-eholdings-coverage-form-display]');
-  hasNoRowsLeftMessage = isPresent('[data-test-eholdings-coverage-fields-no-rows-left]');
+  hasSavingWillRemoveMessage = isPresent('[data-test-eholdings-coverage-fields-saving-will-remove]');
 
   dateRangeRowList = collection('[data-test-eholdings-coverage-fields-date-range-row]', {
     beginDate: new Datepicker('[data-test-eholdings-coverage-fields-date-range-begin]'),

--- a/tests/resource-custom-coverage-test.js
+++ b/tests/resource-custom-coverage-test.js
@@ -135,6 +135,10 @@ describeApplication('ResourceCustomCoverage', () => {
           it('removes the new row', () => {
             expect(ResourceCoverage.dateRangeRowList().length).to.equal(1);
           });
+
+          it('does not display the saving will remove message', () => {
+            expect(ResourceCoverage.hasSavingWillRemoveMessage).to.be.false;
+          });
         });
       });
 
@@ -334,8 +338,8 @@ describeApplication('ResourceCustomCoverage', () => {
           return ResourceCoverage.dateRangeRowList(0).clickRemoveRowButton();
         });
 
-        it('displays the no rows left message', () => {
-          expect(ResourceCoverage.hasNoRowsLeftMessage).to.be.true;
+        it('displays the saving will remove message', () => {
+          expect(ResourceCoverage.hasSavingWillRemoveMessage).to.be.true;
         });
 
         it('enables the save button', () => {

--- a/tests/resource-custom-coverage-test.js
+++ b/tests/resource-custom-coverage-test.js
@@ -136,7 +136,7 @@ describeApplication('ResourceCustomCoverage', () => {
             expect(ResourceCoverage.dateRangeRowList().length).to.equal(1);
           });
 
-          it('does not display the saving will remove message', () => {
+          it.always('does not display the saving will remove message', () => {
             expect(ResourceCoverage.hasSavingWillRemoveMessage).to.be.false;
           });
         });
@@ -338,7 +338,7 @@ describeApplication('ResourceCustomCoverage', () => {
           return ResourceCoverage.dateRangeRowList(0).clickRemoveRowButton();
         });
 
-        it('displays the saving will remove message', () => {
+        it.always('displays the saving will remove message', () => {
           expect(ResourceCoverage.hasSavingWillRemoveMessage).to.be.true;
         });
 


### PR DESCRIPTION
## Purpose
When a user clicks the "circle X" icon to remove custom coverage from a package or resource, they should get a warning that saving changes will remove the previously set date range(s). The message was being shown too eagerly - any time a user removed the last date range row, they saw the "Saving will remove" message, even if they didn't previously have any custom coverage dates set.

## Approach
Check the `initialValue` of `customCoverages` to determine whether to show the "Saving will remove custom coverage" message on removing all date range rows.

## Next Steps
For a package, `customCoverage` is an object with `beginCoverage` and `endCoverage` keys, vs. a resource, which has a `customCoverages` array. The `PackageCoverageFields` component uses a `redux-form` `FieldArray` to have the same UX as setting coverage dates on a resource. Instead of happening in the route, the transformation between an array and a single object should happen in the `PackageCoverageFields` component, since it's a purely presentational concern.

## Screenshot
![localhost_3000_eholdings_resources_1 iphone 6_7_8](https://user-images.githubusercontent.com/230597/38783547-f8cad4a6-40c8-11e8-9302-fadc2fd62daf.png)
