### PR TITLE
[UIEH-354] Replace title management toggle with radios for managed packages

### DIFF
--- a/src/components/package/edit-managed/managed-package-edit.css
+++ b/src/components/package/edit-managed/managed-package-edit.css
@@ -18,3 +18,11 @@
     display: block;
   }
 }
+
+.title-management-radios {
+  max-width: 50em;
+
+  & fieldset {
+    padding: 0;
+  }
+}

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import isEqual from 'lodash/isEqual';
@@ -117,12 +117,6 @@ class ManagedPackageEdit extends Component {
       packageVisible: e.target.checked
     });
   }
-
-  handleAllowKbToAddTitlesToggle = (e) => {
-    this.setState({
-      packageAllowedToAddTitles: e.target.checked
-    });
-  };
 
   handleOnSubmit = (values) => {
     if (this.state.allowFormToSubmit === false && values.isSelected === false) {
@@ -245,9 +239,9 @@ class ManagedPackageEdit extends Component {
               </DetailsViewSection>
               <DetailsViewSection label="Title management">
                 {packageSelected ? (
-                  <div>
+                  <div className={styles['title-management-radios']}>
                     {packageAllowedToAddTitles != null ? (
-                      <React.Fragment>
+                      <Fragment>
                         <Field
                           label="Automatically select new titles"
                           name="allowKbToAddTitles"
@@ -265,7 +259,7 @@ class ManagedPackageEdit extends Component {
                             data-test-eholdings-allow-kb-to-add-titles-radio-no
                           />
                         </Field>
-                      </React.Fragment>
+                      </Fragment>
                     ) : (
                       <label
                         data-test-eholdings-package-details-allow-add-new-titles

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -44,7 +44,6 @@ class ManagedPackageEdit extends Component {
     allowFormToSubmit: false,
     packageSelected: this.props.initialValues.isSelected,
     packageVisible: this.props.initialValues.isVisible,
-    packageAllowedToAddTitles: this.props.initialValues.allowKbToAddTitles,
     formValues: {}
   }
 
@@ -54,13 +53,11 @@ class ManagedPackageEdit extends Component {
     let { router } = this.context;
 
     if ((nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) ||
-    (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible) ||
-    (nextProps.initialValues.packageAllowedToAddTitles !== this.props.initialValues.packageAllowedToAddTitles)) {
+    (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
       this.setState({
         ...this.state,
         packageSelected: nextProps.initialValues.isSelected,
-        packageVisible: nextProps.initialValues.isVisible,
-        packageAllowedToAddTitles: nextProps.initialValues.allowKbToAddTitles
+        packageVisible: nextProps.initialValues.isVisible
       });
     }
 
@@ -85,9 +82,9 @@ class ManagedPackageEdit extends Component {
 
   handleSelectionToggle = (e) => {
     if (e.target.checked) {
+      this.props.change('allowKbToAddTitles', true);
       this.setState({
-        packageSelected: e.target.checked,
-        packageAllowedToAddTitles: true
+        packageSelected: e.target.checked
       });
     } else {
       this.setState({
@@ -134,6 +131,7 @@ class ManagedPackageEdit extends Component {
     }
   }
 
+
   render() {
     let {
       model,
@@ -145,8 +143,7 @@ class ManagedPackageEdit extends Component {
     let {
       showSelectionModal,
       packageSelected,
-      packageVisible,
-      packageAllowedToAddTitles
+      packageVisible
     } = this.state;
 
     let {
@@ -240,7 +237,7 @@ class ManagedPackageEdit extends Component {
               <DetailsViewSection label="Title management">
                 {packageSelected ? (
                   <div className={styles['title-management-radios']}>
-                    {packageAllowedToAddTitles != null ? (
+                    {this.props.initialValues.allowKbToAddTitles != null ? (
                       <Fragment>
                         <Field
                           label="Automatically select new titles"

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -82,7 +82,14 @@ class ManagedPackageEdit extends Component {
 
   handleSelectionToggle = (e) => {
     if (e.target.checked) {
-      this.props.change('allowKbToAddTitles', true);
+      let { initialValues } = this.props;
+
+      // Don't set `allowKbToAddTitles` to true unless `isSelected` has actually changed.
+      // Toggling off and then on again should not set `allowKbToAddTitles` to true.
+      if (e.target.checked !== initialValues.isSelected) {
+        this.props.change('allowKbToAddTitles', true);
+      }
+
       this.setState({
         packageSelected: e.target.checked
       });

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -6,6 +6,8 @@ import isEqual from 'lodash/isEqual';
 import {
   Button,
   Icon,
+  RadioButton,
+  RadioButtonGroup,
 } from '@folio/stripes-components';
 import { processErrors } from '../../utilities';
 
@@ -245,34 +247,33 @@ class ManagedPackageEdit extends Component {
                 {packageSelected ? (
                   <div>
                     {packageAllowedToAddTitles != null ? (
-                      <div>
-                        <label
-                          data-test-eholdings-package-details-allow-add-new-titles
-                          htmlFor="managed-package-details-toggle-allow-add-new-titles-switch"
+                      <React.Fragment>
+                        <Field
+                          label="Automatically select new titles"
+                          name="allowKbToAddTitles"
+                          data-test-eholdings-allow-kb-to-add-titles-radios
+                          component={RadioButtonGroup}
                         >
-                          <h4>
-                            {packageAllowedToAddTitles
-                              ? 'Automatically select new titles'
-                              : 'Do not automatically select new titles'}
-                          </h4>
-                          <br />
-                          <Field
-                            name="allowKbToAddTitles"
-                            component={ToggleSwitch}
-                            checked={packageAllowedToAddTitles}
-                            onChange={this.handleAllowKbToAddTitlesToggle}
-                            id="managed-package-details-toggle-allow-add-new-titles-switch"
+                          <RadioButton
+                            label="Yes"
+                            value="true"
+                            data-test-eholdings-allow-kb-to-add-titles-radio-yes
                           />
-                        </label>
-                      </div>
-                        ) : (
-                          <label
-                            data-test-eholdings-package-details-allow-add-new-titles
-                            htmlFor="managed-package-details-toggle-allow-add-new-titles-switch"
-                          >
-                            <Icon icon="spinner-ellipsis" />
-                          </label>
-                        )}
+                          <RadioButton
+                            label="No"
+                            value="false"
+                            data-test-eholdings-allow-kb-to-add-titles-radio-no
+                          />
+                        </Field>
+                      </React.Fragment>
+                    ) : (
+                      <label
+                        data-test-eholdings-package-details-allow-add-new-titles
+                        htmlFor="managed-package-details-toggle-allow-add-new-titles-switch"
+                      >
+                        <Icon icon="spinner-ellipsis" />
+                      </label>
+                    )}
                   </div>
                   ) : (
                     <p>Knowledge base does not automatically select titles.</p>

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -103,7 +103,7 @@ class PackageEditRoute extends Component {
       }
 
       if ('allowKbToAddTitles' in values) {
-        model.allowKbToAddTitles = values.allowKbToAddTitles;
+        model.allowKbToAddTitles = values.allowKbToAddTitles === 'true'; // turn string into boolean
       }
 
       if ('name' in values) {

--- a/tests/managed-package-edit-add-new-titles-test.js
+++ b/tests/managed-package-edit-add-new-titles-test.js
@@ -215,9 +215,7 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
         expect(PackageEditPage.isSelected).to.be.true;
       });
 
-      // TODO: Fix before merge
-      // Why is this not true? Something weird is going on.
-      it.skip('allow KB to add titles is selected true', () => {
+      it('allow KB to add titles is selected true', () => {
         expect(PackageEditPage.allowKbToAddTitlesRadio).to.be.true;
       });
     });

--- a/tests/managed-package-edit-add-new-titles-test.js
+++ b/tests/managed-package-edit-add-new-titles-test.js
@@ -24,13 +24,14 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
         isSelected: true,
         allowKbToAddTitles: true
       });
+
       return this.visit(`/eholdings/packages/${providerPackage.id}/edit`, () => {
         expect(PackageEditPage.$root).to.exist;
       });
     });
 
-    it('displays an ON allowKbToAddTitles Toggle', () => {
-      expect(PackageEditPage.allowKbToAddTitles).to.be.true;
+    it('allowKbToAddTitles is selected to be true', () => {
+      expect(PackageEditPage.allowKbToAddTitlesRadio).to.be.true;
     });
 
     it('disables the save button', () => {
@@ -47,7 +48,7 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
       });
     });
 
-    describe('toggling the allowKbToAddTitles toggle', () => {
+    describe('changing the allowKbToAddTitles selection', () => {
       beforeEach(function () {
         /*
          * The expectations in the convergent `it` blocks
@@ -59,7 +60,7 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
          * TODO: control timing directly with Mirage
          */
         this.server.timing = 50;
-        return PackageEditPage.toggleAllowKbToAddTitles();
+        return PackageEditPage.clickDisallowKbToAddTitlesRadio();
       });
 
       afterEach(function () {
@@ -106,8 +107,8 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
       });
     });
 
-    it('displays an OFF allowKbToAddTitles Toggle', () => {
-      expect(PackageEditPage.allowKbToAddTitles).to.be.false;
+    it('allowKbToAddTitles is selected to no', () => {
+      expect(PackageEditPage.allowKbToAddTitlesRadio).to.be.false;
     });
 
     it('disables the save button', () => {
@@ -124,7 +125,7 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
       });
     });
 
-    describe('toggling the allowKbToAddTitles toggle', () => {
+    describe('changing the allowKbToAddTitles selection', () => {
       beforeEach(function () {
         /*
          * The expectations in the convergent `it` blocks
@@ -136,7 +137,7 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
          * TODO: control timing directly with Mirage
          */
         this.server.timing = 50;
-        return PackageEditPage.toggleAllowKbToAddTitles();
+        return PackageEditPage.clickAllowKbToAddTitlesRadio();
       });
 
       afterEach(function () {
@@ -184,7 +185,7 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
     });
 
     it.always('does not display the allow KB to add titles toggle switch', () => {
-      expect(PackageEditPage.hastoggleForAllowKbToAddTitles).to.equal(false);
+      expect(PackageEditPage.hasRadioForAllowKbToAddTitles).to.equal(false);
     });
 
     it('disables the save button', () => {
@@ -214,8 +215,10 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
         expect(PackageEditPage.isSelected).to.be.true;
       });
 
-      it('displays an ON Toggle for allow KB to add titles', () => {
-        expect(PackageEditPage.allowKbToAddTitles).to.be.true;
+      // TODO: Fix before merge
+      // Why is this not true? Something weird is going on.
+      it.skip('allow KB to add titles is selected true', () => {
+        expect(PackageEditPage.allowKbToAddTitlesRadio).to.be.true;
       });
     });
   });

--- a/tests/managed-package-edit-selection-test.js
+++ b/tests/managed-package-edit-selection-test.js
@@ -36,8 +36,8 @@ describeApplication('ManagedPackageEditSelection', () => {
       expect(PackageEditPage.isVisibleTogglePresent).to.equal(false);
     });
 
-    it('cannot toggle allow kb to add titles', () => {
-      expect(PackageEditPage.hastoggleForAllowKbToAddTitles).to.equal(false);
+    it('cannot select allow kb to add titles', () => {
+      expect(PackageEditPage.hasRadioForAllowKbToAddTitles).to.equal(false);
     });
 
     it('cannot edit coverage', () => {
@@ -147,8 +147,8 @@ describeApplication('ManagedPackageEditSelection', () => {
       expect(PackageEditPage.isVisibleTogglePresent).to.equal(true);
     });
 
-    it('can toggle allow kb to add titles', () => {
-      expect(PackageEditPage.hastoggleForAllowKbToAddTitles).to.equal(true);
+    it('can select allow kb to add titles', () => {
+      expect(PackageEditPage.hasRadioForAllowKbToAddTitles).to.equal(true);
     });
 
     it('can edit coverage', () => {

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -37,9 +37,13 @@ import Datepicker from './datepicker';
   isHiddenMessage = text('[data-test-eholdings-package-details-is-hidden-reason]');
   isHiddenMessagePresent = isPresent('[data-test-eholdings-package-details-is-hidden-reason]');
   isVisibleTogglePresent = isPresent('[data-test-eholdings-package-details-visible] input');
-  hastoggleForAllowKbToAddTitles = isPresent('[data-test-eholdings-package-details-allow-add-new-titles]');
+  hasRadioForAllowKbToAddTitles = isPresent('[data-test-eholdings-allow-kb-to-add-titles-radios]');
   toggleAllowKbToAddTitles = clickable('[data-test-eholdings-package-details-allow-add-new-titles] input');
   allowKbToAddTitles = property('[data-test-eholdings-package-details-allow-add-new-titles] input', 'checked');
+  disallowKbToAddTitlesRadio = property('[data-test-eholdings-allow-kb-to-add-titles-radio-no]', 'checked')
+  allowKbToAddTitlesRadio = property('[data-test-eholdings-allow-kb-to-add-titles-radio-yes]', 'checked');
+  clickAllowKbToAddTitlesRadio = clickable('[data-test-eholdings-allow-kb-to-add-titles-radio-yes]');
+  clickDisallowKbToAddTitlesRadio = clickable('[data-test-eholdings-allow-kb-to-add-titles-radio-no]');
   hasCoverageDatesPresent = isPresent('[data-test-eholdings-coverage-fields-date-range-row]');
   hasNameFieldPresent = isPresent('[data-test-eholdings-package-name-field]');
   hasReadOnlyNameFieldPresent = isPresent('[data-test-eholdings-package-readonly-name-field]');


### PR DESCRIPTION
## Purpose

This is the first step in replacing our toggles with radio buttons. This is because the toggle switches weren't obvious what state they were in.

## Approach
Remove the toggle switch and use `RadioButtonGroup` with redux form. This removed the weird complexity we had with the toggles. Now it's falling more inline with the way the rest of the form works. 

## TODO
- [ ] Unskip last test. For some reason when you reselect the package `add to kb` isn't true. 

## Screenshots
![2018-05-24 17 44 00](https://user-images.githubusercontent.com/2072894/40517292-1fe9213a-5f7a-11e8-9958-bcda3a63e3f4.gif)

