### PR TITLE
[UIEH-363] Merge attributes data

### DIFF
--- a/mirage/helpers.js
+++ b/mirage/helpers.js
@@ -85,7 +85,11 @@ export function includesWords(testString, query) {
 }
 /**
  * Helper for creating a search route for a resource type.
- * Currently includes pagination and searching by name.
+ *
+ * Currently, our real backend omits some fields for search
+ * results. For this reason, this route helper uses a *List serializer
+ * for the resource type.
+ *
  * @param {String} resourceType - resource type's model name
  * @param {Function} filter - filter function specific to this resource
  * @returns {Function} route handler for a search route of this
@@ -98,9 +102,11 @@ export function searchRouteFor(resourceType, filter) {
     let offset = (page - 1) * count;
 
     let collection = schema[resourceType];
+    // `resourceType` is typically pluralized, the serializer is not
+    let serializerType = `${resourceType.slice(0, -1)}-list`;
     let json = this.serialize(collection.all().filter((model) => {
       return filter(model, req);
-    }));
+    }), serializerType);
 
     json.meta = { totalResults: json.data.length };
 

--- a/mirage/serializers/package-list.js
+++ b/mirage/serializers/package-list.js
@@ -1,17 +1,21 @@
 import PackageSerializer from './package';
 
+// commented attributes are ommitted from our real server
 export default PackageSerializer.extend({
   attrs: [
     'name',
     'providerId',
     'providerName',
     'isSelected',
+    // 'allowKbToAddTitles',
     'contentType',
     'selectedCount',
     'titleCount',
     'customCoverage',
     'visibilityData',
     'isCustom',
-    'packageType'
+    'packageType',
+    // 'proxy',
+    // 'packageToken'
   ]
 });

--- a/mirage/serializers/package-list.js
+++ b/mirage/serializers/package-list.js
@@ -1,0 +1,17 @@
+import PackageSerializer from './package';
+
+export default PackageSerializer.extend({
+  attrs: [
+    'name',
+    'providerId',
+    'providerName',
+    'isSelected',
+    'contentType',
+    'selectedCount',
+    'titleCount',
+    'customCoverage',
+    'visibilityData',
+    'isCustom',
+    'packageType'
+  ]
+});

--- a/mirage/serializers/provider-list.js
+++ b/mirage/serializers/provider-list.js
@@ -1,0 +1,9 @@
+import ProviderSerializer from './provider';
+
+export default ProviderSerializer.extend({
+  attrs: [
+    'name',
+    'packagesSelected',
+    'packagesTotal'
+  ]
+});

--- a/mirage/serializers/provider-list.js
+++ b/mirage/serializers/provider-list.js
@@ -1,9 +1,11 @@
 import ProviderSerializer from './provider';
 
+// commented attributes are ommitted from our real server
 export default ProviderSerializer.extend({
   attrs: [
     'name',
     'packagesSelected',
-    'packagesTotal'
+    'packagesTotal',
+    // 'proxy'
   ]
 });

--- a/mirage/serializers/title-list.js
+++ b/mirage/serializers/title-list.js
@@ -1,12 +1,17 @@
 import TitleSerializer from './title';
 
+// commented attributes are ommitted from our real server
 export default TitleSerializer.extend({
   attrs: [
     'name',
+    // 'edition',
     'publisherName',
     'publicationType',
     'subjects',
+    // 'contributors',
     'identifiers',
-    'isTitleCustom'
+    'isTitleCustom',
+    // 'isPeerReviewed',
+    // 'description'
   ]
 });

--- a/mirage/serializers/title-list.js
+++ b/mirage/serializers/title-list.js
@@ -1,0 +1,12 @@
+import TitleSerializer from './title';
+
+export default TitleSerializer.extend({
+  attrs: [
+    'name',
+    'publisherName',
+    'publicationType',
+    'subjects',
+    'identifiers',
+    'isTitleCustom'
+  ]
+});

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -5,7 +5,7 @@ import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 
 import { qs } from '../components/utilities';
-import { mergeRelationships } from './helpers';
+import { mergeRelationships, mergeAttributes } from './helpers';
 
 // actions
 export const actionTypes = {
@@ -457,7 +457,7 @@ const handlers = {
               ...store.records,
               [record.id]: {
                 ...recordState,
-                attributes: record.attributes || {},
+                attributes: mergeAttributes(recordState.attributes, record.attributes),
                 relationships: mergeRelationships(recordState.relationships, record.relationships),
                 isSaving: false,
                 isLoading: false,

--- a/src/redux/helpers.js
+++ b/src/redux/helpers.js
@@ -5,20 +5,10 @@ import { foldl, append } from 'funcadelic';
  * destructively.  Relationship data held in the store will not
  * be overwritten with empty data: only by new data.
  *
- * NOTE: for now, this is specific to `relationship` keys in the store, and so
- * it may seem strange that it lives in a generic 'helpers' file all by itself.
- * I do not make cuts before they're required, but it seems imminent that this
- * pattern will be applied to other areas of the store.  Pulling in the FP
- * power of Funcadelic here will allow us to extract common logical operations like
- * this one and genericize them to work against complex data structures like
- * the store.
- *
  * @param {Object} existing - `relationship` data from a record in the store
  * @param {Object} incoming - `relationship` data from an incoming request
  * @returns {Object} safely merged relationship data fit to be persisted
  */
-
-// eslint-disable-next-line import/prefer-default-export
 export function mergeRelationships(existing, incoming) {
   if (!incoming) { return existing; }
 
@@ -29,4 +19,19 @@ export function mergeRelationships(existing, incoming) {
       return append(relationships, { [recordType]: existing[recordType] || {} });
     }
   }, {}, incoming);
+}
+
+/**
+ * Helper to merge incoming `attribute` information non-
+ * destructively. If an attribute is defined, it will be written to
+ * the store; if undefined, the store's value (if any) will persist.
+ *
+ * @param {Object} existing - attributes from a record in the store
+ * @param {Object} incoming - attributes from an incoming request
+ * @returns {Object} safely merged attributes fit to be persisted
+ */
+export function mergeAttributes(existing, incoming) {
+  if (!incoming) { return existing; }
+
+  return append(existing, incoming);
 }

--- a/tests/unit/redux-merge-attributes-test.js
+++ b/tests/unit/redux-merge-attributes-test.js
@@ -1,0 +1,43 @@
+/* global describe, beforeEach, it */
+import { expect } from 'chai';
+import { mergeAttributes } from '../../src/redux/helpers';
+
+describe('mergeAttributes', () => {
+  let existing;
+  let incoming;
+
+  beforeEach(() => {
+    existing = {
+      description: 'description'
+    };
+  });
+
+  describe('merging existing data with incomplete incoming data', () => {
+    beforeEach(() => {
+      incoming = {
+        isSelected: false
+      };
+    });
+
+    it('does not overwrite populated keys with empty incoming data', () => {
+      let result = mergeAttributes(existing, incoming);
+      expect(result.description).to.equal('description');
+      expect(result.isSelected).to.be.false;
+    });
+  });
+
+  describe('merging existing data with incoming data', () => {
+    beforeEach(() => {
+      incoming = {
+        description: 'no, this description',
+        isSelected: true
+      };
+    });
+
+    it('replaces existing data with incoming data', () => {
+      let result = mergeAttributes(existing, incoming);
+      expect(result.description).to.equal('no, this description');
+      expect(result.isSelected).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
[UIEH-363](https://issues.folio.org/browse/UIEH-363)

## Purpose

Merge attributes from newly resolved requests and override only values that exist and are not undefined.

This fixes an issue with our search results not returning complete data. If a search is resolved after a find, the find data was replaced with the incomplete data. Now the data gets merged so that any missing data that already exists in the store is not purged.

## Approach

Similar to #271 except with attributes instead of relationships.

Even though the tests do not use mirage, I updated mirage to also omit results like the backend does. The backend serializers inherit from the partial list serializers. But for mirage, the list serializers inherit from the normal serializers and include an additional whitelist which excludes the omitted fields.

#### TODOs and Open Questions

- Eventually, we just want the backend to give us complete results.

## Screenshots

Before (notice how the author disappears after the search resolves)

![before](https://user-images.githubusercontent.com/5005153/40497622-4fa81382-5f42-11e8-8de3-340302f12980.gif)

After (now the author sticks around)

![after](https://user-images.githubusercontent.com/5005153/40497630-54f08086-5f42-11e8-953c-9a76cb244c6a.gif)
