### PR TITLE
[UIEH-408] Fix details view list results count bug

### DIFF
--- a/src/components/details-view/details-view.css
+++ b/src/components/details-view/details-view.css
@@ -79,8 +79,12 @@
     color: var(--subLabelColor #999);
     font-size: 18px;
     font-weight: 600;
-    padding: 1rem 1rem 0;
+    padding: 1rem;
     margin: 0;
+
+    &:not(:only-child) {
+      padding-bottom: 0;
+    }
   }
 
   & .list {

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -276,7 +276,8 @@ export default class DetailsView extends Component {
               <div className={styles['list-header']}>
                 <div>
                   <h3>{capitalize(listType)}</h3>
-                  {resultsLength && (
+
+                  {resultsLength > 0 && (
                     <div data-test-eholdings-details-view-results-count>
                       <p><small>{resultsLength} records found</small></p>
                     </div>


### PR DESCRIPTION
## Purpose

[UIEH-408](https://issues.folio.org/browse/UIEH-408)

When packages were loading within a providers detail view, the number `0` would display until the list loaded.

Also, when there were no results count the bottom padding of the list heading was collapsed.

## Approach

Ensure that the logical operator `&&` has a boolean before it. When the first part of this operator is falsey, it is used. Since the `resultsCount` was returning `0`, that was being rendered to the screen. Actually casting it as a boolean ensures that it is not rendered.

To fix the bottom padding when there is no results count, a css rule for `:not(:only-child)` was added to the heading.

## Screenshots

*Before*

![before](https://user-images.githubusercontent.com/5005153/41121676-c3178bd2-6a5e-11e8-9ef1-e309e99cdc6e.gif)

*After*

![after](https://user-images.githubusercontent.com/5005153/41121683-c64f8bc4-6a5e-11e8-88c0-e4c2d835f741.gif)


