### PR TITLE
Get title attributes from included on resource routes

### DIFF
--- a/mirage/serializers/resource.js
+++ b/mirage/serializers/resource.js
@@ -5,9 +5,12 @@ function mapResourceAttrs(hash, resource) {
   hash.attributes.providerName = resource.package.provider.name;
   hash.attributes.packageId = resource.package.id;
   hash.attributes.packageName = resource.package.name;
-  hash.attributes.contentType = resource.package.contentType;
   hash.attributes.titleId = resource.title.id;
   hash.attributes.name = resource.title.name;
+
+  // these are really title attributes, but have to stick around
+  // until /PUT titles is available in mod-kb-ebsco
+  hash.attributes.contentType = resource.package.contentType;
   hash.attributes.publisherName = resource.title.publisherName;
   hash.attributes.publicationType = resource.title.publicationType;
   hash.attributes.contributors = resource.title.contributors;
@@ -17,6 +20,7 @@ function mapResourceAttrs(hash, resource) {
   hash.attributes.edition = resource.title.edition;
   hash.attributes.description = resource.title.description;
   hash.attributes.isTitleCustom = resource.title.isTitleCustom;
+
   return hash;
 }
 

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -82,8 +82,8 @@ class ResourceEditCustomTitle extends Component {
         <DetailsView
           type="resource"
           model={model}
-          paneTitle={model.name}
-          paneSub={model.packageName}
+          paneTitle={model.title.name}
+          paneSub={model.package.name}
           actionMenuItems={actionMenuItems}
           bodyContent={(
             <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -81,8 +81,8 @@ class ResourceEditManagedTitle extends Component {
         <DetailsView
           type="resource"
           model={model}
-          paneTitle={model.name}
-          paneSub={model.packageName}
+          paneTitle={model.title.name}
+          paneSub={model.package.name}
           actionMenuItems={actionMenuItems}
           bodyContent={(
             <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/components/resource/edit.js
+++ b/src/components/resource/edit.js
@@ -4,7 +4,7 @@ import EditManagedTitle from './edit-managed-title';
 import EditCustomTitle from './edit-custom-title';
 
 export default function ResourceEdit({ model, ...props }) {
-  let View = model.isTitleCustom ? EditCustomTitle : EditManagedTitle;
+  let View = model.title.isTitleCustom ? EditCustomTitle : EditManagedTitle;
 
   return (
     <View

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -140,15 +140,15 @@ export default class ResourceShow extends Component {
         <DetailsView
           type="resource"
           model={model}
-          paneTitle={model.name}
-          paneSub={model.packageName}
+          paneTitle={model.title.name}
+          paneSub={model.package.name}
           actionMenuItems={actionMenuItems}
           lastMenu={(
             <PaneMenu>
               <IconButton
                 data-test-eholdings-resource-edit-link
                 icon="edit"
-                ariaLabel={`Edit ${model.name}`}
+                ariaLabel={`Edit ${model.title.name}`}
                 to={{
                   pathname: `/eholdings/resources/${model.id}/edit`,
                   state: { eholdings: true }
@@ -161,62 +161,62 @@ export default class ResourceShow extends Component {
               <DetailsViewSection label="Title information">
                 <KeyValue label="Title">
                   <Link to={`/eholdings/titles/${model.titleId}`}>
-                    {model.name}
+                    {model.title.name}
                   </Link>
                 </KeyValue>
 
-                {model.edition && (
+                {model.title.edition && (
                   <KeyValue label="Edition">
                     <div data-test-eholdings-resource-show-edition>
-                      {model.edition}
+                      {model.title.edition}
                     </div>
                   </KeyValue>
                 )}
 
-                <ContributorsList data={model.contributors} />
+                <ContributorsList data={model.title.contributors} />
 
-                {model.publisherName && (
+                {model.title.publisherName && (
                   <KeyValue label="Publisher">
                     <div data-test-eholdings-resource-show-publisher-name>
-                      {model.publisherName}
+                      {model.title.publisherName}
                     </div>
                   </KeyValue>
                 )}
 
-                {model.publicationType && (
+                {model.title.publicationType && (
                   <KeyValue label="Publication type">
                     <div data-test-eholdings-resource-show-publication-type>
-                      {model.publicationType}
+                      {model.title.publicationType}
                     </div>
                   </KeyValue>
                 )}
 
-                <IdentifiersList data={model.identifiers} />
+                <IdentifiersList data={model.title.identifiers} />
 
-                {model.subjects.length > 0 && (
+                {model.title.subjects.length > 0 && (
                   <KeyValue label="Subjects">
                     <div data-test-eholdings-resource-show-subjects-list>
-                      {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
+                      {model.title.subjects.map(subjectObj => subjectObj.subject).join('; ')}
                     </div>
                   </KeyValue>
                 )}
 
                 <KeyValue label="Peer reviewed">
                   <div data-test-eholdings-peer-reviewed-field>
-                    {model.isPeerReviewed ? 'Yes' : 'No'}
+                    {model.title.isPeerReviewed ? 'Yes' : 'No'}
                   </div>
                 </KeyValue>
 
                 <KeyValue label="Title type">
                   <div data-test-eholdings-package-details-type>
-                    {model.isTitleCustom ? 'Custom' : 'Managed'}
+                    {model.title.isTitleCustom ? 'Custom' : 'Managed'}
                   </div>
                 </KeyValue>
 
-                {model.description && (
+                {model.title.description && (
                   <KeyValue label="Description">
                     <div data-test-eholdings-description-field>
-                      {model.description}
+                      {model.title.description}
                     </div>
                   </KeyValue>
                 )}
@@ -225,20 +225,20 @@ export default class ResourceShow extends Component {
               <DetailsViewSection label="Package information">
                 <KeyValue label="Package">
                   <div data-test-eholdings-resource-show-package-name>
-                    <Link to={`/eholdings/packages/${model.packageId}`}>{model.packageName}</Link>
+                    <Link to={`/eholdings/packages/${model.packageId}`}>{model.package.name}</Link>
                   </div>
                 </KeyValue>
 
                 <KeyValue label="Provider">
                   <div data-test-eholdings-resource-show-provider-name>
-                    <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
+                    <Link to={`/eholdings/providers/${model.providerId}`}>{model.package.providerName}</Link>
                   </div>
                 </KeyValue>
 
-                {model.contentType && (
+                {model.package.contentType && (
                   <KeyValue label="Content type">
                     <div data-test-eholdings-resource-show-content-type>
-                      {model.contentType}
+                      {model.package.contentType}
                     </div>
                   </KeyValue>
                 )}
@@ -246,7 +246,7 @@ export default class ResourceShow extends Component {
 
               {model.url && (
                 <DetailsViewSection label="Resource information">
-                  <KeyValue label={`${model.isTitleCustom ? 'Custom' : 'Managed'} URL`}>
+                  <KeyValue label={`${model.title.isTitleCustom ? 'Custom' : 'Managed'} URL`}>
                     <div data-test-eholdings-resource-show-url>
                       <a href={model.url} target="_blank">{model.url}</a>
                     </div>

--- a/src/redux/resource.js
+++ b/src/redux/resource.js
@@ -8,21 +8,25 @@ class Resource {
   packageId = 0;
   packageName = '';
   package = belongsTo();
-  publisherName = '';
-  edition = '';
-  publicationType = '';
-  contentType = '';
+  title = belongsTo();
   isSelected = false;
   url = '';
-  subjects = [];
-  contributors = [];
-  identifiers = [];
   managedCoverages = [];
   customCoverages = [];
   managedEmbargoPeriod = {};
   customEmbargoPeriod = {};
   visibilityData = {};
   coverageStatement = '';
+
+  // these are really title attributes, but have to stick around
+  // until /PUT titles is available in mod-kb-ebsco
+  publisherName = '';
+  edition = '';
+  publicationType = '';
+  contentType = '';
+  subjects = [];
+  contributors = [];
+  identifiers = [];
   isTitleCustom = false;
   isPeerReviewed = false;
   description = '';

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -85,7 +85,7 @@ export default connect(
   ({ eholdings: { data } }, { match }) => ({
     model: createResolver(data).find('resources', match.params.id)
   }), {
-    getResource: id => Resource.find(id, { include: 'package' }),
+    getResource: id => Resource.find(id, { include: ['package', 'title'] }),
     updateResource: model => Resource.save(model)
   }
 )(ResourceEditRoute);

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -102,7 +102,7 @@ export default connect(
   ({ eholdings: { data } }, { match }) => ({
     model: createResolver(data).find('resources', match.params.id)
   }), {
-    getResource: id => Resource.find(id, { include: 'package' }),
+    getResource: id => Resource.find(id, { include: ['package', 'title'] }),
     updateResource: model => Resource.save(model)
   }
 )(ResourceShowRoute);


### PR DESCRIPTION
## Purpose
`mod-kb-ebsco` tries to flatten out RM API's `title` and `resource` payloads, but in the process ends up attaching a bunch of attributes to `resources` that actually belong to `titles`.

## Approach
We can't completely untangle until `PUT /titles` and `POST /titles` are available, but this clears up the distinction in the resource show and edit routes.