### PR TITLE
UIEH-214 Search resource list within package detail view

### DIFF
--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -27,12 +27,15 @@ import styles from './package-show.css';
 export default class PackageShow extends Component {
   static propTypes = {
     model: PropTypes.object.isRequired,
+    titles: PropTypes.object.isRequired,
     fetchPackageTitles: PropTypes.func.isRequired,
     toggleSelected: PropTypes.func.isRequired,
     toggleHidden: PropTypes.func.isRequired,
     customCoverageSubmitted: PropTypes.func.isRequired,
     toggleAllowKbToAddTitles: PropTypes.func.isRequired,
-    packageContentTypeSubmitted: PropTypes.func.isRequired
+    packageContentTypeSubmitted: PropTypes.func.isRequired,
+    searchTitles: PropTypes.func.isRequired,
+    searchParams: PropTypes.object.isRequired
   };
 
   static contextTypes = {
@@ -113,7 +116,14 @@ export default class PackageShow extends Component {
   };
 
   render() {
-    let { model, fetchPackageTitles, customCoverageSubmitted } = this.props;
+    let {
+      model,
+      fetchPackageTitles,
+      customCoverageSubmitted,
+      searchTitles,
+      searchParams,
+      titles
+    } = this.props;
     let { intl, router, queryParams } = this.context;
     let {
       showSelectionModal,
@@ -318,13 +328,16 @@ export default class PackageShow extends Component {
               </DetailsViewSection>
             </div>
           )}
+          enableListSearch
           listType="titles"
+          onSearch={searchTitles}
+          searchParams={searchParams}
           renderList={scrollable => (
             <QueryList
               type="package-titles"
               fetch={fetchPackageTitles}
-              collection={model.resources}
-              length={model.titleCount}
+              collection={titles}
+              length={titles.length}
               scrollable={scrollable}
               itemHeight={70}
               renderItem={item => (

--- a/tests/package-show-title-search-test.js
+++ b/tests/package-show-title-search-test.js
@@ -1,0 +1,135 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import PackageShowPage from './pages/package-show';
+
+describeApplication('PackageShow title search', () => {
+  beforeEach(function () {
+    let resources = [];
+
+    let pkg = this.server.create('package', 'withProvider', {
+      titleCount: 5
+    });
+
+    let titles = this.server.createList('title', 5, {
+      name: i => `Title ${i}`,
+      publicationType: 'book'
+    });
+
+    titles[2].update({
+      name: 'Ordinary Title',
+      publicationType: 'report',
+      publisherName: 'Extraordinary Publisher'
+    });
+
+    titles[4].update({
+      name: 'Other Ordinary Title'
+    });
+
+    titles.forEach((title) => {
+      resources.push(this.server.create('resource', {
+        package: pkg,
+        title,
+        isSelected: false
+      }));
+    });
+
+    resources[4].update({
+      isSelected: true
+    });
+
+    return this.visit(`/eholdings/packages/${pkg.id}`, () => {
+      expect(PackageShowPage.$root).to.exist;
+    });
+  });
+
+  describe('clicking the search button', () => {
+    beforeEach(() => {
+      return PackageShowPage.clickListSearch();
+    });
+
+    it('shows the title search modal', () => {
+      expect(PackageShowPage.searchModal.exists).to.be.true;
+    });
+  });
+
+  describe('searching for specific titles', () => {
+    beforeEach(() => {
+      return PackageShowPage.clickListSearch()
+        .append(PackageShowPage.searchModal.search('other ordinary'));
+    });
+
+    it('hides the title search modal', () => {
+      expect(PackageShowPage.searchModal.exists).to.be.false;
+    });
+
+    it('displays titles matching the search term', () => {
+      expect(PackageShowPage.titleList()).to.have.lengthOf(2);
+      expect(PackageShowPage.titleList(0).name).to.equal('Other Ordinary Title');
+      expect(PackageShowPage.titleList(1).name).to.equal('Ordinary Title');
+    });
+
+    describe('reopening the modal', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch();
+      });
+
+      it('shows the previous search term', () => {
+        expect(PackageShowPage.searchModal.searchFieldValue).to.equal('other ordinary');
+      });
+    });
+
+    describe('then filtering the titles by a different type of search query', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch()
+          .append(
+            PackageShowPage
+              .searchModal.selectSearchField('publisher')
+              .search('Extraordinary Publisher')
+          );
+      });
+
+      it('hides the title search modal', () => {
+        expect(PackageShowPage.searchModal.exists).to.be.false;
+      });
+
+      it('displays selected titles matching the search term', () => {
+        expect(PackageShowPage.titleList()).to.have.lengthOf(1);
+        expect(PackageShowPage.titleList(0).name).to.equal('Ordinary Title');
+      });
+    });
+
+    describe('then filtering the titles by selection status', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch()
+          .append(PackageShowPage.searchModal.clickFilter('selected', 'true'));
+      });
+
+      it.always('leaves the search modal open', () => {
+        expect(PackageShowPage.searchModal.exists).to.be.true;
+      });
+
+      it('displays selected titles matching the search term', () => {
+        expect(PackageShowPage.titleList()).to.have.lengthOf(1);
+        expect(PackageShowPage.titleList(0).name).to.equal('Other Ordinary Title');
+      });
+    });
+
+    describe('then filtering the titles by publication type', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch()
+          .append(PackageShowPage.searchModal.clickFilter('type', 'report'));
+      });
+
+      it.always('leaves the search modal open', () => {
+        expect(PackageShowPage.searchModal.exists).to.be.true;
+      });
+
+      it('displays titles matching the search term and publication type', () => {
+        expect(PackageShowPage.titleList()).to.have.lengthOf(1);
+        expect(PackageShowPage.titleList(0).name).to.equal('Ordinary Title');
+      });
+    });
+  });
+});

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -13,6 +13,7 @@ import {
 import { isRootPresent, getComputedStyle, hasClassBeginningWith } from './helpers';
 import Datepicker from './datepicker';
 import Toast from './toast';
+import SearchModal from './search-modal';
 
 @page class PackageShowModal {
   confirmDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-yes]');
@@ -41,6 +42,9 @@ import Toast from './toast';
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button] button');
   detailsPaneContentScrollHeight = property('scrollHeight', '[data-test-eholdings-detail-pane-contents]');
+  clickListSearch = clickable('[data-test-eholdings-details-view-search] button');
+
+  searchModal = new SearchModal('#eholdings-details-view-search-modal');
 
   detailPaneMouseWheel = triggerable('wheel', '[data-test-eholdings-detail-pane-contents]', {
     bubbles: true,
@@ -123,7 +127,7 @@ import Toast from './toast';
   beginDate = new Datepicker('[data-test-eholdings-coverage-fields-date-range-begin]');
   endDate = new Datepicker('[data-test-eholdings-coverage-fields-date-range-end]');
 
-  toast = Toast
+  toast = Toast;
 
   fillDates(beginDate, endDate) {
     return this.beginDate.fillAndBlur(beginDate)

--- a/tests/pages/search-modal.js
+++ b/tests/pages/search-modal.js
@@ -9,7 +9,7 @@ import { isRootPresent } from './helpers';
 export default @page class SearchModal {
   exists = isRootPresent();
   searchType = attribute('data-test-search-form', '[data-test-search-form]')
-  searchFieldValue = value('[data-test-search-field] input[name="search"]');
+  searchFieldValue = value('[data-test-search-form] input[name="search"]');
 
   clickFilter = action(function (name, val) {
     return this.click(`[data-test-eholdings-search-filters] input[name="${name}"][value="${val}"]`);
@@ -19,9 +19,13 @@ export default @page class SearchModal {
     return this.$(`[data-test-eholdings-search-filters] input[name="${name}"]:checked`).value;
   }
 
+  selectSearchField = action(function (searchfield) {
+    return this.fill('[data-test-title-search-field] select', searchfield);
+  });
+
   search = action(function (query) {
     return this
-      .fill('[data-test-search-field] input[name="search"]', query)
+      .fill('[data-test-search-form] input[name="search"]', query)
       .click('[data-test-search-submit]');
   });
 }


### PR DESCRIPTION
## Purpose
Add search icon button and access to filtering a list of resources ("titles") on a package detail view. https://issues.folio.org/browse/UIEH-214

## Approach
Builds on the work in https://github.com/folio-org/ui-eholdings/pull/346.

#### TODOs
The same TODOs from PR #346 apply here:
- The inner search params are not persisted in the URL. This prevents us from deep linking searches within the details view. The current params are persisted in the route state, and in the future we can make this route use query params instead of it's state without changing any other props or components.
- There is no focus management for modals in stripes. Ideally, we would focus-trap the modal when open and focus back to the list when it is closed.
- There should be some indicator when search filters are active (UIEH-216), and another indicator showing how many packages are returned from the search (UIEH-148)

## Screenshots
![2018-04-22 18 41 09](https://user-images.githubusercontent.com/230597/39101263-c8af37d2-465c-11e8-84bf-757b7148efcb.gif)