### PR TITLE
STCOM-259 Deal with all datepicker output as UTC

### DIFF
--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -37,9 +37,9 @@ class PackageCreateRoute extends Component {
     if (values.customCoverages[0]) {
       attrs.customCoverage = {
         beginCoverage: !values.customCoverages[0].beginCoverage ? '' :
-          moment(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD'),
+          moment(values.customCoverages[0].beginCoverage).tz('UTC').format('YYYY-MM-DD'),
         endCoverage: !values.customCoverages[0].endCoverage ? '' :
-          moment(values.customCoverages[0].endCoverage).format('YYYY-MM-DD')
+          moment(values.customCoverages[0].endCoverage).tz('UTC').format('YYYY-MM-DD')
       };
     }
 

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -79,8 +79,8 @@ class PackageEditRoute extends Component {
       let endCoverage = '';
 
       if (values.customCoverages[0]) {
-        beginCoverage = !values.customCoverages[0].beginCoverage ? '' : moment(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD');
-        endCoverage = !values.customCoverages[0].endCoverage ? '' : moment(values.customCoverages[0].endCoverage).format('YYYY-MM-DD');
+        beginCoverage = !values.customCoverages[0].beginCoverage ? '' : moment(values.customCoverages[0].beginCoverage).tz('UTC').format('YYYY-MM-DD');
+        endCoverage = !values.customCoverages[0].endCoverage ? '' : moment(values.customCoverages[0].endCoverage).tz('UTC').format('YYYY-MM-DD');
       }
 
       model.customCoverage = {

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -110,8 +110,8 @@ class PackageShowRoute extends Component {
     let endCoverage = '';
 
     if (values.customCoverages[0]) {
-      beginCoverage = !values.customCoverages[0].beginCoverage ? '' : moment(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD');
-      endCoverage = !values.customCoverages[0].endCoverage ? '' : moment(values.customCoverages[0].endCoverage).format('YYYY-MM-DD');
+      beginCoverage = !values.customCoverages[0].beginCoverage ? '' : moment(values.customCoverages[0].beginCoverage).tz('UTC').format('YYYY-MM-DD');
+      endCoverage = !values.customCoverages[0].endCoverage ? '' : moment(values.customCoverages[0].endCoverage).tz('UTC').format('YYYY-MM-DD');
     }
 
     model.customCoverage = {

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -44,8 +44,8 @@ class ResourceEditRoute extends Component {
       customEmbargoUnit,
     } = values;
     model.customCoverages = customCoverages.map((dateRange) => {
-      let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).format('YYYY-MM-DD');
-      let endCoverage = !dateRange.endCoverage ? null : moment(dateRange.endCoverage).format('YYYY-MM-DD');
+      let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).tz('UTC').format('YYYY-MM-DD');
+      let endCoverage = !dateRange.endCoverage ? null : moment(dateRange.endCoverage).tz('UTC').format('YYYY-MM-DD');
 
       return {
         beginCoverage,

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -66,8 +66,8 @@ class ResourceShowRoute extends Component {
   coverageSubmitted = (values) => {
     let { model, updateResource } = this.props;
     model.customCoverages = values.customCoverages.map((dateRange) => {
-      let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).format('YYYY-MM-DD');
-      let endCoverage = !dateRange.endCoverage ? null : moment(dateRange.endCoverage).format('YYYY-MM-DD');
+      let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).tz('UTC').format('YYYY-MM-DD');
+      let endCoverage = !dateRange.endCoverage ? null : moment(dateRange.endCoverage).tz('UTC').format('YYYY-MM-DD');
 
       return {
         beginCoverage,


### PR DESCRIPTION
## Purpose
`Datepicker`s now return ISO-8601 datetime strings at UTC, instead of the user's time zone.

More info on that:
https://issues.folio.org/browse/UIORG-55

Bug this is addressing:
https://issues.folio.org/browse/STCOM-259

## Approach
Assume that `Datepicker` output is UTC, and adjust `moment()` setup to use that time zone instead of the user's.