### PR TITLE
Explicitly require stripes-components as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,16 @@
     "webpack": "^3.0.0"
   },
   "dependencies": {
+    "@folio/stripes-components": "^2.0.0",
     "classnames": "^2.2.5",
     "funcadelic": "^0.4.0",
     "impagination": "^1.0.0-alpha.3",
     "inflected": "^2.0.3",
     "isomorphic-fetch": "^2.2.1",
     "redux-actions": "^2.2.1"
+  },
+  "peerDependencies": {
+    "react": "*"
   },
   "stripes": {
     "type": "app",


### PR DESCRIPTION
## Purpose
FOLIO UI modules should explicitly require stripes-components as a dependency.

## Approach
We were previously just leaning on whatever platform `ui-eholdings` was running on, but `ui-eholdings` should be more explicit about its `stripes-components` version.

## Learning
I also added a `peerDependency` on `react`, like the `stripes-cli` blueprint for a UI module: https://github.com/folio-org/stripes-cli/blob/master/resources/ui-app/package.json