### PR TITLE
Singularize string when only one search result

### DIFF
--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -112,6 +112,15 @@ export default class SearchPaneset extends React.Component {
       newButton = this.renderNewButton();
     }
 
+    let resultsPaneSub = 'Loading...';
+    if (!isLoading) {
+      resultsPaneSub = `${intl.formatNumber(totalResults)} search result`;
+
+      if (totalResults > 1) {
+        resultsPaneSub += 's';
+      }
+    }
+
     return (
       <div className={styles['search-paneset']}>
         <SearchPaneVignette isHidden={hideFilters} onClick={this.toggleFilters} />
@@ -144,7 +153,7 @@ export default class SearchPaneset extends React.Component {
                   app: 'eholdings'
                 }}
                 paneTitle={capitalize(resultsType)}
-                paneSub={isLoading ? 'Loading...' : `${intl.formatNumber(totalResults)} search results`}
+                paneSub={resultsPaneSub}
                 firstMenu={
                   <div className={styles['results-pane-search-toggle']}>
                     <PaneMenu>

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -96,6 +96,10 @@ describeApplication('PackageSearch', () => {
           return PackageSearchPage.search('SomethingElse');
         });
 
+        it('displays the total number of search results', () => {
+          expect(PackageSearchPage.totalResults).to.equal('1 search result');
+        });
+
         it('removes the preview detail pane', () => {
           expect(PackageSearchPage.packagePreviewPaneIsPresent).to.be.false;
         });

--- a/tests/provider-search-test.js
+++ b/tests/provider-search-test.js
@@ -97,6 +97,10 @@ describeApplication('ProviderSearch', () => {
           return ProviderSearchPage.search('Totally Awesome Co');
         });
 
+        it('displays the total number of search results', () => {
+          expect(ProviderSearchPage.totalResults).to.equal('1 search result');
+        });
+
         it('removes the preview detail pane', () => {
           expect(ProviderSearchPage.providerPreviewPaneIsPresent).to.be.false;
         });

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -140,6 +140,10 @@ describeApplication('TitleSearch', () => {
           return TitleSearchPage.search('SomethingSomethingWhoa');
         });
 
+        it('displays the total number of search results', () => {
+          expect(TitleSearchPage.totalResults).to.equal('1 search result');
+        });
+
         it('removes the preview detail pane', () => {
           expect(TitleSearchPage.titlePreviewPaneIsPresent).to.be.false;
         });


### PR DESCRIPTION
## Purpose
When getting back a single search result, the subtitle of the results pane currently reads "1 search results". _nails scraping on blackboard_

## Approach
Remove the `s` when there's only one search result.

## Screenshots
![localhost_3000_eholdings_searchtype providers q api iphone 5_se](https://user-images.githubusercontent.com/230597/39209213-e2aed290-47ca-11e8-8d12-b329733ccd09.png)

