### PR TITLE
UIEH-360 Attach loading state to title/package create forms and modal

### DIFF
--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -4,6 +4,7 @@ import { reduxForm } from 'redux-form';
 
 import {
   Button,
+  Icon,
   IconButton,
   PaneHeader,
   PaneMenu
@@ -88,19 +89,29 @@ class PackageCreate extends Component {
             </DetailsViewSection>
             <div className={styles['package-create-action-buttons']}>
               <div data-test-eholdings-package-create-cancel-button>
-                <Button type="button" onClick={this.handleCancel}>
+                <Button
+                  disabled={request.isPending}
+                  type="button"
+                  onClick={this.handleCancel}
+                >
                   Cancel
                 </Button>
               </div>
               <div data-test-eholdings-package-create-save-button>
-                <Button type="submit" buttonStyle="primary">
-                  Save
+                <Button
+                  disabled={pristine || request.isPending}
+                  type="submit"
+                  buttonStyle="primary"
+                >
+                  {request.isPending ? 'Saving' : 'Save'}
                 </Button>
               </div>
+              {request.isPending && (
+              <Icon icon="spinner-ellipsis" />
+                )}
             </div>
           </form>
         </div>
-
         <NavigationModal when={!pristine && !request.isResolved} />
       </div>
     );

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -4,6 +4,7 @@ import { reduxForm } from 'redux-form';
 
 import {
   Button,
+  Icon,
   IconButton,
   PaneHeader,
   PaneMenu
@@ -107,15 +108,26 @@ class TitleCreate extends Component {
             </DetailsViewSection>
             <div className={styles['title-create-action-buttons']}>
               <div data-test-eholdings-title-create-cancel-button>
-                <Button type="button" onClick={this.handleCancel}>
+                <Button
+                  disabled={request.isPending}
+                  type="button"
+                  onClick={this.handleCancel}
+                >
                   Cancel
                 </Button>
               </div>
               <div data-test-eholdings-title-create-save-button>
-                <Button type="submit" buttonStyle="primary">
-                  Save
+                <Button
+                  disabled={pristine || request.isPending}
+                  type="submit"
+                  buttonStyle="primary"
+                >
+                  {request.isPending ? 'Saving' : 'Save'}
                 </Button>
               </div>
+              {request.isPending && (
+              <Icon icon="spinner-ellipsis" />
+                )}
             </div>
           </form>
         </div>

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import {
   Button,
+  Icon,
   IconButton,
   KeyValue,
   PaneMenu,
@@ -22,6 +23,7 @@ import styles from './title-show.css';
 
 export default class TitleShow extends Component {
   static propTypes = {
+    request: PropTypes.object.isRequired,
     model: PropTypes.object.isRequired,
     customPackages: PropTypes.object.isRequired,
     addCustomPackage: PropTypes.func.isRequired
@@ -137,7 +139,7 @@ export default class TitleShow extends Component {
   }
 
   render() {
-    let { model, addCustomPackage } = this.props;
+    let { model, addCustomPackage, request } = this.props;
     let { showCustomPackageModal } = this.state;
 
     // this will become a ref that will allow us to submit the form
@@ -250,14 +252,20 @@ export default class TitleShow extends Component {
           id="eholdings-custom-package-modal"
           footer={(
             <div>
+              {request.isPending && (
+              <Icon icon="spinner-ellipsis" />
+                )}
               <Button
                 buttonStyle="primary"
+                disabled={request.isPending}
                 onClick={() => addToPackageForm.submit()}
                 data-test-eholdings-custom-package-modal-submit
               >
                 Submit
               </Button>
               <Button
+                disabled={request.isPending}
+                type="button"
                 onClick={this.toggleCustomPackageModal}
                 data-test-eholdings-custom-package-modal-cancel
               >

--- a/src/routes/title-show.js
+++ b/src/routes/title-show.js
@@ -67,10 +67,11 @@ class TitleShowRoute extends Component {
   };
 
   render() {
-    let { model, customPackages } = this.props;
+    let { model, customPackages, createRequest } = this.props;
 
     return (
       <View
+        request={createRequest}
         model={model}
         customPackages={customPackages}
         addCustomPackage={this.createResource}

--- a/tests/package-create-test.js
+++ b/tests/package-create-test.js
@@ -25,11 +25,23 @@ describeApplication('PackageCreate', () => {
     expect(PackageCreatePage.hasAddCoverageButton).to.be.true;
   });
 
+  it('disables the save button', () => {
+    expect(PackageCreatePage.isSaveDisabled).to.be.true;
+  });
+
   describe('creating a new package', () => {
     beforeEach(() => {
       return PackageCreatePage
         .fillName('My Package')
         .save();
+    });
+
+    it('disables the save button', () => {
+      expect(PackageCreatePage.isSaveDisabled).to.be.true;
+    });
+
+    it('disables the cancel button', () => {
+      expect(PackageCreatePage.isCancelDisabled).to.be.true;
     });
 
     it('redirects to the new package show page', function () {
@@ -112,6 +124,14 @@ describeApplication('PackageCreate', () => {
 
     it('shows an error toast message', () => {
       expect(PackageShowPage.toast.errorText).to.equal('There was an error');
+    });
+
+    it('enables the save button', () => {
+      expect(PackageCreatePage.isSaveDisabled).to.be.false;
+    });
+
+    it('enables the cancel button', () => {
+      expect(PackageCreatePage.isCancelDisabled).to.be.false;
     });
   });
 });

--- a/tests/pages/package-create.js
+++ b/tests/pages/package-create.js
@@ -3,7 +3,8 @@ import {
   isPresent,
   fillable,
   clickable,
-  collection
+  collection,
+  property
 } from '@bigtest/interactor';
 import Datepicker from './datepicker';
 
@@ -16,6 +17,8 @@ import Datepicker from './datepicker';
   addCoverage = clickable('[data-test-eholdings-coverage-fields-add-row-button] button');
   save = clickable('[data-test-eholdings-package-create-save-button] button');
   cancel = clickable('[data-test-eholdings-package-create-cancel-button] button');
+  isSaveDisabled = property('[data-test-eholdings-package-create-save-button] button', 'disabled');
+  isCancelDisabled = property('[data-test-eholdings-package-create-cancel-button] button', 'disabled');
 
   dateRangeRowList = collection('[data-test-eholdings-coverage-fields-date-range-row]', {
     beginDate: new Datepicker('[data-test-eholdings-coverage-fields-date-range-begin]'),

--- a/tests/pages/title-create.js
+++ b/tests/pages/title-create.js
@@ -55,6 +55,8 @@ import {
   isPeerReviewed = property('[data-test-eholdings-peer-reviewed-field] input', 'checked');
   save = clickable('[data-test-eholdings-title-create-save-button] button');
   cancel = clickable('[data-test-eholdings-title-create-cancel-button] button');
+  isSaveDisabled = property('[data-test-eholdings-title-create-save-button] button', 'disabled');
+  isCancelDisabled = property('[data-test-eholdings-title-create-cancel-button] button', 'disabled');
 }
 
 export default new TitleCreatePage();

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -32,6 +32,9 @@ import Toast from './toast';
 
   submit = clickable('[data-test-eholdings-custom-package-modal-submit]');
   cancel = clickable('[data-test-eholdings-custom-package-modal-cancel]');
+
+  isSubmitDisabled = property('[data-test-eholdings-custom-package-modal-submit]', 'disabled');
+  isCancelDisabled = property('[data-test-eholdings-custom-package-modal-cancel]', 'disabled');
 }
 
 @interactor class TitleShowPage {

--- a/tests/title-add-to-custom-package-test.js
+++ b/tests/title-add-to-custom-package-test.js
@@ -87,6 +87,14 @@ describeApplication('TitleShow', () => {
           .customPackageModal.submit();
       });
 
+      it('disables the submit button', () => {
+        expect(TitleShowPage.customPackageModal.isSubmitDisabled).to.be.true;
+      });
+
+      it('disables the cancel button', () => {
+        expect(TitleShowPage.customPackageModal.isCancelDisabled).to.be.true;
+      });
+
       it('Redirects to the newly created resource', function () {
         expect(this.app.history.location.pathname).to.match(/^\/eholdings\/resources\/\d{1,}/);
         expect(ResourceShowPage.titleName).to.equal(title.name);

--- a/tests/title-create-test.js
+++ b/tests/title-create-test.js
@@ -60,12 +60,24 @@ describeApplication('TitleCreate', () => {
     expect(TitleCreatePage.isPeerReviewed).to.be.false;
   });
 
+  it('disables the save button', () => {
+    expect(TitleCreatePage.isSaveDisabled).to.be.true;
+  });
+
   describe('creating a new title', () => {
     beforeEach(() => {
       return TitleCreatePage
         .fillName('My Title')
         .selectPackage(packages[0].id)
         .save();
+    });
+
+    it('disables the save button', () => {
+      expect(TitleCreatePage.isSaveDisabled).to.be.true;
+    });
+
+    it('disables the cancel button', () => {
+      expect(TitleCreatePage.isCancelDisabled).to.be.true;
     });
 
     it('redirects to the new title show page', function () {
@@ -241,6 +253,14 @@ describeApplication('TitleCreate', () => {
 
     it('shows an error toast message', () => {
       expect(TitleShowPage.toast.errorText).to.equal('There was an error');
+    });
+
+    it('enables the save button', () => {
+      expect(TitleCreatePage.isSaveDisabled).to.be.false;
+    });
+
+    it('enables the cancel button', () => {
+      expect(TitleCreatePage.isCancelDisabled).to.be.false;
     });
   });
 });


### PR DESCRIPTION
[UIEH-360 - Attach loading states to custom title forms](https://issues.folio.org/browse/UIEH-360) 

## Purpose

The following forms all do not disable the Save/Submit and Cancel Buttons when the form is being submitted and do not display an animated loading indicator next to the Save Button
- Form for Creating a Custom Title
- Form for Creating a Custom Package 
- Modal for adding a title to a custom package

This PR adds these features to the 3 forms.
Additionally, for Create a Title and Create a Package forms, the Save button is disabled if the form is in a pristine state.

## Approach
Similar as has been done in other forms, added check for request.IsPending to disable the Cancel and Save Buttons and to enable the loading indicator.  Also added disable of Save button on Title Create and Package Create forms.

#### TODOS and Open Questions
- [ ] On Modal for adding a title to a custom package, do not yet have a method to check the pristine state of the form. Ideally would like to disable the Save Button for this case as well

## Screenshots
Before
![before-test](https://user-images.githubusercontent.com/19415226/40026789-d67ab0b8-57a4-11e8-84b5-984dedc1b8dc.gif)
After
![after-test2](https://user-images.githubusercontent.com/19415226/40026796-e0e91c9c-57a4-11e8-82ba-e1f8283c718c.gif)


