### PR TITLE
UIEH-344, UIEH-345: Adds a null check to package-show success toast logic

### DIFF
--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -125,6 +125,7 @@ export default class PackageShow extends Component {
 
     // if coming from creating a new custom package, show a success toast
     if (router.history.action === 'REPLACE' &&
+        router.history.location.state &&
         router.history.location.state.isNewRecord) {
       toasts.push({
         id: `success-package-creation-${model.id}`,


### PR DESCRIPTION
In some flows the package-show component would get into a bad state and throw an error, interrupting the user with a white error screen. This PR adds a simple null check to avoid ever hitting that state.

Resolves [UIEH-344](https://issues.folio.org/browse/UIEH-344) and [UIEH-345](https://issues.folio.org/browse/UIEH-345)

## Screenshots
Error Screen: 

![image](https://user-images.githubusercontent.com/15052791/39481747-13754870-4d32-11e8-8e6b-1e4b97cc105c.png)


