### PR TITLE
UIEH-254: Add description field to custom title

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -244,10 +244,11 @@ export default function configure() {
       customCoverages,
       customEmbargoPeriod,
       coverageStatement,
-      isPeerReviewed,
       publicationType,
       publisherName,
-      name
+      name,
+      description,
+      isPeerReviewed
     } = body.data.attributes;
 
     matchingResource.update('isSelected', isSelected);
@@ -257,6 +258,7 @@ export default function configure() {
     matchingResource.update('coverageStatement', coverageStatement);
     matchingResource.update('isPeerReviewed', isPeerReviewed);
     matchingResource.title.update('name', name);
+    matchingResource.title.update('description', description);
     matchingResource.title.update('publicationType', publicationType);
     matchingResource.title.update('publisherName', publisherName);
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -257,8 +257,8 @@ export default function configure() {
     matchingResource.update('customEmbargoPeriod', customEmbargoPeriod);
     matchingResource.update('coverageStatement', coverageStatement);
     matchingResource.update('isPeerReviewed', isPeerReviewed);
+    matchingResource.update('description', description);
     matchingResource.title.update('name', name);
-    matchingResource.title.update('description', description);
     matchingResource.title.update('publicationType', publicationType);
     matchingResource.title.update('publisherName', publisherName);
 

--- a/mirage/factories/resource.js
+++ b/mirage/factories/resource.js
@@ -8,6 +8,7 @@ export default Factory.extend({
   managedCoverages: [],
   isTitleCustom: false,
   isPeerReviewed: false,
+  description: '',
 
   withTitle: trait({
     afterCreate(resource, server) {

--- a/mirage/factories/title.js
+++ b/mirage/factories/title.js
@@ -23,6 +23,7 @@ export default Factory.extend({
   subjects: () => [],
   contributors: () => [],
   identifiers: () => [],
+  description: '',
 
   withPackages: trait({
     afterCreate(title, server) {

--- a/mirage/factories/title.js
+++ b/mirage/factories/title.js
@@ -23,7 +23,6 @@ export default Factory.extend({
   subjects: () => [],
   contributors: () => [],
   identifiers: () => [],
-  description: '',
 
   withPackages: trait({
     afterCreate(title, server) {

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -37,7 +37,8 @@ export default function defaultScenario(server) {
     package: customPackage,
     title: customTitle,
     isTitleCustom: true,
-    isPeerReviewed: false
+    isPeerReviewed: false,
+    description: ''
   });
 
   createProvider('Economist Intelligence Unit', [

--- a/src/components/resource/_fields/description/description-field.css
+++ b/src/components/resource/_fields/description/description-field.css
@@ -1,0 +1,3 @@
+.description-textarea {
+  max-width: 50em;
+}

--- a/src/components/resource/_fields/description/description-field.js
+++ b/src/components/resource/_fields/description/description-field.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import { Field } from 'redux-form';
+
+import { TextArea } from '@folio/stripes-components';
+import styles from './description-field.css';
+
+export default class DescriptionField extends Component {
+  render() {
+    return (
+      <div
+        data-test-eholdings-description-textarea
+        className={styles['description-textarea']}
+      >
+        <Field
+          name="decriptionField"
+          component={TextArea}
+          label="Description"
+        />
+      </div>
+    );
+  }
+}
+
+export function validate(values) {
+  const errors = {};
+
+  if (values.description && values.description.length > 1500) {
+    errors.description = 'The value entered exceeds the 1500 character limit. Please enter a value that does not exceed 1500 characters.';
+  }
+
+  return errors;
+}

--- a/src/components/resource/_fields/description/description-field.js
+++ b/src/components/resource/_fields/description/description-field.js
@@ -1,25 +1,24 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Field } from 'redux-form';
 
 import { TextArea } from '@folio/stripes-components';
 import styles from './description-field.css';
 
-export default class DescriptionField extends Component {
-  render() {
-    return (
-      <div
-        data-test-eholdings-description-textarea
-        className={styles['description-textarea']}
-      >
-        <Field
-          name="decriptionField"
-          component={TextArea}
-          label="Description"
-        />
-      </div>
-    );
-  }
+export default function DescriptionField() {
+  return (
+    <div
+      data-test-eholdings-description-textarea
+      className={styles['description-textarea']}
+    >
+      <Field
+        name="description"
+        component={TextArea}
+        label="Description"
+      />
+    </div>
+  );
 }
+
 
 export function validate(values) {
   const errors = {};

--- a/src/components/resource/_fields/description/index.js
+++ b/src/components/resource/_fields/description/index.js
@@ -1,0 +1,1 @@
+export { default, validate } from './description-field';

--- a/src/components/resource/edit-custom/custom-resource-edit.js
+++ b/src/components/resource/edit-custom/custom-resource-edit.js
@@ -17,6 +17,7 @@ import CustomEmbargoFields, { validate as validateEmbargo } from '../_fields/cus
 import PublisherNameField, { validate as validatePublisher } from '../_fields/publisher-name';
 import PublicationTypeField from '../_fields/publication-type';
 import PeerReviewedField from '../_fields/peer-reviewed';
+import DescriptionField, { validate as validateDescription } from '../_fields/description';
 import DetailsViewSection from '../../details-view-section';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
@@ -97,6 +98,7 @@ class CustomResourceEdit extends Component {
                 <PublisherNameField />
                 <PublicationTypeField />
                 <PeerReviewedField />
+                <DescriptionField />
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage dates"
@@ -157,7 +159,8 @@ const validate = (values, props) => {
     validatePublisher(values),
     validateCoverageDates(values, props),
     validateCoverageStatement(values),
-    validateEmbargo(values));
+    validateEmbargo(values),
+    validateDescription(values));
 };
 
 export default reduxForm({

--- a/src/components/resource/edit-custom/custom-resource-edit.js
+++ b/src/components/resource/edit-custom/custom-resource-edit.js
@@ -97,8 +97,8 @@ class CustomResourceEdit extends Component {
                 <NameField />
                 <PublisherNameField />
                 <PublicationTypeField />
-                <PeerReviewedField />
                 <DescriptionField />
+                <PeerReviewedField />
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage dates"

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -227,6 +227,12 @@ export default class ResourceShow extends Component {
                     </div>
                   </KeyValue>
                 )}
+
+                <KeyValue label="Description">
+                  <div data-test-eholdings-description-field>
+                    {model.description}
+                  </div>
+                </KeyValue>
               </DetailsViewSection>
               <DetailsViewSection label="Holding status">
                 <label

--- a/src/redux/resource.js
+++ b/src/redux/resource.js
@@ -24,6 +24,7 @@ class Resource {
   coverageStatement = '';
   isTitleCustom = false;
   isPeerReviewed = false;
+  description = '';
 }
 
 export default model({

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -44,6 +44,7 @@ class ResourceEditRoute extends Component {
       customEmbargoUnit,
       name,
       isPeerReviewed,
+      description,
       publicationType,
       publisherName
     } = values;
@@ -69,6 +70,9 @@ class ResourceEditRoute extends Component {
     }
 
     model.isPeerReviewed = isPeerReviewed;
+
+    model.description = description;
+
     updateResource(model);
   }
 
@@ -87,7 +91,8 @@ class ResourceEditRoute extends Component {
           customEmbargoUnit: model.customEmbargoPeriod.embargoUnit,
           isPeerReviewed: model.isPeerReviewed,
           publicationType: model.publicationType,
-          publisherName: model.publisherName
+          publisherName: model.publisherName,
+          description: model.description
         }}
       />
     );

--- a/tests/custom-resource-edit-test.js
+++ b/tests/custom-resource-edit-test.js
@@ -60,12 +60,16 @@ describeApplication('CustomResourceEdit', () => {
       expect(ResourceEditPage.customEmbargoSelectValue).to.equal('');
     });
 
-    it('disables the save button', () => {
-      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    it('shows a description field', () => {
+      expect(ResourceEditPage.descriptionField).to.equal('');
     });
 
     it('shows unchecked peer review box', () => {
       expect(ResourceEditPage.isPeerReviewed).to.be.false;
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
     });
 
     describe('clicking cancel', () => {
@@ -88,6 +92,11 @@ describeApplication('CustomResourceEdit', () => {
             I believe talent is just a pursued interest. Anybody can do what I do.
             We'll put some happy little leaves here and there. Go out on a limb - that's where the fruit is.
             God gave you this gift of imagination. Use it.`)
+          .fillDescription(`Trees cover up a multitude of sins. If you don't think every day is a good day - try missing a few. You'll see. Put light against light - you have nothing. Put dark against dark - you have nothing. It's the contrast of light and dark that each give the other one meaning. Water's like me. It's laaazy. Boy, it always looks for the easiest way to do things We might as well make some Almighty mountains today as well, what the heck.
+            You have to make these big decisions. Just take out whatever you don't want. It'll change your entire perspective. We artists are a different breed of people. We're a happy bunch.
+            All you need to paint is a few tools, a little instruction, and a vision in your mind. Exercising the imagination, experimenting with talents, being creative; these things, to me, are truly the windows to your soul. I guess that would be considered a UFO. A big cotton ball in the sky.
+            La-da-da-da-dah. Just be happy. Clouds are free. They just float around the sky all day and have fun. Let your heart take you to wherever you want to be. Anyone can paint. You don't have to be crazy to do this but it does help. Everyone needs a friend. Friends are the most valuable things in the world.
+            Every time you practice, you learn more. This is a happy place, little squirrels live here and play. Each highlight must have it's own private shadow. If what you're doing doesn't make you happy - you're doing the wrong thing. At home you have unlimited time. Nice little fluffy clouds laying around in the sky being lazy.`)
           .clickAddRowButton()
           .once(() => ResourceEditPage.dateRangeRowList().length > 0)
           .do(() => ResourceEditPage.interaction
@@ -113,6 +122,10 @@ describeApplication('CustomResourceEdit', () => {
       it('displays a validation error for embargo', () => {
         expect(ResourceEditPage.validationErrorOnEmbargoTextField).to.equal('Value cannot be null');
       });
+
+      it('displays a validation error for description', () => {
+        expect(ResourceEditPage.descriptionError).to.be.true;
+      });
     });
 
     describe('entering valid data', () => {
@@ -123,6 +136,7 @@ describeApplication('CustomResourceEdit', () => {
           .do(() => ResourceEditPage.interaction
             .inputCoverageStatement('Only 90s kids would understand.')
             .fillPublisher('Not So Awesome Publisher')
+            .fillDescription('What a super helpful description. Wow.')
             .checkPeerReviewed()
             .append(ResourceEditPage.dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018'))
             .inputEmbargoValue('27')
@@ -164,6 +178,10 @@ describeApplication('CustomResourceEdit', () => {
 
         it('shows the new embargo value', () => {
           expect(ResourceShowPage.customEmbargoPeriod).to.equal('27 Weeks');
+        });
+
+        it('shows the new description', () => {
+          expect(ResourceShowPage.descriptionText).to.equal('What a super helpful description. Wow.');
         });
 
         it('shows YES for peer reviewed', () => {

--- a/tests/pages/resource-edit.js
+++ b/tests/pages/resource-edit.js
@@ -26,6 +26,10 @@ import Datepicker from './datepicker';
   isPeerReviewed = property('checked', '[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
   checkPeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
 
+  descriptionField = value('[data-test-eholdings-description-textarea] textarea');
+  fillDescription = fillable('[data-test-eholdings-description-textarea] textarea');
+  descriptionError = hasClassBeginningWith('feedbackError--', '[data-test-eholdings-description-textarea] textarea')
+
   toast = Toast
 
   name = fillable('[data-test-eholdings-resource-name-field] input');

--- a/tests/pages/resource-show.js
+++ b/tests/pages/resource-show.js
@@ -26,6 +26,7 @@ import Toast from './toast';
 
 @page class ResourceShowPage {
   titleName = text('[data-test-eholdings-details-view-name="resource"]');
+  descriptionText = text('[data-test-eholdings-description-field]');
   publisherName = text('[data-test-eholdings-resource-show-publisher-name]');
   publicationType = text('[data-test-eholdings-resource-show-publication-type]');
   hasPublicationType = isPresent('[data-test-eholdings-resource-show-publication-type]');


### PR DESCRIPTION
## Purpose
Adds editable description to edit page and description field to resource view.

Resolves [UIEH-254](https://issues.folio.org/browse/UIEH-254)

## Screenshots
### Description field
![2018-04-17 14 48 24](https://user-images.githubusercontent.com/25858667/38893942-6f28e2c6-4251-11e8-9313-20af52ccd959.gif)

### Character limit error
![2018-04-17 14 50 35](https://user-images.githubusercontent.com/25858667/38893963-7ac19aec-4251-11e8-8a56-9f70883a607b.gif)