### PR TITLE
UIEH-259: Custom Package Creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/*
 artifacts
 coverage
 .DS_STORE
+/yarn-error.log

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -197,6 +197,7 @@ export default function configure() {
 
     pkg.update('customCoverages', customCoverages);
     pkg.update('isSelected', true);
+    pkg.update('isCustom', true);
 
     return pkg;
   });

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -189,6 +189,8 @@ export default function configure() {
     return matchingPackage;
   });
 
+  this.post('/packages');
+
   // Title resources
   this.get('/titles', searchRouteFor('titles', (title, req) => {
     let params = req.queryParams;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -189,7 +189,17 @@ export default function configure() {
     return matchingPackage;
   });
 
-  this.post('/packages');
+  this.post('/packages', ({ packages }, request) => {
+    let body = JSON.parse(request.requestBody);
+    let pkg = packages.create(body.data.attributes);
+
+    let { customCoverages } = body.data.attributes;
+
+    pkg.update('customCoverages', customCoverages);
+    pkg.update('isSelected', true);
+
+    return pkg;
+  });
 
   // Title resources
   this.get('/titles', searchRouteFor('titles', (title, req) => {

--- a/src/components/details-view-section/details-view-section.css
+++ b/src/components/details-view-section/details-view-section.css
@@ -3,6 +3,10 @@
 .details-view-section {
   border-top: 1px solid var(--minor-divider-color);
   padding-bottom: 1em;
+
+  &.hide-separator {
+    border-top: none;
+  }
 }
 
 .details-view-section-label {

--- a/src/components/details-view-section/details-view-section.js
+++ b/src/components/details-view-section/details-view-section.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 import styles from './details-view-section.css';
+
+const cx = classNames.bind(styles);
 
 export default function DetailsViewSection(props) {
   return (
-    <div className={styles['details-view-section']}>
+    <div className={cx('details-view-section', { 'hide-separator': !props.separator })}>
       <h3 className={styles['details-view-section-label']}>{props.label}</h3>
       <div className={styles['details-view-section-value']}>
         {props.children}
@@ -15,5 +18,10 @@ export default function DetailsViewSection(props) {
 
 DetailsViewSection.propTypes = {
   label: PropTypes.string,
+  separator: PropTypes.bool,
   children: PropTypes.node
+};
+
+DetailsViewSection.defaultProps = {
+  separator: true
 };

--- a/src/components/package/create/index.js
+++ b/src/components/package/create/index.js
@@ -1,0 +1,1 @@
+export { default } from './package-create';

--- a/src/components/package/create/package-create.css
+++ b/src/components/package/create/package-create.css
@@ -1,0 +1,17 @@
+@import '@folio/stripes-components/lib/variables';
+
+.package-create-form-container {
+  overflow-y: auto;
+  padding: 1em;
+}
+
+.package-create-action-buttons {
+  align-items: flex-start;
+  border-top: 1px solid var(--minor-divider-color);
+  display: flex;
+  padding-top: 1em;
+
+  & button {
+    margin-right: 0.25em;
+  }
+}

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -16,7 +16,7 @@ import styles from './package-create.css';
 
 class PackageCreate extends Component {
   static propTypes = {
-    // model: PropTypes.object.isRequired,
+    request: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
     // pristine: PropTypes.bool

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -11,7 +11,11 @@ import {
 
 // import DetailsView from '../../details-view';
 import DetailsViewSection from '../../details-view-section';
-// import NavigationModal from '../../navigation-modal';
+import NameField, { validate as validatePackageName } from '../_fields/name';
+import CoverageFields, { validate as validateCoverageDates } from '../_fields/custom-coverage';
+import ContentTypeField from '../_fields/content-type';
+import NavigationModal from '../../navigation-modal';
+import Toaster from '../../toaster';
 import styles from './package-create.css';
 
 class PackageCreate extends Component {
@@ -25,24 +29,19 @@ class PackageCreate extends Component {
   static contextTypes = {
     router: PropTypes.shape({
       history: PropTypes.shape({
-        push: PropTypes.func.isRequired
+        goBack: PropTypes.func.isRequired
       }).isRequired
     }).isRequired
   };
 
   handleCancel = () => {
-    // this.context.router.history.push(
-    //   `/eholdings/packages/${this.props.model.id}${this.context.router.route.location.search}`,
-    //   { eholdings: true }
-    // );
+    this.context.router.history.goBack();
   }
 
   render() {
     let {
-      // model,
       handleSubmit,
-      onSubmit,
-      // pristine
+      onSubmit
     } = this.props;
 
     return (
@@ -55,12 +54,13 @@ class PackageCreate extends Component {
             <DetailsViewSection
               label="Package information"
             >
-              <Field
-                name="name"
-                type="text"
-                component={TextField}
-                label="Name"
-              />
+              <NameField />
+              <ContentTypeField />
+            </DetailsViewSection>
+            <DetailsViewSection
+              label="Coverage dates"
+            >
+              <CoverageFields />
             </DetailsViewSection>
             <div className={styles['package-create-action-buttons']}>
               <div
@@ -91,10 +91,8 @@ class PackageCreate extends Component {
   }
 }
 
-const validate = () => {
-// const validate = (values, props) => {
-  // return validateCoverageDates(values, props);
-  return [];
+const validate = (values, props) => {
+  return Object.assign({}, validatePackageName(values), validateCoverageDates(values, props));
 };
 
 export default reduxForm({

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -1,0 +1,105 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { reduxForm, Field } from 'redux-form';
+// import isEqual from 'lodash/isEqual';
+
+import {
+  Button,
+  PaneHeader,
+  TextField
+} from '@folio/stripes-components';
+
+// import DetailsView from '../../details-view';
+import DetailsViewSection from '../../details-view-section';
+// import NavigationModal from '../../navigation-modal';
+import styles from './package-create.css';
+
+class PackageCreate extends Component {
+  static propTypes = {
+    // model: PropTypes.object.isRequired,
+    handleSubmit: PropTypes.func,
+    onSubmit: PropTypes.func.isRequired,
+    // pristine: PropTypes.bool
+  };
+
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
+  handleCancel = () => {
+    // this.context.router.history.push(
+    //   `/eholdings/packages/${this.props.model.id}${this.context.router.route.location.search}`,
+    //   { eholdings: true }
+    // );
+  }
+
+  render() {
+    let {
+      // model,
+      handleSubmit,
+      onSubmit,
+      // pristine
+    } = this.props;
+
+    return (
+      <div>
+        <PaneHeader
+          paneTitle="New custom package"
+        />
+        <div className={styles['package-create-form-container']}>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <DetailsViewSection
+              label="Package information"
+            >
+              <Field
+                name="name"
+                type="text"
+                component={TextField}
+                label="Name"
+              />
+            </DetailsViewSection>
+            <div className={styles['package-create-action-buttons']}>
+              <div
+                data-test-eholdings-package-create-cancel-button
+              >
+                <Button
+                  type="button"
+                  onClick={this.handleCancel}
+                >
+                  Cancel
+                </Button>
+              </div>
+              <div
+                data-test-eholdings-package-create-save-button
+              >
+                <Button
+                  type="submit"
+                  buttonStyle="primary"
+                >
+                  Save
+                </Button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    );
+  }
+}
+
+const validate = () => {
+// const validate = (values, props) => {
+  // return validateCoverageDates(values, props);
+  return [];
+};
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'PackageCreate',
+  destroyOnUnmount: false,
+})(PackageCreate);

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -41,7 +41,7 @@ class PackageCreate extends Component {
     } = this.props;
 
     return (
-      <div>
+      <div data-test-eholdings-package-create>
         <Toaster
           position="bottom"
           toasts={request.errors.map(({ title }, index) => ({
@@ -77,7 +77,7 @@ class PackageCreate extends Component {
           </form>
         </div>
 
-        <NavigationModal when={!pristine && !request.isPending} />
+        <NavigationModal when={!pristine && !request.isResolved} />
       </div>
     );
   }

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -1,15 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { reduxForm, Field } from 'redux-form';
-// import isEqual from 'lodash/isEqual';
+import { reduxForm } from 'redux-form';
 
-import {
-  Button,
-  PaneHeader,
-  TextField
-} from '@folio/stripes-components';
+import { Button, PaneHeader } from '@folio/stripes-components';
 
-// import DetailsView from '../../details-view';
 import DetailsViewSection from '../../details-view-section';
 import NameField, { validate as validatePackageName } from '../_fields/name';
 import CoverageFields, { validate as validateCoverageDates } from '../_fields/custom-coverage';
@@ -21,9 +15,9 @@ import styles from './package-create.css';
 class PackageCreate extends Component {
   static propTypes = {
     request: PropTypes.object.isRequired,
-    handleSubmit: PropTypes.func,
+    handleSubmit: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
-    // pristine: PropTypes.bool
+    pristine: PropTypes.bool.isRequired
   };
 
   static contextTypes = {
@@ -40,52 +34,50 @@ class PackageCreate extends Component {
 
   render() {
     let {
+      request,
       handleSubmit,
-      onSubmit
+      onSubmit,
+      pristine
     } = this.props;
 
     return (
       <div>
-        <PaneHeader
-          paneTitle="New custom package"
+        <Toaster
+          position="bottom"
+          toasts={request.errors.map(({ title }, index) => ({
+            id: `error-${request.timestamp}-${index}`,
+            message: title,
+            type: 'error'
+          }))}
         />
+
+        <PaneHeader paneTitle="New custom package" />
+
         <div className={styles['package-create-form-container']}>
           <form onSubmit={handleSubmit(onSubmit)}>
-            <DetailsViewSection
-              label="Package information"
-            >
+            <DetailsViewSection label="Package information" separator={false}>
               <NameField />
               <ContentTypeField />
             </DetailsViewSection>
-            <DetailsViewSection
-              label="Coverage dates"
-            >
+            <DetailsViewSection label="Coverage dates">
               <CoverageFields />
             </DetailsViewSection>
             <div className={styles['package-create-action-buttons']}>
-              <div
-                data-test-eholdings-package-create-cancel-button
-              >
-                <Button
-                  type="button"
-                  onClick={this.handleCancel}
-                >
+              <div data-test-eholdings-package-create-cancel-button>
+                <Button type="button" onClick={this.handleCancel}>
                   Cancel
                 </Button>
               </div>
-              <div
-                data-test-eholdings-package-create-save-button
-              >
-                <Button
-                  type="submit"
-                  buttonStyle="primary"
-                >
+              <div data-test-eholdings-package-create-save-button>
+                <Button type="submit" buttonStyle="primary">
                   Save
                 </Button>
               </div>
             </div>
           </form>
         </div>
+
+        <NavigationModal when={!pristine && !request.isPending} />
       </div>
     );
   }
@@ -99,5 +91,5 @@ export default reduxForm({
   validate,
   enableReinitialize: true,
   form: 'PackageCreate',
-  destroyOnUnmount: false,
+  destroyOnUnmount: false
 })(PackageCreate);

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -149,9 +149,21 @@ export default class PackageShow extends Component {
       });
     }
 
+    let toasts = processErrors(model);
+
+    // if coming from creating a new custom package, show a success toast
+    if (router.history.action === 'REPLACE' &&
+        router.history.location.state.isNewRecord) {
+      toasts.push({
+        id: `success-package-${model.id}`,
+        message: 'Successfully created custom package',
+        type: 'success'
+      });
+    }
+
     return (
       <div>
-        <Toaster toasts={processErrors(model)} position="bottom" />
+        <Toaster toasts={toasts} position="bottom" />
         <DetailsView
           type="package"
           model={model}

--- a/src/components/toaster/toast.js
+++ b/src/components/toaster/toast.js
@@ -21,7 +21,7 @@ class Toast extends Component {
     animationPosition: PropTypes.string,
 
     // the type of toast: warn, error, or success
-    type: PropTypes.string,
+    type: PropTypes.oneOf(['warn', 'error', 'success']),
 
     // the error message is a child of the `Toast` component
     children: PropTypes.node.isRequired,

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import SearchRoute from './routes/search';
 import ProviderShow from './routes/provider-show';
 import PackageShow from './routes/package-show';
 import PackageEdit from './routes/package-edit';
+import PackageCreate from './routes/package-create';
 import TitleShow from './routes/title-show';
 import ResourceShow from './routes/resource-show';
 import ResourceEdit from './routes/resource-edit';
@@ -70,6 +71,7 @@ export default class EHoldings extends Component {
         <Route path={`${rootPath}/:type?/:id?`} component={SearchRoute}>
           <Switch>
             <Route path={`${rootPath}/providers/:providerId`} exact component={ProviderShow} />
+            <Route path={`${rootPath}/packages/new`} exact component={PackageCreate} />
             <Route path={`${rootPath}/packages/:packageId`} exact component={PackageShow} />
             <Route path={`${rootPath}/packages/:packageId/edit`} exact component={PackageEdit} />
             <Route path={`${rootPath}/titles/:titleId`} exact component={TitleShow} />

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -308,11 +308,11 @@ class BaseModel {
    * Action creator for creating a record
    * @param {Object} attrs - the record's attributes
    */
-  static create(attrs) { // eslint-disable-line no-shadow
-    let model = new this();
-    model.data.attributes = attrs;
+  static create(attrs) {
+    let newModel = new this();
+    newModel.data.attributes = attrs;
 
-    return create(this.type, model.serialize(), {
+    return create(this.type, newModel.serialize(), {
       path: this.pathFor()
     });
   }

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -1,7 +1,7 @@
 import dasherize from 'lodash/kebabCase';
 import { pluralize } from 'inflected';
 import { qs } from '../components/utilities';
-import { find, query, save, unload } from './data';
+import { find, query, save, create, unload } from './data';
 
 /**
  * Collection object which provides the request state object created
@@ -305,6 +305,19 @@ class BaseModel {
   }
 
   /**
+   * Action creator for creating a record
+   * @param {Object} attrs - the record's attributes
+   */
+  static create(attrs) { // eslint-disable-line no-shadow
+    let model = new this();
+    model.data.attributes = attrs;
+
+    return create(this.type, model.serialize(), {
+      path: this.pathFor()
+    });
+  }
+
+  /**
    * Action creator for unloading records
    * @param {Model|Collection} modelOrCollection - the record model or collection
    */
@@ -338,7 +351,7 @@ class BaseModel {
   constructor(id, resolver) {
     this.id = id;
     this.resolver = resolver;
-    this.data = resolver.getRecord(this.type, id) || {};
+    this.data = (resolver && resolver.getRecord(this.type, id)) || {};
   }
 
   /**

--- a/src/redux/resolver.js
+++ b/src/redux/resolver.js
@@ -128,14 +128,4 @@ export default class Resolver {
     let ModelClass = this.modelFor(type);
     return new ModelClass(id, this);
   }
-
-  /**
-   * Returns a record model for a specific resource record
-   * @param {String} type - the resource type
-   * @returns {Model} the model for the record
-   */
-  create(type) {
-    let ModelClass = this.modelFor(type);
-    return new ModelClass(null, this);
-  }
 }

--- a/src/redux/resolver.js
+++ b/src/redux/resolver.js
@@ -128,4 +128,14 @@ export default class Resolver {
     let ModelClass = this.modelFor(type);
     return new ModelClass(id, this);
   }
+
+  /**
+   * Returns a record model for a specific resource record
+   * @param {String} type - the resource type
+   * @returns {Model} the model for the record
+   */
+  create(type) {
+    let ModelClass = this.modelFor(type);
+    return new ModelClass(null, this);
+  }
 }

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -9,20 +9,33 @@ import View from '../components/package/create';
 
 class PackageCreateRoute extends Component {
   static propTypes = {
-    model: PropTypes.object.isRequired,
-    updatePackage: PropTypes.func.isRequired
+    request: PropTypes.object.isRequired,
+    createPackage: PropTypes.func.isRequired
   };
 
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        replace: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.request.isResolved && this.props.request.isResolved) {
+      let packageId = this.props.request.records[0];
+      this.context.router.history.replace(`/eholdings/packages/${packageId}`, { eholdings: true });
+    }
+  }
+
   packageCreateSubmitted = (values) => {
-    let { model, updatePackage } = this.props;
-    model.name = values.name;
-    updatePackage(model);
+    this.props.createPackage(values);
   };
 
   render() {
     return (
       <View
-        model={this.props.model}
+        request={this.props.request}
         onSubmit={this.packageCreateSubmitted}
         initialValues={{
           name: ''
@@ -34,8 +47,8 @@ class PackageCreateRoute extends Component {
 
 export default connect(
   ({ eholdings: { data } }) => ({
-    model: createResolver(data).create('packages')
+    request: createResolver(data).getRequest('create', { type: 'packages' })
   }), {
-    updatePackage: model => Package.save(model)
+    createPackage: attrs => Package.create(attrs)
   }
 )(PackageCreateRoute);

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import moment from 'moment';
 
 import { createResolver } from '../redux';
 import Package from '../redux/package';
@@ -29,7 +30,26 @@ class PackageCreateRoute extends Component {
   }
 
   packageCreateSubmitted = (values) => {
-    this.props.createPackage(values);
+    let attrs = {};
+    let beginCoverage = '';
+    let endCoverage = '';
+
+    if (values.customCoverages[0]) {
+      attrs.customCoverage = {
+        beginCoverage: !values.customCoverages[0].beginCoverage ? '' : moment(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD'),
+        endCoverage: !values.customCoverages[0].endCoverage ? '' : moment(values.customCoverages[0].endCoverage).format('YYYY-MM-DD')
+      };
+    }
+
+    if ('name' in values) {
+      attrs.name = values.name;
+    }
+
+    if ('contentType' in values) {
+      attrs.contentType = values.contentType;
+    }
+
+    this.props.createPackage(attrs);
   };
 
   render() {
@@ -38,7 +58,9 @@ class PackageCreateRoute extends Component {
         request={this.props.request}
         onSubmit={this.packageCreateSubmitted}
         initialValues={{
-          name: ''
+          name: '',
+          contentType: '',
+          customCoverages: []
         }}
       />
     );

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { createResolver } from '../redux';
+import Package from '../redux/package';
+
+import View from '../components/package/create';
+
+class PackageCreateRoute extends Component {
+  static propTypes = {
+    model: PropTypes.object.isRequired,
+    updatePackage: PropTypes.func.isRequired
+  };
+
+  packageCreateSubmitted = (values) => {
+    let { model, updatePackage } = this.props;
+    model.name = values.name;
+    updatePackage(model);
+  };
+
+  render() {
+    return (
+      <View
+        model={this.props.model}
+        onSubmit={this.packageCreateSubmitted}
+        initialValues={{
+          name: ''
+        }}
+      />
+    );
+  }
+}
+
+export default connect(
+  ({ eholdings: { data } }) => ({
+    model: createResolver(data).create('packages')
+  }), {
+    updatePackage: model => Package.save(model)
+  }
+)(PackageCreateRoute);

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -10,7 +10,7 @@ import View from '../components/package/create';
 
 class PackageCreateRoute extends Component {
   static propTypes = {
-    request: PropTypes.object.isRequired,
+    createRequest: PropTypes.object.isRequired,
     createPackage: PropTypes.func.isRequired
   };
 
@@ -23,16 +23,14 @@ class PackageCreateRoute extends Component {
   };
 
   componentDidUpdate(prevProps) {
-    if (!prevProps.request.isResolved && this.props.request.isResolved) {
-      let packageId = this.props.request.records[0];
+    if (!prevProps.createRequest.isResolved && this.props.createRequest.isResolved) {
+      let packageId = this.props.createRequest.records[0];
       this.context.router.history.replace(`/eholdings/packages/${packageId}`, { eholdings: true });
     }
   }
 
   packageCreateSubmitted = (values) => {
     let attrs = {};
-    let beginCoverage = '';
-    let endCoverage = '';
 
     if (values.customCoverages[0]) {
       attrs.customCoverage = {
@@ -55,7 +53,7 @@ class PackageCreateRoute extends Component {
   render() {
     return (
       <View
-        request={this.props.request}
+        request={this.props.createRequest}
         onSubmit={this.packageCreateSubmitted}
         initialValues={{
           name: '',
@@ -69,7 +67,7 @@ class PackageCreateRoute extends Component {
 
 export default connect(
   ({ eholdings: { data } }) => ({
-    request: createResolver(data).getRequest('create', { type: 'packages' })
+    createRequest: createResolver(data).getRequest('create', { type: 'packages' })
   }), {
     createPackage: attrs => Package.create(attrs)
   }

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -24,8 +24,10 @@ class PackageCreateRoute extends Component {
 
   componentDidUpdate(prevProps) {
     if (!prevProps.createRequest.isResolved && this.props.createRequest.isResolved) {
-      let packageId = this.props.createRequest.records[0];
-      this.context.router.history.replace(`/eholdings/packages/${packageId}`, { eholdings: true });
+      this.context.router.history.replace(
+        `/eholdings/packages/${this.props.createRequest.records[0]}`,
+        { eholdings: true, isNewRecord: true }
+      );
     }
   }
 
@@ -34,8 +36,10 @@ class PackageCreateRoute extends Component {
 
     if (values.customCoverages[0]) {
       attrs.customCoverage = {
-        beginCoverage: !values.customCoverages[0].beginCoverage ? '' : moment(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD'),
-        endCoverage: !values.customCoverages[0].endCoverage ? '' : moment(values.customCoverages[0].endCoverage).format('YYYY-MM-DD')
+        beginCoverage: !values.customCoverages[0].beginCoverage ? '' :
+          moment(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD'),
+        endCoverage: !values.customCoverages[0].endCoverage ? '' :
+          moment(values.customCoverages[0].endCoverage).format('YYYY-MM-DD')
       };
     }
 

--- a/tests/package-create-test.js
+++ b/tests/package-create-test.js
@@ -96,4 +96,26 @@ describeApplication('PackageCreate', () => {
       expect(NavigationModal.$root).to.exist;
     });
   });
+
+  describe('getting an error when creating a new package', () => {
+    beforeEach(function () {
+      this.server.post('/packages', {
+        errors: [{
+          title: 'There was an error'
+        }]
+      }, 500);
+
+      return PackageCreatePage
+        .fillName('My Package')
+        .save();
+    });
+
+    it.always('does not create the new package', function () {
+      expect(this.app.history.location.pathname).to.equal('/eholdings/packages/new');
+    });
+
+    it('shows an error toast message', () => {
+      expect(PackageShowPage.toast.errorText).to.equal('There was an error');
+    });
+  });
 });

--- a/tests/package-create-test.js
+++ b/tests/package-create-test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import PackageCreatePage from './pages/package-create';
+import PackageShowPage from './pages/package-show';
+import NavigationModal from './pages/navigation-modal';
+
+describeApplication('PackageCreate', () => {
+  beforeEach(function () {
+    return this.visit('/eholdings/packages/new', () => {
+      expect(PackageCreatePage.$root).to.exist;
+    });
+  });
+
+  it('has a package name field', () => {
+    expect(PackageCreatePage.hasName).to.be.true;
+  });
+
+  it('has a content-type field', () => {
+    expect(PackageCreatePage.hasContentType).to.be.true;
+  });
+
+  it('has an add coverage button', () => {
+    expect(PackageCreatePage.hasAddCoverageButton).to.be.true;
+  });
+
+  describe('creating a new package', () => {
+    beforeEach(() => {
+      return PackageCreatePage
+        .fillName('My Package')
+        .save();
+    });
+
+    it('redirects to the new package show page', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
+      expect(PackageShowPage.name).to.equal('My Package');
+    });
+  });
+
+  describe('creating a new package with a specified content type', () => {
+    beforeEach(() => {
+      return PackageCreatePage
+        .fillName('My Package')
+        .chooseContentType('Print')
+        .save();
+    });
+
+    it('redirects to the new package with the specified content type', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
+      expect(PackageShowPage.contentType).to.equal('Print');
+    });
+  });
+
+  describe('creating a new package with custom coverages', () => {
+    beforeEach(() => {
+      return PackageCreatePage
+        .fillName('My Package')
+        .addCoverage()
+        // Currently, `.dateRangeRowList(0)` immediately throws when
+        // it does not exist. When `@bigtest/interaction` is updated,
+        // this `.once().do()` pattern shouldn't be necessary.
+        .once(() => PackageCreatePage.dateRangeRowList(0))
+        .do(list => list.fillDates('12/16/2018', '12/18/2018'))
+        .save();
+    });
+
+    it('redirects to the new package with custom coverages', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
+      expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
+    });
+  });
+
+  describe('clicking cancel', () => {
+    beforeEach(() => {
+      return PackageCreatePage.cancel();
+    });
+
+    it('redirects to the previous page', function () {
+      expect(this.app.history.location.pathname).to.not.equal('/eholdings/packages/new');
+    });
+  });
+
+  describe('clicking cancel after filling in data', () => {
+    beforeEach(() => {
+      return PackageCreatePage
+        .fillName('My Package')
+        .cancel();
+    });
+
+    it('shows a navigations confirmation modal', () => {
+      expect(NavigationModal.$root).to.exist;
+    });
+  });
+});

--- a/tests/package-create-test.js
+++ b/tests/package-create-test.js
@@ -52,7 +52,7 @@ describeApplication('PackageCreate', () => {
 
     it('redirects to the new package with the specified content type', function () {
       expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
-      expect(PackageShowPage.contentType).to.equal('Print');
+      expect(PackageShowPage.customContentType).to.equal('Print');
     });
   });
 

--- a/tests/package-create-test.js
+++ b/tests/package-create-test.js
@@ -36,6 +36,10 @@ describeApplication('PackageCreate', () => {
       expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
       expect(PackageShowPage.name).to.equal('My Package');
     });
+
+    it('shows a success toast message', () => {
+      expect(PackageShowPage.toast.successText).to.equal('Successfully created custom package');
+    });
   });
 
   describe('creating a new package with a specified content type', () => {

--- a/tests/pages/package-create.js
+++ b/tests/pages/package-create.js
@@ -1,0 +1,30 @@
+import {
+  page,
+  isPresent,
+  fillable,
+  clickable,
+  collection
+} from '@bigtest/interaction';
+import Datepicker from './datepicker';
+
+@page class PackageCreatePage {
+  hasName = isPresent('[data-test-eholdings-package-name-field]');
+  fillName = fillable('[data-test-eholdings-package-name-field] input');
+  hasContentType = isPresent('[data-test-eholdings-package-content-type-field]');
+  chooseContentType = fillable('[data-test-eholdings-package-content-type-field] select');
+  hasAddCoverageButton = isPresent('[data-test-eholdings-coverage-fields-add-row-button]');
+  addCoverage = clickable('[data-test-eholdings-coverage-fields-add-row-button] button');
+  save = clickable('[data-test-eholdings-package-create-save-button] button');
+  cancel = clickable('[data-test-eholdings-package-create-cancel-button] button');
+
+  dateRangeRowList = collection('[data-test-eholdings-coverage-fields-date-range-row]', {
+    beginDate: new Datepicker('[data-test-eholdings-coverage-fields-date-range-begin]'),
+    endDate: new Datepicker('[data-test-eholdings-coverage-fields-date-range-end]'),
+    fillDates(beginDate, endDate) {
+      return this.beginDate.fillAndBlur(beginDate)
+        .append(this.endDate.fillAndBlur(endDate));
+    }
+  });
+}
+
+export default new PackageCreatePage('[data-test-eholdings-package-create]');


### PR DESCRIPTION
## Purpose

[UIEH-259](https://issues.folio.org/browse/UIEH-259)

Sets up the route and view for creating a custom package, and adds fields for name, content type, and custom coverage to the creation form.

## Approach

While creating custom packages are not yet supported in the backend, we can utilize mirage to iterate on the frontend.

- The route for creating custom packages is `/eholdings/packages/new`.
- A navigation modal is shown if there are changes to the form and a user clicks "cancel"
- When a custom package is successfully created, the user is redirected to the show route for the newly created package and a toast success message is shown.
- The current fields were preexisting in the edit route, but re-utilized for this creation route.
- A `create` action was added to models which will trigger a request to create the record with the specified attributes. Once resolved, the default resolve reducer takes care of adding the new record to the store.

#### TODOs
- Backend needs to support custom package creation.
- Add a "new package" button in the UI to access this new route.

## Screenshots
![2018-04-17 14 45 50](https://user-images.githubusercontent.com/5005153/38892872-1a325674-424e-11e8-910d-23bf73878002.gif)

