### PR TITLE
UIEH-256 Edit identifiers on a custom title

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -279,7 +279,8 @@ export default function configure() {
       url,
       description,
       isPeerReviewed,
-      edition
+      edition,
+      identifiers
     } = body.data.attributes;
 
     matchingResource.update('isSelected', isSelected);
@@ -295,6 +296,8 @@ export default function configure() {
     matchingResource.update('url', url);
     matchingResource.title.update('publicationType', publicationType);
     matchingResource.title.update('publisherName', publisherName);
+    matchingResource.title.update('edition', edition);
+    matchingResource.title.update('identifiers', identifiers);
 
     return matchingResource;
   });

--- a/src/components/title/_fields/contributor/contributor-field.css
+++ b/src/components/title/_fields/contributor/contributor-field.css
@@ -1,11 +1,9 @@
 @import '@folio/stripes-components/lib/variables';
 
 .contributor-fields {
+  margin: 1em 0;
   max-width: 50em;
-
-  & fieldset {
-    padding: 0;
-  }
+  padding: 0;
 
   & legend {
     margin-bottom: 0.5em;

--- a/src/components/title/_fields/contributor/contributor-field.js
+++ b/src/components/title/_fields/contributor/contributor-field.js
@@ -24,63 +24,61 @@ class ContributorField extends Component {
     function renderFields() {
       return (
         <ul className={styles['contributor-fields-rows']}>
-          <fieldset>
-            <legend>Contributors</legend>
-            {fields.map((contributor, index, allFields) => (
-              <li
-                className={styles['contributor-fields-row']}
-                key={index}
+          {fields.map((contributor, index, allFields) => (
+            <li
+              className={styles['contributor-fields-row']}
+              key={index}
+            >
+              <div
+                data-test-eholdings-contributor-type
+                className={styles['contributor-fields-contributor']}
               >
-                <div
-                  data-test-eholdings-contributor-type
-                  className={styles['contributor-fields-contributor']}
-                >
-                  <Field
-                    name={`${contributor}.type`}
-                    component={Select}
-                    autoFocus={Object.keys(allFields.get(index)).length === 0}
-                    label="Type"
-                    id={`${contributor}-type`}
-                    dataOptions={[
-                      { value: 'author', label: 'Author' },
-                      { value: 'editor', label: 'Editor' },
-                      { value: 'illustrator', label: 'Illustrator' }
-                    ]}
-                  />
-                </div>
-                <div
-                  data-test-eholdings-contributor-contributor
-                  className={styles['contributor-fields-contributor']}
-                >
-                  <Field
-                    name={`${contributor}.contributor`}
-                    type="text"
-                    id={`${contributor}-input`}
-                    component={TextField}
-                    label="Name"
-                  />
-                </div>
+                <Field
+                  name={`${contributor}.type`}
+                  component={Select}
+                  autoFocus={Object.keys(allFields.get(index)).length === 0}
+                  label="Type"
+                  id={`${contributor}-type`}
+                  dataOptions={[
+                    { value: 'author', label: 'Author' },
+                    { value: 'editor', label: 'Editor' },
+                    { value: 'illustrator', label: 'Illustrator' }
+                  ]}
+                />
+              </div>
+              <div
+                data-test-eholdings-contributor-contributor
+                className={styles['contributor-fields-contributor']}
+              >
+                <Field
+                  name={`${contributor}.contributor`}
+                  type="text"
+                  id={`${contributor}-input`}
+                  component={TextField}
+                  label="Name"
+                />
+              </div>
 
-                <div
-                  data-test-eholdings-contributor-fields-remove-row-button
-                  className={styles['contributor-fields-clear-row']}
-                >
-                  <IconButton
-                    icon="hollowX"
-                    aria-label={`Remove ${allFields.get(index).contributor}`}
-                    onClick={() => fields.remove(index)}
-                    size="small"
-                  />
-                </div>
-              </li>
-            ))}
-          </fieldset>
+              <div
+                data-test-eholdings-contributor-fields-remove-row-button
+                className={styles['contributor-fields-clear-row']}
+              >
+                <IconButton
+                  icon="hollowX"
+                  aria-label={`Remove ${allFields.get(index).contributor}`}
+                  onClick={() => fields.remove(index)}
+                  size="small"
+                />
+              </div>
+            </li>
+          ))}
         </ul>
       );
     }
 
     return (
-      <div className={styles['contributor-fields']}>
+      <fieldset className={styles['contributor-fields']}>
+        <legend>Contributors</legend>
         {fields.length === 0
           && initialValue.length > 0
           && initialValue[0].id
@@ -100,7 +98,7 @@ class ContributorField extends Component {
             + Add a contributor
           </Button>
         </div>
-      </div>
+      </fieldset>
     );
   };
 

--- a/src/components/title/_fields/identifiers/identifiers-fields.css
+++ b/src/components/title/_fields/identifiers/identifiers-fields.css
@@ -1,0 +1,37 @@
+@import '@folio/stripes-components/lib/variables';
+
+.identifiers-fields {
+  margin: 1em 0;
+  max-width: 50em;
+  padding: 0;
+
+  & legend {
+    margin-bottom: 1em;
+  }
+}
+
+.identifiers-fields-rows {
+  list-style-type: none;
+  padding: 0;
+}
+
+.identifiers-fields-row {
+  display: flex;
+  align-items: flex-start;
+}
+
+.identifiers-fields-field {
+  align-self: flex-start;
+  flex: 1 1 200px;
+  margin-right: 1em;
+}
+
+.identifiers-fields-clear-row {
+  flex: 0 0 3em;
+  margin-top: 2.25em;
+  text-align: center;
+
+  @media (--mediumUp) {
+    margin-top: 1.5em;
+  }
+}

--- a/src/components/title/_fields/identifiers/identifiers-fields.js
+++ b/src/components/title/_fields/identifiers/identifiers-fields.js
@@ -1,0 +1,133 @@
+import React, { Component } from 'react';
+import { Field, FieldArray } from 'redux-form';
+import PropTypes from 'prop-types';
+
+import {
+  Button,
+  IconButton,
+  Select,
+  TextField
+} from '@folio/stripes-components';
+
+import styles from './identifiers-fields.css';
+
+export default class IdentifiersFields extends Component {
+  static propTypes = {
+    initialValue: PropTypes.array
+  };
+
+  static defaultProps = {
+    initialValue: []
+  };
+
+  renderIdentifierFields = ({ fields }) => {
+    let { initialValue } = this.props;
+
+    return (
+      <fieldset className={styles['identifiers-fields']}>
+        <legend>Identifiers</legend>
+
+        {fields.length === 0
+          && initialValue.length > 0
+          && initialValue[0].id
+          && (
+          <p data-test-eholdings-identifiers-fields-saving-will-remove>
+            No identifiers set. Saving will remove any previously set.
+          </p>
+        )}
+
+        {fields.length > 0 && (
+          <ul className={styles['identifiers-fields-rows']}>
+            {fields.map((identifier, index, allFields) => (
+              <li
+                data-test-eholdings-identifiers-fields-row
+                key={index}
+                className={styles['identifiers-fields-row']}
+              >
+                <div
+                  data-test-eholdings-identifiers-fields-type
+                  className={styles['identifiers-fields-field']}
+                >
+                  <Field
+                    name={`${identifier}.flattenedType`}
+                    type="text"
+                    component={Select}
+                    autoFocus={Object.keys(allFields.get(index)).length === 0}
+                    label="Type"
+                    dataOptions={[
+                      { value: '0', label: 'ISSN (Online)' },
+                      { value: '1', label: 'ISSN (Print)' },
+                      { value: '2', label: 'ISBN (Online)' },
+                      { value: '3', label: 'ISBN (Print)' }
+                    ]}
+                  />
+                </div>
+                <div
+                  data-test-eholdings-identifiers-fields-id
+                  className={styles['identifiers-fields-field']}
+                >
+                  <Field
+                    name={`${identifier}.id`}
+                    type="text"
+                    component={TextField}
+                    label="ID"
+                  />
+                </div>
+
+                <div
+                  data-test-eholdings-identifiers-fields-remove-row-button
+                  className={styles['identifiers-fields-clear-row']}
+                >
+                  <IconButton
+                    icon="hollowX"
+                    ariaLabel={`Remove ${allFields.get(index).id}`}
+                    onClick={() => fields.remove(index)}
+                    size="small"
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div
+          className={styles['identifiers-fields-add-row-button']}
+          data-test-eholdings-identifiers-fields-add-row-button
+        >
+          <Button
+            type="button"
+            onClick={() => fields.push({})}
+          >
+            + Add identifier
+          </Button>
+        </div>
+      </fieldset>
+    );
+  };
+
+  render() {
+    return (
+      <FieldArray name="identifiers" component={this.renderIdentifierFields} />
+    );
+  }
+}
+
+export function validate(values) {
+  let errors = [];
+
+  values.identifiers.forEach((identifier, index) => {
+    let identifierErrors = {};
+
+    if (!identifier.id) {
+      identifierErrors.id = 'ID cannot be blank.';
+    }
+
+    if (identifier.id && identifier.id.length >= 20) {
+      identifierErrors.id = 'Must be less than 20 characters.';
+    }
+
+    errors[index] = identifierErrors;
+  });
+
+  return { identifiers: errors };
+}

--- a/src/components/title/_fields/identifiers/index.js
+++ b/src/components/title/_fields/identifiers/index.js
@@ -1,0 +1,1 @@
+export { default, validate } from './identifiers-fields';

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -13,6 +13,7 @@ import NameField, { validate as validateName } from '../_fields/name';
 import EditionField, { validate as validateEdition } from '../_fields/edition';
 import PublisherNameField, { validate as validatePublisher } from '../_fields/publisher-name';
 import PublicationTypeField from '../_fields/publication-type';
+import IdentifiersFields, { validate as validateIdentifiers } from '../_fields/identifiers';
 import DescriptionField, { validate as validateDescription } from '../_fields/description';
 import ContributorField, { validate as validateContributor } from '../_fields/contributor';
 import PeerReviewedField from '../_fields/peer-reviewed';
@@ -123,12 +124,19 @@ class TitleEdit extends Component {
                 label="Title information"
               >
                 <NameField />
-                <EditionField />
-                <PublisherNameField />
-                <PublicationTypeField />
+
                 <ContributorField
                   initialValue={initialValues.contributors}
                 />
+
+                <EditionField />
+                <PublisherNameField />
+                <PublicationTypeField />
+
+                <IdentifiersFields
+                  initialValue={initialValues.identifiers}
+                />
+
                 <DescriptionField />
                 <PeerReviewedField />
               </DetailsViewSection>
@@ -171,9 +179,10 @@ class TitleEdit extends Component {
 const validate = (values) => {
   return Object.assign({},
     validateName(values),
+    validateContributor(values),
     validateEdition(values),
     validatePublisher(values),
-    validateContributor(values),
+    validateIdentifiers(values),
     validateDescription(values));
 };
 

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -59,9 +59,22 @@ export default function TitleShow({ model }, { queryParams, router }) {
     );
   }
 
+  let toasts = processErrors(model);
+
+  // if coming from saving edits to the package, show a success toast
+  if (router.history.action === 'PUSH' &&
+      router.history.location.state &&
+      router.history.location.state.isFreshlySaved) {
+    toasts.push({
+      id: `success-title-saved-${model.id}`,
+      message: 'Title saved.',
+      type: 'success'
+    });
+  }
+
   return (
     <div>
-      <Toaster toasts={processErrors(model)} position="bottom" />
+      <Toaster toasts={toasts} position="bottom" />
 
       <DetailsView
         type="title"

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -53,10 +53,43 @@ class TitleShowRoute extends Component {
     }
   }
 
+  flattenedIdentifiers = [
+    { type: 'ISSN', subtype: 'Online' },
+    { type: 'ISSN', subtype: 'Print' },
+    { type: 'ISBN', subtype: 'Online' },
+    { type: 'ISBN', subtype: 'Print' }
+  ]
+
+  mergeIdentifiers = (identifiers) => {
+    return identifiers.map(({ id, type, subtype }) => {
+      let mergedTypeIndex = 0;
+
+      if (type && subtype) {
+        mergedTypeIndex = this.flattenedIdentifiers.filter(row =>
+          row.type === type && row.subtype === subtype);
+      }
+
+      return {
+        id,
+        flattenedType: mergedTypeIndex
+      };
+    });
+  }
+
+  expandIdentifiers = (identifiers) => {
+    return identifiers.map(({ id, flattenedType }) => {
+      let flattenedTypeIndex = flattenedType || 0;
+      return { id, ...this.flattenedIdentifiers[flattenedTypeIndex] };
+    });
+  }
+
   titleEditSubmitted = (values) => {
     let { model, updateResource } = this.props;
     let resource = model.resources.records[0];
-    updateResource(Object.assign(resource, values));
+    updateResource(Object.assign(resource, {
+      ...values,
+      identifiers: this.expandIdentifiers(values.identifiers)
+    }));
   }
 
   render() {
@@ -77,7 +110,8 @@ class TitleShowRoute extends Component {
           publicationType: model.publicationType,
           publisherName: model.publisherName,
           description: model.description,
-          contributors: model.contributors
+          contributors: model.contributors,
+          identifiers: this.mergeIdentifiers(model.identifiers)
         }}
       />
     );

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -48,7 +48,7 @@ class TitleShowRoute extends Component {
     if (!prevProps.updateRequest.isResolved && this.props.updateRequest.isResolved) {
       this.context.router.history.push(
         `/eholdings/titles/${this.props.model.id}`,
-        { eholdings: true }
+        { eholdings: true, isFreshlySaved: true }
       );
     }
   }

--- a/tests/custom-title-edit-test.js
+++ b/tests/custom-title-edit-test.js
@@ -131,6 +131,8 @@ describeApplication('CustomTitleEdit', () => {
             I believe talent is just a pursued interest. Anybody can do what I do.
             We'll put some happy little leaves here and there. Go out on a limb - that's where the fruit is.
             God gave you this gift of imagination. Use it.`)
+          .clickAddIdentifiersRowButton()
+          .identifiersRowList(0).id('00000-00000-00000-00000') // eslint-disable-line newline-per-chained-call
           .fillDescription(`Trees cover up a multitude of sins. If you don't think every day is a good day - try missing a few. You'll see. Put light against light - you have nothing. Put dark against dark - you have nothing. It's the contrast of light and dark that each give the other one meaning. Water's like me. It's laaazy. Boy, it always looks for the easiest way to do things We might as well make some Almighty mountains today as well, what the heck.
             You have to make these big decisions. Just take out whatever you don't want. It'll change your entire perspective. We artists are a different breed of people. We're a happy bunch.
             All you need to paint is a few tools, a little instruction, and a vision in your mind. Exercising the imagination, experimenting with talents, being creative; these things, to me, are truly the windows to your soul. I guess that would be considered a UFO. A big cotton ball in the sky.
@@ -150,6 +152,10 @@ describeApplication('CustomTitleEdit', () => {
       it('displays a validation error for contributor', () => {
         expect(TitleEditPage.contributorHasError).to.be.true;
         expect(TitleEditPage.contributorError).to.equal('You must provide a contributor');
+      });
+
+      it('displays a validation error for the first identifier id', () => {
+        expect(TitleEditPage.identifiersRowList(0).idHasError).to.be.true;
       });
 
       it('displays a validation error for the publisher field', () => {
@@ -179,6 +185,8 @@ describeApplication('CustomTitleEdit', () => {
           .fillPublisher('Not So Awesome Publisher')
           .fillContributor('Awesome Author')
           .selectContributorType('Editor')
+          .clickAddIdentifiersRowButton()
+          .identifiersRowList(0).id('1111') // eslint-disable-line newline-per-chained-call
           .fillDescription('What a super helpful description. Wow.')
           .checkPeerReviewed();
       });
@@ -214,6 +222,10 @@ describeApplication('CustomTitleEdit', () => {
           expect(TitleShowPage.contributorsList(0).text).to.equal('Awesome Author');
         });
 
+        it('shows the new ISSN', () => {
+          expect(TitleShowPage.identifiersList(0).text).to.equal('ISSN (Online)1111');
+        });
+
         it('shows the new description', () => {
           expect(TitleShowPage.descriptionText).to.equal('What a super helpful description. Wow.');
         });
@@ -221,93 +233,9 @@ describeApplication('CustomTitleEdit', () => {
         it('shows YES for peer reviewed', () => {
           expect(TitleShowPage.peerReviewedStatus).to.equal('Yes');
         });
-      });
-    });
-  });
 
-  describe('visiting the title edit page', () => {
-    beforeEach(function () {
-      return this.visit(`/eholdings/titles/${title.id}/edit`, () => {
-        expect(TitleEditPage.$root).to.exist;
-      });
-    });
-
-    it('disables the save button', () => {
-      expect(TitleEditPage.isSaveDisabled).to.be.true;
-    });
-
-    it('shows unchecked peer review box', () => {
-      expect(TitleEditPage.isPeerReviewed).to.be.false;
-    });
-
-    describe('clicking cancel', () => {
-      beforeEach(() => {
-        return TitleEditPage.clickCancel();
-      });
-
-      it('goes to the title show page', () => {
-        expect(TitleShowPage.$root).to.exist;
-      });
-
-      it('shows NO for peer reviewed', () => {
-        expect(TitleShowPage.peerReviewedStatus).to.equal('No');
-      });
-    });
-
-    describe('entering invalid data', () => {
-      beforeEach(() => {
-        return TitleEditPage
-          .name('')
-          .clickSave();
-      });
-
-      it('displays a validation error for the name', () => {
-        expect(TitleEditPage.nameHasError).to.be.true;
-      });
-    });
-
-    describe('entering valid data', () => {
-      beforeEach(() => {
-        return TitleEditPage
-          .name('A Different Name')
-          .fillEdition('A Different Edition')
-          .selectPublicationType('Web Site')
-          .checkPeerReviewed();
-      });
-
-      describe('clicking cancel', () => {
-        beforeEach(() => {
-          return TitleEditPage.clickCancel();
-        });
-
-        it('shows a navigation confirmation modal', () => {
-          expect(TitleEditPage.navigationModal.$root).to.exist;
-        });
-      });
-
-      describe('clicking save', () => {
-        beforeEach(() => {
-          return TitleEditPage.clickSave();
-        });
-
-        it('goes to the title show page', () => {
-          expect(TitleShowPage.$root).to.exist;
-        });
-
-        it('reflects the new name', () => {
-          expect(TitleShowPage.titleName).to.equal('A Different Name');
-        });
-
-        it('shows the new edition', () => {
-          expect(TitleEditPage.editionValue).to.equal('A Different Edition');
-        });
-
-        it('shows the new publication type', () => {
-          expect(TitleEditPage.publicationTypeValue).to.equal('Web Site');
-        });
-
-        it('shows YES for peer reviewed', () => {
-          expect(TitleShowPage.peerReviewedStatus).to.equal('Yes');
+        it('shows a success toast message', () => {
+          expect(TitleShowPage.toast.successText).to.equal('Title saved.');
         });
       });
     });

--- a/tests/pages/title-edit.js
+++ b/tests/pages/title-edit.js
@@ -1,12 +1,12 @@
 import {
   clickable,
+  collection,
   fillable,
   isPresent,
   interactor,
   property,
   value,
-  text,
-  collection
+  text
 } from '@bigtest/interactor';
 import { hasClassBeginningWith } from './helpers';
 import Toast from './toast';
@@ -55,6 +55,14 @@ import Toast from './toast';
     remove: clickable('button')
   });
   contributorsWillBeRemoved = text('[data-test-eholdings-contributors-fields-saving-will-remove]');
+
+  clickAddIdentifiersRowButton = clickable('[data-test-eholdings-identifiers-fields-add-row-button] button');
+  identifiersRowList = collection('[data-test-eholdings-identifiers-fields-row]', {
+    type: fillable('[data-test-eholdings-identifiers-fields-type] select'),
+    id: fillable('[data-test-eholdings-identifiers-fields-id] input'),
+    idHasError: hasClassBeginningWith('[data-test-eholdings-identifiers-fields-id] input', 'feedbackError--'),
+    clickRemoveRowButton: clickable('[data-test-eholdings-identifiers-fields-remove-row-button] button')
+  });
 }
 
 export default new TitleEditPage('[data-test-eholdings-details-view="title"]');


### PR DESCRIPTION
## Purpose
Users should be able to edit the identifiers of a custom title.

Finishes https://issues.folio.org/browse/UIEH-256.

## Approach
The server wants separate type and subtype fields; we merge them into one for the UI.

The UI implementation leans heavily on `redux-form`'s `FieldArray`, like we've previously done with custom coverage dates.

## Screenshots
![2018-04-30 21 50 54](https://user-images.githubusercontent.com/230597/39459426-0d495b06-4cc1-11e8-9374-25c46f2665b2.gif)
