### PR TITLE
Remove package view logic from route

### DIFF
--- a/src/components/package/edit.js
+++ b/src/components/package/edit.js
@@ -1,14 +1,42 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import EditManaged from './edit-managed';
-import EditCustom from './edit-custom';
+
+import ManagedPackageEdit from './edit-managed';
+import CustomPackageEdit from './edit-custom';
 
 export default function PackageEdit({ model, ...props }) {
-  let View = model.isCustom ? EditCustom : EditManaged;
+  let initialValues = {};
+  let View;
+
+  if (model.isCustom) {
+    View = CustomPackageEdit;
+    initialValues = {
+      name: model.name,
+      contentType: model.contentType,
+      isSelected: model.isSelected,
+      customCoverages: [{
+        beginCoverage: model.customCoverage.beginCoverage,
+        endCoverage: model.customCoverage.endCoverage
+      }],
+      isVisible: !model.visibilityData.isHidden
+    };
+  } else {
+    View = ManagedPackageEdit;
+    initialValues = {
+      isSelected: model.isSelected,
+      customCoverages: [{
+        beginCoverage: model.customCoverage.beginCoverage,
+        endCoverage: model.customCoverage.endCoverage
+      }],
+      isVisible: !model.visibilityData.isHidden,
+      allowKbToAddTitles: model.allowKbToAddTitles
+    };
+  }
 
   return (
     <View
       model={model}
+      initialValues={initialValues}
       {...props}
     />
   );

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -7,8 +7,7 @@ import { createResolver } from '../redux';
 import Package from '../redux/package';
 import Resource from '../redux/resource';
 
-import ManagedPackageEdit from '../components/package/edit-managed/managed-package-edit';
-import CustomPackageEdit from '../components/package/edit-custom/custom-package-edit';
+import View from '../components/package/edit';
 
 class PackageEditRoute extends Component {
   static propTypes = {
@@ -121,38 +120,11 @@ class PackageEditRoute extends Component {
 
   render() {
     let { model } = this.props;
-    let initialValues = {};
-    let View;
 
-    if (model.isCustom) {
-      View = CustomPackageEdit;
-      initialValues = {
-        name: model.name,
-        contentType: model.contentType,
-        isSelected: model.isSelected,
-        customCoverages: [{
-          beginCoverage: model.customCoverage.beginCoverage,
-          endCoverage: model.customCoverage.endCoverage
-        }],
-        isVisible: !model.visibilityData.isHidden
-      };
-    } else {
-      View = ManagedPackageEdit;
-      initialValues = {
-        isSelected: model.isSelected,
-        customCoverages: [{
-          beginCoverage: model.customCoverage.beginCoverage,
-          endCoverage: model.customCoverage.endCoverage
-        }],
-        isVisible: !model.visibilityData.isHidden,
-        allowKbToAddTitles: model.allowKbToAddTitles
-      };
-    }
     return (
       <View
         model={model}
         onSubmit={this.packageEditSubmitted}
-        initialValues={initialValues}
       />
     );
   }


### PR DESCRIPTION
## Purpose
A Routes responsibility is to pass along data and just return a View not determine which kind of View to return. View branching logic belongs in the View. The View receives data and then looks at that data to determine what kind of View it should return to the Route. 

## Approach
 - Move View Logic from the Route to a intermediate View that will contain the branching logic to determine what kind of View to return.

