### PR TITLE
UIEH-322: Alter Modal css rule to enable scrolling of content

### DIFF
--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -17,7 +17,7 @@
   background-color: #fff;
   max-height: calc(80vh);
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   border-radius: var(--radius, 4px);
   box-shadow: 0 5px 28px 1px rgba(0, 0, 0, 0.2);
   border: 1px solid rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Purpose
When performing a package search from within a provider record, the modal that pops up with the search interface simply cuts off the overflowing filter radio inputs.

Resolves: [UIEH-322](https://issues.folio.org/browse/UIEH-322)

## Approach
I've changed the Modal component content area from `overflow: hidden` to `overflow: auto`.

## Screenshots
![2018-05-08 10 11 26](https://user-images.githubusercontent.com/15052791/39766454-fa0fed5e-52a9-11e8-8fb8-82971a740fe9.gif)
