### PR TITLE
[UIEH-353] Resource Visibility Radios

### DIFF
--- a/src/components/resource/_fields/visibility/index.js
+++ b/src/components/resource/_fields/visibility/index.js
@@ -1,0 +1,1 @@
+export { default } from './visibility-field';

--- a/src/components/resource/_fields/visibility/visibility-field.css
+++ b/src/components/resource/_fields/visibility/visibility-field.css
@@ -1,0 +1,12 @@
+.visibility-field {
+  & fieldset {
+    padding-left: 0;
+  }
+
+  & legend {
+    color: black;
+    font-size: 1rem;
+    font-weight: normal;
+    text-transform: none;
+  }
+}

--- a/src/components/resource/_fields/visibility/visibility-field.js
+++ b/src/components/resource/_fields/visibility/visibility-field.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Field } from 'redux-form';
+
+import { RadioButtonGroup, RadioButton } from '@folio/stripes-components';
+import styles from './visibility-field.css';
+
+export default class VisibilityField extends Component {
+  static propTypes = {
+    disabled: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string
+    ])
+  };
+
+  render() {
+    let { disabled } = this.props;
+    let disabledReason = typeof disabled === 'string' ? disabled : '';
+
+    return (
+      <div
+        className={styles['visibility-field']}
+        data-test-eholdings-resource-visibility-field
+      >
+        <Field
+          name="isVisible"
+          label="Visible to patrons"
+          component={RadioButtonGroup}
+          disabled={!!disabled}
+        >
+          <RadioButton label="Yes" value="true" />
+          <RadioButton label={`No ${disabledReason}`} value="false" />
+        </Field>
+      </div>
+    );
+  }
+}

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import isEqual from 'lodash/isEqual';
@@ -10,6 +10,7 @@ import {
 import { processErrors } from '../../utilities';
 
 import DetailsView from '../../details-view';
+import VisibilityField from '../_fields/visibility';
 import CustomCoverageFields, { validate as validateCoverageDates } from '../_fields/custom-coverage';
 import CustomUrlFields, { validate as validateUrlFields } from '../_fields/custom-url';
 import CoverageStatementFields, { validate as validateCoverageStatement } from '../_fields/coverage-statement';
@@ -41,7 +42,6 @@ class ResourceEditCustomTitle extends Component {
 
   state = {
     resourceSelected: this.props.initialValues.isSelected,
-    resourceVisible: this.props.initialValues.isVisible,
     showSelectionModal: false,
     allowFormToSubmit: false,
     formValues: {}
@@ -52,11 +52,9 @@ class ResourceEditCustomTitle extends Component {
     let needsUpdate = !isEqual(this.props.model, nextProps.model);
 
     if ((nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) ||
-    (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
+        (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
       this.setState({
-        ...this.state,
-        resourceSelected: nextProps.initialValues.isSelected,
-        resourceVisible: nextProps.initialValues.isVisible
+        resourceSelected: nextProps.initialValues.isSelected
       });
     }
 
@@ -78,12 +76,6 @@ class ResourceEditCustomTitle extends Component {
   handleSelectionToggle = (e) => {
     this.setState({
       resourceSelected: e.target.checked
-    });
-  }
-
-  handleVisibilityToggle = (e) => {
-    this.setState({
-      resourceVisible: e.target.checked
     });
   }
 
@@ -130,8 +122,7 @@ class ResourceEditCustomTitle extends Component {
 
     let {
       showSelectionModal,
-      resourceSelected,
-      resourceVisible
+      resourceSelected
     } = this.state;
 
     let actionMenuItems = [
@@ -144,6 +135,10 @@ class ResourceEditCustomTitle extends Component {
       }
     ];
 
+    let visibilityMessage = model.package.visibilityData.isHidden
+      ? '(All titles in this package are hidden)'
+      : model.visibilityData.reason && `(${model.visibilityData.reason})`;
+
     return (
       <div>
         <Toaster toasts={processErrors(model)} position="bottom" />
@@ -155,14 +150,17 @@ class ResourceEditCustomTitle extends Component {
           actionMenuItems={actionMenuItems}
           bodyContent={(
             <form onSubmit={handleSubmit(this.handleOnSubmit)}>
-              <DetailsViewSection
-                label="Resource information"
-              >
+              <DetailsViewSection label="Resource settings">
                 {resourceSelected ? (
-                  <CustomUrlFields />
-                    ) : (
-                      <p>Add the resource to holdings to set custom url.</p>
-                  )}
+                  <Fragment>
+                    <VisibilityField disabled={visibilityMessage} />
+                    <CustomUrlFields />
+                  </Fragment>
+                ) : (
+                  <p data-test-eholdings-resource-edit-settings-message>
+                    Add the resource to holdings to customize resource settings.
+                  </p>
+                )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Holding status"
@@ -181,42 +179,6 @@ class ResourceEditCustomTitle extends Component {
                     id="custom-resource-holding-toggle-switch"
                   />
                 </label>
-              </DetailsViewSection>
-              <DetailsViewSection
-                label="Visibility"
-              >
-                {resourceSelected ? (
-                  <div>
-                    <label
-                      data-test-eholdings-resource-toggle-visibility
-                      htmlFor="custom-resource-visibility-toggle-switch"
-                    >
-                      <h4>
-                        {resourceVisible
-                      ? 'Visible to patrons'
-                    : 'Hidden from patrons'}
-                      </h4>
-                      <br />
-                      <Field
-                        name="isVisible"
-                        component={ToggleSwitch}
-                        checked={resourceVisible}
-                        onChange={this.handleVisibilityToggle}
-                        id="custom-resource-visibility-toggle-switch"
-                      />
-                    </label>
-
-                    {!resourceVisible && (
-                    <div data-test-eholdings-resource-toggle-hidden-reason>
-                      {model.package.visibilityData.isHidden
-                           ? 'All titles in this package are hidden.'
-                           : model.visibilityData.reason}
-                    </div>
-                     )}
-                  </div>
-                 ) : (
-                   <p data-test-eholdings-resource-not-shown-label>Not shown to patrons.</p>
-                 )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage dates"

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -10,6 +10,7 @@ import {
 import { processErrors } from '../../utilities';
 
 import DetailsView from '../../details-view';
+import VisibilityField from '../_fields/visibility';
 import CoverageStatementFields, { validate as validateCoverageStatement } from '../_fields/coverage-statement';
 import CustomCoverageFields, { validate as validateCoverageDates } from '../_fields/custom-coverage';
 import CustomEmbargoFields, { validate as validateEmbargo } from '../_fields/custom-embargo';
@@ -40,7 +41,6 @@ class ResourceEditManagedTitle extends Component {
 
   state = {
     managedResourceSelected: this.props.initialValues.isSelected,
-    managedResourceVisible: this.props.initialValues.isVisible,
     showSelectionModal: false,
     allowFormToSubmit: false,
     formValues: {}
@@ -51,11 +51,9 @@ class ResourceEditManagedTitle extends Component {
     let needsUpdate = !isEqual(this.props.model, nextProps.model);
 
     if ((nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) ||
-    (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
+        (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
       this.setState({
-        ...this.state,
-        managedResourceSelected: nextProps.initialValues.isSelected,
-        managedResourceVisible: nextProps.initialValues.isVisible,
+        managedResourceSelected: nextProps.initialValues.isSelected
       });
     }
 
@@ -77,12 +75,6 @@ class ResourceEditManagedTitle extends Component {
   handleSelectionToggle = (e) => {
     this.setState({
       managedResourceSelected: e.target.checked
-    });
-  }
-
-  handleVisibilityToggle = (e) => {
-    this.setState({
-      managedResourceVisible: e.target.checked
     });
   }
 
@@ -127,8 +119,7 @@ class ResourceEditManagedTitle extends Component {
 
     let {
       showSelectionModal,
-      managedResourceSelected,
-      managedResourceVisible
+      managedResourceSelected
     } = this.state;
 
     let actionMenuItems = [
@@ -141,6 +132,9 @@ class ResourceEditManagedTitle extends Component {
       }
     ];
 
+    let visibilityMessage = model.package.visibilityData.isHidden
+      ? '(All titles in this package are hidden)'
+      : model.visibilityData.reason && `(${model.visibilityData.reason})`;
 
     return (
       <div>
@@ -153,6 +147,15 @@ class ResourceEditManagedTitle extends Component {
           actionMenuItems={actionMenuItems}
           bodyContent={(
             <form onSubmit={handleSubmit(this.handleOnSubmit)}>
+              <DetailsViewSection label="Resource settings">
+                {managedResourceSelected ? (
+                  <VisibilityField disabled={visibilityMessage} />
+                ) : (
+                  <p data-test-eholdings-resource-edit-settings-message>
+                    Add the resource to holdings to customize resource settings.
+                  </p>
+                )}
+              </DetailsViewSection>
               <DetailsViewSection
                 label="Holding status"
               >
@@ -170,42 +173,6 @@ class ResourceEditManagedTitle extends Component {
                     id="managed-resource-holding-toggle-switch"
                   />
                 </label>
-              </DetailsViewSection>
-              <DetailsViewSection
-                label="Visibility"
-              >
-                {managedResourceSelected ? (
-                  <div>
-                    <label
-                      data-test-eholdings-resource-toggle-visibility
-                      htmlFor="managed-resource-visibility-toggle-switch"
-                    >
-                      <h4>
-                        {managedResourceVisible
-                      ? 'Visible to patrons'
-                    : 'Hidden from patrons'}
-                      </h4>
-                      <br />
-                      <Field
-                        name="isVisible"
-                        component={ToggleSwitch}
-                        checked={managedResourceVisible}
-                        onChange={this.handleVisibilityToggle}
-                        id="managed-resource-visibility-toggle-switch"
-                      />
-                    </label>
-
-                    {!managedResourceVisible && (
-                    <div data-test-eholdings-resource-toggle-hidden-reason>
-                      {model.package.visibilityData.isHidden
-                           ? 'All titles in this package are hidden.'
-                           : model.visibilityData.reason}
-                    </div>
-                     )}
-                  </div>
-                 ) : (
-                   <p data-test-eholdings-resource-not-shown-label>Not shown to patrons.</p>
-                 )}
               </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage dates"

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -77,6 +77,9 @@ export default class ResourceShow extends Component {
     } = this.state;
 
     let isSelectInFlight = model.update.isPending && 'isSelected' in model.update.changedAttributes;
+    let visibilityMessage = model.package.visibilityData.isHidden
+      ? '(All titles in this package are hidden)'
+      : model.visibilityData.reason && `(${model.visibilityData.reason})`;
 
     let hasManagedCoverages = model.managedCoverages.length > 0 &&
       isValidCoverageList(model.managedCoverages);
@@ -226,15 +229,23 @@ export default class ResourceShow extends Component {
                 )}
               </DetailsViewSection>
 
-              {model.url && (
-                <DetailsViewSection label="Resource information">
+              <DetailsViewSection label="Resource settings">
+                <KeyValue label="Visible to patrons">
+                  <div data-test-eholdings-resource-show-visibility>
+                    {model.visibilityData.isHidden || !resourceSelected
+                      ? `No ${visibilityMessage}`
+                      : 'Yes'}
+                  </div>
+                </KeyValue>
+
+                {model.url && (
                   <KeyValue label={`${model.title.isTitleCustom ? 'Custom' : 'Managed'} URL`}>
                     <div data-test-eholdings-resource-show-url>
                       <a href={model.url} target="_blank">{model.url}</a>
                     </div>
                   </KeyValue>
-                </DetailsViewSection>
-              )}
+                )}
+              </DetailsViewSection>
 
               <DetailsViewSection label="Holding status">
                 <label
@@ -251,32 +262,7 @@ export default class ResourceShow extends Component {
                   />
                 </label>
               </DetailsViewSection>
-              <DetailsViewSection label="Visibility">
-                {(resourceSelected && !isSelectInFlight) ? (
-                  <div>
-                    <label
-                      data-test-eholdings-resource-hidden-label
-                      htmlFor="resource-show-hide-indicator"
-                    >
-                      <p>
-                        {model.visibilityData.isHidden
-                          ? 'Hidden from patrons'
-                          : 'Visible to patrons'}
-                      </p>
-                    </label>
 
-                    {model.visibilityData.isHidden && (
-                      <div data-test-eholdings-resource-hidden-reason>
-                        {model.package.visibilityData.isHidden
-                          ? 'All titles in this package are hidden.'
-                          : model.visibilityData.reason}
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <p data-test-eholdings-resource-not-shown-label>Not shown to patrons.</p>
-                )}
-              </DetailsViewSection>
               <DetailsViewSection
                 label="Coverage dates"
                 closedByDefault={!hasManagedCoverages && !resourceSelected}

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -90,7 +90,7 @@ class ResourceEditRoute extends Component {
       });
       model.isSelected = values.isSelected;
       model.url = customUrl;
-      model.visibilityData.isHidden = !isVisible;
+      model.visibilityData.isHidden = isVisible === 'false';
       model.coverageStatement = coverageStatement;
       model.customEmbargoPeriod = {
         embargoValue: customEmbargoValue,

--- a/tests/custom-resource-edit-visibility-test.js
+++ b/tests/custom-resource-edit-visibility-test.js
@@ -46,7 +46,7 @@ describeApplication('CustomResourceEditVisibility', () => {
       });
     });
 
-    it('displays an ON visibility toggle (Visible)', () => {
+    it('displays the yes visibility radio is selected', () => {
       expect(ResourceEditPage.isResourceVisible).to.be.true;
     });
 
@@ -112,7 +112,7 @@ describeApplication('CustomResourceEditVisibility', () => {
       });
     });
 
-    it('displays an OFF visibility toggle (Hidden)', () => {
+    it('displays the no visibility radio is selected', () => {
       expect(ResourceEditPage.isResourceVisible).to.be.false;
     });
 
@@ -158,11 +158,11 @@ describeApplication('CustomResourceEditVisibility', () => {
       });
     });
 
-    it('displays an OFF visibility toggle (Hidden)', () => {
+    it('displays the no visibility radio is selected', () => {
       expect(ResourceEditPage.isResourceVisible).to.be.false;
     });
 
-    it('maps the hidden reason text', () => {
+    it('displays the hidden reason text', () => {
       expect(ResourceEditPage.isHiddenMessage).to.equal('The content is for mature audiences only.');
     });
   });
@@ -181,12 +181,12 @@ describeApplication('CustomResourceEditVisibility', () => {
       });
     });
 
-    it('displays an OFF visibility toggle (Hidden)', () => {
+    it('displays the no visibility radio is selected', () => {
       expect(ResourceEditPage.isResourceVisible).to.be.false;
     });
 
-    it('maps the hidden reason text', () => {
-      expect(ResourceEditPage.isHiddenMessage).to.equal('All titles in this package are hidden.');
+    it('displays the hidden reason text', () => {
+      expect(ResourceEditPage.isHiddenMessage).to.equal('All titles in this package are hidden');
     });
   });
 
@@ -202,6 +202,7 @@ describeApplication('CustomResourceEditVisibility', () => {
         expect(ResourceEditPage.$root).to.exist;
       });
     });
+
     it('reflects the desired state of holding status', () => {
       expect(ResourceEditPage.isSelected).to.equal(true);
     });
@@ -216,11 +217,11 @@ describeApplication('CustomResourceEditVisibility', () => {
       });
 
       it('cannot toggle visibility', () => {
-        expect(ResourceEditPage.isVisibleTogglePresent).to.equal(false);
+        expect(ResourceEditPage.isVisibilityFieldPresent).to.equal(false);
       });
 
-      it('displays Visibility label as Not shown to patrons', () => {
-        expect(ResourceEditPage.isResourceNotShownLabelPresent).to.be.true;
+      it('displays a not selected message for resource settings', () => {
+        expect(ResourceEditPage.isResourceNotSelectedLabelPresent).to.be.true;
       });
     });
   });

--- a/tests/managed-resource-edit-visibility-test.js
+++ b/tests/managed-resource-edit-visibility-test.js
@@ -44,7 +44,7 @@ describeApplication('ManagedResourceEditVisibility', () => {
       });
     });
 
-    it('displays an ON visibility toggle (Visible)', () => {
+    it('displays the yes visibility radio is selected', () => {
       expect(ResourceEditPage.isResourceVisible).to.be.true;
     });
 
@@ -110,7 +110,7 @@ describeApplication('ManagedResourceEditVisibility', () => {
       });
     });
 
-    it('displays an OFF visibility toggle (Hidden)', () => {
+    it('displays the no visibility radio is selected', () => {
       expect(ResourceEditPage.isResourceVisible).to.be.false;
     });
 
@@ -156,7 +156,7 @@ describeApplication('ManagedResourceEditVisibility', () => {
       });
     });
 
-    it('displays an OFF visibility toggle (Hidden)', () => {
+    it('displays the no visibility radio is selected', () => {
       expect(ResourceEditPage.isResourceVisible).to.be.false;
     });
 
@@ -179,12 +179,12 @@ describeApplication('ManagedResourceEditVisibility', () => {
       });
     });
 
-    it('displays an OFF visibility toggle (Hidden)', () => {
+    it('displays the no visibility radio is selected', () => {
       expect(ResourceEditPage.isResourceVisible).to.be.false;
     });
 
-    it('maps the hidden reason text', () => {
-      expect(ResourceEditPage.isHiddenMessage).to.equal('All titles in this package are hidden.');
+    it('displays the hidden reason text', () => {
+      expect(ResourceEditPage.isHiddenMessage).to.equal('All titles in this package are hidden');
     });
   });
 
@@ -201,8 +201,8 @@ describeApplication('ManagedResourceEditVisibility', () => {
       });
     });
 
-    it('displays Visibility label as Not shown to patrons', () => {
-      expect(ResourceEditPage.isResourceNotShownLabelPresent).to.be.true;
+    it('displays it is not visible to patrons', () => {
+      expect(ResourceEditPage.isResourceNotSelectedLabelPresent).to.be.true;
     });
   });
 });

--- a/tests/pages/resource-edit.js
+++ b/tests/pages/resource-edit.js
@@ -8,7 +8,8 @@ import {
   interactor,
   property,
   text,
-  value
+  value,
+  computed
 } from '@bigtest/interactor';
 import { hasClassBeginningWith } from './helpers';
 
@@ -36,16 +37,24 @@ import Datepicker from './datepicker';
   checkPeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   isSelected = property('[data-test-eholdings-resource-holding-status] input', 'checked');
-  isResourceVisible = property('[data-test-eholdings-resource-toggle-visibility] input', 'checked');
-  isHiddenMessage = text('[data-test-eholdings-resource-toggle-hidden-reason]');
-  isHiddenMessagePresent = isPresent('[data-test-eholdings-resource-toggle-hidden-reason]');
-  isVisibleTogglePresent = isPresent('[data-test-eholdings-resource-toggle-visibility] input');
-  isResourceNotShownLabelPresent = isPresent('[data-test-eholdings-resource-not-shown-label]');
+  isResourceVisible = property('[data-test-eholdings-resource-visibility-field] input[value="true"]', 'checked');
+  isHiddenMessage = computed(function () {
+    let $node = this.$('[data-test-eholdings-resource-visibility-field] input[value="false"] ~ span:last-child');
+    return $node.textContent.replace(/^No(\s\((.*)\))?$/, '$2');
+  });
+  isHiddenMessagePresent = computed(function () {
+    try { return !!this.isHiddenMessage; } catch (e) { return false; }
+  });
+  isVisibilityFieldPresent = isPresent('[data-test-eholdings-resource-visibility-field]');
+  isResourceNotSelectedLabelPresent = isPresent('[data-test-eholdings-resource-edit-settings-message]');
 
   toggleIsSelected = clickable('[data-test-eholdings-resource-holding-status] input');
-  toggleIsVisible = clickable('[data-test-eholdings-resource-toggle-visibility] input');
-  modal = new ResourceEditModal('#eholdings-resource-confirmation-modal');
+  toggleIsVisible() {
+    let isVisible = (!this.isResourceVisible).toString();
+    return this.click(`[data-test-eholdings-resource-visibility-field] input[value="${isVisible}"]`);
+  }
 
+  modal = new ResourceEditModal('#eholdings-resource-confirmation-modal');
   toast = Toast;
 
   name = fillable('[data-test-eholdings-resource-name-field] input');
@@ -65,7 +74,6 @@ import Datepicker from './datepicker';
 
   hasSavingWillRemoveMessage = isPresent('[data-test-eholdings-coverage-fields-saving-will-remove]');
   hasCoverageStatementArea = isPresent('[data-test-eholdings-coverage-statement-textarea] textarea');
-  toggleVisibility = clickable('[data-test-eholdings-resource-toggle-visibility] input');
   coverageStatement = value('[data-test-eholdings-coverage-statement-textarea] textarea');
   customUrlFieldValue = value('[data-test-eholdings-custom-url-textfield] input');
   fillCoverageStatement = fillable('[data-test-eholdings-coverage-statement-textarea] textarea');

--- a/tests/pages/resource-show.js
+++ b/tests/pages/resource-show.js
@@ -48,17 +48,18 @@ import Toast from './toast';
   clickPackage = clickable('[data-test-eholdings-resource-show-package-name] a');
   deselectionModal = new ResourceShowDeselectionModal('#eholdings-resource-deselection-confirmation-modal');
   navigationModal = new ResourceShowNavigationModal('#navigation-modal');
-  resourceVisibilityLabel = text('[data-test-eholdings-resource-hidden-label]');
+  resourceVisibilityLabel = text('[data-test-eholdings-resource-show-visibility]');
   isResourceHidden = computed(function () {
-    return this.resourceVisibilityLabel === 'Hidden from patrons';
+    return /^No/.test(this.resourceVisibilityLabel);
   });
   isResourceVisible = computed(function () {
-    return this.resourceVisibilityLabel === 'Visible to patrons';
-  })
-  hiddenReason = text('[data-test-eholdings-resource-hidden-reason]');
-  isResourceNotShownLabelPresent = isPresent('[data-test-eholdings-resource-not-shown-label]');
-  clickEditButton = clickable('[data-test-eholdings-resource-edit-link]');
+    return this.resourceVisibilityLabel === 'Yes';
+  });
+  hiddenReason = computed(function () {
+    return this.isResourceHidden ? this.resourceVisibilityLabel.replace(/^No(\s\((.*)\))?$/, '$2') : '';
+  });
 
+  clickEditButton = clickable('[data-test-eholdings-resource-edit-link]');
   peerReviewedStatus = text('[data-test-eholdings-peer-reviewed-field]');
 
   toast = Toast

--- a/tests/resource-edit-custom-title-test.js
+++ b/tests/resource-edit-custom-title-test.js
@@ -87,14 +87,13 @@ describeApplication('ResourceEditCustomTitle', () => {
       expect(ResourceEditPage.customUrlFieldValue).to.equal('https://frontside.io');
     });
 
-    it('shows a form with a visibility toggle', () => {
+    it('shows a form with a visibility field', () => {
       expect(ResourceEditPage.isResourceVisible).to.equal(false);
     });
 
     it('disables the save button', () => {
       expect(ResourceEditPage.isSaveDisabled).to.be.true;
     });
-
 
     describe('clicking cancel', () => {
       beforeEach(() => {
@@ -172,7 +171,7 @@ describeApplication('ResourceEditCustomTitle', () => {
       beforeEach(() => {
         return ResourceEditPage
           .clickAddRowButton()
-          .toggleVisibility()
+          .toggleIsVisible()
           .dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018')
           .inputCoverageStatement('Only 90s kids would understand.')
           .clickAddCustomEmbargoButton()

--- a/tests/resource-edit-deselection-test.js
+++ b/tests/resource-edit-deselection-test.js
@@ -52,12 +52,12 @@ describeApplication('ResourceEditDeselection', () => {
           return ResourceEditPage.toggleIsSelected();
         });
 
-        it('disables custom url field', () => {
+        it('hides custom url field', () => {
           expect(ResourceEditPage.hasCustomUrlField).to.equal(false);
         });
 
-        it('disables visibiliy toggle', () => {
-          expect(ResourceEditPage.isVisibleTogglePresent).to.equal(false);
+        it('hides visibility field', () => {
+          expect(ResourceEditPage.isVisibilityFieldPresent).to.equal(false);
         });
 
         it('hides add date range button', () => {

--- a/tests/resource-edit-managed-title-test.js
+++ b/tests/resource-edit-managed-title-test.js
@@ -144,7 +144,7 @@ describeApplication('ResourceEditManagedTitleInManagedPackage', () => {
       beforeEach(() => {
         return ResourceEditPage
           .clickAddRowButton()
-          .toggleVisibility()
+          .toggleIsVisible()
           .dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018')
           .inputCoverageStatement('Only 90s kids would understand.')
           .clickAddCustomEmbargoButton()

--- a/tests/resource-visibility-test.js
+++ b/tests/resource-visibility-test.js
@@ -27,7 +27,7 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays Visibility label as Visible to patrons', () => {
+    it('displays it is visible to patrons', () => {
       expect(ResourceShowPage.isResourceVisible).to.be.true;
     });
   });
@@ -45,8 +45,8 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays Visibility label as Not shown to patrons', () => {
-      expect(ResourceShowPage.isResourceNotShownLabelPresent).to.be.true;
+    it('displays it is not visible to patrons', () => {
+      expect(ResourceShowPage.isResourceHidden).to.be.true;
     });
   });
 
@@ -63,11 +63,11 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays Visibility label as hidden from patrons', () => {
+    it('displays it is not visible to patrons', () => {
       expect(ResourceShowPage.isResourceHidden).to.be.true;
     });
 
-    it('maps the hidden reason text', () => {
+    it('displays the hidden reason text', () => {
       expect(ResourceShowPage.hiddenReason).to.equal('The content is for mature audiences only.');
     });
   });
@@ -85,11 +85,11 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays Visibility label as hidden from patrons', () => {
+    it('displays it is not visibile to patrons', () => {
       expect(ResourceShowPage.isResourceHidden).to.be.true;
     });
 
-    it('maps the hidden reason text', () => {
+    it('displays an empty hidden reason text', () => {
       expect(ResourceShowPage.hiddenReason).to.equal('');
     });
   });
@@ -109,12 +109,12 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays Visibility label as hidden from patrons', () => {
+    it('displays it is not visibile to patrons', () => {
       expect(ResourceShowPage.isResourceHidden).to.be.true;
     });
 
-    it('maps the hidden reason text', () => {
-      expect(ResourceShowPage.hiddenReason).to.equal('All titles in this package are hidden.');
+    it('displays the hidden reason text', () => {
+      expect(ResourceShowPage.hiddenReason).to.equal('All titles in this package are hidden');
     });
   });
 });


### PR DESCRIPTION
## Purpose

[UIEH-353](https://issues.folio.org/browse/UIEH-353)

A resource's visibility setting is more clear when using radio buttons as oppose to a toggle with a dynamic label. The visibility setting should also be included in "resource settings" as opposed to it's own "visibility" section.

## Approach

For the show page, the "Resource information" section was changed to "Resource settings" to line up with "Package settings" and the screenshot attached to the ticket. Resource settings includes the managed or custom URL along with the visibility data. When a reason is given with the visibility data, it is displayed inline next to the visibility status ("yes" or "no").

A new field was created for the edit page so it can be reused on the custom and managed resource edit pages. When a resource's visibility settings are set by it's package, the visibility field is disabled and a message is shown adjacent to the "No" radio button.

Since we are no longer using the toggle, the visibility being controlled through the component's state is no longer necessary. Upon updating the resource, the string value is cast back into a real boolean for the server to consume.

## Screenshots

*Before*

![before](https://user-images.githubusercontent.com/5005153/41120446-24883d7a-6a5b-11e8-8016-6b902599df0f.gif)

*After*

![after](https://user-images.githubusercontent.com/5005153/41120452-2910a076-6a5b-11e8-9578-3b309632dba7.gif)
