### PR TITLE
UIEH-310 Show success toast when package saved

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -55,7 +55,7 @@ class CustomPackageEdit extends Component {
       router.history.push({
         pathname: `/eholdings/packages/${this.props.model.id}`,
         search: router.route.location.search,
-        state: { eholdings: true }
+        state: { eholdings: true, isFreshlySaved: true }
       });
     }
   }

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -43,7 +43,7 @@ class ManagedPackageEdit extends Component {
       router.history.push({
         pathname: `/eholdings/packages/${this.props.model.id}`,
         search: router.route.location.search,
-        state: { eholdings: true }
+        state: { eholdings: true, isFreshlySaved: true }
       });
     }
   }

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -127,8 +127,19 @@ export default class PackageShow extends Component {
     if (router.history.action === 'REPLACE' &&
         router.history.location.state.isNewRecord) {
       toasts.push({
-        id: `success-package-${model.id}`,
-        message: 'Successfully created custom package',
+        id: `success-package-creation-${model.id}`,
+        message: 'Custom package created.',
+        type: 'success'
+      });
+    }
+
+    // if coming from saving edits to the package, show a success toast
+    if (router.history.action === 'PUSH' &&
+        router.history.location.state &&
+        router.history.location.state.isFreshlySaved) {
+      toasts.push({
+        id: `success-package-saved-${model.id}`,
+        message: 'Package saved.',
         type: 'success'
       });
     }

--- a/tests/custom-package-edit-test.js
+++ b/tests/custom-package-edit-test.js
@@ -160,6 +160,10 @@ describeApplication('CustomPackageEdit', () => {
         it('displays the new coverage dates', () => {
           expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
         });
+
+        it('shows a success toast message', () => {
+          expect(PackageShowPage.toast.successText).to.equal('Package saved.');
+        });
       });
     });
   });

--- a/tests/managed-package-edit-test.js
+++ b/tests/managed-package-edit-test.js
@@ -87,6 +87,10 @@ describeApplication('ManagedPackageEdit', () => {
         it('displays the new coverage dates', () => {
           expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
         });
+
+        it('shows a success toast message', () => {
+          expect(PackageShowPage.toast.successText).to.equal('Package saved.');
+        });
       });
     });
   });

--- a/tests/package-create-test.js
+++ b/tests/package-create-test.js
@@ -38,7 +38,7 @@ describeApplication('PackageCreate', () => {
     });
 
     it('shows a success toast message', () => {
-      expect(PackageShowPage.toast.successText).to.equal('Successfully created custom package');
+      expect(PackageShowPage.toast.successText).to.equal('Custom package created.');
     });
   });
 


### PR DESCRIPTION
## Purpose
When successfully saving changes to a package (either managed or custom) on `/eholdings/packages/:id/edit`, show a success toast on redirecting to back to `/eholdings/packages/:id`.

Resolves https://issues.folio.org/browse/UIEH-310

## Screenshots
![2018-04-30 15 01 46](https://user-images.githubusercontent.com/230597/39447809-9d0bcdc0-4c88-11e8-8659-2b38323e5e91.gif)
