### PR TITLE
UIEH-261 Custom Package holding status

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -202,6 +202,20 @@ export default function configure() {
     return pkg;
   });
 
+  this.delete('/packages/:id', ({ packages, resources }, request) => {
+    let matchingPackage = packages.find(request.params.id);
+    let matchingResources = resources.where({
+      packageId: request.params.id
+    });
+
+    matchingPackage.destroy();
+    matchingResources.destroy();
+
+    return {};
+  });
+
+  this.get('/packages/:id/resources', nestedResourceRouteFor('package', 'resources'));
+
   // Title resources
   this.get('/titles', searchRouteFor('titles', (title, req) => {
     let params = req.queryParams;

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -109,7 +109,7 @@ const Modal = (props) => {
             </div>
           </div>
         }
-        <div className={css.modalContent}>
+        <div data-test-eholdings-modal-content className={css.modalContent}>
           {props.children}
         </div>
         { props.footer &&

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { reduxForm } from 'redux-form';
+import { reduxForm, Field } from 'redux-form';
 import isEqual from 'lodash/isEqual';
 
 import {
@@ -55,13 +55,21 @@ class CustomPackageEdit extends Component {
     );
   }
 
+  handleSelectionToggle = () => {
+    console.log('HEY');
+    this.setState({
+      packageSelected: !this.props.model.isSelected
+    });
+  }
+
   render() {
     let {
       model,
       initialValues,
       handleSubmit,
       onSubmit,
-      pristine
+      pristine,
+      initialValues
     } = this.props;
 
     let {
@@ -98,6 +106,19 @@ class CustomPackageEdit extends Component {
               >
                 <NameField />
                 <ContentTypeField />
+              </DetailsViewSection>
+              <DetailsViewSection label="Holding status">
+                <label
+                  data-test-eholdings-custom-package-details-selected
+                  htmlFor="custom-package-details-toggle-switch"
+                >
+                  <Field
+                    name="isSelected"
+                    component={ToggleSwitch}
+                    onChange={this.handleSelectionToggle}
+                    checked={model.isSelected}
+                  />
+                </label>
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage dates"

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -15,6 +15,8 @@ import CoverageFields, { validate as validateCoverageDates } from '../_fields/cu
 import ContentTypeField from '../_fields/content-type';
 import DetailsViewSection from '../../details-view-section';
 import NavigationModal from '../../navigation-modal';
+import ToggleSwitch from '../../toggle-switch/toggle-switch';
+import Modal from '../../modal/modal';
 import Toaster from '../../toaster';
 import styles from './custom-package-edit.css';
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -221,7 +221,6 @@ export default class PackageShow extends Component {
                     checked={packageSelected}
                     isPending={model.update.isPending && 'isSelected' in model.update.changedAttributes}
                     id="package-details-toggle-switch"
-                    disabled={model.isCustom}
                   />
                 </label>
               </DetailsViewSection>
@@ -362,7 +361,7 @@ export default class PackageShow extends Component {
             </div>
           )}
         >
-          Are you sure you want to remove this package and all its titles from your holdings? All customizations will be lost.
+           Are you sure you want to remove this package and all its titles from your holdings? All customizations will be lost.
         </Modal>
 
         <NavigationModal when={isCoverageEditable} />

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -218,8 +218,10 @@ export default class PackageShow extends Component {
                   <br />
                   <ToggleSwitch
                     onChange={this.handleSelectionToggle}
-                    checked={packageSelected}
-                    isPending={model.update.isPending && 'isSelected' in model.update.changedAttributes}
+                    // if destroying selection status is always false
+                    checked={model.destroy.isPending ? false : packageSelected}
+                    isPending={model.destroy.isPending ||
+                      (model.update.isPending && 'isSelected' in model.update.changedAttributes)}
                     id="package-details-toggle-switch"
                   />
                 </label>

--- a/src/components/toggle-switch/toggle-switch.css
+++ b/src/components/toggle-switch/toggle-switch.css
@@ -7,7 +7,12 @@
   width: 60px;
 
   & input {
-    display: none;
+    /* makes input visually hidden but accessible */
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    clip-path: inset(50%);
+    border: 0;
   }
 
   & input:checked + .toggle-switch-slider {

--- a/src/components/toggle-switch/toggle-switch.js
+++ b/src/components/toggle-switch/toggle-switch.js
@@ -1,54 +1,67 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './toggle-switch.css';
 
 const cx = classNames.bind(styles);
 
-export default class ToggleSwitch extends Component {
+export default class ToggleSwitch extends React.Component {
   static propTypes = {
-    checked: PropTypes.bool,
+    input: PropTypes.object,
     onChange: PropTypes.func,
+    name: PropTypes.string,
+    id: PropTypes.string,
     disabled: PropTypes.bool,
-    isPending: PropTypes.bool,
-    id: PropTypes.string
-  };
+    checked: PropTypes.bool,
+    isPending: PropTypes.bool
+  }
 
   state = {
-    checked: this.props.checked
-  };
+    inputChecked: this.props.checked
+  }
 
   componentWillReceiveProps(nextProps) {
     let wasPending = this.props.isPending && !nextProps.isPending;
     let needsUpdate = this.props.checked !== nextProps.checked;
 
     if (wasPending || needsUpdate) {
-      this.setState({ checked: nextProps.checked });
+      this.setState({ inputChecked: nextProps.checked });
     }
   }
 
-  toggle = () => {
-    this.setState({ checked: !this.state.checked });
-    this.props.onChange();
-  };
+  toggle = (e) => {
+    if (this.props.input && this.props.input.onChange) {
+      this.props.input.onChange(e);
+    }
+
+    if (this.props.onChange) {
+      this.props.onChange(e);
+    }
+  }
 
   render() {
-    let { isPending, disabled, id } = this.props;
-    let { checked } = this.state;
+    let { isPending, id, name, disabled, checked } = this.props;
+    let inputChecked;
+    if (this.props.input && this.props.checked) {
+      inputChecked = this.state.inputChecked;
+    } else {
+      inputChecked = checked;
+    }
 
     return (
       <div
         data-test-toggle-switch
         className={cx(styles['toggle-switch'], {
-          'is-pending': isPending
-        })}
+            'is-pending': isPending
+          })}
       >
         <input
           type="checkbox"
+          checked={(inputChecked !== undefined && inputChecked)}
+          id={id}
+          name={name}
           onChange={this.toggle}
           disabled={disabled || isPending}
-          checked={checked}
-          id={id}
         />
         <div className={styles['toggle-switch-slider']} />
       </div>

--- a/src/components/toggle-switch/toggle-switch.js
+++ b/src/components/toggle-switch/toggle-switch.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './toggle-switch.css';
 
 const cx = classNames.bind(styles);
 
-export default class ToggleSwitch extends React.Component {
+export default class ToggleSwitch extends Component {
   static propTypes = {
     input: PropTypes.object,
     onChange: PropTypes.func,

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -66,16 +66,17 @@ export const qs = {
   stringify: params => queryString.stringify(params, { encodeValuesOnly: true })
 };
 
-export const processErrors = ({ request, update }) => {
+export const processErrors = ({ request, update, destroy }) => {
   let processErrorsSet = ({ errors, timestamp }) => errors.map((error, index) => ({
     message: error.title,
     type: 'error',
     id: `error-${timestamp}-${index}`
   }));
 
-  let hasErrors = update.isRejected || request.isRejected;
+  let hasErrors = update.isRejected || request.isRejected || destroy.isRejected;
   let putErrors = hasErrors ? processErrorsSet(update) : [];
   let getErrors = hasErrors ? processErrorsSet(request) : [];
+  let destroyErrors = hasErrors ? processErrorsSet(destroy) : [];
 
-  return getErrors.concat(putErrors);
+  return [...putErrors, ...getErrors, ...destroyErrors];
 };

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -1,7 +1,7 @@
 import dasherize from 'lodash/kebabCase';
 import { pluralize } from 'inflected';
 import { qs } from '../components/utilities';
-import { find, query, save, unload, destroy } from './data';
+import { find, query, save, unload, destroy, create } from './data';
 
 /**
  * Collection object which provides the request state object created

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -1,7 +1,7 @@
 import dasherize from 'lodash/kebabCase';
 import { pluralize } from 'inflected';
 import { qs } from '../components/utilities';
-import { find, query, save, create, unload } from './data';
+import { find, query, save, unload, destroy } from './data';
 
 /**
  * Collection object which provides the request state object created
@@ -318,6 +318,16 @@ class BaseModel {
   }
 
   /**
+   * Action creator for deleting a record
+   * @param {Model} model - the record's model
+   */
+  static destroy(model) { // eslint-disable-line no-shadow
+    return destroy(this.type, model.serialize(), {
+      path: this.pathFor(model.id)
+    });
+  }
+
+  /**
    * Action creator for unloading records
    * @param {Model|Collection} modelOrCollection - the record model or collection
    */
@@ -406,6 +416,24 @@ class BaseModel {
     });
 
     return update;
+  }
+
+  /**
+   * Lazily looks up an delete request for this record
+   * @returns {Object} the delete request state object
+   */
+  get destroy() {
+    let destroyReq = this.resolver.getRequest('destroy', {
+      type: this.type,
+      params: { id: this.id }
+    });
+
+    // this will essentially cache this request
+    Object.defineProperty(this, 'destroy', {
+      get() { return destroyReq; }
+    });
+
+    return destroyReq;
   }
 
   // simple properties to map type, id, and status

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -56,6 +56,10 @@ class PackageEditRoute extends Component {
       endCoverage
     };
 
+    if ('isSelected' in values) {
+      model.isSelected = values.isSelected;
+    }
+
     if ('name' in values) {
       model.name = values.name;
     }

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -134,14 +134,7 @@ class PackageEditRoute extends Component {
       <View
         model={model}
         onSubmit={this.packageEditSubmitted}
-        initialValues={{
-          name: model.name,
-          contentType: model.contentType,
-          customCoverages: [{
-            beginCoverage: model.customCoverage.beginCoverage,
-            endCoverage: model.customCoverage.endCoverage
-          }]
-        }}
+        initialValues={initialValues}
       />
     );
   }

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -69,6 +69,29 @@ class PackageEditRoute extends Component {
 
   render() {
     let { model } = this.props;
+    let initialValues = {};
+    let View;
+
+    if (model.isCustom) {
+      View = CustomPackageEdit;
+      initialValues = {
+        name: model.name,
+        contentType: model.contentType,
+        isSelected: model.isSelected,
+        customCoverages: [{
+          beginCoverage: model.customCoverage.beginCoverage,
+          endCoverage: model.customCoverage.endCoverage
+        }]
+      };
+    } else {
+      View = ManagedPackageEdit;
+      initialValues = {
+        customCoverages: [{
+          beginCoverage: model.customCoverage.beginCoverage,
+          endCoverage: model.customCoverage.endCoverage
+        }]
+      };
+    }
 
     return (
       <View

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -153,7 +153,7 @@ export default connect(
     model: createResolver(data).find('packages', match.params.packageId),
   }), {
     getPackage: id => Package.find(id),
-    getPackageTitles: (id, params) => Package.queryRelated(id, 'customerResources', params),
+    getPackageTitles: (id, params) => Package.queryRelated(id, 'resources', params),
     unloadResources: collection => Resource.unload(collection),
     updatePackage: model => Package.save(model),
     destroyPackage: model => Package.destroy(model)

--- a/tests/custom-package-edit-test.js
+++ b/tests/custom-package-edit-test.js
@@ -30,6 +30,10 @@ describeApplication('CustomPackageEdit', () => {
       });
     });
 
+    it('has holding status toggle', () => {
+      expect(PackageEditPage.holdingStatusToggle).to.exist();
+    });
+
     it('shows blank datepicker fields', () => {
       expect(PackageEditPage.dateRangeRowList(0).beginDate.value).to.equal('');
       expect(PackageEditPage.dateRangeRowList(0).endDate.value).to.equal('');

--- a/tests/custom-package-selection-test.js
+++ b/tests/custom-package-selection-test.js
@@ -3,9 +3,8 @@ import { expect } from 'chai';
 
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/package-show';
-import ApplicationPage from './pages/application';
 
-describeApplication.only('CustomPackageSelection', () => {
+describeApplication('CustomPackageSelection', () => {
   let provider,
     providerPackage;
 

--- a/tests/custom-package-selection-test.js
+++ b/tests/custom-package-selection-test.js
@@ -1,0 +1,173 @@
+import { beforeEach, afterEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import PackageShowPage from './pages/package-show';
+import ApplicationPage from './pages/application';
+
+describeApplication.only('CustomPackageSelection', () => {
+  let provider,
+    providerPackage;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create('package', 'withTitles', {
+      provider,
+      name: 'Cool Custom Package',
+      contentType: 'E-Book',
+      isCustom: true
+    });
+  });
+
+  describe('visiting the package details page', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/packages/${providerPackage.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('automatically has the custom package in my holdings', () => {
+      expect(PackageShowPage.isSelected).to.equal(true);
+    });
+
+    describe('deselecting a custom package', () => {
+      beforeEach(function () {
+        /*
+         * The expectations in the convergent `it` blocks
+         * get run once every 10ms.  We were seeing test flakiness
+         * when a toggle action dispatched and resolved before an
+         * expectation had the chance to run.  We sidestep this by
+         * temporarily increasing the mirage server's response time
+         * to 50ms.
+         * TODO: control timing directly with Mirage
+         */
+        this.server.timing = 50;
+        return PackageShowPage.toggleIsSelected();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('reflects the desired state (not selected)', () => {
+        expect(PackageShowPage.isSelected).to.equal(false);
+      });
+
+
+      describe('canceling the deselection', () => {
+        beforeEach(() => {
+          return PackageShowPage.modal.cancelDeselection();
+        });
+
+        it('reverts back to the selected state', () => {
+          expect(PackageShowPage.isSelected).to.equal(true);
+        });
+      });
+
+
+      describe('confirming the deselection', () => {
+        beforeEach(function () {
+          this.server.timing = 50;
+          return PackageShowPage.modal.confirmDeselection();
+        });
+
+        afterEach(function () {
+          this.server.timing = 0;
+        });
+
+        it('reflects the desired state (Unselected)', () => {
+          expect(PackageShowPage.isSelected).to.equal(false);
+        });
+
+        it('indicates it is working to get to desired state', () => {
+          expect(PackageShowPage.isSelecting).to.equal(true);
+        });
+
+        it('cannot be interacted with while the request is in flight', () => {
+          expect(PackageShowPage.isSelectedToggleDisabled).to.equal(true);
+        });
+
+        describe('when the request succeeds', () => {
+          it('reflect the desired state was set', () => {
+            expect(PackageShowPage.isSelected).to.equal(false);
+          });
+
+          it('indicates it is no longer working', () => {
+            expect(PackageShowPage.isSelecting).to.equal(false);
+          });
+
+          it('should show the package titles are not all selected', () => {
+            expect(PackageShowPage.allTitlesSelected).to.equal(false);
+          });
+
+          it('updates the selected title count', () => {
+            expect(PackageShowPage.numTitlesSelected).to.equal(`${providerPackage.titleCount}`);
+          });
+
+          it('removes custom coverage', () => {
+            expect(PackageShowPage.hasCustomCoverage).to.equal(false);
+          });
+
+          it('is not hideable', () => {
+            expect(PackageShowPage.isHiddenTogglePresent).to.equal(false);
+          });
+        });
+      });
+    });
+
+    describe('unsuccessfully deselecting a custom package', () => {
+      beforeEach(function () {
+        this.server.put('/packages/:packageId', {
+          errors: [{
+            title: 'There was an error'
+          }]
+        }, 500);
+
+        this.server.timing = 50;
+        return PackageShowPage.toggleIsSelected();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('reflects the desired state (Unselected)', () => {
+        expect(PackageShowPage.isSelected).to.equal(false);
+      });
+
+      // it('shows a confirmation modal',)
+
+      describe('confirming the deselection', () => {
+        beforeEach(function () {
+          this.server.timing = 50;
+          return PackageShowPage.modal.confirmDeselection();
+        });
+
+        afterEach(function () {
+          this.server.timing = 0;
+        });
+
+        it('cannot be interacted with while the request is in flight', () => {
+          expect(PackageShowPage.isSelectedToggleDisabled).to.equal(true);
+        });
+
+        describe('when the request fails', () => {
+          it('reflect the desired state was not set', () => {
+            expect(PackageShowPage.isSelected).to.equal(true);
+          });
+
+          it('indicates it is no longer working', () => {
+            expect(PackageShowPage.isSelecting).to.equal(false);
+          });
+
+          it('shows the error as a toast', () => {
+            expect(PackageShowPage.toast.errorText).to.equal('There was an error');
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/custom-package-show-selection-test.js
+++ b/tests/custom-package-show-selection-test.js
@@ -4,7 +4,12 @@ import { expect } from 'chai';
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/package-show';
 
-describeApplication('CustomPackageSelection', () => {
+// This test though named custom package show is essentially a Package
+// and uses most of the same components as a Package.
+// However, there are some nuances between that of a Package and CustomPackage
+// so those are excersised in this test.
+
+describeApplication('CustomPackageShowSelection', () => {
   let provider,
     providerPackage;
 
@@ -94,59 +99,34 @@ describeApplication('CustomPackageSelection', () => {
             expect(PackageShowPage.isSelected).to.equal(false);
           });
 
-          it('indicates it is no longer working', () => {
-            expect(PackageShowPage.isSelecting).to.equal(false);
-          });
-
-          it('should show the package titles are not all selected', () => {
-            expect(PackageShowPage.allTitlesSelected).to.equal(false);
-          });
-
-          it('updates the selected title count', () => {
-            expect(PackageShowPage.numTitlesSelected).to.equal(`${providerPackage.titleCount}`);
-          });
-
-          it('removes custom coverage', () => {
-            expect(PackageShowPage.hasCustomCoverage).to.equal(false);
-          });
-
-          it('is not hideable', () => {
-            expect(PackageShowPage.isHiddenTogglePresent).to.equal(false);
+          it('removes package detail pane', () => {
+            expect(PackageShowPage.exist).to.equal(false);
           });
         });
       });
     });
 
+    // when you are deleting you are hitting the delete endpoint and not put
+    // put is only on updating a custom packge.
+
     describe('unsuccessfully deselecting a custom package', () => {
       beforeEach(function () {
-        this.server.put('/packages/:packageId', {
+        this.server.delete('/packages/:packageId', {
           errors: [{
             title: 'There was an error'
           }]
         }, 500);
 
-        this.server.timing = 50;
         return PackageShowPage.toggleIsSelected();
-      });
-
-      afterEach(function () {
-        this.server.timing = 0;
       });
 
       it('reflects the desired state (Unselected)', () => {
         expect(PackageShowPage.isSelected).to.equal(false);
       });
 
-      // it('shows a confirmation modal',)
-
       describe('confirming the deselection', () => {
-        beforeEach(function () {
-          this.server.timing = 50;
+        beforeEach(() => {
           return PackageShowPage.modal.confirmDeselection();
-        });
-
-        afterEach(function () {
-          this.server.timing = 0;
         });
 
         it('cannot be interacted with while the request is in flight', () => {

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -10,7 +10,11 @@ import { hasClassBeginningWith, isRootPresent } from './helpers';
 import Toast from './toast';
 import Datepicker from './datepicker';
 
-@page class PackageEditNavigationModal {}
+@page class PackageEditNavigationModal {
+  exists = isRootPresent();
+  cancelNavigation = clickable('[data-test-navigation-modal-dismiss]');
+  confirmNavigation = clickable('[data-test-navigation-modal-continue]');
+}
 
 @page class PackageEditModal {
   exists = isRootPresent();
@@ -19,6 +23,7 @@ import Datepicker from './datepicker';
 }
 
 @page class PackageEditPage {
+  exists = isRootPresent();
   navigationModal = new PackageEditNavigationModal('#navigation-modal');
 
   clickCancel = clickable('[data-test-eholdings-package-cancel-button] button');

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -4,13 +4,19 @@ import {
   fillable,
   isPresent,
   page,
-  property
+  property,
 } from '@bigtest/interaction';
-import { hasClassBeginningWith } from './helpers';
+import { hasClassBeginningWith, isRootPresent } from './helpers';
 import Toast from './toast';
 import Datepicker from './datepicker';
 
 @page class PackageEditNavigationModal {}
+
+@page class PackageEditModal {
+  exists = isRootPresent();
+  cancelDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-no]');
+  confirmDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-yes]');
+}
 
 @page class PackageEditPage {
   navigationModal = new PackageEditNavigationModal('#navigation-modal');
@@ -19,8 +25,11 @@ import Datepicker from './datepicker';
   clickSave = clickable('[data-test-eholdings-package-save-button] button');
   isSaveDisabled = property('disabled', '[data-test-eholdings-package-save-button] button');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="package"]');
+  toggleIsSelected = clickable('[data-test-eholdings-custom-package-details-selected] input');
+  isSelected = property('checked', '[data-test-eholdings-custom-package-details-selected] input');
+  modal = new PackageEditModal('#eholdings-custom-package-confirmation-modal');
 
-  toast = Toast
+  toast = Toast;
 
   name = fillable('[data-test-eholdings-package-name-field] input');
   contentType = fillable('[data-test-eholdings-package-content-type-field] select');

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -17,7 +17,7 @@ import { isRootPresent } from './helpers';
   exists = isRootPresent();
   fillSearch = fillable('[data-test-search-field] input[name="search"]');
   submitSearch = clickable('[data-test-search-submit]');
-  isSearchDisabled = property('disabled', '[data-test-search-submit]')
+  isSearchDisabled = property('disabled', '[data-test-search-submit]');
   hasSearchField = isPresent('[data-test-search-field] input[name="search"]');
   hasSearchFilters = isPresent('[data-test-eholdings-search-filters="packages"]');
   searchFieldValue = value('[data-test-search-field] input[name="search"]');
@@ -37,19 +37,19 @@ import { isRootPresent } from './helpers';
 
   hasLoaded = computed(function () {
     return this.packageList().length > 0;
-  })
+  });
 
   changeSearchType = action(function (searchType) {
     return this.click(`[data-test-search-type-button="${searchType}"]`);
-  })
+  });
 
   clickFilter = action(function (name, val) {
     return this.click(`[data-test-eholdings-search-filters="packages"] input[name="${name}"][value="${val}"]`);
-  })
+  });
 
   clearFilter = action(function (name) {
     return this.click(`#filter-packages-${name} button[icon="clearX"]`);
-  })
+  });
 
   getFilter(name) {
     return this.$(`[data-test-eholdings-search-filters="packages"] input[name="${name}"]:checked`).value;
@@ -68,7 +68,7 @@ import { isRootPresent } from './helpers';
     return this
       .fillSearch(query)
       .submitSearch();
-  })
+  });
 
   packageList = collection('[data-test-eholdings-package-list-item]', {
     name: text('[data-test-eholdings-package-list-item-name]'),


### PR DESCRIPTION
## Purpose
With a custom-package as a resource librarian I want to be able to remove that custom-package from my holdings. 

## Approach
 - Ensure holding-status work within and not within a context of a Redux-Form
 - Make Toggle Switch accessible. Making sure the toggle is usable from Assistive Devices.
 - Report holding-status toggle / removal errors back to the user.
   - Add destroys Errors to Toast
   - Keeps user on current page to make a decision based on the failure.
 - Add the capability to to adjust holding-status from both inline and full-page edit mode.
 - Allow the custom package holding-status is adjusted from either direct access from pasting into URL or navigating after a search.
 - Redirect the user after a successful removal of a custom-package from either a inline, full-page and from either direct input of URL or navigating after a search.

#### TODOS and Open Questions.
1. Its possible that we may need to add a notification based on a successful removal as well.

#### Jira
https://issues.folio.org/browse/UIEH-261

## Screenshots
### Accessible Toggle Switch
![2018-04-17 17 55 33](https://user-images.githubusercontent.com/1953098/38903022-a0ba4106-4268-11e8-8219-e00b5f1d9ea1.gif)


### Error on trying to remove custom-package -- inline edit
![2018-04-17 16 09 32](https://user-images.githubusercontent.com/1953098/38902595-d78645f6-4266-11e8-8c97-f9660093c78a.gif)

### Error on trying to remove custom-package -- full page edit
![2018-04-17 16 10 01](https://user-images.githubusercontent.com/1953098/38902632-f0ad011e-4266-11e8-9eda-bb6311c87208.gif)

### Successful removal of custom-package --inline edit
![2018-04-17 16 14 05](https://user-images.githubusercontent.com/1953098/38902654-03612786-4267-11e8-9453-9cd662d7bbc4.gif)

### Successful removal of custom-package
  - Direct input of URL in address bar
![2018-04-17 17 49 32](https://user-images.githubusercontent.com/1953098/38902852-e4cd6fe0-4267-11e8-9f18-d71c1936cc86.gif)


### Successful removal of custom-package -- full page edit
![2018-04-17 16 14 49](https://user-images.githubusercontent.com/1953098/38902684-2fa0b23a-4267-11e8-9c79-6d67c6e1a54f.gif)







