### PR TITLE
UIEH-341 Smooth out back button logic

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -49,20 +49,25 @@ class CustomPackageEdit extends Component {
   componentWillReceiveProps(nextProps) {
     let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
     let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+    let { router } = this.context;
 
     if (wasPending && needsUpdate) {
-      this.context.router.history.push(
-        `/eholdings/packages/${this.props.model.id}${this.context.router.route.location.search}`,
-        { eholdings: true }
-      );
+      router.history.push({
+        pathname: `/eholdings/packages/${this.props.model.id}`,
+        search: router.route.location.search,
+        state: { eholdings: true }
+      });
     }
   }
 
   handleCancel = () => {
-    this.context.router.history.push(
-      `/eholdings/packages/${this.props.model.id}${this.context.router.route.location.search}`,
-      { eholdings: true }
-    );
+    let { router } = this.context;
+
+    router.history.push({
+      pathname: `/eholdings/packages/${this.props.model.id}`,
+      search: this.context.router.route.location.search,
+      state: { eholdings: true }
+    });
   }
 
   handleSelectionToggle = (e) => {
@@ -124,14 +129,21 @@ class CustomPackageEdit extends Component {
     let actionMenuItems = [
       {
         label: 'Cancel editing',
-        to: `/eholdings/packages/${model.id}${router.route.location.search}`
+        to: {
+          pathname: `/eholdings/packages/${model.id}`,
+          search: router.route.location.search,
+          state: { eholdings: true }
+        }
       }
     ];
 
     if (queryParams) {
       actionMenuItems.push({
         label: 'Full view',
-        to: `/eholdings/packages/${model.id}/edit`
+        to: {
+          pathname: `/eholdings/packages/${model.id}/edit`,
+          state: { eholdings: true }
+        }
       });
     }
 

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -37,20 +37,25 @@ class ManagedPackageEdit extends Component {
   componentWillReceiveProps(nextProps) {
     let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
     let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+    let { router } = this.context;
 
     if (wasPending && needsUpdate) {
-      this.context.router.history.push(
-        `/eholdings/packages/${this.props.model.id}${this.context.router.route.location.search}`,
-        { eholdings: true }
-      );
+      router.history.push({
+        pathname: `/eholdings/packages/${this.props.model.id}`,
+        search: router.route.location.search,
+        state: { eholdings: true }
+      });
     }
   }
 
   handleCancel = () => {
-    this.context.router.history.push(
-      `/eholdings/packages/${this.props.model.id}${this.context.router.route.location.search}`,
-      { eholdings: true }
-    );
+    let { router } = this.context;
+
+    router.history.push({
+      pathname: `/eholdings/packages/${this.props.model.id}`,
+      search: router.route.location.search,
+      state: { eholdings: true }
+    });
   }
 
   render() {
@@ -70,14 +75,21 @@ class ManagedPackageEdit extends Component {
     let actionMenuItems = [
       {
         label: 'Cancel editing',
-        to: `/eholdings/packages/${model.id}${router.route.location.search}`
+        to: {
+          pathname: `/eholdings/packages/${model.id}`,
+          search: router.route.location.search,
+          state: { eholdings: true }
+        }
       }
     ];
 
     if (queryParams) {
       actionMenuItems.push({
         label: 'Full view',
-        to: `/eholdings/packages/${model.id}/edit`
+        to: {
+          pathname: `/eholdings/packages/${model.id}/edit`,
+          state: { eholdings: true }
+        }
       });
     }
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -104,6 +104,7 @@ export default class PackageShow extends Component {
         label: 'Edit',
         to: {
           pathname: `/eholdings/packages/${model.id}/edit`,
+          search: router.route.location.search,
           state: { eholdings: true }
         }
       }
@@ -143,9 +144,14 @@ export default class PackageShow extends Component {
           lastMenu={(
             <PaneMenu>
               <IconButton
+                data-test-eholdings-package-edit-link
                 icon="edit"
                 ariaLabel={`Edit ${model.name}`}
-                href={`/eholdings/packages/${model.id}/edit${router.route.location.search}`}
+                href={{
+                  pathname: `/eholdings/packages/${model.id}/edit`,
+                  search: router.route.location.search,
+                  state: { eholdings: true }
+                }}
               />
             </PaneMenu>
           )}

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -146,9 +146,13 @@ export default class ResourceShow extends Component {
           lastMenu={(
             <PaneMenu>
               <IconButton
+                data-test-eholdings-resource-edit-link
                 icon="edit"
                 ariaLabel={`Edit ${model.name}`}
-                href={`/eholdings/resources/${model.id}/edit`}
+                href={{
+                  pathname: `/eholdings/resources/${model.id}/edit`,
+                  state: { eholdings: true }
+                }}
               />
             </PaneMenu>
           )}

--- a/src/components/title/edit/title-edit.css
+++ b/src/components/title/edit/title-edit.css
@@ -10,3 +10,11 @@
     margin-right: 0.25em;
   }
 }
+
+.full-view-link {
+  display: none;
+
+  @media (--mediumUp) {
+    display: block;
+  }
+}

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -34,26 +34,32 @@ class TitleEdit extends Component {
       history: PropTypes.shape({
         push: PropTypes.func.isRequired
       }).isRequired
-    }).isRequired
+    }).isRequired,
+    queryParams: PropTypes.object
   };
 
   componentWillReceiveProps(nextProps) {
     let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
     let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+    let { router } = this.context;
 
     if (wasPending && needsUpdate) {
-      this.context.router.history.push(
-        `/eholdings/titles/${this.props.model.id}`,
-        { eholdings: true }
-      );
+      router.history.push({
+        pathname: `/eholdings/titles/${this.props.model.id}`,
+        search: router.route.location.search,
+        state: { eholdings: true }
+      });
     }
   }
 
   handleCancel = () => {
-    this.context.router.history.push(
-      `/eholdings/titles/${this.props.model.id}`,
-      { eholdings: true }
-    );
+    let { router } = this.context;
+
+    router.history.push({
+      pathname: `/eholdings/titles/${this.props.model.id}`,
+      search: router.route.location.search,
+      state: { eholdings: true }
+    });
   }
 
   render() {
@@ -65,15 +71,32 @@ class TitleEdit extends Component {
       updateRequest
     } = this.props;
 
+    let {
+      queryParams,
+      router
+    } = this.context;
+
     let actionMenuItems = [
       {
         label: 'Cancel editing',
         to: {
           pathname: `/eholdings/titles/${model.id}`,
+          search: router.route.location.search,
           state: { eholdings: true }
         }
       }
     ];
+
+    if (queryParams.searchType) {
+      actionMenuItems.push({
+        label: 'Full view',
+        to: {
+          pathname: `/eholdings/titles/${model.id}`,
+          state: { eholdings: true }
+        },
+        className: styles['full-view-link']
+      });
+    }
 
     return (
       <div>

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -16,7 +16,7 @@ import DetailsViewSection from '../../details-view-section';
 import Toaster from '../../toaster';
 import styles from './title-show.css';
 
-export default function TitleShow({ model }, { queryParams }) {
+export default function TitleShow({ model }, { queryParams, router }) {
   let actionMenuItems = [];
 
   if (model.isTitleCustom) {
@@ -24,6 +24,7 @@ export default function TitleShow({ model }, { queryParams }) {
       label: 'Edit',
       to: {
         pathname: `/eholdings/titles/${model.id}/edit`,
+        search: router.route.location.search,
         state: { eholdings: true }
       }
     });
@@ -45,9 +46,14 @@ export default function TitleShow({ model }, { queryParams }) {
     lastMenu = (
       <PaneMenu>
         <IconButton
+          data-test-eholdings-title-edit-link
           icon="edit"
           ariaLabel={`Edit ${model.name}`}
-          href={`/eholdings/titles/${model.id}/edit`}
+          href={{
+            pathname: `/eholdings/titles/${model.id}/edit`,
+            search: router.route.location.search,
+            state: { eholdings: true }
+          }}
         />
       </PaneMenu>
     );

--- a/tests/custom-title-edit-test.js
+++ b/tests/custom-title-edit-test.js
@@ -26,7 +26,8 @@ describeApplication('CustomTitleEdit', () => {
       name: 'Best Title Ever',
       publicationType: 'Streaming Video',
       publisherName: 'Amazing Publisher',
-      isPeerReviewed: false
+      isPeerReviewed: false,
+      isTitleCustom: true
     });
 
     title.save();
@@ -266,6 +267,24 @@ describeApplication('CustomTitleEdit', () => {
 
       it('pops up an error', () => {
         expect(TitleEditPage.toast.errorText).to.equal('There was an error');
+      });
+    });
+  });
+
+  describe('visiting the title show page', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/titles/${title.id}`, () => {
+        expect(TitleShowPage.$root).to.exist;
+      });
+    });
+
+    describe('clicking the edit button', () => {
+      beforeEach(() => {
+        return TitleShowPage.clickEditButton();
+      });
+
+      it('should display the back button in pane header', () => {
+        expect(TitleEditPage.hasBackButton).to.be.true;
       });
     });
   });

--- a/tests/managed-package-edit-test.js
+++ b/tests/managed-package-edit-test.js
@@ -208,4 +208,22 @@ describeApplication('ManagedPackageEdit', () => {
       });
     });
   });
+
+  describe('visiting the package show page', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/packages/${providerPackage.id}`, () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    describe('clicking the edit button', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickEditButton();
+      });
+
+      it('should display the back button in pane header', () => {
+        expect(PackageEditPage.hasBackButton).to.be.true;
+      });
+    });
+  });
 });

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -33,6 +33,7 @@ import Datepicker from './datepicker';
   toggleIsSelected = clickable('[data-test-eholdings-custom-package-details-selected] input');
   isSelected = property('checked', '[data-test-eholdings-custom-package-details-selected] input');
   modal = new PackageEditModal('#eholdings-custom-package-confirmation-modal');
+  hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
 
   toast = Toast;
 

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -40,6 +40,7 @@ import Toast from './toast';
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button] button');
   detailsPaneContentScrollHeight = property('scrollHeight', '[data-test-eholdings-detail-pane-contents]');
+  clickEditButton = clickable('[data-test-eholdings-package-edit-link]');
 
   detailPaneMouseWheel = triggerable('wheel', '[data-test-eholdings-detail-pane-contents]', {
     bubbles: true,

--- a/tests/pages/resource-edit.js
+++ b/tests/pages/resource-edit.js
@@ -25,6 +25,7 @@ import Datepicker from './datepicker';
   hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
   isPeerReviewed = property('checked', '[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
   checkPeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
+  hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
 
   toast = Toast
 

--- a/tests/pages/resource-show.js
+++ b/tests/pages/resource-show.js
@@ -57,6 +57,7 @@ import Toast from './toast';
   isHiddenDisabled = property('disabled', '[data-test-eholdings-resource-toggle-hidden] input[type=checkbox]');
   toggleIsHidden = clickable('[data-test-eholdings-resource-toggle-hidden] input');
   isHiding = hasClassBeginningWith('is-pending--', '[data-test-eholdings-resource-toggle-hidden] [data-test-toggle-switch]');
+  clickEditButton = clickable('[data-test-eholdings-resource-edit-link]');
 
   peerReviewedStatus = text('[data-test-eholdings-peer-reviewed-field]');
 

--- a/tests/pages/title-edit.js
+++ b/tests/pages/title-edit.js
@@ -24,6 +24,7 @@ import Toast from './toast';
   descriptionField = value('[data-test-eholdings-description-textarea] textarea');
   fillDescription = fillable('[data-test-eholdings-description-textarea] textarea');
   descriptionError = hasClassBeginningWith('feedbackError--', '[data-test-eholdings-description-textarea] textarea');
+  hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
 
   toast = Toast
 

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -1,5 +1,6 @@
 import {
   action,
+  clickable,
   collection,
   computed,
   isPresent,
@@ -27,6 +28,7 @@ import Toast from './toast';
   detailsPaneContentsOverFlowY = getComputedStyle('overflow-y', '[data-test-eholdings-detail-pane-contents]');
   peerReviewedStatus = text('[data-test-eholdings-peer-reviewed-field]');
   descriptionText = text('[data-test-eholdings-description-field]');
+  clickEditButton = clickable('[data-test-eholdings-title-edit-link]');
 
   toast = Toast
 

--- a/tests/resource-edit-test.js
+++ b/tests/resource-edit-test.js
@@ -285,4 +285,22 @@ describeApplication('ResourceEdit', () => {
       expect(ResourceEditPage.hasErrors).to.be.true;
     });
   });
+
+  describe('visiting the resource show page', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/resources/${resource.id}`, () => {
+        expect(ResourceShowPage.$root).to.exist;
+      });
+    });
+
+    describe('clicking the edit button', () => {
+      beforeEach(() => {
+        return ResourceShowPage.clickEditButton();
+      });
+
+      it('should display the back button in pane header', () => {
+        expect(ResourceEditPage.hasBackButton).to.be.true;
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Purpose
When clicking to edit a package, title, or package-title, there's not reason to leave the three-pane search results layout.

When leaving to a full-page layout, the back button was occasionally not being shown, because we were not passing the `eholdings: true` state through `stripes-components` `<IconButton>`s.

https://issues.folio.org/browse/UIEH-341

## Next Steps
The `IconButton` `href` prop actually accepts a router location object, even though its `PropTypes` throw a warning if the `href` isn't a string:
```
Warning: Failed prop type: Invalid prop `href` of type `object` supplied to `IconButton`, expected `string`.
```

## Screenshots
![2018-04-24 11 42 16](https://user-images.githubusercontent.com/230597/39201581-11ff3230-47b5-11e8-91c1-3fbc2dffed3b.gif)