### PR TITLE
Send JSON API content type header for POSTs

### DIFF
--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -517,7 +517,7 @@ const getHeaders = (method, { okapi }) => {
     'X-Okapi-Token': okapi.token
   };
 
-  if (method === 'PUT') {
+  if (method === 'PUT' || method === 'POST') {
     headers['Content-Type'] = 'application/vnd.api+json';
   }
 


### PR DESCRIPTION
`POST`s from `ui-eholdings` to `mod-kb-ebsco` were failing because `jsonapi-rails` was receiving `content-type: application/json` instead of `content-type: application/vnd.api+json`.