### PR TITLE
UIEH-253 - Add edition field to custom title edit page

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -278,7 +278,8 @@ export default function configure() {
       name,
       url,
       description,
-      isPeerReviewed
+      isPeerReviewed,
+      edition
     } = body.data.attributes;
 
     matchingResource.update('isSelected', isSelected);
@@ -287,6 +288,7 @@ export default function configure() {
     matchingResource.update('customEmbargoPeriod', customEmbargoPeriod);
     matchingResource.update('coverageStatement', coverageStatement);
     matchingResource.title.update('isPeerReviewed', isPeerReviewed);
+    matchingResource.title.update('edition', edition);
     matchingResource.title.update('description', description);
     matchingResource.title.update('name', name);
     matchingResource.update('url', url);

--- a/mirage/factories/title.js
+++ b/mirage/factories/title.js
@@ -25,6 +25,7 @@ export default Factory.extend({
   identifiers: () => [],
   isTitleCustom: false,
   isPeerReviewed: false,
+  edition: '',
   description: '',
 
   withPackages: trait({

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -33,6 +33,7 @@ export default function defaultScenario(server) {
     name: 'Single, Double, and Triple Paradiddles',
     isTitleCustom: true,
     isPeerReviewed: false,
+    edition: '',
     description: ''
   });
 

--- a/mirage/serializers/resource.js
+++ b/mirage/serializers/resource.js
@@ -14,6 +14,7 @@ function mapResourceAttrs(hash, resource) {
   hash.attributes.identifiers = resource.title.identifiers;
   hash.attributes.subjects = resource.title.subjects;
   hash.attributes.isPeerReviewed = resource.title.isPeerReviewed;
+  hash.attributes.edition = resource.title.edition;
   hash.attributes.description = resource.title.description;
   hash.attributes.isTitleCustom = resource.title.isTitleCustom;
   return hash;

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -165,6 +165,14 @@ export default class ResourceShow extends Component {
                   </Link>
                 </KeyValue>
 
+                {model.edition && (
+                  <KeyValue label="Edition">
+                    <div data-test-eholdings-resource-show-edition>
+                      {model.edition}
+                    </div>
+                  </KeyValue>
+                )}
+
                 <ContributorsList data={model.contributors} />
 
                 {model.publisherName && (

--- a/src/components/title/_fields/edition/edition-field.css
+++ b/src/components/title/_fields/edition/edition-field.css
@@ -1,0 +1,3 @@
+.edition-field {
+  max-width: 50em;
+}

--- a/src/components/title/_fields/edition/edition-field.js
+++ b/src/components/title/_fields/edition/edition-field.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Field } from 'redux-form';
+
+import { TextField } from '@folio/stripes-components';
+import styles from './edition-field.css';
+
+export default function EditionField() {
+  return (
+    <div
+      data-test-eholdings-edition-field
+      className={styles['edition-field']}
+    >
+      <Field
+        name="edition"
+        component={TextField}
+        label="Edition"
+      />
+    </div>
+  );
+}
+
+export function validate(values) {
+  const errors = {};
+
+  if (values.edition && values.edition.trim() === '') {
+    errors.edition = 'Invalid value.';
+  }
+
+  if (values.edition && values.edition.length > 250) {
+    errors.edition = 'Value exceeds the 250 character limit.';
+  }
+
+  return errors;
+}

--- a/src/components/title/_fields/edition/index.js
+++ b/src/components/title/_fields/edition/index.js
@@ -1,0 +1,1 @@
+export { default, validate } from './edition-field';

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -10,6 +10,7 @@ import {
 
 import DetailsView from '../../details-view';
 import NameField, { validate as validateName } from '../_fields/name';
+import EditionField, { validate as validateEdition } from '../_fields/edition';
 import PublisherNameField, { validate as validatePublisher } from '../_fields/publisher-name';
 import PublicationTypeField from '../_fields/publication-type';
 import DescriptionField, { validate as validateDescription } from '../_fields/description';
@@ -120,6 +121,7 @@ class TitleEdit extends Component {
                 label="Title information"
               >
                 <NameField />
+                <EditionField />
                 <PublisherNameField />
                 <PublicationTypeField />
                 <DescriptionField />
@@ -164,6 +166,7 @@ class TitleEdit extends Component {
 const validate = (values) => {
   return Object.assign({},
     validateName(values),
+    validateEdition(values),
     validatePublisher(values),
     validateDescription(values));
 };

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -73,6 +73,14 @@ export default function TitleShow({ model }, { queryParams, router }) {
           <DetailsViewSection label="Title information">
             <ContributorsList data={model.contributors} />
 
+            {model.edition && (
+              <KeyValue label="Edition">
+                <div data-test-eholdings-title-show-edition>
+                  {model.edition}
+                </div>
+              </KeyValue>
+            )}
+
             {model.publisherName && (
               <KeyValue label="Publisher">
                 <div data-test-eholdings-title-show-publisher-name>

--- a/src/redux/resource.js
+++ b/src/redux/resource.js
@@ -9,6 +9,7 @@ class Resource {
   packageName = '';
   package = belongsTo();
   publisherName = '';
+  edition = '';
   publicationType = '';
   contentType = '';
   isSelected = false;

--- a/src/redux/title.js
+++ b/src/redux/title.js
@@ -2,6 +2,7 @@ import model, { hasMany } from './model';
 
 class Title {
   name = '';
+  edition = '';
   publisherName = '';
   publicationType = '';
   subjects = [];

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -72,6 +72,7 @@ class TitleShowRoute extends Component {
         updateRequest={updateRequest}
         initialValues={{
           name: model.name,
+          edition: model.edition,
           isPeerReviewed: model.isPeerReviewed,
           publicationType: model.publicationType,
           publisherName: model.publisherName,

--- a/tests/custom-title-edit-test.js
+++ b/tests/custom-title-edit-test.js
@@ -24,6 +24,7 @@ describeApplication('CustomTitleEdit', () => {
 
     title = this.server.create('title', {
       name: 'Best Title Ever',
+      edition: 'Test Edition',
       publicationType: 'Streaming Video',
       publisherName: 'Amazing Publisher',
       isPeerReviewed: false,
@@ -46,6 +47,10 @@ describeApplication('CustomTitleEdit', () => {
       return this.visit(`/eholdings/titles/${title.id}/edit`, () => {
         expect(TitleEditPage.$root).to.exist;
       });
+    });
+
+    it('shows a field for edition', () => {
+      expect(TitleEditPage.editionValue).to.equal('Test Edition');
     });
 
     it('shows a field for publisher', () => {
@@ -78,6 +83,9 @@ describeApplication('CustomTitleEdit', () => {
       beforeEach(() => {
         return TitleEditPage
           .name('')
+          .fillEdition(`In the realm of narrative psychology, a person’s life story is not a Wikipedia biography of the facts and
+            events of a life, but rather the way a person integrates those facts and events internally—picks them apart and weaves them back
+            together to make meaning. `)
           .fillPublisher(`The only prerequisite is that it makes you happy.
             If it makes you happy then it's good. All kinds of happy little splashes.
             I started painting as a hobby when I was little. I didn't know I had any talent.
@@ -96,14 +104,34 @@ describeApplication('CustomTitleEdit', () => {
         expect(TitleEditPage.nameHasError).to.be.true;
       });
 
+      it('displays a validation error for the edition field', () => {
+        expect(TitleEditPage.editionHasError).to.be.true;
+      });
+
       it('displays a validation error for the publisher field', () => {
         expect(TitleEditPage.publisherHasError).to.be.true;
+      });
+    });
+
+    describe('entering empty spaces for edition', () => {
+      beforeEach(() => {
+        return TitleEditPage
+          .name('some name')
+          .fillEdition('        ')
+          .fillPublisher('some publisher')
+          .fillDescription('some description')
+          .clickSave();
+      });
+
+      it('displays a validation error for the edition field', () => {
+        expect(TitleEditPage.editionHasError).to.be.true;
       });
     });
 
     describe('entering valid data', () => {
       beforeEach(() => {
         return TitleEditPage
+          .fillEdition('testing edition again')
           .fillPublisher('Not So Awesome Publisher')
           .fillDescription('What a super helpful description. Wow.')
           .checkPeerReviewed();
@@ -126,6 +154,10 @@ describeApplication('CustomTitleEdit', () => {
 
         it('goes to the title show page', () => {
           expect(TitleShowPage.$root).to.exist;
+        });
+
+        it('reflects the new edition', () => {
+          expect(TitleShowPage.edition).to.equal('testing edition again');
         });
 
         it('reflects the new publisher', () => {
@@ -188,6 +220,7 @@ describeApplication('CustomTitleEdit', () => {
       beforeEach(() => {
         return TitleEditPage
           .name('A Different Name')
+          .fillEdition('A Different Edition')
           .selectPublicationType('Web Site')
           .checkPeerReviewed();
       });
@@ -213,6 +246,10 @@ describeApplication('CustomTitleEdit', () => {
 
         it('reflects the new name', () => {
           expect(TitleShowPage.titleName).to.equal('A Different Name');
+        });
+
+        it('shows the new edition', () => {
+          expect(TitleEditPage.editionValue).to.equal('A Different Edition');
         });
 
         it('shows the new publication type', () => {
@@ -262,6 +299,7 @@ describeApplication('CustomTitleEdit', () => {
         return TitleEditPage
           .checkPeerReviewed()
           .name('A Different Name')
+          .fillEdition('A Different Edition')
           .clickSave();
       });
 

--- a/tests/pages/resource-show.js
+++ b/tests/pages/resource-show.js
@@ -24,6 +24,7 @@ import Toast from './toast';
 
 @interactor class ResourceShowPage {
   titleName = text('[data-test-eholdings-details-view-name="resource"]');
+  edition = text('[data-test-eholdings-resource-show-edition]');
   descriptionText = text('[data-test-eholdings-description-field]');
   publisherName = text('[data-test-eholdings-resource-show-publisher-name]');
   publicationType = text('[data-test-eholdings-resource-show-publication-type]');

--- a/tests/pages/title-edit.js
+++ b/tests/pages/title-edit.js
@@ -33,9 +33,12 @@ import Toast from './toast';
 
   selectPublicationType = fillable('[data-test-eholdings-publication-type-field] select');
   publicationTypeValue = value('[data-test-eholdings-publication-type-field] select');
+  fillEdition = fillable('[data-test-eholdings-edition-field] input');
   fillPublisher = fillable('[data-test-eholdings-publisher-name-field] input');
+  editionValue = value('[data-test-eholdings-edition-field] input');
   publisherValue = value('[data-test-eholdings-publisher-name-field] input');
   publisherHasError = hasClassBeginningWith('[data-test-eholdings-publisher-name-field] input', 'feedbackError--');
+  editionHasError = hasClassBeginningWith('[data-test-eholdings-edition-field] input', 'feedbackError--');
 }
 
 export default new TitleEditPage('[data-test-eholdings-details-view="title"]');

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -14,6 +14,7 @@ import Toast from './toast';
 @interactor class TitleShowPage {
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   titleName = text('[data-test-eholdings-details-view-name="title"]');
+  edition = text('[data-test-eholdings-title-show-edition]');
   publisherName = text('[data-test-eholdings-title-show-publisher-name]');
   publicationType = text('[data-test-eholdings-title-show-publication-type]');
   hasPublicationType = isPresent('[data-test-eholdings-title-show-publication-type]');

--- a/tests/resource-show-test.js
+++ b/tests/resource-show-test.js
@@ -24,6 +24,7 @@ describeApplication('ResourceShow', () => {
 
     let title = this.server.create('title', {
       name: 'Best Title Ever',
+      edition: 'Best Edition',
       publicationType: 'Streaming Video',
       publisherName: 'Amazing Publisher'
     });
@@ -74,6 +75,10 @@ describeApplication('ResourceShow', () => {
 
     it('displays the title name', () => {
       expect(ResourcePage.titleName).to.equal('Best Title Ever');
+    });
+
+    it('displays the edition', () => {
+      expect(ResourcePage.edition).to.equal('Best Edition');
     });
 
     it('displays the authors', () => {
@@ -264,6 +269,7 @@ describeApplication('ResourceShow', () => {
 
       let title = this.server.create('title', {
         name: 'Best Title Ever',
+        edition: 'Best Edition Ever',
         publicationType: ''
       });
 
@@ -280,6 +286,10 @@ describeApplication('ResourceShow', () => {
 
     it('displays the title name', () => {
       expect(ResourcePage.titleName).to.equal('Best Title Ever');
+    });
+
+    it('displays the edition', () => {
+      expect(ResourcePage.edition).to.equal('Best Edition Ever');
     });
 
     it.always('does not display a content type', () => {

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -11,6 +11,7 @@ describeApplication('TitleShow', () => {
   beforeEach(function () {
     title = this.server.create('title', 'withPackages', {
       name: 'Cool Title',
+      edition: 'Cool Edition',
       publisherName: 'Cool Publisher',
       publicationType: 'Website'
     });
@@ -53,6 +54,10 @@ describeApplication('TitleShow', () => {
 
     it('displays the title name', () => {
       expect(TitleShowPage.titleName).to.equal('Cool Title');
+    });
+
+    it('displays the edition', () => {
+      expect(TitleShowPage.edition).to.equal('Cool Edition');
     });
 
     it('displays the publisher name', () => {
@@ -132,6 +137,7 @@ describeApplication('TitleShow', () => {
     beforeEach(function () {
       title = this.server.create('title', {
         name: 'Cool Title',
+        edition: 'Cool Edition',
         publisherName: 'Cool Publisher',
         publicationType: ''
       });
@@ -145,6 +151,10 @@ describeApplication('TitleShow', () => {
 
     it('displays the title name', () => {
       expect(TitleShowPage.titleName).to.equal('Cool Title');
+    });
+
+    it('displays the edition', () => {
+      expect(TitleShowPage.edition).to.equal('Cool Edition');
     });
 
     it('displays the publisher name', () => {
@@ -176,6 +186,7 @@ describeApplication('TitleShow', () => {
     beforeEach(function () {
       title = this.server.create('title', {
         name: 'Cool Title',
+        edition: 'Cool Edition',
         publisherName: 'Cool Publisher',
         publicationType: 'UnknownPublicationType'
       });
@@ -189,6 +200,10 @@ describeApplication('TitleShow', () => {
 
     it('displays the title name', () => {
       expect(TitleShowPage.titleName).to.equal('Cool Title');
+    });
+
+    it('displays the edition', () => {
+      expect(TitleShowPage.edition).to.equal('Cool Edition');
     });
 
     it('displays the publisher name', () => {


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-253, users should be able to add or edit an edition for a custom title and view the same on title-record as well as resource-record pages.

## Approach
- Created a component called "edition" in _fields in title
- Used that component in title-edit, resource-show and title-show
- Added needed config for mirage
- Added unit tests

#### TODOS and Open Questions
- [ ] When we refresh a title, after editing "edition" or "description" or "peer-reviewed", those values are getting reset in the redux layer; coordinating with @cherewaty for ideas
- [ ] This PR takes care of editing edition from title-edit page, we might want to do something similar on title-create page after Wil's PR is merged.
- [x] Unable to create gif because title search is timing out on me. Will try and create one tomorrow.

## Screenshots

![edition_custom_title](https://user-images.githubusercontent.com/33662516/39528874-4dad5d2c-4df3-11e8-8855-6726e4c4c3d0.gif)
