### PR TITLE
[UIEH-386] Full Page Edit of Resource with Multiple Custom Coverage Dates Error

### DIFF
--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -22,6 +22,7 @@ class ResourceEditRoute extends Component {
   };
 
   static contextTypes = {
+    intl: PropTypes.object.isRequired,
     router: PropTypes.shape({
       history: PropTypes.shape({
         replace: PropTypes.func.isRequired
@@ -101,11 +102,13 @@ class ResourceEditRoute extends Component {
 
   render() {
     let { model } = this.props;
+    let { intl } = this.context;
 
     return (
       <View
         model={model}
         onSubmit={this.resourceEditSubmitted}
+        intl={intl}
       />
     );
   }

--- a/tests/resource-edit-managed-title-test.js
+++ b/tests/resource-edit-managed-title-test.js
@@ -195,6 +195,10 @@ describeApplication('ResourceEditManagedTitleInManagedPackage', () => {
         this.server.create('custom-coverage', {
           beginCoverage: '1969-07-16',
           endCoverage: '1972-12-19'
+        }),
+        this.server.create('custom-coverage', {
+          beginCoverage: '1973-01-01',
+          endCoverage: '1979-12-31'
         })
       ];
       resource.update('customCoverages', customCoverages.map(item => item.toJSON()));


### PR DESCRIPTION
## Purpose

[UIEH-386](https://issues.folio.org/browse/UIEH-386)

The missing `intl` from props was causing the validation to throw an error for coverage dates because `formatISODateWithoutTime` is dependent on `intl.formatDate()`.

## Approach

Provide `intl` as a prop in the route for editing resources

To cause a test failures, I only needed to add an additional coverage date to some existing tests. Providing the `intl` as described above caused them all to start passing again.

#### Open Questions
- Why is the validation run for multiple coverages but not single coverages?

## Screenshots

**Before**

<img width="980" alt="before" src="https://user-images.githubusercontent.com/5005153/40733084-77caf142-63fa-11e8-8945-b988936e1743.png">

**After**

<img width="980" alt="after" src="https://user-images.githubusercontent.com/5005153/40733090-7a3b7cb2-63fa-11e8-9a46-f0a0b0b77f57.png">