### PR TITLE
UIEH-215 Search resource list within title detail view

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -146,7 +146,7 @@ export default function configure() {
   };
 
   this.get('/packages', searchRouteFor('packages', packagesFilter));
-  this.get('/providers/:id/packages', nestedResourceRouteFor('provider', 'packages', packagesFilter));
+  this.get('/providers/:id/packages', nestedResourceRouteFor('provider', 'packages', 'name', packagesFilter));
 
   this.get('/packages/:id', ({ packages }, request) => {
     let pkg = packages.find(request.params.id);
@@ -253,6 +253,29 @@ export default function configure() {
   this.get('/titles/:id', ({ titles }, request) => {
     return titles.find(request.params.id);
   });
+
+  let titlePackagesFilter = (resource, req) => {
+    let params = req.queryParams;
+    let type = params['filter[type]'];
+    let selected = params['filter[selected]'];
+    let filtered = true;
+
+    if (params.q && resource.package.name) {
+      filtered = includesWords(resource.package.name, params.q.toLowerCase());
+    }
+
+    if (filtered && type && type !== 'all') {
+      filtered = resource.package.contentType.toLowerCase() === type;
+    }
+
+    if (filtered && selected) {
+      filtered = resource.isSelected.toString() === selected;
+    }
+
+    return filtered;
+  };
+
+  this.get('/titles/:id/resources', nestedResourceRouteFor('title', 'resources', 'packageName', titlePackagesFilter));
 
   // Resources
   this.get('/packages/:id/resources', nestedResourceRouteFor('package', 'resources'));

--- a/src/components/provider-show/provider-show.js
+++ b/src/components/provider-show/provider-show.js
@@ -57,28 +57,30 @@ export default function ProviderShow({
             </KeyValue>
           </DetailsViewSection>
         )}
-        enableListSearch
+        enableListSearch={model.packages.length > 0}
         listType="packages"
         onSearch={searchPackages}
         searchParams={searchParams}
-        renderList={scrollable => (
-          <QueryList
-            type="provider-packages"
-            fetch={fetchPackages}
-            collection={packages}
-            length={packages.length}
-            scrollable={scrollable}
-            itemHeight={70}
-            renderItem={item => (
-              <PackageListItem
-                link={item.content && `/eholdings/packages/${item.content.id}`}
-                item={item.content}
-                showTitleCount
-                headingLevel='h4'
-              />
-            )}
-          />
-        )}
+        renderList={scrollable => {
+          return model.packages.length > 0 && (
+            <QueryList
+              type="provider-packages"
+              fetch={fetchPackages}
+              collection={packages}
+              length={packages.length}
+              scrollable={scrollable}
+              itemHeight={70}
+              renderItem={item => (
+                <PackageListItem
+                  link={item.content && `/eholdings/packages/${item.content.id}`}
+                  item={item.content}
+                  showTitleCount
+                  headingLevel='h4'
+                />
+              )}
+            />
+          );
+        }}
       />
     </div>
   );

--- a/src/components/title-show/title-show.js
+++ b/src/components/title-show/title-show.js
@@ -4,7 +4,7 @@ import { KeyValue } from '@folio/stripes-components';
 
 import { processErrors } from '../utilities';
 import DetailsView from '../details-view';
-import ScrollView from '../scroll-view';
+import QueryList from '../query-list';
 import PackageListItem from '../package-list-item';
 import IdentifiersList from '../identifiers-list';
 import ContributorsList from '../contributors-list';
@@ -12,7 +12,15 @@ import DetailsViewSection from '../details-view-section';
 import Toaster from '../toaster';
 import styles from './title-show.css';
 
-export default function TitleShow({ model }, { queryParams }) {
+export default function TitleShow({
+  model,
+  packages,
+  fetchPackages,
+  searchPackages,
+  searchParams
+}, {
+  queryParams
+}) {
   let actionMenuItems = [];
 
   if (queryParams.searchType) {
@@ -64,31 +72,41 @@ export default function TitleShow({ model }, { queryParams }) {
             )}
           </DetailsViewSection>
         )}
+        enableListSearch={model.resources.length > 0}
         listType="packages"
-        renderList={scrollable => (
-          <ScrollView
-            itemHeight={70}
-            items={model.resources}
-            scrollable={scrollable}
-            data-test-query-list="title-packages"
-          >
-            {item => (
-              <PackageListItem
-                link={`/eholdings/resources/${item.id}`}
-                packageName={item.packageName}
-                item={item}
-                headingLevel='h4'
-              />
-            )}
-          </ScrollView>
-        )}
+        onSearch={searchPackages}
+        searchParams={searchParams}
+        renderList={scrollable => {
+          return model.resources.length > 0 && (
+            <QueryList
+              type="title-packages"
+              fetch={fetchPackages}
+              collection={packages}
+              length={packages.length}
+              scrollable={scrollable}
+              itemHeight={70}
+              renderItem={item => (
+                <PackageListItem
+                  link={item.content && `/eholdings/resources/${item.content.id}`}
+                  packageName={item.content && item.content.packageName}
+                  item={item.content}
+                  headingLevel='h4'
+                />
+              )}
+            />
+          );
+        }}
       />
     </div>
   );
 }
 
 TitleShow.propTypes = {
-  model: PropTypes.object.isRequired
+  model: PropTypes.object.isRequired,
+  packages: PropTypes.object.isRequired,
+  fetchPackages: PropTypes.func.isRequired,
+  searchPackages: PropTypes.func.isRequired,
+  searchParams: PropTypes.object.isRequired
 };
 
 TitleShow.contextTypes = {

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -1,5 +1,6 @@
 import {
   action,
+  clickable,
   collection,
   computed,
   isPresent,
@@ -9,6 +10,7 @@ import {
 } from '@bigtest/interaction';
 import { getComputedStyle } from './helpers';
 import Toast from './toast';
+import SearchModal from './search-modal';
 
 @page class TitleShowPage {
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
@@ -25,8 +27,10 @@ import Toast from './toast';
   detailsPaneScrollsHeight = property('scrollHeight', '[data-test-eholdings-detail-pane-contents]');
   detailsPaneContentsHeight = property('offsetHeight', '[data-test-eholdings-detail-pane-contents]');
   detailsPaneContentsOverFlowY = getComputedStyle('overflow-y', '[data-test-eholdings-detail-pane-contents]');
+  clickListSearch = clickable('[data-test-eholdings-details-view-search] button');
 
-toast = Toast
+  toast = Toast;
+  searchModal = new SearchModal('#eholdings-details-view-search-modal');
 
   detailsPaneScrollTop = action(function (offset) {
     return this.find('[data-test-query-list="package-titles"]')

--- a/tests/title-show-package-search-test.js
+++ b/tests/title-show-package-search-test.js
@@ -1,0 +1,128 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import TitleShowPage from './pages/title-show';
+
+describeApplication('TitleShow package search', () => {
+  beforeEach(function () {
+    let title = this.server.create('title', {
+      name: 'Cool Title',
+      publisherName: 'Cool Publisher'
+    });
+
+    let packages = this.server.createList('package', 5, 'withProvider', {
+      name: i => `Package ${i}`,
+      contentType: 'Print'
+    });
+
+    packages[2].update({
+      name: 'Ordinary Package',
+      contentType: 'eBook',
+      isSelected: false
+    });
+
+    packages[4].update({
+      name: 'Other Ordinary Package',
+      isSelected: true
+    });
+
+    packages.forEach((pkg) => {
+      this.server.create('resource', {
+        package: pkg,
+        title,
+        isSelected: pkg.isSelected
+      });
+    });
+
+    return this.visit(`/eholdings/titles/${title.id}`, () => {
+      expect(TitleShowPage.$root).to.exist;
+    });
+  });
+
+  describe('clicking the search button', () => {
+    beforeEach(() => {
+      return TitleShowPage.clickListSearch();
+    });
+
+    it('shows the package search modal', () => {
+      expect(TitleShowPage.searchModal.exists).to.be.true;
+    });
+  });
+
+  describe('searching for specific packages', () => {
+    beforeEach(() => {
+      return TitleShowPage.clickListSearch()
+        .append(TitleShowPage.searchModal.search('other ordinary'));
+    });
+
+    it('hides the package search modal', () => {
+      expect(TitleShowPage.searchModal.exists).to.be.false;
+    });
+
+    it('displays packages matching the search term', () => {
+      expect(TitleShowPage.packageList()).to.have.lengthOf(2);
+      expect(TitleShowPage.packageList(0).name).to.equal('Other Ordinary Package');
+      expect(TitleShowPage.packageList(1).name).to.equal('Ordinary Package');
+    });
+
+    describe('reopening the modal', () => {
+      beforeEach(() => {
+        return TitleShowPage.clickListSearch();
+      });
+
+      it('shows the previous search term', () => {
+        expect(TitleShowPage.searchModal.searchFieldValue).to.equal('other ordinary');
+      });
+    });
+
+    describe('then sorting by package name', () => {
+      beforeEach(() => {
+        return TitleShowPage.clickListSearch()
+          .append(TitleShowPage.searchModal.clickFilter('sort', 'name'));
+      });
+
+      it.always('leaves the search modal open', () => {
+        expect(TitleShowPage.searchModal.exists).to.be.true;
+      });
+
+      it('displays packages matching the search term ordered by name', () => {
+        expect(TitleShowPage.packageList()).to.have.lengthOf(2);
+        expect(TitleShowPage.packageList(0).name).to.equal('Ordinary Package');
+        expect(TitleShowPage.packageList(1).name).to.equal('Other Ordinary Package');
+      });
+    });
+
+    describe('then filtering the packages by selection status', () => {
+      beforeEach(() => {
+        return TitleShowPage.clickListSearch()
+          .append(TitleShowPage.searchModal.clickFilter('selected', 'true'));
+      });
+
+      it.always('leaves the search modal open', () => {
+        expect(TitleShowPage.searchModal.exists).to.be.true;
+      });
+
+      it('displays selected packages matching the search term', () => {
+        expect(TitleShowPage.packageList()).to.have.lengthOf(1);
+        expect(TitleShowPage.packageList(0).name).to.equal('Other Ordinary Package');
+      });
+    });
+
+    describe('then filtering the packages by content type', () => {
+      beforeEach(() => {
+        return TitleShowPage.clickListSearch()
+          .append(TitleShowPage.searchModal.clickFilter('type', 'ebook'));
+      });
+
+      it.always('leaves the search modal open', () => {
+        expect(TitleShowPage.searchModal.exists).to.be.true;
+      });
+
+      it('displays packages matching the search term and content type', () => {
+        expect(TitleShowPage.packageList()).to.have.lengthOf(1);
+        expect(TitleShowPage.packageList(0).name).to.equal('Ordinary Package');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Add search icon button and access to filtering a list of resources ("packages") on a title detail view. https://issues.folio.org/browse/UIEH-215

## Approach
Builds on the work in https://github.com/folio-org/ui-eholdings/pull/346.

One minor change from that PR: if the title doesn't have any related packages to begin with, the search functionality doesn't even appear, which theoretically may only be a problem with mirage data. I don't think there's ever a title with production data that's not related to any packages.

#### TODOs
The same TODOs from PR #346 apply here:
- The inner search params are not persisted in the URL. This prevents us from deep linking searches within the details view. The current params are persisted in the route state, and in the future we can make this route use query params instead of it's state without changing any other props or components.
- There is no focus management for modals in stripes. Ideally, we would focus-trap the modal when open and focus back to the list when it is closed.
- There should be some indicator when search filters are active (UIEH-216), and another indicator showing how many packages are returned from the search (UIEH-148)

_Additionally, there's some needed back-end work._

## Screenshots
![2018-04-22 15 12 14](https://user-images.githubusercontent.com/230597/39099365-923d648e-463f-11e8-99c4-13d254575d6b.gif)
