### PR TITLE
WIP to try and order such that list loads ahead of detail record - UIEH-357

### DIFF
--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -15,6 +15,7 @@ class ProviderShowRoute extends Component {
       }).isRequired
     }).isRequired,
     model: PropTypes.object.isRequired,
+    search: PropTypes.object,
     resolver: PropTypes.object.isRequired,
     getProvider: PropTypes.func.isRequired,
     getPackages: PropTypes.func.isRequired
@@ -34,12 +35,14 @@ class ProviderShowRoute extends Component {
     let { pkgSearchParams } = this.state;
     let { providerId } = match.params;
 
-    if (providerId !== prevProps.match.params.providerId) {
-      this.props.getProvider(providerId);
-    }
+    if (this.props.search !== undefined) {
+      if (providerId !== prevProps.match.params.providerId) {
+        this.props.getProvider(providerId);
+      }
 
-    if (pkgSearchParams !== prevState.pkgSearchParams) {
-      getPackages(providerId, pkgSearchParams);
+      if (pkgSearchParams !== prevState.pkgSearchParams) {
+        getPackages(providerId, pkgSearchParams);
+      }
     }
   }
 
@@ -78,7 +81,13 @@ class ProviderShowRoute extends Component {
 export default connect(
   ({ eholdings: { data } }, { match }) => {
     let resolver = createResolver(data);
-
+    if (match.url && match.url.includes('searchType')) {
+      return {
+        model: resolver.find('providers', match.params.providerId),
+        search: resolver.getRequest('query', { type: 'providers' }),
+        resolver
+      };
+    }
     return {
       model: resolver.find('providers', match.params.providerId),
       resolver


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-357, for both managed and custom titles, we see that the detail-record loads ahead of the list as a result of which in the redux data layer, search list record overrides the detail record data and unfortunately, search list records might not have all fields of a detail-record. Effect is that certain fields are missing on detail record.

## Approach
To alleviate the situation above, try to order the events such that detail record does not load until the search completes rendering. @wwilsman suggested these changes and is a work in progress.

#### TODOS and Open Questions
- [ ] I might have misunderstood your suggestion and might be doing something wrong. While the provider detail is still present in the third pane, this change is not able to load list of packages for a given provider. 
- [ ] When I tried to debug, search is not returning the last search request as we expected.
- [ ] If this solution works for providers, then port it over for packages and titles.

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
