### PR TITLE
UIEH-287 Adjust number of custom packages fetched

### DIFF
--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -113,14 +113,14 @@ export default connect(
       createRequest: resolver.getRequest('create', { type: 'titles' }),
       customPackages: resolver.query('packages', {
         filter: { custom: true },
-        count: 1000
+        count: 100
       })
     };
   }, {
     createTitle: attrs => Title.create(attrs),
     getCustomPackages: () => Package.query({
       filter: { custom: true },
-      count: 1000
+      count: 100
     })
   }
 )(TitleCreateRoute);


### PR DESCRIPTION
## Purpose
While working on https://github.com/folio-org/mod-kb-ebsco/pull/128, I discovered that RM API's max page size is 100.

## Approach
We should request 100 custom packages, instead of 1000.

## Next Steps
Use some type of UI element that can paginate for showing the list of available custom packages.