### PR TITLE
UIEH-351 Introduce translations file

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash": "^4.17.4",
     "mocha": "^4.0.1",
     "moment": "^2.22.2",
+    "prop-types": "^15.6.1",
     "qs": "^6.5.1",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
@@ -55,6 +56,7 @@
     "funcadelic": "^0.4.0",
     "impagination": "^1.0.0-alpha.3",
     "inflected": "^2.0.3",
+    "react-intl": "^2.4.0",
     "redux-actions": "^2.2.1"
   },
   "peerDependencies": {

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -7,6 +7,8 @@ import {
   PaneMenu
 } from '@folio/stripes-components';
 import capitalize from 'lodash/capitalize';
+import { injectIntl, intlShape } from 'react-intl';
+
 import { qs } from '../utilities';
 import SearchPane from '../search-pane';
 import ResultsPane from '../results-pane';
@@ -15,7 +17,7 @@ import SearchPaneVignette from '../search-pane-vignette';
 import Link from '../link';
 import styles from './search-paneset.css';
 
-export default class SearchPaneset extends React.Component {
+class SearchPaneset extends React.Component {
   static propTypes = {
     searchForm: PropTypes.node,
     hideFilters: PropTypes.bool,
@@ -27,7 +29,8 @@ export default class SearchPaneset extends React.Component {
     location: PropTypes.shape({
       pathname: PropTypes.string.isRequired,
       search: PropTypes.string.isRequired
-    }).isRequired
+    }).isRequired,
+    intl: intlShape.isRequired
   };
 
   static defaultProps = {
@@ -35,7 +38,6 @@ export default class SearchPaneset extends React.Component {
   };
 
   static contextTypes = {
-    intl: PropTypes.object,
     router: PropTypes.shape({
       history: PropTypes.object
     })
@@ -100,9 +102,9 @@ export default class SearchPaneset extends React.Component {
       resultsView,
       detailsView,
       totalResults,
-      isLoading
+      isLoading,
+      intl
     } = this.props;
-    let { intl } = this.context;
 
     // only hide filters if there are results and always hide filters when a detail view is visible
     hideFilters = (hideFilters && !!resultsView) || !!detailsView;
@@ -114,11 +116,10 @@ export default class SearchPaneset extends React.Component {
 
     let resultsPaneSub = 'Loading...';
     if (!isLoading) {
-      resultsPaneSub = `${intl.formatNumber(totalResults)} search result`;
-
-      if (totalResults > 1) {
-        resultsPaneSub += 's';
-      }
+      resultsPaneSub = intl.formatMessage(
+        { id: 'ui-eholdings.resultCount' },
+        { count: totalResults }
+      );
     }
 
     return (
@@ -200,3 +201,5 @@ export default class SearchPaneset extends React.Component {
     );
   }
 }
+
+export default injectIntl(SearchPaneset);

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -1,0 +1,3 @@
+{
+  "resultCount": "{count, number} {count, plural, one {search result} other {search results}}"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,7 +348,7 @@
     react-router-dom "^4.0.0"
     redux-form "^7.0.3"
 
-"@folio/ui-testing@github:folio-org/ui-testing#framework-only":
+"@folio/ui-testing@folio-org/ui-testing#framework-only":
   version "4.0.0"
   resolved "https://codeload.github.com/folio-org/ui-testing/tar.gz/90a425c1a8d12552e04c72dfeec2f623a81af629"
   dependencies:


### PR DESCRIPTION
## Purpose
Resolves https://issues.folio.org/browse/UIEH-351

## Approach
Starts using `react-intl`'s `injectIntl()` higher-order component instead of getting `intl` from context. `injectIntl()` uses the old React context under the hood, but is intended to be forward-compatible when `react-intl` starts using the new context API. We should start phasing out uses of the old context API to be future-friendly (`react-router` being the biggest question mark).