### PR TITLE
UIEH-304 Create Custom Titles

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -254,6 +254,16 @@ export default function configure() {
     return titles.find(request.params.id);
   });
 
+  this.post('/titles', ({ titles }, request) => {
+    let body = JSON.parse(request.requestBody);
+    let title = titles.create(body.data.attributes);
+
+    title.update('isSelected', true);
+    title.update('isCustom', true);
+
+    return title;
+  });
+
   // Resources
   this.get('/packages/:id/resources', nestedResourceRouteFor('package', 'resources'));
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -262,14 +262,17 @@ export default function configure() {
 
   this.post('/titles', (schema, request) => {
     let body = JSON.parse(request.requestBody);
-    let { packageId, ...titleAttrs } = body.data.attributes;
-    let title = schema.titles.create(titleAttrs);
-    let pkg = schema.packages.find(packageId);
+    let title = schema.titles.create(body.data.attributes);
 
     title.update('isSelected', true);
     title.update('isTitleCustom', true);
 
-    schema.resources.create({ package: pkg, title });
+    for (let include of body.included) {
+      if (include.type === 'resource') {
+        let pkg = schema.packages.find(include.attributes.packageId);
+        schema.resources.create({ package: pkg, title });
+      }
+    }
 
     return title;
   });

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -13,6 +13,7 @@ export default function defaultScenario(server) {
 
   let customProvider = server.create('provider', {
     name: 'Atlanta A&T Library',
+    packagesSelected: 1,
     packagesTotal: 1
   });
 
@@ -20,8 +21,9 @@ export default function defaultScenario(server) {
     provider: customProvider,
     name: 'Atlanta A&T Drumming Books',
     contentType: 'AggregatedFullText',
-    isSelected: false,
+    isSelected: true,
     isCustom: true,
+    selectedCount: 1,
     titleCount: 1
   });
 
@@ -29,7 +31,7 @@ export default function defaultScenario(server) {
     name: 'Single, Double, and Triple Paradiddles',
     isTitleCustom: true,
     isPeerReviewed: false,
-    isSelected: false,
+    isSelected: true,
     description: '',
     edition: ''
   });

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -2,39 +2,36 @@
 export default function defaultScenario(server) {
   function createProvider(name, packages = []) {
     let provider = server.create('provider', {
-      providerName: name,
-      packagesTotal: 0
+      packagesTotal: packages.length,
+      name
     });
+
     packages.forEach((pkg) => {
       server.create('package', 'withTitles', { ...pkg, provider });
     });
   }
 
-  createProvider('Atlanta A&T Library', [
-    {
-      name: 'Atlanta A&T Drumming Books',
-      contentType: 'AggregatedFullText',
-      isCustom: true
-    },
-  ]);
-
   let customProvider = server.create('provider', {
-    name: 'Atlanta A&T Library'
+    name: 'Atlanta A&T Library',
+    packagesTotal: 1
   });
 
   let customPackage = server.create('package', {
+    provider: customProvider,
     name: 'Atlanta A&T Drumming Books',
     contentType: 'AggregatedFullText',
+    isSelected: false,
     isCustom: true,
-    provider: customProvider
+    titleCount: 1
   });
 
   let customTitle = server.create('title', {
     name: 'Single, Double, and Triple Paradiddles',
     isTitleCustom: true,
     isPeerReviewed: false,
-    edition: '',
-    description: ''
+    isSelected: false,
+    description: '',
+    edition: ''
   });
 
   server.create('resource', {

--- a/mirage/serializers/title.js
+++ b/mirage/serializers/title.js
@@ -1,3 +1,5 @@
 import ApplicationSerializer from './application';
 
-export default ApplicationSerializer.extend();
+export default ApplicationSerializer.extend({
+  include: ['resources']
+});

--- a/src/components/title/_fields/package-select/index.js
+++ b/src/components/title/_fields/package-select/index.js
@@ -1,0 +1,1 @@
+export { default, validate } from './package-select-field';

--- a/src/components/title/_fields/package-select/package-select-field.css
+++ b/src/components/title/_fields/package-select/package-select-field.css
@@ -1,0 +1,3 @@
+.package-select-field {
+  max-width: 50em;
+}

--- a/src/components/title/_fields/package-select/package-select-field.js
+++ b/src/components/title/_fields/package-select/package-select-field.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Field } from 'redux-form';
+
+import { Select } from '@folio/stripes-components';
+import styles from './package-select-field.css';
+
+export default function PackageSelectField({ packages }) {
+  let options = packages.map(pkg => ({ label: pkg.name, value: pkg.id }));
+
+  options.unshift({
+    label: options.length ? 'Choose a package' : '...Loading',
+    disabled: true,
+    value: ''
+  });
+
+  return (
+    <div
+      data-test-eholdings-package-select-field
+      className={styles['package-select-field']}
+    >
+      <Field
+        name="packageId"
+        component={Select}
+        label="Package"
+        dataOptions={options}
+      />
+    </div>
+  );
+}
+
+PackageSelectField.propTypes = {
+  packages: PropTypes.object.isRequired
+};
+
+export function validate(values) {
+  let errors = {};
+
+  if (!values.packageId) {
+    errors.packageId = 'Custom titles must belong to a package.';
+  }
+
+  return errors;
+}

--- a/src/components/title/create/index.js
+++ b/src/components/title/create/index.js
@@ -1,0 +1,1 @@
+export { default } from './title-create';

--- a/src/components/title/create/title-create.css
+++ b/src/components/title/create/title-create.css
@@ -1,0 +1,17 @@
+@import '@folio/stripes-components/lib/variables';
+
+.title-create-form-container {
+  overflow-y: auto;
+  padding: 1em;
+}
+
+.title-create-action-buttons {
+  align-items: flex-start;
+  border-top: 1px solid var(--minor-divider-color);
+  display: flex;
+  padding-top: 1em;
+
+  & button {
+    margin-right: 0.25em;
+  }
+}

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -10,9 +10,11 @@ import {
 } from '@folio/stripes-components';
 
 import DetailsViewSection from '../../details-view-section';
-import NameField, { validate as validateTitleName } from '../_fields/name';
+import NameField, { validate as validateName } from '../_fields/name';
+import EditionField, { validate as validateEdition } from '../_fields/edition';
 import PublisherNameField, { validate as validatePublisherName } from '../_fields/publisher-name';
 import PackageSelectField, { validate as validatePackageSelection } from '../_fields/package-select';
+import ContributorField, { validate as validateContributor } from '../_fields/contributor';
 import DescriptionField, { validate as validateDescription } from '../_fields/description';
 import PublicationTypeField from '../_fields/publication-type';
 import PeerReviewedField from '../_fields/peer-reviewed';
@@ -86,6 +88,8 @@ class TitleCreate extends Component {
           <form onSubmit={handleSubmit(onSubmit)}>
             <DetailsViewSection label="Title information" separator={false}>
               <NameField />
+              <ContributorField />
+              <EditionField />
               <PublisherNameField />
               <PublicationTypeField />
               <DescriptionField />
@@ -116,13 +120,13 @@ class TitleCreate extends Component {
 }
 
 const validate = (values) => {
-  return Object.assign(
-    {},
-    validateTitleName(values),
+  return Object.assign({},
+    validateName(values),
+    validateContributor(values),
+    validateEdition(values),
     validatePublisherName(values),
-    validatePackageSelection(values),
     validateDescription(values),
-  );
+    validatePackageSelection(values));
 };
 
 export default reduxForm({

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -1,0 +1,126 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+
+import {
+  Button,
+  IconButton,
+  PaneHeader,
+  PaneMenu
+} from '@folio/stripes-components';
+
+import DetailsViewSection from '../../details-view-section';
+import NameField, { validate as validateTitleName } from '../_fields/name';
+import PublisherNameField, { validate as validatePublisherName } from '../_fields/publisher-name';
+import DescriptionField, { validate as validateDescription } from '../_fields/description';
+import PublicationTypeField from '../_fields/publication-type';
+import PeerReviewedField from '../_fields/peer-reviewed';
+import NavigationModal from '../../navigation-modal';
+import Toaster from '../../toaster';
+import styles from './title-create.css';
+
+class TitleCreate extends Component {
+  static propTypes = {
+    request: PropTypes.object.isRequired,
+    handleSubmit: PropTypes.func.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    pristine: PropTypes.bool.isRequired
+  };
+
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        goBack: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
+  handleCancel = () => {
+    this.context.router.history.goBack();
+  }
+
+  render() {
+    let {
+      request,
+      handleSubmit,
+      onSubmit,
+      pristine
+    } = this.props;
+
+    let {
+      router
+    } = this.context;
+
+    let historyState = router.history.location.state;
+
+    return (
+      <div data-test-eholdings-title-create>
+        <Toaster
+          position="bottom"
+          toasts={request.errors.map(({ title }, index) => ({
+            id: `error-${request.timestamp}-${index}`,
+            message: title,
+            type: 'error'
+          }))}
+        />
+
+        <PaneHeader
+          paneTitle="New custom title"
+          firstMenu={historyState && historyState.eholdings && (
+            <PaneMenu>
+              <div data-test-eholdings-details-view-back-button>
+                <IconButton
+                  icon="left-arrow"
+                  ariaLabel="Go back"
+                  onClick={this.handleCancel}
+                />
+              </div>
+            </PaneMenu>
+          )}
+        />
+
+        <div className={styles['title-create-form-container']}>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <DetailsViewSection label="Title information" separator={false}>
+              <NameField />
+              <PublisherNameField />
+              <PublicationTypeField />
+              <DescriptionField />
+              <PeerReviewedField />
+            </DetailsViewSection>
+            <div className={styles['title-create-action-buttons']}>
+              <div data-test-eholdings-title-create-cancel-button>
+                <Button type="button" onClick={this.handleCancel}>
+                  Cancel
+                </Button>
+              </div>
+              <div data-test-eholdings-title-create-save-button>
+                <Button type="submit" buttonStyle="primary">
+                  Save
+                </Button>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <NavigationModal when={!pristine && !request.isResolved} />
+      </div>
+    );
+  }
+}
+
+const validate = (values) => {
+  return Object.assign(
+    {},
+    validateTitleName(values),
+    validatePublisherName(values),
+    validateDescription(values)
+  );
+};
+
+export default reduxForm({
+  validate,
+  enableReinitialize: true,
+  form: 'TitleCreate',
+  destroyOnUnmount: false
+})(TitleCreate);

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -12,6 +12,7 @@ import {
 import DetailsViewSection from '../../details-view-section';
 import NameField, { validate as validateTitleName } from '../_fields/name';
 import PublisherNameField, { validate as validatePublisherName } from '../_fields/publisher-name';
+import PackageSelectField, { validate as validatePackageSelection } from '../_fields/package-select';
 import DescriptionField, { validate as validateDescription } from '../_fields/description';
 import PublicationTypeField from '../_fields/publication-type';
 import PeerReviewedField from '../_fields/peer-reviewed';
@@ -22,6 +23,7 @@ import styles from './title-create.css';
 class TitleCreate extends Component {
   static propTypes = {
     request: PropTypes.object.isRequired,
+    customPackages: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool.isRequired
@@ -42,6 +44,7 @@ class TitleCreate extends Component {
   render() {
     let {
       request,
+      customPackages,
       handleSubmit,
       onSubmit,
       pristine
@@ -86,6 +89,7 @@ class TitleCreate extends Component {
               <PublisherNameField />
               <PublicationTypeField />
               <DescriptionField />
+              <PackageSelectField packages={customPackages} />
               <PeerReviewedField />
             </DetailsViewSection>
             <div className={styles['title-create-action-buttons']}>
@@ -114,7 +118,8 @@ const validate = (values) => {
     {},
     validateTitleName(values),
     validatePublisherName(values),
-    validateDescription(values)
+    validatePackageSelection(values),
+    validateDescription(values),
   );
 };
 

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -89,8 +89,10 @@ class TitleCreate extends Component {
               <PublisherNameField />
               <PublicationTypeField />
               <DescriptionField />
-              <PackageSelectField packages={customPackages} />
               <PeerReviewedField />
+            </DetailsViewSection>
+            <DetailsViewSection label="Package information">
+              <PackageSelectField packages={customPackages} />
             </DetailsViewSection>
             <div className={styles['title-create-action-buttons']}>
               <div data-test-eholdings-title-create-cancel-button>

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -15,6 +15,7 @@ import EditionField, { validate as validateEdition } from '../_fields/edition';
 import PublisherNameField, { validate as validatePublisherName } from '../_fields/publisher-name';
 import PackageSelectField, { validate as validatePackageSelection } from '../_fields/package-select';
 import ContributorField, { validate as validateContributor } from '../_fields/contributor';
+import IdentifiersFields, { validate as validateIdentifiers } from '../_fields/identifiers';
 import DescriptionField, { validate as validateDescription } from '../_fields/description';
 import PublicationTypeField from '../_fields/publication-type';
 import PeerReviewedField from '../_fields/peer-reviewed';
@@ -92,6 +93,7 @@ class TitleCreate extends Component {
               <EditionField />
               <PublisherNameField />
               <PublicationTypeField />
+              <IdentifiersFields />
               <DescriptionField />
               <PeerReviewedField />
             </DetailsViewSection>
@@ -125,6 +127,7 @@ const validate = (values) => {
     validateContributor(values),
     validateEdition(values),
     validatePublisherName(values),
+    validateIdentifiers(values),
     validateDescription(values),
     validatePackageSelection(values));
 };

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -61,6 +61,17 @@ export default function TitleShow({ model }, { queryParams, router }) {
 
   let toasts = processErrors(model);
 
+  // if coming from creating a new custom package, show a success toast
+  if (router.history.action === 'REPLACE' &&
+      router.history.location.state &&
+      router.history.location.state.isNewRecord) {
+    toasts.push({
+      id: `success-title-${model.id}`,
+      message: 'Custom title created.',
+      type: 'success'
+    });
+  }
+
   // if coming from saving edits to the package, show a success toast
   if (router.history.action === 'PUSH' &&
       router.history.location.state &&

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import PackageEdit from './routes/package-edit';
 import PackageCreate from './routes/package-create';
 import TitleShow from './routes/title-show';
 import TitleEdit from './routes/title-edit';
+import TitleCreate from './routes/title-create';
 import ResourceShow from './routes/resource-show';
 import ResourceEdit from './routes/resource-edit';
 
@@ -75,6 +76,7 @@ export default class EHoldings extends Component {
             <Route path={`${rootPath}/packages/new`} exact component={PackageCreate} />
             <Route path={`${rootPath}/packages/:packageId`} exact component={PackageShow} />
             <Route path={`${rootPath}/packages/:packageId/edit`} exact component={PackageEdit} />
+            <Route path={`${rootPath}/titles/new`} exact component={TitleCreate} />
             <Route path={`${rootPath}/titles/:titleId`} exact component={TitleShow} />
             <Route path={`${rootPath}/titles/:titleId/edit`} exact component={TitleEdit} />
             <Route path={`${rootPath}/resources/:id`} exact component={ResourceShow} />

--- a/src/redux/title.js
+++ b/src/redux/title.js
@@ -13,8 +13,27 @@ class Title {
   isPeerReviewed = false;
   description = '';
 
-  // only used for title creation
-  packageId = '';
+  // slightly customized serializer that adds included resources to
+  // new title record payloads
+  serialize() {
+    let data = { id: this.id, type: this.type };
+    let { resources, ...attributes } = this.data.attributes;
+    let payload = { data };
+
+    data.attributes = Object.keys(attributes).reduce((attrs, attr) => {
+      return Object.assign(attrs, { [attr]: this[attr] });
+    }, {});
+
+    // when serizing a new title we need to include any new resources
+    if (!this.id && resources) {
+      payload.included = resources.map((resource) => ({
+        type: 'resource',
+        attributes: resource
+      }));
+    }
+
+    return payload;
+  }
 }
 
 export default model({

--- a/src/redux/title.js
+++ b/src/redux/title.js
@@ -12,6 +12,9 @@ class Title {
   isTitleCustom = false;
   isPeerReviewed = false;
   description = '';
+
+  // only used for title creation
+  packageId = '';
 }
 
 export default model({

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -37,11 +37,45 @@ class TitleCreateRoute extends Component {
     }
   }
 
+  flattenedIdentifiers = [
+    { type: 'ISSN', subtype: 'Online' },
+    { type: 'ISSN', subtype: 'Print' },
+    { type: 'ISBN', subtype: 'Online' },
+    { type: 'ISBN', subtype: 'Print' }
+  ]
+
+  mergeIdentifiers = (identifiers) => {
+    return identifiers.map(({ id, type, subtype }) => {
+      let mergedTypeIndex = 0;
+
+      if (type && subtype) {
+        mergedTypeIndex = this.flattenedIdentifiers.filter(row =>
+          row.type === type && row.subtype === subtype);
+      }
+
+      return {
+        id,
+        flattenedType: mergedTypeIndex
+      };
+    });
+  }
+
+  expandIdentifiers = (identifiers) => {
+    return identifiers.map(({ id, flattenedType }) => {
+      let flattenedTypeIndex = flattenedType || 0;
+      return { id, ...this.flattenedIdentifiers[flattenedTypeIndex] };
+    });
+  }
+
   createTitle = (values) => {
     let { packageId, ...attrs } = values;
+
     // a resource is created along with the title
     attrs.resources = [{ packageId }];
-    this.props.createTitle(attrs);
+
+    this.props.createTitle(Object.assign(attrs, {
+      identifiers: this.expandIdentifiers(attrs.identifiers)
+    }));
   };
 
   render() {
@@ -62,6 +96,7 @@ class TitleCreateRoute extends Component {
           publicationType: 'Unspecified',
           isPeerReviewed: false,
           contributors: [],
+          identifiers: [],
           description: '',
           packageId: ''
         }}

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -57,9 +57,11 @@ class TitleCreateRoute extends Component {
         onSubmit={this.createTitle}
         initialValues={{
           name: '',
+          edition: '',
           publisherName: '',
           publicationType: 'Unspecified',
           isPeerReviewed: false,
+          contributors: [],
           description: '',
           packageId: ''
         }}

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { createResolver } from '../redux';
+import Title from '../redux/title';
+
+import View from '../components/title/create';
+
+class TitleCreateRoute extends Component {
+  static propTypes = {
+    createRequest: PropTypes.object.isRequired,
+    createTitle: PropTypes.func.isRequired
+  };
+
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        replace: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.createRequest.isResolved && this.props.createRequest.isResolved) {
+      this.context.router.history.replace(
+        `/eholdings/titles/${this.props.createRequest.records[0]}`,
+        { eholdings: true, isNewRecord: true }
+      );
+    }
+  }
+
+  render() {
+    return (
+      <View
+        request={this.props.createRequest}
+        onSubmit={this.props.createTitle}
+        initialValues={{
+          name: '',
+          publisherName: '',
+          publicationType: 'Unspecified',
+          isPeerReviewed: false,
+          description: '',
+        }}
+      />
+    );
+  }
+}
+
+export default connect(
+  ({ eholdings: { data } }) => ({
+    createRequest: createResolver(data).getRequest('create', { type: 'titles' })
+  }), {
+    createTitle: attrs => Title.create(attrs)
+  }
+)(TitleCreateRoute);

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -37,18 +37,24 @@ class TitleCreateRoute extends Component {
     }
   }
 
+  createTitle = (values) => {
+    let { packageId, ...attrs } = values;
+    // a resource is created along with the title
+    attrs.resources = [{ packageId }];
+    this.props.createTitle(attrs);
+  };
+
   render() {
     let {
       createRequest,
-      customPackages,
-      createTitle
+      customPackages
     } = this.props;
 
     return (
       <View
         request={createRequest}
         customPackages={customPackages}
-        onSubmit={createTitle}
+        onSubmit={this.createTitle}
         initialValues={{
           name: '',
           publisherName: '',

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -4,13 +4,16 @@ import { connect } from 'react-redux';
 
 import { createResolver } from '../redux';
 import Title from '../redux/title';
+import Package from '../redux/package';
 
 import View from '../components/title/create';
 
 class TitleCreateRoute extends Component {
   static propTypes = {
     createRequest: PropTypes.object.isRequired,
-    createTitle: PropTypes.func.isRequired
+    customPackages: PropTypes.object.isRequired,
+    createTitle: PropTypes.func.isRequired,
+    getCustomPackages: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -20,6 +23,10 @@ class TitleCreateRoute extends Component {
       }).isRequired
     }).isRequired
   };
+
+  componentDidMount() {
+    this.props.getCustomPackages();
+  }
 
   componentDidUpdate(prevProps) {
     if (!prevProps.createRequest.isResolved && this.props.createRequest.isResolved) {
@@ -31,16 +38,24 @@ class TitleCreateRoute extends Component {
   }
 
   render() {
+    let {
+      createRequest,
+      customPackages,
+      createTitle
+    } = this.props;
+
     return (
       <View
-        request={this.props.createRequest}
-        onSubmit={this.props.createTitle}
+        request={createRequest}
+        customPackages={customPackages}
+        onSubmit={createTitle}
         initialValues={{
           name: '',
           publisherName: '',
           publicationType: 'Unspecified',
           isPeerReviewed: false,
           description: '',
+          packageId: ''
         }}
       />
     );
@@ -48,9 +63,21 @@ class TitleCreateRoute extends Component {
 }
 
 export default connect(
-  ({ eholdings: { data } }) => ({
-    createRequest: createResolver(data).getRequest('create', { type: 'titles' })
-  }), {
-    createTitle: attrs => Title.create(attrs)
+  ({ eholdings: { data } }) => {
+    let resolver = createResolver(data);
+
+    return {
+      createRequest: resolver.getRequest('create', { type: 'titles' }),
+      customPackages: resolver.query('packages', {
+        filter: { custom: true },
+        count: 1000
+      })
+    };
+  }, {
+    createTitle: attrs => Title.create(attrs),
+    getCustomPackages: () => Package.query({
+      filter: { custom: true },
+      count: 1000
+    })
   }
 )(TitleCreateRoute);

--- a/tests/pages/title-create.js
+++ b/tests/pages/title-create.js
@@ -4,7 +4,8 @@ import {
   fillable,
   clickable,
   property,
-  value
+  value,
+  count
 } from '@bigtest/interactor';
 
 @interactor class TitleCreatePage {
@@ -19,6 +20,9 @@ import {
   publicationType = value('[data-test-eholdings-publication-type-field] select');
   hasDescription = isPresent('[data-test-eholdings-description-textarea]');
   fillDescription = fillable('[data-test-eholdings-description-textarea] textarea');
+  hasPackageSelect = isPresent('[data-test-eholdings-package-select-field]');
+  packagesCount = count('[data-test-eholdings-package-select-field] option:not(:disabled)');
+  selectPackage = fillable('[data-test-eholdings-package-select-field] select');
   hasPeerReviewed = isPresent('[data-test-eholdings-peer-reviewed-field]');
   togglePeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input');
   isPeerReviewed = property('[data-test-eholdings-peer-reviewed-field] input', 'checked');

--- a/tests/pages/title-create.js
+++ b/tests/pages/title-create.js
@@ -13,6 +13,17 @@ import {
 
   hasName = isPresent('[data-test-eholdings-title-name-field]');
   fillName = fillable('[data-test-eholdings-title-name-field] input');
+
+  hasContributorBtn = isPresent('[data-test-eholdings-contributor-fields-add-row-button]');
+  addContributor(type, name) {
+    return this
+      .click('[data-test-eholdings-contributor-fields-add-row-button] button')
+      .fill('[data-test-eholdings-contributor-type] select', type)
+      .fill('[data-test-eholdings-contributor-contributor] input', name);
+  }
+
+  hasEdition = isPresent('[data-test-eholdings-edition-field]');
+  fillEdition = fillable('[data-test-eholdings-edition-field] input');
   hasPublisher = isPresent('[data-test-eholdings-publisher-name-field]');
   fillPublisher = fillable('[data-test-eholdings-publisher-name-field] input');
   hasPublicationType = isPresent('[data-test-eholdings-publication-type-field]');

--- a/tests/pages/title-create.js
+++ b/tests/pages/title-create.js
@@ -29,6 +29,22 @@ import {
   hasPublicationType = isPresent('[data-test-eholdings-publication-type-field]');
   choosePublicationType = fillable('[data-test-eholdings-publication-type-field] select');
   publicationType = value('[data-test-eholdings-publication-type-field] select');
+
+  hasIdentifiersBtn = isPresent('[data-test-eholdings-identifiers-fields-add-row-button]');
+  addIdentifier(type, id) {
+    let values = {
+      'ISSN (Online)': '0',
+      'ISSN (Print)': '1',
+      'ISBN (Online)': '2',
+      'ISBN (Print)': '3'
+    };
+
+    return this
+      .click('[data-test-eholdings-identifiers-fields-add-row-button] button')
+      .fill('[data-test-eholdings-identifiers-fields-type] select', values[type])
+      .fill('[data-test-eholdings-identifiers-fields-id] input', id);
+  }
+
   hasDescription = isPresent('[data-test-eholdings-description-textarea]');
   fillDescription = fillable('[data-test-eholdings-description-textarea] textarea');
   hasPackageSelect = isPresent('[data-test-eholdings-package-select-field]');

--- a/tests/pages/title-create.js
+++ b/tests/pages/title-create.js
@@ -1,0 +1,29 @@
+import {
+  interactor,
+  isPresent,
+  fillable,
+  clickable,
+  property,
+  value
+} from '@bigtest/interactor';
+
+@interactor class TitleCreatePage {
+  static defaultScope = '[data-test-eholdings-title-create]';
+
+  hasName = isPresent('[data-test-eholdings-title-name-field]');
+  fillName = fillable('[data-test-eholdings-title-name-field] input');
+  hasPublisher = isPresent('[data-test-eholdings-publisher-name-field]');
+  fillPublisher = fillable('[data-test-eholdings-publisher-name-field] input');
+  hasPublicationType = isPresent('[data-test-eholdings-publication-type-field]');
+  choosePublicationType = fillable('[data-test-eholdings-publication-type-field] select');
+  publicationType = value('[data-test-eholdings-publication-type-field] select');
+  hasDescription = isPresent('[data-test-eholdings-description-textarea]');
+  fillDescription = fillable('[data-test-eholdings-description-textarea] textarea');
+  hasPeerReviewed = isPresent('[data-test-eholdings-peer-reviewed-field]');
+  togglePeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input');
+  isPeerReviewed = property('[data-test-eholdings-peer-reviewed-field] input', 'checked');
+  save = clickable('[data-test-eholdings-title-create-save-button] button');
+  cancel = clickable('[data-test-eholdings-title-create-cancel-button] button');
+}
+
+export default new TitleCreatePage();

--- a/tests/title-create-test.js
+++ b/tests/title-create-test.js
@@ -1,0 +1,155 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import TitleCreatePage from './pages/title-create';
+import TitleShowPage from './pages/title-show';
+import NavigationModal from './pages/navigation-modal';
+
+describeApplication('TitleCreate', () => {
+  beforeEach(function () {
+    return this.visit('/eholdings/titles/new', () => {
+      expect(TitleCreatePage.$root).to.exist;
+    });
+  });
+
+  it('has a title name field', () => {
+    expect(TitleCreatePage.hasName).to.be.true;
+  });
+
+  it('has a publisher name field', () => {
+    expect(TitleCreatePage.hasPublisher).to.be.true;
+  });
+
+  it('has a publication type field', () => {
+    expect(TitleCreatePage.hasPublicationType).to.be.true;
+    expect(TitleCreatePage.publicationType).to.equal('Unspecified');
+  });
+
+  it('has a description field', () => {
+    expect(TitleCreatePage.hasDescription).to.be.true;
+  });
+
+  it('has a peer reviewed toggle', () => {
+    expect(TitleCreatePage.hasPeerReviewed).to.be.true;
+    expect(TitleCreatePage.isPeerReviewed).to.be.false;
+  });
+
+  describe('creating a new title', () => {
+    beforeEach(() => {
+      return TitleCreatePage
+        .fillName('My Title')
+        .save();
+    });
+
+    it('redirects to the new title show page', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+      expect(TitleShowPage.titleName).to.equal('My Title');
+    });
+
+    it('shows a success toast message', () => {
+      expect(TitleShowPage.toast.successText).to.equal('Custom title created.');
+    });
+  });
+
+  describe('creating a new title with a publisher', () => {
+    beforeEach(() => {
+      return TitleCreatePage
+        .fillName('My Title')
+        .fillPublisher('Me')
+        .save();
+    });
+
+    it('redirects to the new title show page with the specified publisher', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+      expect(TitleShowPage.publisherName).to.equal('Me');
+    });
+  });
+
+  describe('creating a new title with a specified publication type', () => {
+    beforeEach(() => {
+      return TitleCreatePage
+        .fillName('My Title')
+        .choosePublicationType('Book')
+        .save();
+    });
+
+    it('redirects to the new package with the specified content type', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+      expect(TitleShowPage.publicationType).to.equal('Book');
+    });
+  });
+
+  describe('creating a new title with a description', () => {
+    beforeEach(() => {
+      return TitleCreatePage
+        .fillName('My Title')
+        .fillDescription('This is my title')
+        .save();
+    });
+
+    it('redirects to the new package with the specified description', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+      expect(TitleShowPage.descriptionText).to.equal('This is my title');
+    });
+  });
+
+  describe('creating a new title and specifying peer reviewed status', () => {
+    beforeEach(() => {
+      return TitleCreatePage
+        .fillName('My Title')
+        .fillPublisher('Me')
+        .togglePeerReviewed()
+        .save();
+    });
+
+    it('redirects to the new package with the specified content type', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+      expect(TitleShowPage.peerReviewedStatus).to.equal('Yes');
+    });
+  });
+
+  describe('clicking cancel', () => {
+    beforeEach(() => {
+      return TitleCreatePage.cancel();
+    });
+
+    it('redirects to the previous page', function () {
+      expect(this.app.history.location.pathname).to.not.equal('/eholdings/titles/new');
+    });
+  });
+
+  describe('clicking cancel after filling in data', () => {
+    beforeEach(() => {
+      return TitleCreatePage
+        .fillName('My Title')
+        .cancel();
+    });
+
+    it('shows a navigations confirmation modal', () => {
+      expect(NavigationModal.$root).to.exist;
+    });
+  });
+
+  describe('getting an error when creating a new title', () => {
+    beforeEach(function () {
+      this.server.post('/titles', {
+        errors: [{
+          title: 'There was an error'
+        }]
+      }, 500);
+
+      return TitleCreatePage
+        .fillName('My Title')
+        .save();
+    });
+
+    it.always('does not create the title', function () {
+      expect(this.app.history.location.pathname).to.equal('/eholdings/titles/new');
+    });
+
+    it('shows an error toast message', () => {
+      expect(TitleShowPage.toast.errorText).to.equal('There was an error');
+    });
+  });
+});

--- a/tests/title-create-test.js
+++ b/tests/title-create-test.js
@@ -25,6 +25,14 @@ describeApplication('TitleCreate', () => {
     expect(TitleCreatePage.hasName).to.be.true;
   });
 
+  it('has an add contributor button', () => {
+    expect(TitleCreatePage.hasContributorBtn).to.be.true;
+  });
+
+  it('has an edition field', () => {
+    expect(TitleCreatePage.hasEdition).to.be.true;
+  });
+
   it('has a publisher name field', () => {
     expect(TitleCreatePage.hasPublisher).to.be.true;
   });
@@ -64,6 +72,36 @@ describeApplication('TitleCreate', () => {
 
     it('shows a success toast message', () => {
       expect(TitleShowPage.toast.successText).to.equal('Custom title created.');
+    });
+  });
+
+  describe('creating a new title with a contributor', () => {
+    beforeEach(() => {
+      return TitleCreatePage
+        .fillName('My Title')
+        .addContributor('author', 'Me')
+        .selectPackage(packages[0].id)
+        .save();
+    });
+
+    it('redirects to the new title show page with the specified contributor', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+      expect(TitleShowPage.contributorsList(0).text).to.equal('AuthorMe');
+    });
+  });
+
+  describe('creating a new title with an edition', () => {
+    beforeEach(() => {
+      return TitleCreatePage
+        .fillName('My Title')
+        .fillEdition('My Edition')
+        .selectPackage(packages[0].id)
+        .save();
+    });
+
+    it('redirects to the new title show page with the specified edition', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+      expect(TitleShowPage.edition).to.equal('My Edition');
     });
   });
 

--- a/tests/title-create-test.js
+++ b/tests/title-create-test.js
@@ -7,7 +7,15 @@ import TitleShowPage from './pages/title-show';
 import NavigationModal from './pages/navigation-modal';
 
 describeApplication('TitleCreate', () => {
+  let packages;
+
   beforeEach(function () {
+    packages = this.server.createList('package', 2, {
+      name: i => `Custom Package ${i + 1}`,
+      provider: this.server.create('provider'),
+      isCustom: true
+    });
+
     return this.visit('/eholdings/titles/new', () => {
       expect(TitleCreatePage.$root).to.exist;
     });
@@ -30,6 +38,11 @@ describeApplication('TitleCreate', () => {
     expect(TitleCreatePage.hasDescription).to.be.true;
   });
 
+  it('has a package select field', () => {
+    expect(TitleCreatePage.hasPackageSelect).to.be.true;
+    expect(TitleCreatePage.packagesCount).to.equal(2);
+  });
+
   it('has a peer reviewed toggle', () => {
     expect(TitleCreatePage.hasPeerReviewed).to.be.true;
     expect(TitleCreatePage.isPeerReviewed).to.be.false;
@@ -39,12 +52,14 @@ describeApplication('TitleCreate', () => {
     beforeEach(() => {
       return TitleCreatePage
         .fillName('My Title')
+        .selectPackage(packages[0].id)
         .save();
     });
 
     it('redirects to the new title show page', function () {
       expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
       expect(TitleShowPage.titleName).to.equal('My Title');
+      expect(TitleShowPage.packageList(0).name).to.equal('Custom Package 1');
     });
 
     it('shows a success toast message', () => {
@@ -57,6 +72,7 @@ describeApplication('TitleCreate', () => {
       return TitleCreatePage
         .fillName('My Title')
         .fillPublisher('Me')
+        .selectPackage(packages[0].id)
         .save();
     });
 
@@ -71,6 +87,7 @@ describeApplication('TitleCreate', () => {
       return TitleCreatePage
         .fillName('My Title')
         .choosePublicationType('Book')
+        .selectPackage(packages[0].id)
         .save();
     });
 
@@ -85,6 +102,7 @@ describeApplication('TitleCreate', () => {
       return TitleCreatePage
         .fillName('My Title')
         .fillDescription('This is my title')
+        .selectPackage(packages[0].id)
         .save();
     });
 
@@ -94,12 +112,27 @@ describeApplication('TitleCreate', () => {
     });
   });
 
+  describe('creating a new title with a different package', () => {
+    beforeEach(() => {
+      return TitleCreatePage
+        .fillName('My Title')
+        .selectPackage(packages[1].id)
+        .save();
+    });
+
+    it('redirects to the new package with the specified package', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+      expect(TitleShowPage.packageList(0).name).to.equal('Custom Package 2');
+    });
+  });
+
   describe('creating a new title and specifying peer reviewed status', () => {
     beforeEach(() => {
       return TitleCreatePage
         .fillName('My Title')
         .fillPublisher('Me')
         .togglePeerReviewed()
+        .selectPackage(packages[0].id)
         .save();
     });
 
@@ -141,6 +174,7 @@ describeApplication('TitleCreate', () => {
 
       return TitleCreatePage
         .fillName('My Title')
+        .selectPackage(packages[0].id)
         .save();
     });
 

--- a/tests/title-create-test.js
+++ b/tests/title-create-test.js
@@ -42,6 +42,10 @@ describeApplication('TitleCreate', () => {
     expect(TitleCreatePage.publicationType).to.equal('Unspecified');
   });
 
+  it('has an add identifier button', () => {
+    expect(TitleCreatePage.hasIdentifiersBtn).to.be.true;
+  });
+
   it('has a description field', () => {
     expect(TitleCreatePage.hasDescription).to.be.true;
   });
@@ -132,6 +136,21 @@ describeApplication('TitleCreate', () => {
     it('redirects to the new package with the specified content type', function () {
       expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
       expect(TitleShowPage.publicationType).to.equal('Book');
+    });
+  });
+
+  describe('creating a new title with an identifier', () => {
+    beforeEach(() => {
+      return TitleCreatePage
+        .fillName('My Title')
+        .addIdentifier('ISBN (Print)', '90210')
+        .selectPackage(packages[0].id)
+        .save();
+    });
+
+    it('redirects to the new title show page with the specified identifier', function () {
+      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+      expect(TitleShowPage.identifiersList(0).text).to.equal('ISBN (Print)90210');
     });
   });
 


### PR DESCRIPTION
## Purpose

[UIEH-304](https://issues.folio.org/browse/UIEH-304) 

There should be a route where we can create custom titles just like the custom package creation route.

## Approach

The custom title creation route is `/eholdings/titles/new`. It includes a navigation modal that appears when attempting to navigate away with unsaved changes, and an error toast when a server error is encountered. When the custom title is successfully created, the title show page for the new title is shown with a success toast.

The existing fields that can be found when editing a custom title were included in the creation form. Additionally, a package select field was added. This field requires us to get a list of custom packages when the route component is mounted. For now, we can develop and iterate on this page using mirage, but the backend will need support for querying packages matching `filter[custom]=true`.

Two important things to note:

- Custom packages can possibly be paginated. For now, I've set the page size to 1000. But a more future-proof implementation might include a type-ahead field.

- In order to pass the `packageId` with a title, the title's model needs to specify it as an attribute. We can either leave this as is, alter the data-layer to allow non-attributes, or create another model representing a new custom title.

## Screenshots
![title-create](https://user-images.githubusercontent.com/5005153/39452285-50174cec-4c97-11e8-8699-30d7fe74d3d5.gif)
