### PR TITLE
Add build step to Circle workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,16 @@ jobs:
           name: Lint CSS
           command: yarn stylelint
 
+  build:
+    docker:
+      - image: circleci/node:9
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Build bundle
+          command: NODE_ENV=production yarn build
+
   test-chrome:
     docker:
       - image: circleci/node:9-browsers
@@ -132,6 +142,9 @@ workflows:
           requires:
             - checkout-and-install
       - stylelint:
+          requires:
+            - checkout-and-install
+      - build:
           requires:
             - checkout-and-install
       - test-chrome:


### PR DESCRIPTION
## Purpose
https://github.com/folio-org/ui-eholdings/pull/415 broke the `build` command, but that wasn't caught until `folio-ui-eholdings-deploy` tried to run it.

## Approach
Test `yarn build` as part of the Circle workflow for `ui-eholdings`. I confirmed that this would've caught the previous bug: https://circleci.com/gh/folio-org/ui-eholdings/3650