### PR TITLE
UIEH-380 - Title Package:Issue with Visibility and IsSelected + Remove Inline Edit of Visibility

### DIFF
--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -41,7 +41,7 @@ class ResourceEditCustomTitle extends Component {
 
   state = {
     resourceSelected: this.props.initialValues.isSelected,
-    resourceHidden: this.props.initialValues.isHidden,
+    resourceVisible: this.props.initialValues.isVisible,
     showSelectionModal: false,
     allowFormToSubmit: false,
     formValues: {}
@@ -49,7 +49,16 @@ class ResourceEditCustomTitle extends Component {
 
   componentWillReceiveProps(nextProps) {
     let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
-    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+    let needsUpdate = !isEqual(this.props.model, nextProps.model);
+
+    if ((nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) ||
+    (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
+      this.setState({
+        ...this.state,
+        resourceSelected: nextProps.initialValues.isSelected,
+        resourceVisible: nextProps.initialValues.isVisible
+      });
+    }
 
     if (wasPending && needsUpdate) {
       this.context.router.history.push(
@@ -74,7 +83,7 @@ class ResourceEditCustomTitle extends Component {
 
   handleVisibilityToggle = (e) => {
     this.setState({
-      resourceHidden: !e.target.checked
+      resourceVisible: e.target.checked
     });
   }
 
@@ -122,7 +131,7 @@ class ResourceEditCustomTitle extends Component {
     let {
       showSelectionModal,
       resourceSelected,
-      resourceHidden
+      resourceVisible
     } = this.state;
 
     let actionMenuItems = [
@@ -176,25 +185,38 @@ class ResourceEditCustomTitle extends Component {
               <DetailsViewSection
                 label="Visibility"
               >
-                <label
-                  data-test-eholdings-resource-toggle-visibility
-                  htmlFor="custom-resource-visibility-toggle-switch"
-                >
-                  <h4>
-                    {resourceHidden
-                      ? 'Hidden from patrons'
-                    : 'Visible to patrons'}
-                  </h4>
-                  <br />
-                  {resourceSelected ? (
-                    <Field
-                      name="isHidden"
-                      component={ToggleSwitch}
-                      checked={!resourceHidden}
-                      onChange={this.handleVisibilityToggle}
-                      id="custom-resource-visibility-toggle-switch"
-                    />) : null}
-                </label>
+                {resourceSelected ? (
+                  <div>
+                    <label
+                      data-test-eholdings-resource-toggle-visibility
+                      htmlFor="custom-resource-visibility-toggle-switch"
+                    >
+                      <h4>
+                        {resourceVisible
+                      ? 'Visible to patrons'
+                    : 'Hidden from patrons'}
+                      </h4>
+                      <br />
+                      <Field
+                        name="isVisible"
+                        component={ToggleSwitch}
+                        checked={resourceVisible}
+                        onChange={this.handleVisibilityToggle}
+                        id="custom-resource-visibility-toggle-switch"
+                      />
+                    </label>
+
+                    {!resourceVisible && (
+                    <div data-test-eholdings-resource-toggle-hidden-reason>
+                      {model.package.visibilityData.isHidden
+                           ? 'All titles in this package are hidden.'
+                           : model.visibilityData.reason}
+                    </div>
+                     )}
+                  </div>
+                 ) : (
+                   <p data-test-eholdings-resource-not-shown-label>Not shown to patrons.</p>
+                 )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage dates"

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -40,7 +40,7 @@ class ResourceEditManagedTitle extends Component {
 
   state = {
     managedResourceSelected: this.props.initialValues.isSelected,
-    managedResourceHidden: this.props.initialValues.isHidden,
+    managedResourceVisible: this.props.initialValues.isVisible,
     showSelectionModal: false,
     allowFormToSubmit: false,
     formValues: {}
@@ -48,13 +48,14 @@ class ResourceEditManagedTitle extends Component {
 
   componentWillReceiveProps(nextProps) {
     let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
-    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+    let needsUpdate = !isEqual(this.props.model, nextProps.model);
 
-    if (nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) {
+    if ((nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) ||
+    (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
       this.setState({
         ...this.state,
         managedResourceSelected: nextProps.initialValues.isSelected,
-        managedResourceHidden: nextProps.initialValues.isHidden,
+        managedResourceVisible: nextProps.initialValues.isVisible,
       });
     }
 
@@ -81,7 +82,7 @@ class ResourceEditManagedTitle extends Component {
 
   handleVisibilityToggle = (e) => {
     this.setState({
-      managedResourceHidden: !e.target.checked
+      managedResourceVisible: e.target.checked
     });
   }
 
@@ -127,7 +128,7 @@ class ResourceEditManagedTitle extends Component {
     let {
       showSelectionModal,
       managedResourceSelected,
-      managedResourceHidden
+      managedResourceVisible
     } = this.state;
 
     let actionMenuItems = [
@@ -173,25 +174,38 @@ class ResourceEditManagedTitle extends Component {
               <DetailsViewSection
                 label="Visibility"
               >
-                <label
-                  data-test-eholdings-resource-toggle-visibility
-                  htmlFor="managed-resource-visibility-toggle-switch"
-                >
-                  <h4>
-                    {managedResourceHidden
-                      ? 'Hidden from patrons'
-                    : 'Visible to patrons'}
-                  </h4>
-                  <br />
-                  {managedResourceSelected ? (
-                    <Field
-                      name="isHidden"
-                      component={ToggleSwitch}
-                      checked={!managedResourceHidden}
-                      onChange={this.handleVisibilityToggle}
-                      id="managed-resource-visibility-toggle-switch"
-                    />) : null}
-                </label>
+                {managedResourceSelected ? (
+                  <div>
+                    <label
+                      data-test-eholdings-resource-toggle-visibility
+                      htmlFor="managed-resource-visibility-toggle-switch"
+                    >
+                      <h4>
+                        {managedResourceVisible
+                      ? 'Visible to patrons'
+                    : 'Hidden from patrons'}
+                      </h4>
+                      <br />
+                      <Field
+                        name="isVisible"
+                        component={ToggleSwitch}
+                        checked={managedResourceVisible}
+                        onChange={this.handleVisibilityToggle}
+                        id="managed-resource-visibility-toggle-switch"
+                      />
+                    </label>
+
+                    {!managedResourceVisible && (
+                    <div data-test-eholdings-resource-toggle-hidden-reason>
+                      {model.package.visibilityData.isHidden
+                           ? 'All titles in this package are hidden.'
+                           : model.visibilityData.reason}
+                    </div>
+                     )}
+                  </div>
+                 ) : (
+                   <p data-test-eholdings-resource-not-shown-label>Not shown to patrons.</p>
+                 )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage dates"

--- a/src/components/resource/edit.js
+++ b/src/components/resource/edit.js
@@ -12,7 +12,7 @@ export default function ResourceEdit({ model, ...props }) {
     View = CustomResourceEdit;
     initialValues = {
       isSelected: model.isSelected,
-      isHidden: model.visibilityData.isHidden,
+      isVisible: !model.visibilityData.isHidden,
       customCoverages: model.customCoverages,
       coverageStatement: model.coverageStatement,
       customEmbargoValue: model.customEmbargoPeriod.embargoValue,
@@ -23,7 +23,7 @@ export default function ResourceEdit({ model, ...props }) {
     View = ManagedResourceEdit;
     initialValues = {
       isSelected: model.isSelected,
-      isHidden: model.visibilityData.isHidden,
+      isVisible: !model.visibilityData.isHidden,
       customCoverages: model.customCoverages,
       coverageStatement: model.coverageStatement,
       customEmbargoValue: model.customEmbargoPeriod.embargoValue,

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -27,7 +27,6 @@ export default class ResourceShow extends Component {
   static propTypes = {
     model: PropTypes.object.isRequired,
     toggleSelected: PropTypes.func.isRequired,
-    toggleHidden: PropTypes.func.isRequired,
     customEmbargoSubmitted: PropTypes.func.isRequired,
     coverageSubmitted: PropTypes.func.isRequired,
     coverageStatementSubmitted: PropTypes.func.isRequired
@@ -42,7 +41,6 @@ export default class ResourceShow extends Component {
   state = {
     showSelectionModal: false,
     resourceSelected: this.props.model.isSelected,
-    resourceHidden: this.props.model.visibilityData.isHidden,
     isCoverageEditable: false,
     isEmbargoEditable: false,
     isCoverageStatementEditable: false
@@ -51,8 +49,7 @@ export default class ResourceShow extends Component {
   componentWillReceiveProps({ model }) {
     if (!model.isSaving) {
       this.setState({
-        resourceSelected: model.isSelected,
-        resourceHidden: model.visibilityData.isHidden
+        resourceSelected: model.isSelected
       });
     }
   }
@@ -99,7 +96,6 @@ export default class ResourceShow extends Component {
     let {
       showSelectionModal,
       resourceSelected,
-      resourceHidden,
       isCoverageEditable,
       isEmbargoEditable,
       isCoverageStatementEditable
@@ -293,26 +289,18 @@ export default class ResourceShow extends Component {
                 {(resourceSelected && !isSelectInFlight) ? (
                   <div>
                     <label
-                      data-test-eholdings-resource-toggle-hidden
-                      htmlFor="resource-show-hide-toggle-switch"
+                      data-test-eholdings-resource-hidden-label
+                      htmlFor="resource-show-hide-indicator"
                     >
                       <h4>
                         {model.visibilityData.isHidden
                           ? 'Hidden from patrons'
                           : 'Visible to patrons'}
                       </h4>
-                      <br />
-                      <ToggleSwitch
-                        onChange={this.props.toggleHidden}
-                        checked={!resourceHidden}
-                        isPending={model.update.isPending &&
-                          ('visibilityData' in model.update.changedAttributes)}
-                        id="resource-show-hide-toggle-switch"
-                      />
                     </label>
 
                     {model.visibilityData.isHidden && (
-                      <div data-test-eholdings-resource-toggle-hidden-reason>
+                      <div data-test-eholdings-resource-hidden-reason>
                         {model.package.visibilityData.isHidden
                           ? 'All titles in this package are hidden.'
                           : model.visibilityData.reason}
@@ -320,7 +308,7 @@ export default class ResourceShow extends Component {
                     )}
                   </div>
                 ) : (
-                  <p>Not shown to patrons.</p>
+                  <p data-test-eholdings-resource-not-shown-label>Not shown to patrons.</p>
                 )}
               </DetailsViewSection>
               <DetailsViewSection

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -60,19 +60,21 @@ class ResourceEditRoute extends Component {
       customEmbargoValue,
       customEmbargoUnit,
       customUrl,
-      isHidden
+      isVisible
     } = values;
 
     if (values.isSelected === false && model.package.isCustom) {
       destroyResource(model);
     } else if (values.isSelected === false) {
-      model.isSelected = !model.isSelected;
+      model.isSelected = false;
       model.customCoverages = [];
-      model.visibilityData.isHidden = !isHidden;
+      model.visibilityData.isHidden = false;
       model.identifiersList = [];
       model.identifiers = {};
       model.customStatement = '';
       model.customEmbargoPeriod = {};
+      model.contributors = [];
+      model.coverageStatement = '';
 
       updateResource(model);
     } else {
@@ -85,9 +87,9 @@ class ResourceEditRoute extends Component {
           endCoverage
         };
       });
-
+      model.isSelected = values.isSelected;
       model.url = customUrl;
-      model.visibilityData.isHidden = !isHidden;
+      model.visibilityData.isHidden = !isVisible;
       model.coverageStatement = coverageStatement;
       model.customEmbargoPeriod = {
         embargoValue: customEmbargoValue,

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -80,12 +80,6 @@ class ResourceShowRoute extends Component {
     }
   }
 
-  toggleHidden = () => {
-    let { model, updateResource } = this.props;
-    model.visibilityData.isHidden = !model.visibilityData.isHidden;
-    updateResource(model);
-  }
-
   customEmbargoSubmitted = (values) => {
     let { model, updateResource } = this.props;
     model.customEmbargoPeriod = {
@@ -121,7 +115,6 @@ class ResourceShowRoute extends Component {
       <View
         model={this.props.model}
         toggleSelected={this.toggleSelected}
-        toggleHidden={this.toggleHidden}
         customEmbargoSubmitted={this.customEmbargoSubmitted}
         coverageSubmitted={this.coverageSubmitted}
         coverageStatementSubmitted={this.coverageStatementSubmitted}

--- a/tests/custom-resource-edit-visibility-test.js
+++ b/tests/custom-resource-edit-visibility-test.js
@@ -1,0 +1,227 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import ResourceEditPage from './pages/resource-edit';
+import ResourceShowPage from './pages/resource-show';
+
+describeApplication('CustomResourceEditVisibility', () => {
+  let provider,
+    providerPackage,
+    title,
+    resource;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create('package', 'withTitles', {
+      provider,
+      name: 'Star Wars Custom Package',
+      contentType: 'Online',
+      isCustom: true
+    });
+
+    title = this.server.create('title', {
+      name: 'Hans Solo Director Cut',
+      publicationType: 'Streaming Video',
+      publisherName: 'Amazing Publisher',
+      isTitleCustom: true
+    });
+
+    title.save();
+  });
+
+  describe('visiting the resource edit page and hiding a resource', () => {
+    beforeEach(function () {
+      resource = this.server.create('resource', {
+        package: providerPackage,
+        isSelected: true,
+        title
+      });
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('displays an ON visibility toggle (Visible)', () => {
+      expect(ResourceEditPage.isResourceVisible).to.be.true;
+    });
+
+    it('does not display hidden message', () => {
+      expect(ResourceEditPage.isHiddenMessagePresent).to.equal(false);
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return ResourceEditPage.clickCancel();
+      });
+
+      it('goes to the resource show page', () => {
+        expect(ResourceShowPage.$root).to.exist;
+      });
+    });
+
+    describe('toggling the visibility toggle', () => {
+      beforeEach(() => {
+        return ResourceEditPage.toggleIsVisible();
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickCancel();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(ResourceEditPage.navigationModal.$root).to.exist;
+        });
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('goes to the resource show page', () => {
+          expect(ResourceShowPage.$root).to.exist;
+        });
+
+        it('displays the new visibility status', () => {
+          expect(ResourceShowPage.isResourceHidden).to.be.true;
+        });
+      });
+    });
+  });
+
+  describe('visiting the resource edit page and showing a hidden without reason resource', () => {
+    beforeEach(function () {
+      resource = this.server.create('resource', 'isHiddenWithoutReason', {
+        package: providerPackage,
+        isSelected: true,
+        title
+      });
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('displays an OFF visibility toggle (Hidden)', () => {
+      expect(ResourceEditPage.isResourceVisible).to.be.false;
+    });
+
+    it('does not display hidden message', () => {
+      expect(ResourceEditPage.isHiddenMessagePresent).to.equal(false);
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('toggling the visibility toggle', () => {
+      beforeEach(() => {
+        return ResourceEditPage.toggleIsVisible();
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('goes to the resource show page', () => {
+          expect(ResourceShowPage.$root).to.exist;
+        });
+
+        it('displays the new visibility status', () => {
+          expect(ResourceShowPage.isResourceVisible).to.be.true;
+        });
+      });
+    });
+  });
+
+  describe('visiting the resource edit page with a hidden resource and a reason', () => {
+    beforeEach(function () {
+      resource = this.server.create('resource', 'isHidden', {
+        package: providerPackage,
+        isSelected: true,
+        title
+      });
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('displays an OFF visibility toggle (Hidden)', () => {
+      expect(ResourceEditPage.isResourceVisible).to.be.false;
+    });
+
+    it('maps the hidden reason text', () => {
+      expect(ResourceEditPage.isHiddenMessage).to.equal('The content is for mature audiences only.');
+    });
+  });
+
+  describe('visiting the resource edit page and all titles in package are hidden', () => {
+    beforeEach(function () {
+      providerPackage.visibilityData.isHidden = true;
+      providerPackage.visibilityData.reason = 'Hidden by EP';
+      resource = this.server.create('resource', 'isHidden', {
+        package: providerPackage,
+        title,
+        isSelected: true
+      });
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('displays an OFF visibility toggle (Hidden)', () => {
+      expect(ResourceEditPage.isResourceVisible).to.be.false;
+    });
+
+    it('maps the hidden reason text', () => {
+      expect(ResourceEditPage.isHiddenMessage).to.equal('All titles in this package are hidden.');
+    });
+  });
+
+  describe('visiting the resource edit page with a custom (default selected) resource', () => {
+    beforeEach(function () {
+      resource = this.server.create('resource', {
+        package: providerPackage,
+        isSelected: true,
+        title
+      });
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+    it('reflects the desired state of holding status', () => {
+      expect(ResourceEditPage.isSelected).to.equal(true);
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('toggling the selection toggle', () => {
+      beforeEach(() => {
+        return ResourceEditPage.toggleIsSelected();
+      });
+
+      it('cannot toggle visibility', () => {
+        expect(ResourceEditPage.isVisibleTogglePresent).to.equal(false);
+      });
+
+      it('displays Visibility label as Not shown to patrons', () => {
+        expect(ResourceEditPage.isResourceNotShownLabelPresent).to.be.true;
+      });
+    });
+  });
+});

--- a/tests/managed-resource-edit-visibility-test.js
+++ b/tests/managed-resource-edit-visibility-test.js
@@ -1,0 +1,208 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from './helpers';
+import ResourceEditPage from './pages/resource-edit';
+import ResourceShowPage from './pages/resource-show';
+
+describeApplication('ManagedResourceEditVisibility', () => {
+  let provider,
+    providerPackage,
+    title,
+    resource;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create('package', 'withTitles', {
+      provider,
+      name: 'Star Wars Custom Package',
+      contentType: 'Online'
+    });
+
+    title = this.server.create('title', {
+      name: 'Hans Solo Director Cut',
+      publicationType: 'Streaming Video',
+      publisherName: 'Amazing Publisher'
+    });
+
+    title.save();
+  });
+
+  describe('visiting the managed resource edit page and hiding a resource', () => {
+    beforeEach(function () {
+      resource = this.server.create('resource', {
+        package: providerPackage,
+        isSelected: true,
+        title
+      });
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('displays an ON visibility toggle (Visible)', () => {
+      expect(ResourceEditPage.isResourceVisible).to.be.true;
+    });
+
+    it('does not display hidden message', () => {
+      expect(ResourceEditPage.isHiddenMessagePresent).to.equal(false);
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return ResourceEditPage.clickCancel();
+      });
+
+      it('goes to the resource show page', () => {
+        expect(ResourceShowPage.$root).to.exist;
+      });
+    });
+
+    describe('toggling the visiblity toggle', () => {
+      beforeEach(() => {
+        return ResourceEditPage.toggleIsVisible();
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickCancel();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(ResourceEditPage.navigationModal.$root).to.exist;
+        });
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('goes to the resource show page', () => {
+          expect(ResourceShowPage.$root).to.exist;
+        });
+
+        it('displays the new visibility status', () => {
+          expect(ResourceShowPage.isResourceHidden).to.be.true;
+        });
+      });
+    });
+  });
+
+  describe('visiting the resource edit page and showing a hidden without reason resource', () => {
+    beforeEach(function () {
+      resource = this.server.create('resource', 'isHiddenWithoutReason', {
+        package: providerPackage,
+        isSelected: true,
+        title
+      });
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('displays an OFF visibility toggle (Hidden)', () => {
+      expect(ResourceEditPage.isResourceVisible).to.be.false;
+    });
+
+    it('does not display hidden message', () => {
+      expect(ResourceEditPage.isHiddenMessagePresent).to.equal(false);
+    });
+
+    it('disables the save button', () => {
+      expect(ResourceEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('toggling the visiblity toggle', () => {
+      beforeEach(() => {
+        return ResourceEditPage.toggleIsVisible();
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return ResourceEditPage.clickSave();
+        });
+
+        it('goes to the resource show page', () => {
+          expect(ResourceShowPage.$root).to.exist;
+        });
+
+        it('displays the new visibility status', () => {
+          expect(ResourceShowPage.isResourceVisible).to.be.true;
+        });
+      });
+    });
+  });
+
+  describe('visiting the resource edit page with a hidden resource and a reason', () => {
+    beforeEach(function () {
+      resource = this.server.create('resource', 'isHidden', {
+        package: providerPackage,
+        isSelected: true,
+        title
+      });
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('displays an OFF visibility toggle (Hidden)', () => {
+      expect(ResourceEditPage.isResourceVisible).to.be.false;
+    });
+
+    it('maps the hidden reason text', () => {
+      expect(ResourceEditPage.isHiddenMessage).to.equal('The content is for mature audiences only.');
+    });
+  });
+
+  describe('visiting the resource edit page and all titles in package are hidden', () => {
+    beforeEach(function () {
+      providerPackage.visibilityData.isHidden = true;
+      providerPackage.visibilityData.reason = 'Hidden by EP';
+      resource = this.server.create('resource', 'isHidden', {
+        package: providerPackage,
+        title,
+        isSelected: true
+      });
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('displays an OFF visibility toggle (Hidden)', () => {
+      expect(ResourceEditPage.isResourceVisible).to.be.false;
+    });
+
+    it('maps the hidden reason text', () => {
+      expect(ResourceEditPage.isHiddenMessage).to.equal('All titles in this package are hidden.');
+    });
+  });
+
+  describe('visiting the resource edit page with a resource that is not selected', () => {
+    beforeEach(function () {
+      resource = this.server.create('resource', {
+        package: providerPackage,
+        isSelected: false,
+        title
+      });
+
+      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
+        expect(ResourceEditPage.$root).to.exist;
+      });
+    });
+
+    it('displays Visibility label as Not shown to patrons', () => {
+      expect(ResourceEditPage.isResourceNotShownLabelPresent).to.be.true;
+    });
+  });
+});

--- a/tests/pages/resource-edit.js
+++ b/tests/pages/resource-edit.js
@@ -34,7 +34,13 @@ import Datepicker from './datepicker';
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   isSelected = property('[data-test-eholdings-resource-holding-status] input', 'checked');
   isResourceVisible = property('[data-test-eholdings-resource-toggle-visibility] input', 'checked');
+  isHiddenMessage = text('[data-test-eholdings-resource-toggle-hidden-reason]');
+  isHiddenMessagePresent = isPresent('[data-test-eholdings-resource-toggle-hidden-reason]');
+  isVisibleTogglePresent = isPresent('[data-test-eholdings-resource-toggle-visibility] input');
+  isResourceNotShownLabelPresent = isPresent('[data-test-eholdings-resource-not-shown-label]');
+
   toggleIsSelected = clickable('[data-test-eholdings-resource-holding-status] input');
+  toggleIsVisible = clickable('[data-test-eholdings-resource-toggle-visibility] input');
   modal = new ResourceEditModal('#eholdings-resource-confirmation-modal');
 
   toast = Toast;

--- a/tests/pages/resource-show.js
+++ b/tests/pages/resource-show.js
@@ -2,6 +2,7 @@ import {
   blurrable,
   clickable,
   collection,
+  computed,
   fillable,
   isPresent,
   interactor,
@@ -51,12 +52,15 @@ import Toast from './toast';
   clickPackage = clickable('[data-test-eholdings-resource-show-package-name] a');
   deselectionModal = new ResourceShowDeselectionModal('#eholdings-resource-deselection-confirmation-modal');
   navigationModal = new ResourceShowNavigationModal('#navigation-modal');
-  hasHiddenToggle = isPresent('[data-test-eholdings-resource-toggle-hidden] input');
-  isResourceVisible = property('[data-test-eholdings-resource-toggle-hidden] input', 'checked');
-  hiddenReason = text('[data-test-eholdings-resource-toggle-hidden-reason]');
-  isHiddenDisabled = property('[data-test-eholdings-resource-toggle-hidden] input[type=checkbox]', 'disabled');
-  toggleIsHidden = clickable('[data-test-eholdings-resource-toggle-hidden] input');
-  isHiding = hasClassBeginningWith('[data-test-eholdings-resource-toggle-hidden] [data-test-toggle-switch]', 'is-pending--');
+  resourceVisibilityLabel = text('[data-test-eholdings-resource-hidden-label]');
+  isResourceHidden = computed(function () {
+    return this.resourceVisibilityLabel === 'Hidden from patrons';
+  });
+  isResourceVisible = computed(function () {
+    return this.resourceVisibilityLabel === 'Visible to patrons';
+  })
+  hiddenReason = text('[data-test-eholdings-resource-hidden-reason]');
+  isResourceNotShownLabelPresent = isPresent('[data-test-eholdings-resource-not-shown-label]');
   clickEditButton = clickable('[data-test-eholdings-resource-edit-link]');
 
   peerReviewedStatus = text('[data-test-eholdings-peer-reviewed-field]');

--- a/tests/resource-visibility-test.js
+++ b/tests/resource-visibility-test.js
@@ -27,7 +27,7 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays an ON visibility toggle (Visible)', () => {
+    it('displays Visibility label as Visible to patrons', () => {
       expect(ResourceShowPage.isResourceVisible).to.be.true;
     });
   });
@@ -45,8 +45,8 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it.always('does not display the visibility toggle', () => {
-      expect(ResourceShowPage.visibilitySection).to.not.exist;
+    it('displays Visibility label as Not shown to patrons', () => {
+      expect(ResourceShowPage.isResourceNotShownLabelPresent).to.be.true;
     });
   });
 
@@ -63,8 +63,8 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays an OFF visibility toggle (Hidden)', () => {
-      expect(ResourceShowPage.isResourceVisible).to.be.false;
+    it('displays Visibility label as hidden from patrons', () => {
+      expect(ResourceShowPage.isResourceHidden).to.be.true;
     });
 
     it('maps the hidden reason text', () => {
@@ -85,101 +85,12 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays an OFF visibility toggle (Hidden)', () => {
-      expect(ResourceShowPage.isResourceVisible).to.be.false;
+    it('displays Visibility label as hidden from patrons', () => {
+      expect(ResourceShowPage.isResourceHidden).to.be.true;
     });
 
     it('maps the hidden reason text', () => {
       expect(ResourceShowPage.hiddenReason).to.equal('');
-    });
-  });
-
-  describe('visiting the resource show page and hiding a resource', () => {
-    beforeEach(function () {
-      resource = this.server.create('resource', {
-        package: pkg,
-        isSelected: true,
-        title
-      });
-
-      return this.visit(`/eholdings/resources/${resource.id}`, () => {
-        expect(ResourceShowPage.$root).to.exist;
-      });
-    });
-
-    it('displays an ON visibility toggle (Visible)', () => {
-      expect(ResourceShowPage.isResourceVisible).to.be.true;
-    });
-
-    describe('successfully hiding a resource', () => {
-      beforeEach(() => {
-        return ResourceShowPage.toggleIsHidden();
-      });
-
-      it('reflects the desired state OFF (Hidden)', () => {
-        expect(ResourceShowPage.isResourceVisible).to.be.false;
-      });
-
-      it('cannot be interacted with while the request is in flight', () => {
-        expect(ResourceShowPage.isHiddenDisabled).to.be.false;
-      });
-
-      describe('when the request succeeds', () => {
-        it('reflects the desired state OFF (Hidden)', () => {
-          expect(ResourceShowPage.isResourceVisible).to.be.false;
-        });
-
-        it('indicates it is no longer pending', () => {
-          expect(ResourceShowPage.isHiding).to.be.false;
-        });
-      });
-    });
-  });
-
-  describe('visiting the resource show page and showing a hidden resource', () => {
-    beforeEach(function () {
-      pkg.isSelected = true;
-      resource = this.server.create('resource', 'isHiddenWithoutReason', {
-        package: pkg,
-        isSelected: true,
-        title
-      });
-
-      return this.visit(`/eholdings/resources/${resource.id}`, () => {
-        expect(ResourceShowPage.$root).to.exist;
-      });
-    });
-
-    it('displays an OFF visibility toggle (Hidden)', () => {
-      expect(ResourceShowPage.isResourceVisible).to.be.false;
-    });
-
-    it('maps the hidden reason text', () => {
-      expect(ResourceShowPage.hiddenReason).to.equal('');
-    });
-
-    describe('successfully showing a resource', () => {
-      beforeEach(() => {
-        return ResourceShowPage.toggleIsHidden();
-      });
-
-      it('reflects the desired state ON (Visible)', () => {
-        expect(ResourceShowPage.isResourceVisible).to.be.true;
-      });
-
-      it('cannot be interacted while the request is in flight', () => {
-        expect(ResourceShowPage.isHiddenDisabled).to.be.false;
-      });
-
-      describe('when the request succeeds', () => {
-        it('reflects the desired state ON (Visible)', () => {
-          expect(ResourceShowPage.isResourceVisible).to.be.true;
-        });
-
-        it('indicates it is no longer pending', () => {
-          expect(ResourceShowPage.isHiding).to.be.false;
-        });
-      });
     });
   });
 
@@ -198,12 +109,8 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays an OFF visibility toggle (Hidden)', () => {
-      expect(ResourceShowPage.isResourceVisible).to.be.false;
-    });
-
-    it('the visibility toggle is disabled', () => {
-      expect(ResourceShowPage.isHiddenDisabled).to.be.false;
+    it('displays Visibility label as hidden from patrons', () => {
+      expect(ResourceShowPage.isResourceHidden).to.be.true;
     });
 
     it('maps the hidden reason text', () => {


### PR DESCRIPTION
[UIEH-380 - Package Title Edit: Issue with Visibility and isSelected in Combo](https://issues.folio.org/browse/UIEH-380) 
[UIEH-365 -Remove Inline Editing - Title+Package Show - Visibility Field ONLY](https://issues.folio.org/browse/UIEH-365) 

## Purpose

This PR resolves Title Package Edit  issues noted in UIEH-380, specifically the following issues exist for  managed title package (full page edits)
- Go to a managed title package record (select full page edit mode) . Toggle visibility status - note that the Save Button remains disabled. It should be enabled upon a change.
-  Go to a managed title package record that is both selected and visible (full page edit mode). Toggle to NOT selected and save
Get error (Invalid Hidden and Invalid Contributor) pop up as toast messages.

Additionally, as noted in UIEH-365, remove inline editing of fields for Title Package Show. This PR partially implements this feature by removing the inline edit of Visibility. Of note, Visibility in full page edit mode did not display visibility hidden reason message. This functionality has been added as part of this PR.

## Approach

For UIEH-380 Issues: 
- For Save Button not enabled when visibility is toggled.  Flipped toggle state to `isVisible` to have state which is the same value as toggle on redux-form and to be consistent with package edit handling of the same field.
- Also updated check for needsUpdate to work off of changes to model. Without change, was not correctly transitioning from full page edit page to show page on a Save when there are Visibility changes
- For error message when deselecting a managed title - added clearing out of model values for fields that are not currently cleared when a resource is deselected- Specifically isHidden, contributors and coverage statement

For UIE-365 (remove inline edit of visibility) 
- confirmed that existing/tests and functionality are covered in full page edits. 
- Added visibility hidden message and  additional logic for all "titles hidden message" as appears on show page
- Removed toggle and interaction from show page. Replaced with text and continued to show same messaging for hidden reason.
- Moved tests that appeared for inline edit over to full page edit
- Kept test in in line edit to confirm read only visibility settings and reasons

Related PR for package full page edits https://github.com/folio-org/ui-eholdings/pull/385

#### TODOS and Open Questions
- [ ] Remaining inline edit fields for UIEH-365 will be addressed in a follow on PR.


## Screenshots

Updates for UIEH-380
![2018-05-23 13 38 52](https://user-images.githubusercontent.com/19415226/40441379-dcb3da0e-5e8e-11e8-832a-0340c49b1644.gif)


Updates for Visibility UIEH-365
![2018-05-23 13 34 22](https://user-images.githubusercontent.com/19415226/40441210-56aeb226-5e8e-11e8-9832-8ddc0d01c66c.gif)





