### PR TITLE
[WIP] Don’t send payloads for DELETE requests

### DIFF
--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -101,8 +101,7 @@ export const destroy = (type, payload, { path }) => ({
     path,
     params: { id: payload.data.id },
     timestamp: Date.now()
-  },
-  payload
+  }
 });
 
 /**


### PR DESCRIPTION
## Purpose
`DELETE` requests shouldn't send a body.

Replaces https://github.com/folio-org/ui-eholdings/pull/362.

## Approach
Don't send the payload from the `destroy` action creator.
