### PR TITLE
Run Circle CI on node 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 jobs:
   checkout-and-install:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9
     steps:
       - checkout
       - restore_cache:
@@ -21,7 +21,7 @@ jobs:
 
   eslint:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9
     steps:
       - attach_workspace:
           at: ~/
@@ -31,7 +31,7 @@ jobs:
 
   stylelint:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9
     steps:
       - attach_workspace:
           at: ~/
@@ -41,7 +41,7 @@ jobs:
 
   test-chrome:
     docker:
-      - image: circleci/node:latest-browsers
+      - image: circleci/node:9-browsers
     steps:
       - attach_workspace:
           at: ~/
@@ -59,7 +59,7 @@ jobs:
 
   test-safari:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9
     steps:
       - attach_workspace:
           at: ~/
@@ -74,7 +74,7 @@ jobs:
 
   test-firefox:
     docker:
-      - image: circleci/node:latest-browsers
+      - image: circleci/node:9-browsers
     steps:
       - attach_workspace:
           at: ~/
@@ -95,7 +95,7 @@ jobs:
 
   test-edge:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9
     steps:
       - attach_workspace:
           at: ~/
@@ -110,7 +110,7 @@ jobs:
 
   test-ie:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:9
     steps:
       - attach_workspace:
           at: ~/


### PR DESCRIPTION
CircleCI's `latest` images started using node 10, which caused some dependency errors: https://circleci.com/gh/folio-org/ui-eholdings/2523