### PR TITLE
UIEH-355 Hide editable areas when managed-title in managed-package is unselected

### DIFF
--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -141,7 +141,11 @@ class ResourceEditCustomTitle extends Component {
               <DetailsViewSection
                 label="Resource information"
               >
-                <CustomUrlFields />
+                {resourceSelected ? (
+                  <CustomUrlFields />
+                    ) : (
+                      <p>Add the resource to holdings to set custom url.</p>
+                  )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Holding status"
@@ -150,6 +154,8 @@ class ResourceEditCustomTitle extends Component {
                   data-test-eholdings-resource-holding-status
                   htmlFor="custom-resource-holding-toggle-switch"
                 >
+                  <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
+                  <br />
                   <Field
                     name="isSelected"
                     component={ToggleSwitch}
@@ -162,26 +168,39 @@ class ResourceEditCustomTitle extends Component {
               <DetailsViewSection
                 label="Coverage dates"
               >
-                <CustomCoverageFields
-                  initialValue={initialValues.customCoverages}
-                />
+                {resourceSelected ? (
+                  <CustomCoverageFields
+                    initialValue={initialValues.customCoverages}
+                  />
+                  ) : (
+                    <p>Add the resource to holdings to set custom coverage dates.</p>
+                )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage statement"
               >
-                <CoverageStatementFields />
+                {resourceSelected ? (
+                  <CoverageStatementFields />
+                  ) : (
+                    <p>Add the resource to holdings to set coverage statement.</p>
+                  )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Embargo period"
               >
-                <CustomEmbargoFields
-                  change={change}
-                  showInputs={(initialValues.customEmbargoValue > 0)}
-                  initialValue={{
-                    customEmbargoValue: initialValues.customEmbargoValue,
-                    customEmbargoUnit: initialValues.customEmbargoUnit
+                {resourceSelected ? (
+                  <CustomEmbargoFields
+                    change={change}
+                    showInputs={(initialValues.customEmbargoValue > 0)}
+                    initialValue={{
+                      customEmbargoValue: initialValues.customEmbargoValue,
+                      customEmbargoUnit: initialValues.customEmbargoUnit
                   }}
-                />
+                  />
+                ) : (
+                  <p>Add the resource to holdings to set custom embargo.</p>
+                )}
+
               </DetailsViewSection>
               <div className={styles['resource-edit-action-buttons']}>
                 <div

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -150,6 +150,8 @@ class ResourceEditManagedTitle extends Component {
                   data-test-eholdings-resource-holding-status
                   htmlFor="managed-resource-holding-toggle-switch"
                 >
+                  <h4>{managedResourceSelected ? 'Selected' : 'Not selected'}</h4>
+                  <br />
                   <Field
                     name="isSelected"
                     component={ToggleSwitch}
@@ -162,26 +164,38 @@ class ResourceEditManagedTitle extends Component {
               <DetailsViewSection
                 label="Coverage dates"
               >
-                <CustomCoverageFields
-                  initialValue={initialValues.customCoverages}
-                />
+                {managedResourceSelected ? (
+                  <CustomCoverageFields
+                    initialValue={initialValues.customCoverages}
+                  />
+                ) : (
+                  <p>Add the resource to holdings to set custom coverage dates.</p>
+                )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage statement"
               >
-                <CoverageStatementFields />
+                {managedResourceSelected ? (
+                  <CoverageStatementFields />
+                  ) : (
+                    <p>Add the resource to holdings to set coverage statement.</p>
+                  )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Embargo period"
               >
-                <CustomEmbargoFields
-                  change={change}
-                  showInputs={(initialValues.customEmbargoValue > 0)}
-                  initialValue={{
+                {managedResourceSelected ? (
+                  <CustomEmbargoFields
+                    change={change}
+                    showInputs={(initialValues.customEmbargoValue > 0)}
+                    initialValue={{
                     customEmbargoValue: initialValues.customEmbargoValue,
                     customEmbargoUnit: initialValues.customEmbargoUnit
                   }}
-                />
+                  />
+                  ) : (
+                    <p>Add the resource to holdings to set custom embargo.</p>
+                  )}
               </DetailsViewSection>
               <div className={styles['resource-edit-action-buttons']}>
                 <div

--- a/tests/pages/resource-edit.js
+++ b/tests/pages/resource-edit.js
@@ -53,6 +53,7 @@ import Datepicker from './datepicker';
     }
   });
 
+  hasCoverageStatementArea = isPresent('[data-test-eholdings-coverage-statement-textarea] textarea');
   coverageStatement = value('[data-test-eholdings-coverage-statement-textarea] textarea');
   customUrlFieldValue = value('[data-test-eholdings-custom-url-textfield] input');
   fillCoverageStatement = fillable('[data-test-eholdings-coverage-statement-textarea] textarea');
@@ -74,6 +75,7 @@ import Datepicker from './datepicker';
   blurEmbargoValue = blurrable('[data-test-eholdings-custom-embargo-textfield] input');
   blurEmbargoUnit = blurrable('[data-test-eholdings-custom-embargo-select] select');
   validationErrorOnEmbargoTextField = text('[data-test-eholdings-custom-embargo-textfield] [class^="feedbackError--"]');
+  hasAddCustomCoverageButton = isPresent('[data-test-eholdings-coverage-fields-add-row-button] button');
   hasAddCustomEmbargoButton = isPresent('[data-test-eholdings-custom-embargo-add-row-button] button');
   clickAddCustomEmbargoButton = clickable('[data-test-eholdings-custom-embargo-add-row-button] button');
   hasSavingWillRemoveEmbargoMessage = isPresent('[data-test-eholdings-embargo-fields-saving-will-remove]');

--- a/tests/resource-edit-custom-title-test.js
+++ b/tests/resource-edit-custom-title-test.js
@@ -40,6 +40,32 @@ describeApplication('ResourceEditCustomTitle', () => {
     });
   });
 
+  describe('visting the custom resource edit page but the resource is unselected', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    describe('with the resource unselected', () => {
+      beforeEach(() => {
+        return ResourceEditPage.toggleIsSelected();
+      });
+
+      it('should not display the coverage button', () => {
+        expect(ResourceEditPage.hasAddCustomCoverageButton).to.be.false;
+      });
+
+      it('should not display the custom embargo button', () => {
+        expect(ResourceEditPage.hasAddCustomCoverageButton).to.be.false;
+      });
+
+      it('should not display the coverage statement textarea', () => {
+        expect(ResourceEditPage.hasCoverageStatementArea).to.be.false;
+      });
+    });
+  });
+
   describe('visiting the resource edit page without coverage dates or statements', () => {
     beforeEach(function () {
       return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {

--- a/tests/resource-edit-managed-title-test.js
+++ b/tests/resource-edit-managed-title-test.js
@@ -38,6 +38,32 @@ describeApplication('ResourceEditManagedTitleInManagedPackage', () => {
     });
   });
 
+  describe('visting the managed resource edit page but the resource is unselected', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    describe('with the resource unselected', () => {
+      beforeEach(() => {
+        return ResourceEditPage.toggleIsSelected();
+      });
+
+      it('should not display the coverage button', () => {
+        expect(ResourceEditPage.hasAddCustomCoverageButton).to.be.false;
+      });
+
+      it('should not display the custom embargo button', () => {
+        expect(ResourceEditPage.hasAddCustomCoverageButton).to.be.false;
+      });
+
+      it('should not display the coverage statement textarea', () => {
+        expect(ResourceEditPage.hasCoverageStatementArea).to.be.false;
+      });
+    });
+  });
+
   describe('visiting the resource edit page without coverage dates, statement, or embargo', () => {
     beforeEach(function () {
       return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {


### PR DESCRIPTION
## Purpose

Managed-Titles and Managed-Packages are capable of being 'unselected' from a users electronic holdings and not not viewable to a patron but still present and able to be interacted with by a eHoldings application user. However, the level of interaction a user can have with a title differs from when the title is 'selected' vs 'unselected'. Until a title is 'selected'  the user should not be able to make any customization to that title because titles that are not selected are essentially not added to the user eHoldings and giving them permission to make customizations. 
 
## Approach
 - Hide / Disable editable sections until the title is "selected".

## Jira
 - https://issues.folio.org/browse/UIEH-355

## Screenshots
![2018-05-08 15 51 11](https://user-images.githubusercontent.com/1953098/39824496-72cb6ad8-537d-11e8-987b-2187eda6cffd.gif)

