### PR TITLE
[UIEH-286] Add title to custom package

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -325,6 +325,21 @@ export default function configure() {
     return matchingResource;
   });
 
+  this.post('/resources', ({ resources, packages }, request) => {
+    let body = JSON.parse(request.requestBody);
+    let { packageId, titleId } = body.data.attributes;
+    let { providerId } = packages.find(packageId);
+
+    let resource = resources.create({
+      isSelected: true,
+      providerId,
+      packageId,
+      titleId
+    });
+
+    return resource;
+  });
+
   this.delete('/resources/:id', ({ resources }, request) => {
     let matchingResource = resources.find(request.params.id);
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -327,14 +327,15 @@ export default function configure() {
 
   this.post('/resources', ({ resources, packages }, request) => {
     let body = JSON.parse(request.requestBody);
-    let { packageId, titleId } = body.data.attributes;
+    let { packageId, titleId, url } = body.data.attributes;
     let { providerId } = packages.find(packageId);
 
     let resource = resources.create({
       isSelected: true,
       providerId,
       packageId,
-      titleId
+      titleId,
+      url
     });
 
     return resource;

--- a/src/components/title/_fields/package-select/package-select-field.js
+++ b/src/components/title/_fields/package-select/package-select-field.js
@@ -5,14 +5,12 @@ import { Field } from 'redux-form';
 import { Select } from '@folio/stripes-components';
 import styles from './package-select-field.css';
 
-export default function PackageSelectField({ packages }) {
-  let options = packages.map(pkg => ({ label: pkg.name, value: pkg.id }));
-
-  options.unshift({
+export default function PackageSelectField({ options }) {
+  let optionsWithPlaceholder = [{
     label: options.length ? 'Choose a package' : '...Loading',
     disabled: true,
     value: ''
-  });
+  }, ...options];
 
   return (
     <div
@@ -23,14 +21,14 @@ export default function PackageSelectField({ packages }) {
         name="packageId"
         component={Select}
         label="Package"
-        dataOptions={options}
+        dataOptions={optionsWithPlaceholder}
       />
     </div>
   );
 }
 
 PackageSelectField.propTypes = {
-  packages: PropTypes.object.isRequired
+  options: PropTypes.array.isRequired
 };
 
 export function validate(values) {

--- a/src/components/title/_forms/add-to-package.js
+++ b/src/components/title/_forms/add-to-package.js
@@ -2,12 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 
-import PackageSelectField, { validate } from '../_fields/package-select';
+import PackageSelectField, { validate as validatePackage } from '../_fields/package-select';
+import CustomURLField, { validate as validateURL } from '../../resource/_fields/custom-url';
 
 function AddTitleToPackageForm({ handleSubmit, onSubmit, packageOptions }) {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <PackageSelectField options={packageOptions} />
+      <CustomURLField />
     </form>
   );
 }
@@ -17,6 +19,12 @@ AddTitleToPackageForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   packageOptions: PropTypes.array.isRequired
 };
+
+function validate(values) {
+  return Object.assign({},
+    validatePackage(values),
+    validateURL(values));
+}
 
 export default reduxForm({
   form: 'AppTitleToPackage',

--- a/src/components/title/_forms/add-to-package.js
+++ b/src/components/title/_forms/add-to-package.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+
+import PackageSelectField, { validate } from '../_fields/package-select';
+
+function AddTitleToPackageForm({ handleSubmit, onSubmit, packageOptions }) {
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <PackageSelectField options={packageOptions} />
+    </form>
+  );
+}
+
+AddTitleToPackageForm.propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  packageOptions: PropTypes.array.isRequired
+};
+
+export default reduxForm({
+  form: 'AppTitleToPackage',
+  enableReinitialize: true,
+  destroyOnUnmount: false,
+  validate
+})(AddTitleToPackageForm);

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -59,6 +59,11 @@ class TitleCreate extends Component {
 
     let historyState = router.history.location.state;
 
+    let packageOptions = customPackages.map(pkg => ({
+      label: pkg.name,
+      value: pkg.id
+    }));
+
     return (
       <div data-test-eholdings-title-create>
         <Toaster
@@ -98,7 +103,7 @@ class TitleCreate extends Component {
               <PeerReviewedField />
             </DetailsViewSection>
             <DetailsViewSection label="Package information">
-              <PackageSelectField packages={customPackages} />
+              <PackageSelectField options={packageOptions} />
             </DetailsViewSection>
             <div className={styles['title-create-action-buttons']}>
               <div data-test-eholdings-title-create-cancel-button>

--- a/src/components/title/show/title-show.css
+++ b/src/components/title/show/title-show.css
@@ -7,3 +7,7 @@
     display: block;
   }
 }
+
+.add-to-custom-package-button {
+  margin: 2em 0 0;
+}

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+
 import {
+  Button,
   IconButton,
   KeyValue,
-  PaneMenu
+  PaneMenu,
 } from '@folio/stripes-components';
 
 import { processErrors } from '../../utilities';
@@ -13,173 +15,264 @@ import PackageListItem from '../../package-list-item';
 import IdentifiersList from '../../identifiers-list';
 import ContributorsList from '../../contributors-list';
 import DetailsViewSection from '../../details-view-section';
+import AddToPackageForm from '../_forms/add-to-package';
 import Toaster from '../../toaster';
+import Modal from '../../modal';
 import styles from './title-show.css';
 
-export default function TitleShow({ model }, { queryParams, router }) {
-  let actionMenuItems = [];
+export default class TitleShow extends Component {
+  static propTypes = {
+    model: PropTypes.object.isRequired,
+    customPackages: PropTypes.object.isRequired,
+    addCustomPackage: PropTypes.func.isRequired
+  };
 
-  if (model.isTitleCustom) {
-    actionMenuItems.push({
-      label: 'Edit',
-      to: {
-        pathname: `/eholdings/titles/${model.id}/edit`,
-        search: router.route.location.search,
-        state: { eholdings: true }
-      }
-    });
+  static contextTypes = {
+    router: PropTypes.object,
+    queryParams: PropTypes.object
+  };
+
+  state = {
+    showCustomPackageModal: false
+  };
+
+  get actionMenuItems() {
+    let { model } = this.props;
+    let { queryParams, router } = this.context;
+    let items = [];
+
+    if (model.isTitleCustom) {
+      items.push({
+        label: 'Edit',
+        to: {
+          pathname: `/eholdings/titles/${model.id}/edit`,
+          search: router.route.location.search,
+          state: { eholdings: true }
+        }
+      });
+    }
+
+    if (queryParams.searchType) {
+      items.push({
+        label: 'Full view',
+        to: {
+          pathname: `/eholdings/titles/${model.id}`,
+          state: { eholdings: true }
+        },
+        className: styles['full-view-link']
+      });
+    }
+
+    return items;
   }
 
-  if (queryParams.searchType) {
-    actionMenuItems.push({
-      label: 'Full view',
-      to: {
-        pathname: `/eholdings/titles/${model.id}`,
-        state: { eholdings: true }
-      },
-      className: styles['full-view-link']
-    });
+  get lastMenu() {
+    let { model } = this.props;
+    let { router } = this.context;
+
+    if (model.isTitleCustom) {
+      return (
+        <PaneMenu>
+          <IconButton
+            data-test-eholdings-title-edit-link
+            icon="edit"
+            ariaLabel={`Edit ${model.name}`}
+            to={{
+              pathname: `/eholdings/titles/${model.id}/edit`,
+              search: router.route.location.search,
+              state: { eholdings: true }
+            }}
+          />
+        </PaneMenu>
+      );
+    } else {
+      return null;
+    }
   }
 
-  let lastMenu;
-  if (model.isTitleCustom) {
-    lastMenu = (
-      <PaneMenu>
-        <IconButton
-          data-test-eholdings-title-edit-link
-          icon="edit"
-          ariaLabel={`Edit ${model.name}`}
-          to={{
-            pathname: `/eholdings/titles/${model.id}/edit`,
-            search: router.route.location.search,
-            state: { eholdings: true }
-          }}
+  get toasts() {
+    let { model } = this.props;
+    let { router } = this.context;
+    let toasts = processErrors(model);
+
+    // if coming from creating a new custom package, show a success toast
+    if (router.history.action === 'REPLACE' &&
+        router.history.location.state &&
+        router.history.location.state.isNewRecord) {
+      toasts.push({
+        id: `success-title-${model.id}`,
+        message: 'Custom title created.',
+        type: 'success'
+      });
+    }
+
+    // if coming from saving edits to the package, show a success toast
+    if (router.history.action === 'PUSH' &&
+        router.history.location.state &&
+        router.history.location.state.isFreshlySaved) {
+      toasts.push({
+        id: `success-title-saved-${model.id}`,
+        message: 'Title saved.',
+        type: 'success'
+      });
+    }
+
+    return toasts;
+  }
+
+  get customPackageOptions() {
+    let titlePackageIds = this.props.model.resources.map(({ id }) => id);
+
+    return this.props.customPackages.map(pkg => ({
+      disabled: titlePackageIds.includes(pkg.id),
+      label: pkg.name,
+      value: pkg.id
+    }));
+  }
+
+  toggleCustomPackageModal = () => {
+    this.setState(({ showCustomPackageModal }) => ({
+      showCustomPackageModal: !showCustomPackageModal
+    }));
+  }
+
+  render() {
+    let { model, addCustomPackage } = this.props;
+    let { showCustomPackageModal } = this.state;
+
+    // this will become a ref that will allow us to submit the form
+    // from our modal footer buttons
+    let addToPackageForm;
+
+    return (
+      <div>
+        <Toaster toasts={this.toasts} position="bottom" />
+
+        <DetailsView
+          type="title"
+          model={model}
+          paneTitle={model.name}
+          actionMenuItems={this.actionMenuItems}
+          lastMenu={this.lastMenu}
+          bodyContent={(
+            <DetailsViewSection label="Title information">
+              <ContributorsList data={model.contributors} />
+
+              {model.edition && (
+                <KeyValue label="Edition">
+                  <div data-test-eholdings-title-show-edition>
+                    {model.edition}
+                  </div>
+                </KeyValue>
+              )}
+
+              {model.publisherName && (
+                <KeyValue label="Publisher">
+                  <div data-test-eholdings-title-show-publisher-name>
+                    {model.publisherName}
+                  </div>
+                </KeyValue>
+              )}
+
+              {model.publicationType && (
+                <KeyValue label="Publication Type">
+                  <div data-test-eholdings-title-show-publication-type>
+                    {model.publicationType}
+                  </div>
+                </KeyValue>
+              )}
+
+              <IdentifiersList data={model.identifiers} />
+
+              {model.subjects.length > 0 && (
+                <KeyValue label="Subjects">
+                  <div data-test-eholdings-title-show-subjects-list>
+                    {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
+                  </div>
+                </KeyValue>
+              )}
+
+              <KeyValue label="Peer reviewed">
+                <div data-test-eholdings-peer-reviewed-field>
+                  {model.isPeerReviewed ? 'Yes' : 'No'}
+                </div>
+              </KeyValue>
+
+              <KeyValue label="Title type">
+                <div data-test-eholdings-title-details-type>
+                  {model.isTitleCustom ? 'Custom' : 'Managed'}
+                </div>
+              </KeyValue>
+
+              {model.description && (
+                <KeyValue label="Description">
+                  <div data-test-eholdings-description-field>
+                    {model.description}
+                  </div>
+                </KeyValue>
+              )}
+
+              <div className={styles['add-to-custom-package-button']}>
+                <Button
+                  data-test-eholdings-add-to-custom-package-button
+                  onClick={this.toggleCustomPackageModal}
+                >
+                  Add to custom package
+                </Button>
+              </div>
+            </DetailsViewSection>
+          )}
+          listType="packages"
+          renderList={scrollable => (
+            <ScrollView
+              itemHeight={70}
+              items={model.resources}
+              scrollable={scrollable}
+              data-test-query-list="title-packages"
+            >
+              {item => (
+                <PackageListItem
+                  link={`/eholdings/resources/${item.id}`}
+                  packageName={item.packageName}
+                  item={item}
+                  headingLevel='h4'
+                />
+              )}
+            </ScrollView>
+          )}
         />
-      </PaneMenu>
+
+        <Modal
+          open={showCustomPackageModal}
+          size="small"
+          label="Add title to custom package"
+          scope="root"
+          id="eholdings-custom-package-modal"
+          footer={(
+            <div>
+              <Button
+                buttonStyle="primary"
+                onClick={() => addToPackageForm.submit()}
+                data-test-eholdings-custom-package-modal-submit
+              >
+                Submit
+              </Button>
+              <Button
+                onClick={this.toggleCustomPackageModal}
+                data-test-eholdings-custom-package-modal-cancel
+              >
+                Cancel
+              </Button>
+            </div>
+          )}
+        >
+          <AddToPackageForm
+            ref={(form) => { addToPackageForm = form; }}
+            packageOptions={this.customPackageOptions}
+            onSubmit={addCustomPackage}
+          />
+        </Modal>
+      </div>
     );
   }
-
-  let toasts = processErrors(model);
-
-  // if coming from creating a new custom package, show a success toast
-  if (router.history.action === 'REPLACE' &&
-      router.history.location.state &&
-      router.history.location.state.isNewRecord) {
-    toasts.push({
-      id: `success-title-${model.id}`,
-      message: 'Custom title created.',
-      type: 'success'
-    });
-  }
-
-  // if coming from saving edits to the package, show a success toast
-  if (router.history.action === 'PUSH' &&
-      router.history.location.state &&
-      router.history.location.state.isFreshlySaved) {
-    toasts.push({
-      id: `success-title-saved-${model.id}`,
-      message: 'Title saved.',
-      type: 'success'
-    });
-  }
-
-  return (
-    <div>
-      <Toaster toasts={toasts} position="bottom" />
-
-      <DetailsView
-        type="title"
-        model={model}
-        paneTitle={model.name}
-        actionMenuItems={actionMenuItems}
-        lastMenu={lastMenu}
-        bodyContent={(
-          <DetailsViewSection label="Title information">
-            <ContributorsList data={model.contributors} />
-
-            {model.edition && (
-              <KeyValue label="Edition">
-                <div data-test-eholdings-title-show-edition>
-                  {model.edition}
-                </div>
-              </KeyValue>
-            )}
-
-            {model.publisherName && (
-              <KeyValue label="Publisher">
-                <div data-test-eholdings-title-show-publisher-name>
-                  {model.publisherName}
-                </div>
-              </KeyValue>
-            )}
-
-            {model.publicationType && (
-              <KeyValue label="Publication Type">
-                <div data-test-eholdings-title-show-publication-type>
-                  {model.publicationType}
-                </div>
-              </KeyValue>
-            )}
-
-            <IdentifiersList data={model.identifiers} />
-
-            {model.subjects.length > 0 && (
-              <KeyValue label="Subjects">
-                <div data-test-eholdings-title-show-subjects-list>
-                  {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
-                </div>
-              </KeyValue>
-            )}
-
-            <KeyValue label="Peer reviewed">
-              <div data-test-eholdings-peer-reviewed-field>
-                {model.isPeerReviewed ? 'Yes' : 'No'}
-              </div>
-            </KeyValue>
-
-            <KeyValue label="Title type">
-              <div data-test-eholdings-title-details-type>
-                {model.isTitleCustom ? 'Custom' : 'Managed'}
-              </div>
-            </KeyValue>
-
-            {model.description && (
-              <KeyValue label="Description">
-                <div data-test-eholdings-description-field>
-                  {model.description}
-                </div>
-              </KeyValue>
-            )}
-          </DetailsViewSection>
-        )}
-        listType="packages"
-        renderList={scrollable => (
-          <ScrollView
-            itemHeight={70}
-            items={model.resources}
-            scrollable={scrollable}
-            data-test-query-list="title-packages"
-          >
-            {item => (
-              <PackageListItem
-                link={`/eholdings/resources/${item.id}`}
-                packageName={item.packageName}
-                item={item}
-                headingLevel='h4'
-              />
-            )}
-          </ScrollView>
-        )}
-      />
-    </div>
-  );
 }
-
-TitleShow.propTypes = {
-  model: PropTypes.object.isRequired
-};
-
-TitleShow.contextTypes = {
-  router: PropTypes.object,
-  queryParams: PropTypes.object
-};

--- a/src/routes/title-show.js
+++ b/src/routes/title-show.js
@@ -55,11 +55,12 @@ class TitleShowRoute extends Component {
     }
   }
 
-  createResource = ({ packageId }) => {
+  createResource = ({ packageId, customUrl }) => {
     let { match, createResource } = this.props;
     let { titleId } = match.params;
 
     createResource({
+      url: customUrl,
       packageId,
       titleId
     });

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -6,10 +6,31 @@ import {
   isPresent,
   property,
   interactor,
+  fillable,
   text
 } from '@bigtest/interactor';
-import { getComputedStyle } from './helpers';
+
+import {
+  hasClassBeginningWith,
+  getComputedStyle
+} from './helpers';
+
 import Toast from './toast';
+
+@interactor class AddToCustomPackageModal {
+  hasPackageError = hasClassBeginningWith(
+    '[data-test-eholdings-package-select-field] select',
+    'feedbackError--'
+  );
+
+  choosePackage = fillable('[data-test-eholdings-package-select-field] select');
+  packages = collection('[data-test-eholdings-package-select-field] option', {
+    isDisabled: property('disabled')
+  });
+
+  submit = clickable('[data-test-eholdings-custom-package-modal-submit]');
+  cancel = clickable('[data-test-eholdings-custom-package-modal-cancel]');
+}
 
 @interactor class TitleShowPage {
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
@@ -57,6 +78,9 @@ import Toast from './toast';
   contributorsList = collection('[data-test-eholdings-contributors-list-item]', {
     contributorText: text()
   });
+
+  clickAddToCustomPackageButton = clickable('[data-test-eholdings-add-to-custom-package-button]');
+  customPackageModal = new AddToCustomPackageModal('#eholdings-custom-package-modal');
 }
 
 export default new TitleShowPage('[data-test-eholdings-details-view="title"]');

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -28,6 +28,8 @@ import Toast from './toast';
     isDisabled: property('disabled')
   });
 
+  fillUrl = fillable('[data-test-eholdings-custom-url-textfield] input');
+
   submit = clickable('[data-test-eholdings-custom-package-modal-submit]');
   cancel = clickable('[data-test-eholdings-custom-package-modal-cancel]');
 }

--- a/tests/title-add-to-custom-package-test.js
+++ b/tests/title-add-to-custom-package-test.js
@@ -93,5 +93,25 @@ describeApplication('TitleShow', () => {
         expect(ResourceShowPage.packageName).to.equal(customPackage.name);
       });
     });
+
+    describe('adding a URL and clicking submit', () => {
+      let customPackage;
+
+      beforeEach(function () {
+        customPackage = this.server.schema.packages.findBy({
+          name: 'Custom Package 2'
+        });
+
+        return TitleShowPage
+          .customPackageModal.choosePackage(customPackage.id)
+          .customPackageModal.fillUrl('http://my.url')
+          .customPackageModal.submit();
+      });
+
+      it('Redirects to the newly created resource with the specified URL', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/resources\/\d{1,}/);
+        expect(ResourceShowPage.url).to.equal('http://my.url');
+      });
+    });
   });
 });

--- a/tests/title-add-to-custom-package-test.js
+++ b/tests/title-add-to-custom-package-test.js
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+
+import { describeApplication } from './helpers';
+import TitleShowPage from './pages/title-show';
+import ResourceShowPage from './pages/resource-show';
+
+describeApplication('TitleShow', () => {
+  let title;
+
+  beforeEach(function () {
+    title = this.server.create('title', 'withPackages', {
+      name: 'Cool Title',
+      publisherName: 'Cool Publisher',
+      publicationType: 'Website'
+    });
+
+    // make sure one of these packages are custom
+    title.resources.models[0].package.update({
+      name: 'Custom Package 1',
+      isCustom: true
+    });
+
+    // new custom package for assignment
+    this.server.create('package', {
+      name: 'Custom Package 2',
+      provider: this.server.create('provider'),
+      isCustom: true
+    });
+
+    return this.visit(`/eholdings/titles/${title.id}`, () => {
+      expect(TitleShowPage.$root).to.exist;
+    });
+  });
+
+  describe('clicking the add to custom package button', () => {
+    beforeEach(() => {
+      return TitleShowPage.clickAddToCustomPackageButton();
+    });
+
+    it('shows the modal for adding a custom package', () => {
+      expect(TitleShowPage.customPackageModal.isPresent).to.be.true;
+    });
+
+    it('contains a list of custom packages with existing relationships disabled', () => {
+      // index `0` is the "Choose a package" placeholder option
+      let first = TitleShowPage.customPackageModal.packages(1);
+      let second = TitleShowPage.customPackageModal.packages(2);
+
+      expect(first.text).to.equal('Custom Package 1');
+      expect(first.isDisabled).to.be.true;
+
+      expect(second.text).to.equal('Custom Package 2');
+      expect(second.isDisabled).to.be.false;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return TitleShowPage.customPackageModal.cancel();
+      });
+
+      it('dismisses the modal', () => {
+        expect(TitleShowPage.customPackageModal.isPresent).to.be.false;
+      });
+    });
+
+    describe('clicking submit', () => {
+      beforeEach(() => {
+        return TitleShowPage.customPackageModal.submit();
+      });
+
+      it('shows an error with no selected package', () => {
+        expect(TitleShowPage.customPackageModal.hasPackageError).to.be.true;
+      });
+    });
+
+    describe('selecting a package and clicking submit', () => {
+      let customPackage;
+
+      beforeEach(function () {
+        customPackage = this.server.schema.packages.findBy({
+          name: 'Custom Package 2'
+        });
+
+        return TitleShowPage
+          .customPackageModal.choosePackage(customPackage.id)
+          .customPackageModal.submit();
+      });
+
+      it('Redirects to the newly created resource', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/resources\/\d{1,}/);
+        expect(ResourceShowPage.titleName).to.equal(title.name);
+        expect(ResourceShowPage.packageName).to.equal(customPackage.name);
+      });
+    });
+  });
+});


### PR DESCRIPTION
[UIEH-286](https://issues.folio.org/browse/UIEH-286)

## Purpose

We need the ability to add titles to a custom package and create a resource as a result.

## Approach

Added a button to titles that will open a modal allowing the user to choose a custom package to add the title to, which will then send a request to `POST /resources` to create the related resource.

Updated the `PackageSelectField` component to accept an array of options instead of a collection so that the view component can control which fields are disabled.

Packages that already contain the title (i.e. the title's resources) are disabled in the package select field instead of being omitted entirely.

## Screenshots
![2018-05-09 13 14 04](https://user-images.githubusercontent.com/5005153/39831711-ebea02fa-538a-11e8-9e07-60ff9d57f61d.gif)


