### PR TITLE
UIEH-326 Hide full view link when not in three-pane layout

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.css
+++ b/src/components/package/edit-custom/custom-package-edit.css
@@ -10,3 +10,11 @@
     margin-right: 0.25em;
   }
 }
+
+.full-view-link {
+  display: none;
+
+  @media (--mediumUp) {
+    display: block;
+  }
+}

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -155,13 +155,14 @@ class CustomPackageEdit extends Component {
       }
     ];
 
-    if (queryParams) {
+    if (queryParams.searchType) {
       actionMenuItems.push({
         label: 'Full view',
         to: {
           pathname: `/eholdings/packages/${model.id}/edit`,
           state: { eholdings: true }
-        }
+        },
+        className: styles['full-view-link']
       });
     }
 

--- a/src/components/package/edit-managed/managed-package-edit.css
+++ b/src/components/package/edit-managed/managed-package-edit.css
@@ -10,3 +10,11 @@
     margin-right: 0.25em;
   }
 }
+
+.full-view-link {
+  display: none;
+
+  @media (--mediumUp) {
+    display: block;
+  }
+}

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -169,13 +169,14 @@ class ManagedPackageEdit extends Component {
       }
     ];
 
-    if (queryParams) {
+    if (queryParams.searchType) {
       actionMenuItems.push({
         label: 'Full view',
         to: {
           pathname: `/eholdings/packages/${model.id}/edit`,
           state: { eholdings: true }
-        }
+        },
+        className: styles['full-view-link']
       });
     }
 


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UIEH-326

Package editing didn't have the right logic for when the "Full view" link needs to show in the pane header dropdown.

## Approach
I spent a few minutes trying to write a test for this, but quickly bailed. The pane header dropdown menu opens in a tether, without any ids or `data-test` attributes. We should write an interactor for the `Dropdown` in `stripes-components`.

Another thing to consider re: testing this feature: screen size. Writing tests to detect whether the "Full view" link is present would fail in a too-small browser window.

## Screenshots
![2018-05-16 16 51 47](https://user-images.githubusercontent.com/230597/40147216-7d2cdb68-592e-11e8-9180-bdd03278cbd6.gif)
