### PR TITLE
UIEH-308 Add pane header to results pane even if no search yet

### DIFF
--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -2,7 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 
-import { Button, PaneHeader } from '@folio/stripes-components';
+import {
+  Button,
+  IconButton,
+  PaneHeader,
+  PaneMenu
+} from '@folio/stripes-components';
 
 import DetailsViewSection from '../../details-view-section';
 import NameField, { validate as validatePackageName } from '../_fields/name';
@@ -40,6 +45,12 @@ class PackageCreate extends Component {
       pristine
     } = this.props;
 
+    let {
+      router
+    } = this.context;
+
+    let historyState = router.history.location.state;
+
     return (
       <div data-test-eholdings-package-create>
         <Toaster
@@ -51,7 +62,20 @@ class PackageCreate extends Component {
           }))}
         />
 
-        <PaneHeader paneTitle="New custom package" />
+        <PaneHeader
+          paneTitle="New custom package"
+          firstMenu={historyState && historyState.eholdings && (
+            <PaneMenu>
+              <div data-test-eholdings-details-view-back-button>
+                <IconButton
+                  icon="left-arrow"
+                  ariaLabel="Go back"
+                  onClick={this.handleCancel}
+                />
+              </div>
+            </PaneMenu>
+          )}
+        />
 
         <div className={styles['package-create-form-container']}>
           <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/components/search-paneset/search-paneset.css
+++ b/src/components/search-paneset/search-paneset.css
@@ -34,3 +34,70 @@
   overflow-y: auto;
   -webkit-overflow-scroll: touch;
 }
+
+.pre-search-pane {
+  background: #fff;
+  display: block;
+  margin-left: 320px;
+  height: 100%;
+  overflow: hidden;
+  z-index: 10;
+
+  @media (--mediumUp) {
+    flex: 5 0 320px;
+    flex-flow: column nowrap;
+  }
+
+  @media (--largeUp) {
+    margin-left: 0;
+  }
+}
+
+.pre-search-pane-content {
+  padding: 0 15px;
+  color: rgba(0, 0, 0, 0.62);
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #f9f9f9;
+  flex-direction: column;
+}
+
+.pre-search-pane-content-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 22px;
+}
+
+.search-new-button {
+  padding: 3px 10px 7px;
+  height: 24px;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background-color 0.25s, color 0.25s, opacity 0.4s, box-shadow 0s;
+  margin-left: 2px;
+  overflow: hidden;
+  white-space: nowrap;
+  line-height: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  outline: 0;
+  box-shadow: 0 0 0 18px transparent;
+  opacity: 1;
+  background-color: #2b75bb;
+  border: 1px solid #2b75bb;
+  font-weight: 600;
+  color: #fff;
+  margin-right: 15px;
+
+  &:visited {
+    color: #fff;
+  }
+}

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -12,6 +12,7 @@ import SearchPane from '../search-pane';
 import ResultsPane from '../results-pane';
 import PreviewPane from '../preview-pane';
 import SearchPaneVignette from '../search-pane-vignette';
+import Link from '../link';
 import styles from './search-paneset.css';
 
 export default class SearchPaneset extends React.Component {
@@ -78,6 +79,19 @@ export default class SearchPaneset extends React.Component {
     });
   };
 
+  renderNewButton = () => {
+    return (
+      <PaneMenu>
+        <Link
+          className={styles['search-new-button']}
+          to={`/eholdings/${this.props.resultsType}/new`}
+        >
+          + New
+        </Link>
+      </PaneMenu>
+    );
+  };
+
   render() {
     let { hideFilters } = this.state;
     let {
@@ -93,11 +107,14 @@ export default class SearchPaneset extends React.Component {
     // only hide filters if there are results and always hide filters when a detail view is visible
     hideFilters = (hideFilters && !!resultsView) || !!detailsView;
 
+    let newButton = (<PaneMenu />);
+    if (resultsType === 'packages') {
+      newButton = this.renderNewButton();
+    }
+
     return (
       <div className={styles['search-paneset']}>
-        {!!resultsView && (
-          <SearchPaneVignette isHidden={hideFilters} onClick={this.toggleFilters} />
-        )}
+        <SearchPaneVignette isHidden={hideFilters} onClick={this.toggleFilters} />
 
         {!!detailsView && (
           <SearchPaneVignette onClick={this.closePreview} />
@@ -119,10 +136,13 @@ export default class SearchPaneset extends React.Component {
           </div>
         </SearchPane>
 
-        {!!resultsView && (
+        {resultsView ? (
           <ResultsPane>
             <div data-test-eholdings-search-results-header>
               <PaneHeader
+                appIcon={{
+                  app: 'eholdings'
+                }}
                 paneTitle={capitalize(resultsType)}
                 paneSub={isLoading ? 'Loading...' : `${intl.formatNumber(totalResults)} search results`}
                 firstMenu={
@@ -135,12 +155,31 @@ export default class SearchPaneset extends React.Component {
                     </PaneMenu>
                   </div>
                 }
+                lastMenu={newButton}
               />
             </div>
             <div className={styles['scrollable-container']}>
               {resultsView}
             </div>
           </ResultsPane>
+        ) : (
+          <div
+            data-test-eholdings-pre-search-pane
+            className={styles['pre-search-pane']}
+          >
+            <PaneHeader
+              appIcon={{
+                app: 'eholdings'
+              }}
+              paneTitle={capitalize(resultsType)}
+              lastMenu={newButton}
+            />
+            <div className={styles['pre-search-pane-content']}>
+              <div className={styles['pre-search-pane-content-label']}>
+                <p>Enter a query to show search results.</p>
+              </div>
+            </div>
+          </div>
         )}
 
         {!!detailsView && (

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -35,9 +35,17 @@ describeApplication('PackageSearch', () => {
     expect(PackageSearchPage.isSearchDisabled).to.be.true;
   });
 
+  it('has a pre-results pane', () => {
+    expect(PackageSearchPage.hasPreSearchPane).to.equal(true);
+  });
+
   describe('searching for a package', () => {
     beforeEach(() => {
       return PackageSearchPage.search('Package');
+    });
+
+    it('removes the pre-results pane', () => {
+      expect(PackageSearchPage.hasPreSearchPane).to.equal(false);
     });
 
     it("displays package entries related to 'Package'", () => {

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -34,6 +34,7 @@ import { isRootPresent } from './helpers';
   selectedSearchType = collection('[data-test-search-form-type-switcher] a[class^="is-active--"]');
   sortBy = value('[data-test-eholdings-search-filters="packages"] input[name="sort"]:checked');
   clickCloseButton = clickable('[data-test-eholdings-details-view-close-button] a');
+  hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
 
   hasLoaded = computed(function () {
     return this.packageList().length > 0;

--- a/tests/pages/provider-search.js
+++ b/tests/pages/provider-search.js
@@ -34,6 +34,7 @@ import { isRootPresent, hasClassBeginningWith } from './helpers';
   isSearchButtonDisabled = property('disabled', '[data-test-search-submit]');
   isSearchVignetteHidden = hasClassBeginningWith('is-hidden---', '[data-test-search-vignette]');
   clickCloseButton = clickable('[data-test-eholdings-details-view-close-button] a');
+  hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
 
   hasLoaded = computed(function () {
     return this.providerList().length > 0;

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -36,6 +36,7 @@ import { isRootPresent, hasClassBeginningWith } from './helpers';
   selectedSearchType = collection('[data-test-search-form-type-switcher] a[class^="is-active--"]');
   isSearchVignetteHidden = hasClassBeginningWith('is-hidden--', '[data-test-search-vignette]');
   clickCloseButton = clickable('[data-test-eholdings-details-view-close-button] a');
+  hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
 
   hasLoaded = computed(function () {
     return this.titleList().length > 0;

--- a/tests/provider-search-test.js
+++ b/tests/provider-search-test.js
@@ -32,9 +32,17 @@ describeApplication('ProviderSearch', () => {
     expect(ProviderSearchPage.isSearchButtonDisabled).to.equal(true);
   });
 
+  it('has a pre-results pane', () => {
+    expect(ProviderSearchPage.hasPreSearchPane).to.equal(true);
+  });
+
   describe('searching for a provider', () => {
     beforeEach(() => {
       return ProviderSearchPage.search('Provider');
+    });
+
+    it('removes the pre-results pane', () => {
+      expect(ProviderSearchPage.hasPreSearchPane).to.equal(false);
     });
 
     it("displays provider entries related to 'Provider'", () => {

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -71,9 +71,17 @@ describeApplication('TitleSearch', () => {
     expect(TitleSearchPage.isSearchButtonDisabled).to.be.true;
   });
 
+  it('has a pre-results pane', () => {
+    expect(TitleSearchPage.hasPreSearchPane).to.equal(true);
+  });
+
   describe('searching for a title', () => {
     beforeEach(() => {
       return TitleSearchPage.search('Title');
+    });
+
+    it('removes the pre-results pane', () => {
+      expect(TitleSearchPage.hasPreSearchPane).to.equal(false);
     });
 
     it('has enabled search button', () => {


### PR DESCRIPTION
## Purpose
Making eHoldings more consistent with the `<SearchAndSort>` UX used by other FOLIO modules.

We'll need the header there to add "+ New" buttons for custom packages and titles.

## Approach
Add a pane header and mimic the `stripes-smart-components` `<NoResultsMessage>`, which unfortunately is tightly coupled to `<SearchAndSort>`.

I decided against reusing a `<ResultsPane>` for the empty state to avoid the scroll logic there.

## Known drawbacks
The "+ New" button that will soon appear in the header won't be accessible on small screens until conducting a search.

## Screenshots
![localhost_3000_eholdings_packages_new](https://user-images.githubusercontent.com/230597/38959984-56611a6a-4328-11e8-834c-54bbb9907a38.png)
