### PR TITLE
Run Safari tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,3 +163,6 @@ workflows:
       - test-firefox:
           requires:
             - checkout-and-install
+      - test-safari:
+          requires:
+            - checkout-and-install

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,10 +14,10 @@ module.exports = (config) => {
       project: 'ui-eholdings'
     },
 
-    browserDisconnectTimeout: 3e5,
+    browserDisconnectTimeout: 900000,
     browserDisconnectTolerance: 3,
-    browserNoActivityTimeout: 3e5,
-    captureTimeout: 3e5,
+    browserNoActivityTimeout: 900000,
+    captureTimeout: 900000,
 
     customLaunchers: {
       bs_safari_11: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = (config) => {
         os: 'OS X',
         os_version: 'High Sierra',
         browser: 'safari',
-        browser_version: '11.0'
+        browser_version: '11.1'
       },
       bs_firefox_mac: {
         base: 'BrowserStack',


### PR DESCRIPTION
BrowserStack upgraded the version of Safari on their boxes, which caused `ui-eholdings` tests in Safari to start failing.