### PR TITLE
UIEH-285 Deselect managed and custom titles

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -325,6 +325,14 @@ export default function configure() {
     return matchingResource;
   });
 
+  this.delete('/resources/:id', ({ resources }, request) => {
+    let matchingResource = resources.find(request.params.id);
+
+    matchingResource.destroy();
+
+    return {};
+  });
+
   // translation bundle passthrough
   this.pretender.get(`${__webpack_public_path__}translations/:rand.json`, this.pretender.passthrough); // eslint-disable-line
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -134,6 +134,17 @@ export default class PackageShow extends Component {
       });
     }
 
+    // if coming from destroying a custom or managed title, show a success toast
+    if (router.history.action === 'REPLACE' &&
+        router.history.location.state &&
+        router.history.location.state.isDestroyed) {
+      toasts.push({
+        id: `success-resource-destruction-${model.id}`,
+        message: 'Title removed from package',
+        type: 'success'
+      });
+    }
+
     // if coming from saving edits to the package, show a success toast
     if (router.history.action === 'PUSH' &&
         router.history.location.state &&

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -134,7 +134,8 @@ export default class PackageShow extends Component {
       });
     }
 
-    // if coming from destroying a custom or managed title, show a success toast
+    // if coming from destroying a custom or managed title
+    // from within custom-package, show a success toast
     if (router.history.action === 'REPLACE' &&
         router.history.location.state &&
         router.history.location.state.isDestroyed) {

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -53,7 +53,7 @@ class ResourceEditCustomTitle extends Component {
     if (wasPending && needsUpdate) {
       this.context.router.history.push(
         `/eholdings/resources/${this.props.model.id}`,
-        { eholdings: true }
+        { eholdings: true, isFreshlySaved: true }
       );
     }
   }

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -239,7 +239,25 @@ class ResourceEditCustomTitle extends Component {
             </div>
           )}
         >
-        Are you sure you want to remove this title from your holdings? By removing this title, you will lose all customization to this title in this package only.
+          {
+              /*
+                we use <= here to account for the case where a user
+                selects and then immediately deselects the
+                resource
+              */
+              model.title.resources.length <= 1 ? (
+                <span data-test-eholdings-deselect-final-title-warning>
+                  Are you sure you want to remove this title from your holdings?
+                  It is also the last title selected in this package. By removing
+                  this title, you will also remove this package from your holdings
+                  and all customizations will be lost.
+                </span>
+              ) : (
+                <span data-test-eholdings-deselect-title-warning>
+                Are you sure you want to remove this title from your holdings? By removing this title, you will lose all customization to this title in this package only.
+                </span>
+              )
+            }
         </Modal>
       </div>
     );

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { reduxForm } from 'redux-form';
+import { reduxForm, Field } from 'redux-form';
 import isEqual from 'lodash/isEqual';
 
 import {
@@ -16,6 +16,8 @@ import CoverageStatementFields, { validate as validateCoverageStatement } from '
 import CustomEmbargoFields, { validate as validateEmbargo } from '../_fields/custom-embargo';
 import DetailsViewSection from '../../details-view-section';
 import NavigationModal from '../../navigation-modal';
+import ToggleSwitch from '../../toggle-switch/toggle-switch';
+import Modal from '../../modal/modal';
 import Toaster from '../../toaster';
 import styles from './resource-edit-custom-title.css';
 
@@ -37,6 +39,13 @@ class ResourceEditCustomTitle extends Component {
     }).isRequired
   };
 
+  state = {
+    resourceSelected: this.props.initialValues.isSelected,
+    showSelectionModal: false,
+    allowFormToSubmit: false,
+    formValues: {}
+  }
+
   componentWillReceiveProps(nextProps) {
     let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
     let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
@@ -56,15 +65,57 @@ class ResourceEditCustomTitle extends Component {
     );
   }
 
+  handleSelectionToggle = (e) => {
+    this.setState({
+      resourceSelected: e.target.checked
+    });
+  }
+
+  commitSelectionToggle = () => {
+    this.setState({
+      showSelectionModal: false,
+      allowFormToSubmit: true
+    }, () => { this.handleOnSubmit(this.state.formValues); });
+  };
+
+  cancelSelectionToggle = () => {
+    this.setState({
+      showSelectionModal: false,
+      resourceSelected: true,
+    }, () => {
+      this.props.change('isSelected', true);
+    });
+  };
+
+  handleOnSubmit = (values) => {
+    if (this.state.allowFormToSubmit === false && values.isSelected === false) {
+      this.setState({
+        showSelectionModal: true,
+        formValues: values
+      });
+    } else {
+      this.setState({
+        allowFormToSubmit: false,
+        formValues: {}
+      }, () => {
+        this.props.onSubmit(values);
+      });
+    }
+  }
+
   render() {
     let {
       model,
       initialValues,
       handleSubmit,
-      onSubmit,
       pristine,
       change
     } = this.props;
+
+    let {
+      showSelectionModal,
+      resourceSelected
+    } = this.state;
 
     let actionMenuItems = [
       {
@@ -86,11 +137,27 @@ class ResourceEditCustomTitle extends Component {
           paneSub={model.package.name}
           actionMenuItems={actionMenuItems}
           bodyContent={(
-            <form onSubmit={handleSubmit(onSubmit)}>
+            <form onSubmit={handleSubmit(this.handleOnSubmit)}>
               <DetailsViewSection
                 label="Resource information"
               >
                 <CustomUrlFields />
+              </DetailsViewSection>
+              <DetailsViewSection
+                label="Holding status"
+              >
+                <label
+                  data-test-eholdings-resource-holding-status
+                  htmlFor="custom-resource-holding-toggle-switch"
+                >
+                  <Field
+                    name="isSelected"
+                    component={ToggleSwitch}
+                    checked={resourceSelected}
+                    onChange={this.handleSelectionToggle}
+                    id="custom-resource-holding-toggle-switch"
+                  />
+                </label>
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage dates"
@@ -132,14 +199,14 @@ class ResourceEditCustomTitle extends Component {
                   data-test-eholdings-resource-save-button
                 >
                   <Button
-                    disabled={pristine || model.update.isPending}
+                    disabled={pristine || model.update.isPending || model.destroy.isPending}
                     type="submit"
                     buttonStyle="primary"
                   >
-                    {model.update.isPending ? 'Saving' : 'Save'}
+                    {model.update.isPending || model.destroy.isPending ? 'Saving' : 'Save'}
                   </Button>
                 </div>
-                {model.update.isPending && (
+                {(model.update.isPending || model.destroy.isPending) && (
                   <Icon icon="spinner-ellipsis" />
                 )}
               </div>
@@ -147,6 +214,33 @@ class ResourceEditCustomTitle extends Component {
             </form>
           )}
         />
+
+        <Modal
+          open={showSelectionModal}
+          size="small"
+          label="Remove title from holdings?"
+          scope="root"
+          id="eholdings-resource-confirmation-modal"
+          footer={(
+            <div>
+              <Button
+                buttonStyle="primary"
+                onClick={this.commitSelectionToggle}
+                data-test-eholdings-resource-deselection-confirmation-modal-yes
+              >
+                Yes, remove
+              </Button>
+              <Button
+                onClick={this.cancelSelectionToggle}
+                data-test-eholdings-resource-deselection-confirmation-modal-no
+              >
+                No, do not remove
+              </Button>
+            </div>
+          )}
+        >
+        Are you sure you want to remove this title from your holdings? By removing this title, you will lose all customization to this title in this package only.
+        </Modal>
       </div>
     );
   }

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -59,7 +59,7 @@ class ResourceEditManagedTitle extends Component {
     if (wasPending && needsUpdate) {
       this.context.router.history.push(
         `/eholdings/resources/${this.props.model.id}`,
-        { eholdings: true }
+        { eholdings: true, isFreshlySaved: true }
       );
     }
   }

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -40,6 +40,13 @@ class ResourceEditManagedTitle extends Component {
     let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
     let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
 
+    if (nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) {
+      this.setState({
+        ...this.state,
+        managedResourceSelected: nextProps.initialValues.isSelected
+      });
+    }
+
     if (wasPending && needsUpdate) {
       this.context.router.history.push(
         `/eholdings/resources/${this.props.model.id}`,

--- a/src/components/resource/resource-view/index.js
+++ b/src/components/resource/resource-view/index.js
@@ -1,0 +1,1 @@
+export { default } from './resource-view';

--- a/src/components/resource/resource-view/resource-view.js
+++ b/src/components/resource/resource-view/resource-view.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ManagedResourceEdit from '../edit-managed-title';
+import CustomResourceEdit from '../edit-custom-title';
+
+export default function ResourceView({ model, ...props }) {
+  let initialValues = {};
+  let View;
+
+  if (model.isTitleCustom === true || model.destroy.params.isTitleCustom === true) {
+    View = CustomResourceEdit;
+    initialValues = {
+      isSelected: model.isSelected,
+      customCoverages: model.customCoverages,
+      coverageStatement: model.coverageStatement,
+      customEmbargoValue: model.customEmbargoPeriod.embargoValue,
+      customEmbargoUnit: model.customEmbargoPeriod.embargoUnit,
+      customUrl: model.url
+    };
+  } else if (model.isTitleCustom === false) {
+    View = ManagedResourceEdit;
+    initialValues = {
+      isSelected: model.isSelected,
+      customCoverages: model.customCoverages,
+      coverageStatement: model.coverageStatement,
+      customEmbargoValue: model.customEmbargoPeriod.embargoValue,
+      customEmbargoUnit: model.customEmbargoPeriod.embargoUnit
+    };
+  }
+
+  return (
+    <View
+      model={model}
+      initialValues={initialValues}
+      {...props}
+    />
+  );
+}
+
+ResourceView.propTypes = {
+  model: PropTypes.object.isRequired
+};

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -264,7 +264,8 @@ export default class ResourceShow extends Component {
                   <ToggleSwitch
                     onChange={this.handleSelectionToggle}
                     checked={resourceSelected}
-                    isPending={model.update.isPending && 'isSelected' in model.update.changedAttributes}
+                    isPending={model.destroy.isPending ||
+                    (model.update.isPending && 'isSelected' in model.update.changedAttributes)}
                     id="resource-show-toggle-switch"
                   />
                 </label>

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -436,7 +436,7 @@ export default class ResourceShow extends Component {
                selects and then immediately deselects the
                resource
             */
-            model.package.selectedCount <= 1 ? (
+            (model.title.resources.length <= 1 && model.title.isTitleCustom) ? (
               <span data-test-eholdings-deselect-final-title-warning>
                 Are you sure you want to remove this title from your holdings?
                 It is also the last title selected in this package. By removing

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -35,6 +35,7 @@ export default class ResourceShow extends Component {
 
   static contextTypes = {
     locale: PropTypes.string,
+    router: PropTypes.object,
     intl: PropTypes.object
   };
 
@@ -66,7 +67,10 @@ export default class ResourceShow extends Component {
   };
 
   commitSelectionToggle = () => {
-    this.setState({ showSelectionModal: false });
+    this.setState({
+      showSelectionModal: false,
+      resourceSelected: false
+    });
     this.props.toggleSelected();
   };
 
@@ -91,7 +95,7 @@ export default class ResourceShow extends Component {
 
   render() {
     let { model, customEmbargoSubmitted, coverageSubmitted, coverageStatementSubmitted } = this.props;
-    let { locale, intl } = this.context;
+    let { locale, intl, router } = this.context;
     let {
       showSelectionModal,
       resourceSelected,
@@ -133,9 +137,23 @@ export default class ResourceShow extends Component {
       }
     ];
 
+    let toasts = processErrors(model);
+
+    // if coming from updating any value on managed title in a managed package
+    // show a success toast
+    if (router.history.action === 'PUSH' &&
+        router.history.location.state &&
+        router.history.location.state.isFreshlySaved) {
+      toasts.push({
+        id: `success-package-creation-${model.id}`,
+        message: 'Title was updated.',
+        type: 'success'
+      });
+    }
+
     return (
       <div>
-        <Toaster toasts={processErrors(model)} position="bottom" />
+        <Toaster toasts={toasts} position="bottom" />
 
         <DetailsView
           type="resource"
@@ -263,7 +281,7 @@ export default class ResourceShow extends Component {
                   <br />
                   <ToggleSwitch
                     onChange={this.handleSelectionToggle}
-                    checked={resourceSelected}
+                    checked={model.destroy.isPending ? false : resourceSelected}
                     isPending={model.destroy.isPending ||
                     (model.update.isPending && 'isSelected' in model.update.changedAttributes)}
                     id="resource-show-toggle-switch"

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -105,6 +105,8 @@ export default class ResourceShow extends Component {
       isCoverageStatementEditable
     } = this.state;
 
+    let isSelectInFlight = model.update.isPending && 'isSelected' in model.update.changedAttributes;
+
     let hasManagedCoverages = model.managedCoverages.length > 0 &&
       isValidCoverageList(model.managedCoverages);
     let hasManagedEmbargoPeriod = model.managedEmbargoPeriod &&
@@ -282,14 +284,13 @@ export default class ResourceShow extends Component {
                   <ToggleSwitch
                     onChange={this.handleSelectionToggle}
                     checked={model.destroy.isPending ? false : resourceSelected}
-                    isPending={model.destroy.isPending ||
-                    (model.update.isPending && 'isSelected' in model.update.changedAttributes)}
+                    isPending={model.destroy.isPending || isSelectInFlight}
                     id="resource-show-toggle-switch"
                   />
                 </label>
               </DetailsViewSection>
               <DetailsViewSection label="Visibility">
-                {resourceSelected ? (
+                {(resourceSelected && !isSelectInFlight) ? (
                   <div>
                     <label
                       data-test-eholdings-resource-toggle-hidden
@@ -337,7 +338,7 @@ export default class ResourceShow extends Component {
                   </KeyValue>
                 )}
 
-                {resourceSelected && (
+                {(resourceSelected && !isSelectInFlight) && (
                   <CustomCoverage
                     initialValues={{ customCoverages }}
                     packageCoverage={model.package.customCoverage}
@@ -359,7 +360,7 @@ export default class ResourceShow extends Component {
               <DetailsViewSection
                 label="Coverage statement"
               >
-                {resourceSelected && (
+                {(resourceSelected && !isSelectInFlight) && (
                   <CoverageStatement
                     initialValues={{ coverageStatement: model.coverageStatement }}
                     isEditable={isCoverageStatementEditable}
@@ -387,7 +388,7 @@ export default class ResourceShow extends Component {
                   </KeyValue>
                 )}
 
-                {resourceSelected && (
+                {(resourceSelected && !isSelectInFlight) && (
                   <CustomEmbargo
                     initialValues={{ customEmbargoValue, customEmbargoUnit }}
                     isEditable={isEmbargoEditable}

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -409,7 +409,7 @@ const handlers = {
         if (request.type === 'destroy' || !request.records.some(id => data.ids.includes(id))) {
           reqs[timestamp] = request;
 
-        // if a query request includes unloaded ids, falg is with `hasUnloaded`
+        // if a query request includes unloaded ids, flag is with `hasUnloaded`
         } else if (request.type === 'query') {
           reqs[timestamp] = {
             ...request,
@@ -444,29 +444,29 @@ const handlers = {
       }
     }));
 
-    // then we reduce each record in the set of records
-    next = records.reduce((next, record) => { // eslint-disable-line no-shadow
-      return reduceData(record.type, next, (store) => {
-        let recordState = getRecord(store, record.id);
-
-        return {
-          records: {
-            ...store.records,
-            [record.id]: {
-              ...recordState,
-              attributes: record.attributes || {},
-              relationships: mergeRelationships(recordState.relationships, record.relationships),
-              isSaving: false,
-              isLoading: false,
-              isLoaded: true
-            }
-          }
-        };
-      });
-    }, next);
-
     if (request.type === 'destroy') {
       next = handlers[actionTypes.UNLOAD](next, action);
+    } else {
+      // then we reduce each record in the set of records
+      next = records.reduce((next, record) => { // eslint-disable-line no-shadow
+        return reduceData(record.type, next, (store) => {
+          let recordState = getRecord(store, record.id);
+
+          return {
+            records: {
+              ...store.records,
+              [record.id]: {
+                ...recordState,
+                attributes: record.attributes || {},
+                relationships: mergeRelationships(recordState.relationships, record.relationships),
+                isSaving: false,
+                isLoading: false,
+                isLoaded: true
+              }
+            }
+          };
+        });
+      }, next);
     }
 
     return next;

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -99,7 +99,10 @@ export const destroy = (type, payload, { path }) => ({
   data: {
     type,
     path,
-    params: { id: payload.data.id },
+    params: {
+      id: payload.data.id,
+      isTitleCustom: payload.data.attributes.isTitleCustom
+    },
     timestamp: Date.now()
   }
 });

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -6,8 +6,7 @@ import moment from 'moment';
 import { createResolver } from '../redux';
 import Resource from '../redux/resource';
 
-import ManagedResourceEdit from '../components/resource/edit-managed-title';
-import CustomResourceEdit from '../components/resource/edit-custom-title';
+import ResourceView from '../components/resource/resource-view';
 
 
 class ResourceEditRoute extends Component {
@@ -99,35 +98,11 @@ class ResourceEditRoute extends Component {
 
   render() {
     let { model } = this.props;
-    let initialValues = {};
-    let View;
-
-    if (model.isTitleCustom === true || model.destroy.params.isTitleCustom === true) {
-      View = CustomResourceEdit;
-      initialValues = {
-        isSelected: model.isSelected,
-        customCoverages: model.customCoverages,
-        coverageStatement: model.coverageStatement,
-        customEmbargoValue: model.customEmbargoPeriod.embargoValue,
-        customEmbargoUnit: model.customEmbargoPeriod.embargoUnit,
-        customUrl: model.url
-      };
-    } else if (model.isTitleCustom === false) {
-      View = ManagedResourceEdit;
-      initialValues = {
-        isSelected: model.isSelected,
-        customCoverages: model.customCoverages,
-        coverageStatement: model.coverageStatement,
-        customEmbargoValue: model.customEmbargoPeriod.embargoValue,
-        customEmbargoUnit: model.customEmbargoPeriod.embargoUnit
-      };
-    }
 
     return (
-      <View
+      <ResourceView
         model={model}
         onSubmit={this.resourceEditSubmitted}
-        initialValues={initialValues}
       />
     );
   }

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -64,8 +64,18 @@ class ResourceEditRoute extends Component {
       customUrl
     } = values;
 
-    if (values.isSelected === false) {
+    if (values.isSelected === false && model.package.isCustom) {
       destroyResource(model);
+    } else if (values.isSelected === false) {
+      model.isSelected = !model.isSelected;
+      model.customCoverages = [];
+      model.visibilityData.isHidden = false;
+      model.identifiersList = [];
+      model.identifiers = {};
+      model.customStatement = '';
+      model.customEmbargoPeriod = {};
+
+      updateResource(model);
     } else {
       model.customCoverages = customCoverages.map((dateRange) => {
         let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).format('YYYY-MM-DD');

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -69,7 +69,7 @@ class ResourceEditRoute extends Component {
     let initialValues = {};
     let View;
 
-    if (model.isTitleCustom) {
+    if (model.isTitleCustom || model.destroy.params.isTitleCustom === true) {
       View = CustomResourceEdit;
       initialValues = {
         isSelected: model.isSelected,

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -6,7 +6,9 @@ import moment from 'moment';
 import { createResolver } from '../redux';
 import Resource from '../redux/resource';
 
-import View from '../components/resource/edit';
+import ManagedResourceEdit from '../components/resource/edit-managed/managed-resource-edit';
+import CustomResourceEdit from '../components/resource/edit-custom/custom-resource-edit';
+
 
 class ResourceEditRoute extends Component {
   static propTypes = {
@@ -64,18 +66,35 @@ class ResourceEditRoute extends Component {
 
   render() {
     let { model } = this.props;
+    let initialValues = {};
+    let View;
+
+    if (model.isTitleCustom) {
+      View = CustomResourceEdit;
+      initialValues = {
+        isSelected: model.isSelected,
+        customCoverages: model.customCoverages,
+        coverageStatement: model.coverageStatement,
+        customEmbargoValue: model.customEmbargoPeriod.embargoValue,
+        customEmbargoUnit: model.customEmbargoPeriod.embargoUnit,
+        customUrl: model.url
+      };
+    } else {
+      View = ManagedResourceEdit;
+      initialValues = {
+        isSelected: model.isSelected,
+        customCoverages: model.customCoverages,
+        coverageStatement: model.coverageStatement,
+        customEmbargoValue: model.customEmbargoPeriod.embargoValue,
+        customEmbargoUnit: model.customEmbargoPeriod.embargoUnit
+      };
+    }
 
     return (
       <View
         model={model}
         onSubmit={this.resourceEditSubmitted}
-        initialValues={{
-          customCoverages: model.customCoverages,
-          coverageStatement: model.coverageStatement,
-          customEmbargoValue: model.customEmbargoPeriod.embargoValue,
-          customEmbargoUnit: model.customEmbargoPeriod.embargoUnit,
-          customUrl: model.url
-        }}
+        initialValues={initialValues}
       />
     );
   }

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -6,8 +6,8 @@ import moment from 'moment';
 import { createResolver } from '../redux';
 import Resource from '../redux/resource';
 
-import ManagedResourceEdit from '../components/resource/edit-managed/managed-resource-edit';
-import CustomResourceEdit from '../components/resource/edit-custom/custom-resource-edit';
+import ManagedResourceEdit from '../components/resource/edit-managed-title';
+import CustomResourceEdit from '../components/resource/edit-custom-title';
 
 
 class ResourceEditRoute extends Component {
@@ -19,7 +19,16 @@ class ResourceEditRoute extends Component {
     }).isRequired,
     model: PropTypes.object.isRequired,
     getResource: PropTypes.func.isRequired,
-    updateResource: PropTypes.func.isRequired
+    updateResource: PropTypes.func.isRequired,
+    destroyResource: PropTypes.func.isRequired
+  };
+
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        replace: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
   };
 
   componentWillMount() {
@@ -37,8 +46,16 @@ class ResourceEditRoute extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    let { packageName, packageId } = prevProps.model;
+    if (!prevProps.model.destroy.isResolved && this.props.model.destroy.isResolved) {
+      this.context.router.history.replace(`/eholdings/packages/${packageId}?searchType=packages&q=${packageName}`,
+        { eholdings: true, isDestroyed: true });
+    }
+  }
+
   resourceEditSubmitted = (values) => {
-    let { model, updateResource } = this.props;
+    let { model, updateResource, destroyResource } = this.props;
     let {
       coverageStatement,
       customCoverages,
@@ -46,22 +63,28 @@ class ResourceEditRoute extends Component {
       customEmbargoUnit,
       customUrl
     } = values;
-    model.customCoverages = customCoverages.map((dateRange) => {
-      let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).tz('UTC').format('YYYY-MM-DD');
-      let endCoverage = !dateRange.endCoverage ? null : moment(dateRange.endCoverage).tz('UTC').format('YYYY-MM-DD');
 
-      return {
-        beginCoverage,
-        endCoverage
+    if (values.isSelected === false) {
+      destroyResource(model);
+    } else {
+      model.customCoverages = customCoverages.map((dateRange) => {
+        let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).format('YYYY-MM-DD');
+        let endCoverage = !dateRange.endCoverage ? null : moment(dateRange.endCoverage).format('YYYY-MM-DD');
+
+        return {
+          beginCoverage,
+          endCoverage
+        };
+      });
+
+      model.url = customUrl;
+      model.coverageStatement = coverageStatement;
+      model.customEmbargoPeriod = {
+        embargoValue: customEmbargoValue,
+        embargoUnit: customEmbargoUnit
       };
-    });
-    model.url = customUrl;
-    model.coverageStatement = coverageStatement;
-    model.customEmbargoPeriod = {
-      embargoValue: customEmbargoValue,
-      embargoUnit: customEmbargoUnit
-    };
-    updateResource(model);
+      updateResource(model);
+    }
   }
 
   render() {
@@ -69,7 +92,7 @@ class ResourceEditRoute extends Component {
     let initialValues = {};
     let View;
 
-    if (model.isTitleCustom || model.destroy.params.isTitleCustom === true) {
+    if (model.isTitleCustom === true || model.destroy.params.isTitleCustom === true) {
       View = CustomResourceEdit;
       initialValues = {
         isSelected: model.isSelected,
@@ -79,7 +102,7 @@ class ResourceEditRoute extends Component {
         customEmbargoUnit: model.customEmbargoPeriod.embargoUnit,
         customUrl: model.url
       };
-    } else {
+    } else if (model.isTitleCustom === false) {
       View = ManagedResourceEdit;
       initialValues = {
         isSelected: model.isSelected,
@@ -105,6 +128,7 @@ export default connect(
     model: createResolver(data).find('resources', match.params.id)
   }), {
     getResource: id => Resource.find(id, { include: ['package', 'title'] }),
-    updateResource: model => Resource.save(model)
+    updateResource: model => Resource.save(model),
+    destroyResource: model => Resource.destroy(model)
   }
 )(ResourceEditRoute);

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -43,10 +43,21 @@ class ResourceShowRoute extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    let wasUpdated = !this.props.model.update.isPending && prevProps.model.update.isPending && (!this.props.model.update.errors.length > 0);
+    let { router } = this.context;
+
     let { packageName, packageId } = prevProps.model;
     if (!prevProps.model.destroy.isResolved && this.props.model.destroy.isResolved) {
       this.context.router.history.replace(`/eholdings/packages/${packageId}?searchType=packages&q=${packageName}`,
         { eholdings: true, isDestroyed: true });
+    }
+
+    if (wasUpdated) {
+      router.history.push({
+        pathname: `/eholdings/resources/${this.props.model.id}`,
+        search: router.route.location.search,
+        state: { eholdings: true, isFreshlySaved: true }
+      });
     }
   }
 
@@ -54,12 +65,13 @@ class ResourceShowRoute extends Component {
     let { model, updateResource, destroyResource } = this.props;
     model.isSelected = !model.isSelected;
 
-    if (model.isSelected === false) {
+    if (model.isSelected === false && model.package.isCustom) {
       destroyResource(model);
     } else {
       // clear out any customizations before sending to server
       model.visibilityData.isHidden = false;
       model.customCoverages = [];
+      model.coverageStatement = '';
       model.customEmbargoPeriod = {};
       model.identifiersList = [];
       model.identifiers = {};

--- a/tests/custom-package-show-selection-test.js
+++ b/tests/custom-package-show-selection-test.js
@@ -60,7 +60,6 @@ describeApplication('CustomPackageShowSelection', () => {
         expect(PackageShowPage.isSelected).to.equal(false);
       });
 
-
       describe('canceling the deselection', () => {
         beforeEach(() => {
           return PackageShowPage.modal.cancelDeselection();
@@ -70,7 +69,6 @@ describeApplication('CustomPackageShowSelection', () => {
           expect(PackageShowPage.isSelected).to.equal(true);
         });
       });
-
 
       describe('confirming the deselection', () => {
         beforeEach(function () {

--- a/tests/custom-resource-edit-selection-test.js
+++ b/tests/custom-resource-edit-selection-test.js
@@ -35,7 +35,6 @@ describeApplication('CustomResourceHoldingSelection', () => {
       package: providerPackage,
       title,
       url: 'https://www.frontside.io',
-      isTitleCustom: true,
       isSelected: true
     });
   });

--- a/tests/custom-resource-edit-selection-test.js
+++ b/tests/custom-resource-edit-selection-test.js
@@ -1,0 +1,172 @@
+import { beforeEach, afterEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import ResourceEditPage from './pages/resource-edit';
+import PackageSearchPage from './pages/package-search';
+
+describeApplication('CustomResourceHoldingSelection', () => {
+  let provider,
+    providerPackage,
+    resource;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create('package', 'withTitles', {
+      provider,
+      name: 'Star Wars Custom Package',
+      contentType: 'Online',
+      isCustom: true
+    });
+
+    let title = this.server.create('title', {
+      name: 'Hans Solo Director Cut',
+      publicationType: 'Streaming Video',
+      publisherName: 'Amazing Publisher',
+      isTitleCustom: true
+    });
+
+    title.save();
+
+    resource = this.server.create('resource', {
+      package: providerPackage,
+      title,
+      url: 'https://www.frontside.io',
+      isTitleCustom: true,
+      isSelected: true
+    });
+  });
+
+  describe('visiting the package details page', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('shows the custom package as selected in my holdings', () => {
+      expect(ResourceEditPage.isSelected).to.equal(true);
+    });
+
+    it('shows save button to be disabled', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.equal(true);
+    });
+
+
+    describe('deselecting a custom resource', () => {
+      beforeEach(function () {
+        /*
+         * The expectations in the convergent `it` blocks
+         * get run once every 10ms.  We were seeing test flakiness
+         * when a toggle action dispatched and resolved before an
+         * expectation had the chance to run.  We sidestep this by
+         * temporarily increasing the mirage server's response time
+         * to 50ms.
+         * TODO: control timing directly with Mirage
+         */
+        this.server.timing = 50;
+        return ResourceEditPage.toggleIsSelected();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('reflects the desired state (not selected)', () => {
+        expect(ResourceEditPage.isSelected).to.equal(false);
+      });
+
+      describe('clicking save button', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('shows the confirmation modal', () => {
+          expect(ResourceEditPage.modal.isPresent).to.equal(true);
+        });
+
+        describe('confirming the save and continue deselection', () => {
+          beforeEach(() => {
+            return ResourceEditPage.modal.confirmDeselection();
+          });
+
+          it('transition to package search page', () => {
+            expect(PackageSearchPage.isPresent).to.equal(true);
+          });
+
+          it('has search prefilled with package name', () => {
+            expect(PackageSearchPage.searchFieldValue).to.equal('Star Wars Custom Package');
+          });
+
+          it('does not have an association to the above package', () => {
+            expect(PackageSearchPage.packageTitleList().length).to.equal(0);
+          });
+
+          it('has a success Toast notification', () => {
+            expect(PackageSearchPage.toast.successText).to.equal('Title removed from package');
+          });
+        });
+
+        describe('canceling the save and discontinue deselection', () => {
+          beforeEach(() => {
+            return ResourceEditPage.modal.cancelDeselection();
+          });
+
+          it('should not transition to package search page', () => {
+            expect(PackageSearchPage.isPresent).to.equal(false);
+            expect(ResourceEditPage.isPresent).to.equal(true);
+          });
+
+          it('reverts holding status back to original state', () => {
+            expect(ResourceEditPage.isSelected).to.equal(true);
+          });
+        });
+      });
+    });
+
+    describe('unsuccessfully deselecting a custom resource', () => {
+      beforeEach(function () {
+        this.server.delete('/resources/:id', {
+          errors: [{
+            title: 'There was an error'
+          }]
+        }, 500);
+
+        return ResourceEditPage.toggleIsSelected();
+      });
+
+      it('reflects the desired state (Unselected)', () => {
+        expect(ResourceEditPage.isSelected).to.equal(false);
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        describe('confirm and continue deselection', () => {
+          beforeEach(() => {
+            return ResourceEditPage.modal.confirmDeselection();
+          });
+
+          it('cannot be interacted with while the request is in flight', () => {
+            expect(ResourceEditPage.isSaveDisabled).to.equal(true);
+          });
+
+          describe('when the request fails', () => {
+            it('indicates it is no longer working', () => {
+              expect(ResourceEditPage.isSaveDisabled).to.equal(false);
+            });
+
+            it('shows the error as a toast', () => {
+              expect(ResourceEditPage.toast.errorText).to.equal('There was an error');
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/custom-title-edit-test.js
+++ b/tests/custom-title-edit-test.js
@@ -44,7 +44,7 @@ describeApplication('CustomTitleEdit', () => {
       package: providerPackage,
       isSelected: true,
       title,
-      url: 'frontside.io',
+      url: 'https://www.frontside.io',
       isTitleCustom: true
     });
   });

--- a/tests/managed-resource-edit-selection-test.js
+++ b/tests/managed-resource-edit-selection-test.js
@@ -1,0 +1,171 @@
+import { beforeEach, afterEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import ResourceEditPage from './pages/resource-edit';
+import PackageSearchPage from './pages/package-search';
+
+describeApplication('ManagedResourceHoldingSelection', () => {
+  let provider,
+    providerPackage,
+    resource;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'The Coolest Provider'
+    });
+
+    providerPackage = this.server.create('package', 'withTitles', {
+      provider,
+      name: 'Star Wars Custom Package',
+      contentType: 'Online',
+      isCustom: true,
+      isSelected: true
+    });
+
+    let title = this.server.create('title', {
+      name: 'Empire Strikes Back Directors Cut',
+      publicationType: 'Streaming Video',
+      publisherName: 'Amazing Publisher',
+    });
+
+    title.save();
+
+    resource = this.server.create('resource', {
+      package: providerPackage,
+      title,
+      url: 'https://frontside.io',
+      isSelected: true
+    });
+  });
+
+  describe('visiting the package details page', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('shows the managed resource as selected in my holdings', () => {
+      expect(ResourceEditPage.isSelected).to.equal(true);
+    });
+
+    it('shows save button to be disabled', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.equal(true);
+    });
+
+
+    describe('deselecting a managed resource', () => {
+      beforeEach(function () {
+        /*
+         * The expectations in the convergent `it` blocks
+         * get run once every 10ms.  We were seeing test flakiness
+         * when a toggle action dispatched and resolved before an
+         * expectation had the chance to run.  We sidestep this by
+         * temporarily increasing the mirage server's response time
+         * to 50ms.
+         * TODO: control timing directly with Mirage
+         */
+        this.server.timing = 50;
+        return ResourceEditPage.toggleIsSelected();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('reflects the desired state (not selected)', () => {
+        expect(ResourceEditPage.isSelected).to.equal(false);
+      });
+
+      describe('clicking save button', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('shows the confirmation modal', () => {
+          expect(ResourceEditPage.modal.isPresent).to.equal(true);
+        });
+
+        describe('confirming the save and continue deselection', () => {
+          beforeEach(() => {
+            return ResourceEditPage.modal.confirmDeselection();
+          });
+
+          it('transition to package search page', () => {
+            expect(PackageSearchPage.isPresent).to.equal(true);
+          });
+
+          it('has search prefilled with package name', () => {
+            expect(PackageSearchPage.searchFieldValue).to.equal('Star Wars Custom Package');
+          });
+
+          it('does not have an association to the above package', () => {
+            expect(PackageSearchPage.packageTitleList().length).to.equal(0);
+          });
+
+          it('has a success Toast notification', () => {
+            expect(PackageSearchPage.toast.successText).to.equal('Title removed from package');
+          });
+        });
+
+        describe('canceling the save and discontinue deselection', () => {
+          beforeEach(() => {
+            return ResourceEditPage.modal.cancelDeselection();
+          });
+
+          it('should not transition to title search page', () => {
+            expect(PackageSearchPage.isPresent).to.equal(false);
+            expect(ResourceEditPage.isPresent).to.equal(true);
+          });
+
+          it('reverts holding status back to original state', () => {
+            expect(ResourceEditPage.isSelected).to.equal(true);
+          });
+        });
+      });
+    });
+
+    describe('unsuccessfully deselecting a managed resource', () => {
+      beforeEach(function () {
+        this.server.delete('/resources/:id', {
+          errors: [{
+            title: 'There was an error'
+          }]
+        }, 500);
+
+        return ResourceEditPage.toggleIsSelected();
+      });
+
+      it('reflects the desired state (Unselected)', () => {
+        expect(ResourceEditPage.isSelected).to.equal(false);
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        describe('confirm and continue deselection', () => {
+          beforeEach(() => {
+            return ResourceEditPage.modal.confirmDeselection();
+          });
+
+          it('cannot be interacted with while the request is in flight', () => {
+            expect(ResourceEditPage.isSaveDisabled).to.equal(true);
+          });
+
+          describe('when the request fails', () => {
+            it('indicates it is no longer working', () => {
+              expect(ResourceEditPage.isSaveDisabled).to.equal(false);
+            });
+
+            it('shows the error as a toast', () => {
+              expect(ResourceEditPage.toast.errorText).to.equal('There was an error');
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/managed-resource-edit-test.js
+++ b/tests/managed-resource-edit-test.js
@@ -34,7 +34,7 @@ describeApplication('ManagedResourceEdit', () => {
       package: providerPackage,
       isSelected: true,
       title,
-      url: 'frontside.io'
+      url: 'https://www.frontside.io'
     });
   });
 

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -12,6 +12,8 @@ import {
   is
 } from '@bigtest/interactor';
 
+import Toast from './toast';
+
 @interactor class PackageSearchPage {
   fillSearch = fillable('[data-test-search-field] input[name="search"]');
   submitSearch = clickable('[data-test-search-submit]');
@@ -33,6 +35,8 @@ import {
   sortBy = value('[data-test-eholdings-search-filters="packages"] input[name="sort"]:checked');
   clickCloseButton = clickable('[data-test-eholdings-details-view-close-button] a');
   hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
+
+  toast = Toast;
 
   hasLoaded = computed(function () {
     return this.packageList().length > 0;

--- a/tests/pages/resource-edit.js
+++ b/tests/pages/resource-edit.js
@@ -11,10 +11,16 @@ import {
   value
 } from '@bigtest/interactor';
 import { hasClassBeginningWith } from './helpers';
+
 import Toast from './toast';
 import Datepicker from './datepicker';
 
 @interactor class ResourceEditNavigationModal {}
+
+@interactor class ResourceEditModal {
+  confirmDeselection = clickable('[data-test-eholdings-resource-deselection-confirmation-modal-yes]');
+  cancelDeselection = clickable('[data-test-eholdings-resource-deselection-confirmation-modal-no]');
+}
 
 @interactor class ResourceEditPage {
   navigationModal = new ResourceEditNavigationModal('#navigation-modal');
@@ -26,8 +32,11 @@ import Datepicker from './datepicker';
   isPeerReviewed = property('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]', 'checked');
   checkPeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
+  isSelected = property('[data-test-eholdings-resource-holding-status] input', 'checked');
+  toggleIsSelected = clickable('[data-test-eholdings-resource-holding-status] input');
+  modal = new ResourceEditModal('#eholdings-resource-confirmation-modal');
 
-  toast = Toast
+  toast = Toast;
 
   name = fillable('[data-test-eholdings-resource-name-field] input');
   nameHasError = hasClassBeginningWith('[data-test-eholdings-resource-name-field] input', 'feedbackError--');

--- a/tests/provider-search-test.js
+++ b/tests/provider-search-test.js
@@ -5,8 +5,6 @@ import { describeApplication } from './helpers';
 import ProviderSearchPage from './pages/provider-search';
 import PackageShowPage from './pages/package-show';
 
-window.ProviderSearchPage = ProviderSearchPage;
-
 describeApplication('ProviderSearch', () => {
   beforeEach(function () {
     this.server.createList('provider', 3, 'withPackagesAndTitles', {

--- a/tests/resource-custom-coverage-test.js
+++ b/tests/resource-custom-coverage-test.js
@@ -222,7 +222,7 @@ describeApplication('ResourceCustomCoverage', () => {
                 .dateRangeRowList(1).fillDates('12/18/2018', '12/19/2018');
             });
 
-            it.pause('indicates validation error on begin dates', () => {
+            it('indicates validation error on begin dates', () => {
               expect(ResourceCoverage.dateRangeRowList(0).beginDate.isInvalid).to.be.true;
               expect(ResourceCoverage.dateRangeRowList(1).beginDate.isInvalid).to.be.true;
             });

--- a/tests/resource-deselection-test.js
+++ b/tests/resource-deselection-test.js
@@ -100,21 +100,13 @@ describeApplication('ResourceDeselection', () => {
             return ResourcePage.deselectionModal.confirmDeselection();
           });
 
-          it('transition to Package Search Page', () => {
-            expect(PackageSearchPage.isPresent).to.be.true;
+          it('remains on Resource Page', () => {
+            expect(ResourcePage.isPresent).to.be.true;
           });
 
           describe('when the request succeeds', () => {
-            it('has search prefilled with package name', () => {
-              expect(PackageSearchPage.searchFieldValue).to.equal('Cool Package');
-            });
-
-            it('does not have an association to the above package', () => {
-              expect(PackageSearchPage.packageTitleList().length).to.equal(0);
-            });
-
-            it('shows a success Toast notification', () => {
-              expect(PackageSearchPage.toast.successText).to.equal('Title removed from package');
+            it.skip('shows a success Toast notification', () => {
+              expect(PackageSearchPage.toast.successText).to.equal('Title was updated');
             });
           });
         });

--- a/tests/resource-deselection-test.js
+++ b/tests/resource-deselection-test.js
@@ -53,7 +53,7 @@ describeApplication('ResourceDeselection', () => {
         });
 
         it('warns the user they are deselecting the final title in the package', () => {
-          expect(ResourcePage.deselectionModal.hasDeselectFinalTitleWarning).to.be.true;
+          expect(ResourcePage.deselectionModal.hasDeselectTitleWarning).to.be.true;
         });
       });
     });

--- a/tests/resource-deselection-test.js
+++ b/tests/resource-deselection-test.js
@@ -105,8 +105,8 @@ describeApplication('ResourceDeselection', () => {
           });
 
           describe('when the request succeeds', () => {
-            it.skip('shows a success Toast notification', () => {
-              expect(PackageSearchPage.toast.successText).to.equal('Title was updated');
+            it('shows a success Toast notification', () => {
+              expect(PackageSearchPage.toast.successText).to.equal('Title was updated.');
             });
           });
         });

--- a/tests/resource-deselection-test.js
+++ b/tests/resource-deselection-test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 
 import { describeApplication } from './helpers';
 import ResourcePage from './pages/resource-show';
+import PackageSearchPage from './pages/package-search';
 
 describeApplication('ResourceDeselection', () => {
   let provider,
@@ -99,34 +100,21 @@ describeApplication('ResourceDeselection', () => {
             return ResourcePage.deselectionModal.confirmDeselection();
           });
 
-          it('reflects the desired state (not selected)', () => {
-            expect(ResourcePage.isSelected).to.equal(false);
-          });
-
-          it('indicates it is working to get to desired state', () => {
-            expect(ResourcePage.isSelecting).to.equal(true);
-          });
-
-          it('cannot be interacted with while the request is in flight', () => {
-            expect(ResourcePage.isSelectedToggleDisabled).to.equal(true);
+          it('transition to Package Search Page', () => {
+            expect(PackageSearchPage.isPresent).to.be.true;
           });
 
           describe('when the request succeeds', () => {
-            it('reflects the desired state was set', () => {
-              expect(ResourcePage.isSelected).to.equal(false);
+            it('has search prefilled with package name', () => {
+              expect(PackageSearchPage.searchFieldValue).to.equal('Cool Package');
             });
 
-            it('indicates it is no longer working', () => {
-              expect(ResourcePage.isSelecting).to.equal(false);
+            it('does not have an association to the above package', () => {
+              expect(PackageSearchPage.packageTitleList().length).to.equal(0);
             });
 
-            it('removes custom embargo', () => {
-              expect(ResourcePage.hasCustomEmbargoPeriod).to.equal(false);
-            });
-
-            it('is not hidden', () => {
-              expect(resource.visibilityData.isHidden).to.equal(false);
-              expect(ResourcePage.hasHiddenToggle).to.equal(false);
+            it('shows a success Toast notification', () => {
+              expect(PackageSearchPage.toast.successText).to.equal('Title removed from package');
             });
           });
         });

--- a/tests/resource-edit-managed-title-in-custom-package-test.js
+++ b/tests/resource-edit-managed-title-in-custom-package-test.js
@@ -5,7 +5,7 @@ import { describeApplication } from './helpers';
 import ResourceEditPage from './pages/resource-edit';
 import PackageSearchPage from './pages/package-search';
 
-describeApplication('ManagedResourceHoldingSelection', () => {
+describeApplication('ResourceEditManagedTitleInCustomPackage', () => {
   let provider,
     providerPackage,
     resource;

--- a/tests/resource-edit-managed-title-test.js
+++ b/tests/resource-edit-managed-title-test.js
@@ -5,7 +5,7 @@ import { describeApplication } from './helpers';
 import ResourceShowPage from './pages/resource-show';
 import ResourceEditPage from './pages/resource-edit';
 
-describeApplication('ResourceEditManagedTitle', () => {
+describeApplication('ResourceEditManagedTitleInManagedPackage', () => {
   let provider,
     providerPackage,
     resource;

--- a/tests/resource-edit-managed-title-test.js
+++ b/tests/resource-edit-managed-title-test.js
@@ -34,7 +34,7 @@ describeApplication('ResourceEditManagedTitle', () => {
       package: providerPackage,
       isSelected: true,
       title,
-      url: 'frontside.io'
+      url: 'https://www.frontside.io'
     });
   });
 

--- a/tests/resource-show-test.js
+++ b/tests/resource-show-test.js
@@ -201,7 +201,7 @@ describeApplication('ResourceShow', () => {
           .clickProvider();
       });
 
-      it.always.skip('does not navigate away', function () {
+      it.always('does not navigate away', function () {
         expect(this.app.history.location.pathname)
           .to.equal(`/eholdings/resources/${resource.titleId}`);
       });
@@ -234,7 +234,7 @@ describeApplication('ResourceShow', () => {
           expect(NavigationModal.isPresent).to.be.false;
         });
 
-        it.always.skip('does not navigation away', function () {
+        it.always('does not navigation away', function () {
           expect(this.app.history.location.pathname)
             .to.equal(`/eholdings/resources/${resource.titleId}`);
         });


### PR DESCRIPTION
## Purpose
The eholdings application allows users to add and remove a resource aka title from their holdings. To add a resource aka title to their holdings they "select" it which means its now in their holdings and they have the rights for patrons to access it. A user adding a resource / title to their holdings can happen in two types of packages within eholdings a `'Managed Package'` or a `'Custom Package'` and the resource / title its self can either be a `'Managed-Title'` or a `'Custom-Title'`.

`Managed Packages` are Packages that are completely managed / controlled by the Knowledge Base. `Custom-Packages` are Packages that are created by a eholdings user and the user is now responsible for the maintenance of the Package, for example any name changes, or ISBN updates, etc. These same descriptions hold true for  both `Managed` and `Custom` titles as well.

Within the Knowledge Base `Managed Packages` can only contain `Managed-Titles` but this is not the same for `Custom-Packages`.  A `Custom-Package` allows a eholdings user create a package containing both `Managed-Titles` and `Custom-Titles`. Whenever any title is associated with a custom package, we call this a “custom resource”.

When a user creates a `Custom-Title` it is automatically set to "selected" within the declared `Custom-Package` and added to their holdings. The same is true for adding a `Managed-Title` within a `Custom-Package` it is automatically set to "selected".

As stated the Knowledge Base differentiates between a`Managed` and `Custom` package as well as Titles so when a user decides to remove a title from a Package the Knowledge base treats that removal / deselection slightly differently depending on wether the user is Removing / Deselecting a:

  -  Managed-Title from within a Managed Package.
  -  Managed-Title from within a Custom Package.
  -  Custom-Title from within a Custom Package

When i user deselects / removes a managed-title from a Managed Package the title is just not shown in the current managed-package and not in the user holdings but is still present in the knowledge base. With Custom-Packages though when a user deselects / removes a custom-title it will be only present in the knowledge based if there is another instance of custom-title in another Custom-Package if not the custom-title will no longer be present to be used. Removing a managed title from a custom-package removes it from the custom-package but it is still present in the knowledge.

So, ultimately even though the Knowledge Base treats these entities differently we want to try to make the User Experience for removal of Titles as uniform and predictable for the user as possible.

## Approach
RMAPI has some nuance behavior in regards to how it handles removing titles that are within Custom Packages and Managed Packages. We wants to hide and make those nuances as similar to the user as possible.
- Handle removing a custom-title or managed-title that is within a custom-package as a destructive behavior and DELETE is from the parent/containing custom-package that it is included in.
  - Transition the user to containing/parent custom-package page 
   - Show a Success Toast upon the successful removal
- Treat the removal of a managed-title from a managed-package as a UPDATE of that managed package and just UNSELECT it from the parent/containing managed-package.
  - Show Success Toast upon successful update of UNSELECT on title.

#### TODOS and Open Questions

###### TODO:
- Change Messaging in Modal when the title is the last Title and not within any other packages.
  - Currently the messaging works if the user navigates to the resource show or custom-title-edit page from a search or just clicking through. We then have access to the `model.title.resources` Array, which is the Array of all Resources that this title is located within. The issue is if a user paste the URL into the browser that Array is not populated. So the messaging IF its the last title in any package will not pop.

###### Open Questions:
 - There are two ways to get to a title that is within a Custom Package. The user can do a Title Search or a Package Search. After the removal of the title should we take them back to where they came from? Title search or Package search. This will based on feedback in User Experience Testing but it is a open question.

## Jira
https://issues.folio.org/browse/UIEH-285

## Screenshots
#### Removal of Custom or Managed title from within a Custom Package.
 - The behavior is the same from a edit page as well.
![2018-05-03 18 36 32](https://user-images.githubusercontent.com/1953098/39606566-0811801a-4f04-11e8-891a-5449425390df.gif)

#### Deselection of Managed title from within a Managed Package.
 - From View Page
![2018-05-03 18 37 38](https://user-images.githubusercontent.com/1953098/39606567-081ed17a-4f04-11e8-9eda-dfbe6cf6b112.gif)

- From Edit Page
![2018-05-03 19 15 05](https://user-images.githubusercontent.com/1953098/39606984-62effbe0-4f06-11e8-9ad7-4100efbc1b65.gif)


-->
