### PR TITLE
UIEH-351 Introduce translations file 

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash": "^4.17.4",
     "mocha": "^4.0.1",
     "moment": "^2.22.2",
+    "prop-types": "^15.6.1",
     "qs": "^6.5.1",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
@@ -55,6 +56,7 @@
     "funcadelic": "^0.4.0",
     "impagination": "^1.0.0-alpha.3",
     "inflected": "^2.0.3",
+    "react-intl": "^2.4.0",
     "redux-actions": "^2.2.1"
   },
   "peerDependencies": {

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -7,6 +7,8 @@ import {
   PaneMenu
 } from '@folio/stripes-components';
 import capitalize from 'lodash/capitalize';
+import { FormattedMessage } from 'react-intl';
+
 import { qs } from '../utilities';
 import SearchPane from '../search-pane';
 import ResultsPane from '../results-pane';
@@ -35,7 +37,6 @@ export default class SearchPaneset extends React.Component {
   };
 
   static contextTypes = {
-    intl: PropTypes.object,
     router: PropTypes.shape({
       history: PropTypes.object
     })
@@ -102,7 +103,6 @@ export default class SearchPaneset extends React.Component {
       totalResults,
       isLoading
     } = this.props;
-    let { intl } = this.context;
 
     // only hide filters if there are results and always hide filters when a detail view is visible
     hideFilters = (hideFilters && !!resultsView) || !!detailsView;
@@ -114,11 +114,14 @@ export default class SearchPaneset extends React.Component {
 
     let resultsPaneSub = 'Loading...';
     if (!isLoading) {
-      resultsPaneSub = `${intl.formatNumber(totalResults)} search result`;
-
-      if (totalResults > 1) {
-        resultsPaneSub += 's';
-      }
+      resultsPaneSub = (
+        <FormattedMessage
+          id="ui-eholdings.resultCount"
+          values={{
+            count: totalResults
+          }}
+        />
+      );
     }
 
     return (

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -1,0 +1,3 @@
+{
+  "resultCount": "{count, number} {count, plural, one {search result} other {search results}}"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,7 +348,7 @@
     react-router-dom "^4.0.0"
     redux-form "^7.0.3"
 
-"@folio/ui-testing@github:folio-org/ui-testing#framework-only":
+"@folio/ui-testing@folio-org/ui-testing#framework-only":
   version "4.0.0"
   resolved "https://codeload.github.com/folio-org/ui-testing/tar.gz/90a425c1a8d12552e04c72dfeec2f623a81af629"
   dependencies:


### PR DESCRIPTION
## Purpose
Replaces https://github.com/folio-org/ui-eholdings/pull/421

## Approach
After more reading about `react-intl`, this feels like the better approach. `injectIntl()` is really only needed when you need to get a bare string. In most cases the `<FormattedMessage>` component is the way to go.