### PR TITLE
UIEH-358 - Custom Package Full Page Edit (Name/Content Type Disable when deselected)

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -6,6 +6,7 @@ import isEqual from 'lodash/isEqual';
 import {
   Button,
   Icon,
+  KeyValue
 } from '@folio/stripes-components';
 import { processErrors } from '../../utilities';
 
@@ -177,8 +178,25 @@ class CustomPackageEdit extends Component {
               <DetailsViewSection
                 label="Package information"
               >
-                <NameField />
-                <ContentTypeField />
+                {packageSelected ? (
+                  <NameField />
+               ) : (
+                 <KeyValue label="Name">
+                   <div data-test-eholdings-package-readonly-name-field>
+                     {model.name}
+                   </div>
+                 </KeyValue>
+
+               )}
+                {packageSelected ? (
+                  <ContentTypeField />
+               ) : (
+                 <KeyValue label="Content type">
+                   <div data-test-eholdings-package-details-readonly-content-type>
+                     {model.contentType}
+                   </div>
+                 </KeyValue>
+               )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Holding status"

--- a/tests/custom-package-edit-selection-test.js
+++ b/tests/custom-package-edit-selection-test.js
@@ -1,0 +1,175 @@
+import { expect } from 'chai';
+import { describe, beforeEach, afterEach, it } from '@bigtest/mocha';
+
+import { describeApplication } from './helpers';
+import PackageShowPage from './pages/package-show';
+import PackageEditPage from './pages/package-edit';
+import PackageSearchPage from './pages/package-search';
+
+describeApplication('CustomPackageEditSelection', () => {
+  let provider,
+    providerPackage;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create('package', {
+      provider,
+      name: 'Cool Package',
+      contentType: 'E-Book',
+      isCustom: true
+    });
+  });
+
+  describe('visiting the package edit page', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/packages/${providerPackage.id}/edit`, () => {
+        expect(PackageEditPage.$root).to.exist;
+      });
+    });
+
+    it('displays the correct holdings status (ON)', () => {
+      expect(PackageEditPage.isSelected).to.equal(true);
+    });
+
+    it('disables the save button', () => {
+      expect(PackageEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return PackageEditPage.clickCancel();
+      });
+
+      it('goes to the package show page', () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    describe('toggling the selection toggle (OFF)', () => {
+      beforeEach(function () {
+        /*
+         * The expectations in the convergent `it` blocks
+         * get run once every 10ms.  We were seeing test flakiness
+         * when a toggle action dispatched and resolved before an
+         * expectation had the chance to run.  We sidestep this by
+         * temporarily increasing the mirage server's response time
+         * to 50ms.
+         * TODO: control timing directly with Mirage
+         */
+        this.server.timing = 50;
+        return PackageEditPage.toggleIsSelected();
+      });
+
+      afterEach(function () {
+        this.server.timing = 0;
+      });
+
+      it('cannot toggle visibility', () => {
+        expect(PackageEditPage.isVisibleTogglePresent).to.equal(false);
+      });
+
+      it('cannot edit coverage', () => {
+        expect(PackageEditPage.hasCoverageDatesPresent).to.equal(false);
+      });
+
+      it('cannot edit package name', () => {
+        expect(PackageEditPage.hasReadOnlyNameFieldPresent).to.equal(true);
+        expect(PackageEditPage.hasNameFieldPresent).to.equal(false);
+      });
+
+      it('cannot edit content type', () => {
+        expect(PackageEditPage.hasReadOnlyContentTypeFieldPresent).to.equal(true);
+        expect(PackageEditPage.hasContentTypeFieldPresent).to.equal(false);
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return PackageEditPage.clickSave();
+        });
+
+        it('shows the modal', () => {
+          expect(PackageEditPage.modal.isPresent).to.equal(true);
+        });
+
+        it('reflects the desired state of holding status', () => {
+          expect(PackageEditPage.isSelected).to.equal(false);
+        });
+
+        describe('clicking confirm', () => {
+          beforeEach(() => {
+            return PackageEditPage.modal.confirmDeselection();
+          });
+
+          it('transitions to the package search page', function () {
+            expect(this.app.history.location.search).to.include('?searchType=packages');
+          });
+
+          describe('searching for package after confirming', () => {
+            beforeEach(() => {
+              return PackageSearchPage.search('Cool Package');
+            });
+
+            it('does not find package', () => {
+              expect(PackageSearchPage.noResultsMessage).to.equal('No packages found for "Cool Package".');
+            });
+          });
+        });
+
+        describe('clicking cancel', () => {
+          beforeEach(() => {
+            return PackageEditPage.modal.cancelDeselection();
+          });
+
+          it('removes the modal', () => {
+            expect(PackageEditPage.modal.isPresent).to.equal(false);
+          });
+
+          it('reflects the correct holding status', () => {
+            expect(PackageEditPage.isSelected).to.equal(true);
+          });
+        });
+      });
+
+      describe('toggling the selection toggle ON', () => {
+        beforeEach(function () {
+          /*
+           * The expectations in the convergent `it` blocks
+           * get run once every 10ms.  We were seeing test flakiness
+           * when a toggle action dispatched and resolved before an
+           * expectation had the chance to run.  We sidestep this by
+           * temporarily increasing the mirage server's response time
+           * to 50ms.
+           * TODO: control timing directly with Mirage
+           */
+          this.server.timing = 50;
+          return PackageEditPage.toggleIsSelected();
+        });
+
+        afterEach(function () {
+          this.server.timing = 0;
+        });
+
+        it('can toggle visibility', () => {
+          expect(PackageEditPage.isVisibleTogglePresent).to.equal(true);
+        });
+
+        it('can edit coverage', () => {
+          expect(PackageEditPage.hasCoverageDatesPresent).to.equal(true);
+        });
+
+        it('can edit package name', () => {
+          expect(PackageEditPage.hasReadOnlyNameFieldPresent).to.equal(false);
+          expect(PackageEditPage.hasNameFieldPresent).to.equal(true);
+        });
+
+        it('can edit content type', () => {
+          expect(PackageEditPage.hasReadOnlyContentTypeFieldPresent).to.equal(false);
+          expect(PackageEditPage.hasContentTypeFieldPresent).to.equal(true);
+        });
+      });
+    });
+  });
+});

--- a/tests/custom-package-edit-test.js
+++ b/tests/custom-package-edit-test.js
@@ -1,10 +1,9 @@
 import { expect } from 'chai';
-import { describe, beforeEach, afterEach, it } from '@bigtest/mocha';
+import { describe, beforeEach, it } from '@bigtest/mocha';
 
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/package-show';
 import PackageEditPage from './pages/package-edit';
-import PackageSearchPage from './pages/package-search';
 
 describeApplication('CustomPackageEdit', () => {
   let provider,
@@ -50,82 +49,6 @@ describeApplication('CustomPackageEdit', () => {
 
       it('goes to the package show page', () => {
         expect(PackageShowPage.$root).to.exist;
-      });
-    });
-
-    describe('toggling the selection toggle', () => {
-      beforeEach(function () {
-        /*
-         * The expectations in the convergent `it` blocks
-         * get run once every 10ms.  We were seeing test flakiness
-         * when a toggle action dispatched and resolved before an
-         * expectation had the chance to run.  We sidestep this by
-         * temporarily increasing the mirage server's response time
-         * to 50ms.
-         * TODO: control timing directly with Mirage
-         */
-        this.server.timing = 50;
-        return PackageEditPage.toggleIsSelected();
-      });
-
-      afterEach(function () {
-        this.server.timing = 0;
-      });
-
-      it('cannot toggle visibility', () => {
-        expect(PackageEditPage.isVisibleTogglePresent).to.equal(false);
-      });
-
-      it('cannot edit coverage', () => {
-        expect(PackageEditPage.hasCoverageDatesPresent).to.equal(false);
-      });
-
-      describe('clicking save', () => {
-        beforeEach(() => {
-          return PackageEditPage.clickSave();
-        });
-
-        it('shows the modal', () => {
-          expect(PackageEditPage.modal.isPresent).to.equal(true);
-        });
-
-        it('reflects the desired state of holding status', () => {
-          expect(PackageEditPage.isSelected).to.equal(false);
-        });
-
-        describe('clicking confirm', () => {
-          beforeEach(() => {
-            return PackageEditPage.modal.confirmDeselection();
-          });
-
-          it('transitions to the package search page', function () {
-            expect(this.app.history.location.search).to.include('?searchType=packages');
-          });
-
-          describe('searching for package after confirming', () => {
-            beforeEach(() => {
-              return PackageSearchPage.search('Cool Package');
-            });
-
-            it('does not find package', () => {
-              expect(PackageSearchPage.noResultsMessage).to.equal('No packages found for "Cool Package".');
-            });
-          });
-        });
-
-        describe('clicking cancel', () => {
-          beforeEach(() => {
-            return PackageEditPage.modal.cancelDeselection();
-          });
-
-          it('removes the modal', () => {
-            expect(PackageEditPage.modal.isPresent).to.equal(false);
-          });
-
-          it('reflects the correct holding status', () => {
-            expect(PackageEditPage.isSelected).to.equal(true);
-          });
-        });
       });
     });
 

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -41,6 +41,10 @@ import Datepicker from './datepicker';
   toggleAllowKbToAddTitles = clickable('[data-test-eholdings-package-details-allow-add-new-titles] input');
   allowKbToAddTitles = property('[data-test-eholdings-package-details-allow-add-new-titles] input', 'checked');
   hasCoverageDatesPresent = isPresent('[data-test-eholdings-coverage-fields-date-range-row]');
+  hasNameFieldPresent = isPresent('[data-test-eholdings-package-name-field]');
+  hasReadOnlyNameFieldPresent = isPresent('[data-test-eholdings-package-readonly-name-field]');
+  hasContentTypeFieldPresent = isPresent('[data-test-eholdings-package-content-type-field]');
+  hasReadOnlyContentTypeFieldPresent = isPresent('[data-test-eholdings-package-details-readonly-content-type]');
 
   toast = Toast;
 


### PR DESCRIPTION
[UIEH-358 - Edit: unselect Package Details Records (package name/content type)](https://issues.folio.org/browse/UIEH-358)

## Purpose
When users are on the full page edit form for a custom package, they can toggle the packages Holding Status from Selected to Unselected.  The toggle is changed on the form, but not yet committed to the backend. The commit is only done once the form is submitted via a Save button. In the case of Unselecting a Custom Package and committing via Save, the package is essentially deleted. When the toggle appears as unselected on the full page edit form (and has not yet been submitted), all other editable fields should be disabled. The majority of this work was addressed in the following PR: 
https://github.com/folio-org/ui-eholdings/pull/385 
This PR addresses the disabling of 2 Custom Package Fields (Package Name and Content Type)

## Approach
Updated Name and Content type fields to appear as readonly KeyValue fields when Holding Status is UnSelected.
Similar to Coverage Dates and Visibility, the check is done in the CustomPackageEdit form 
Moved Custom Package Edit Selection tests into a separate test file from Custom Package Edit Tests

#### TODOS and Open Questions
- [ ] Looked into moving isReadonly logic into Name and Content-Type _fields components (as is visible in earlier commits to this branch). I opted to keep the logic in the form - solution seems simpler. But interested in other opinions on this and what are best practices

## Learning
https://github.com/erikras/redux-form
## Screenshots
![custom-package-edit-fields-visible](https://user-images.githubusercontent.com/19415226/39775626-7b578490-52cc-11e8-9799-a130cfe0ade5.gif)
Below scenario - shows edit of inputs, deselect (name and content type revert to original values) and save of custom package (package is deleted)
![edit-and-save](https://user-images.githubusercontent.com/19415226/39783129-1a6120a4-52e2-11e8-8900-8c80c1969a00.gif)
