### PR TITLE
UIEH-212 Refactor root proxy to use new endpoints

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -90,27 +90,38 @@ export default function configure() {
     return JSON.parse(request.requestBody);
   });
 
-  // Root Proxies
-  this.get('/root-proxies', {
+  // Current root proxy
+  this.get('/root-proxy', {
+    data:
+      {
+        id: 'eholdings/root-proxy',
+        type: 'rootProxies',
+        attributes: {
+          id: 'eholdings/root-proxy',
+          proxyTypeId: 'EZProxy'
+        }
+      }
+  });
+
+  // Available root proxies
+  this.get('/proxy-types', {
     data: [
       {
         id: 'some-selected-value',
-        type: 'rootProxy',
+        type: 'proxyTypes',
         attributes: {
           id: 'some-selected-value',
           name: 'some-default-name',
           urlMask: '',
-          selected: true
         }
       },
       {
         id: 'some-unselected-value',
-        type: 'rootProxy',
+        type: 'proxyTypes',
         attributes: {
           id: 'some-unselected-value',
           name: 'some-name',
           urlMask: '',
-          selected: false
         }
       }
     ]

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -94,34 +94,39 @@ export default function configure() {
   this.get('/root-proxy', {
     data:
       {
-        id: 'eholdings/root-proxy',
+        id: 'root-proxy',
         type: 'rootProxies',
         attributes: {
-          id: 'eholdings/root-proxy',
-          proxyTypeId: 'EZProxy'
+          id: 'root-proxy',
+          proxyTypeId: 'bigTestJS'
         }
       }
+  });
+
+  // update root proxy
+  this.put('/root-proxy', (_, request) => {
+    return JSON.parse(request.requestBody);
   });
 
   // Available root proxies
   this.get('/proxy-types', {
     data: [
       {
-        id: 'some-selected-value',
+        id: 'bigTestJS',
         type: 'proxyTypes',
         attributes: {
-          id: 'some-selected-value',
-          name: 'some-default-name',
-          urlMask: '',
+          id: 'bigTestJS',
+          name: 'bigTestJS',
+          urlMask: 'https://github.com/bigtestjs',
         }
       },
       {
-        id: 'some-unselected-value',
+        id: 'microstates',
         type: 'proxyTypes',
         attributes: {
-          id: 'some-unselected-value',
-          name: 'some-name',
-          urlMask: '',
+          id: 'microstates',
+          name: 'microstates',
+          urlMask: 'https://github.com/microstates',
         }
       }
     ]

--- a/mirage/models/rootProxy.js
+++ b/mirage/models/rootProxy.js
@@ -1,0 +1,3 @@
+import { Model } from '@bigtest/mirage';
+
+export default Model.extend();

--- a/src/components/settings-root-proxy/_fields/root-proxy-select/root-proxy-select-field.js
+++ b/src/components/settings-root-proxy/_fields/root-proxy-select/root-proxy-select-field.js
@@ -6,14 +6,14 @@ import { Select } from '@folio/stripes-components';
 import styles from './root-proxy-select-field.css';
 
 export default function RootProxySelectField({ proxyTypes }) {
-  let rootProxyRecords = proxyTypes.resolver.state.proxyTypes.records;
+  let proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
   let options = [];
 
-  if (rootProxyRecords) {
-    for (let rootProxyRecord in rootProxyRecords) {
-      if (Object.prototype.hasOwnProperty.call(rootProxyRecords, rootProxyRecord)) {
-        options.push({ label: rootProxyRecords[rootProxyRecord].attributes.name,
-          value: rootProxyRecords[rootProxyRecord].attributes.id });
+  if (proxyTypesRecords) {
+    for (let proxyTypesRecord in proxyTypesRecords) {
+      if (Object.prototype.hasOwnProperty.call(proxyTypesRecords, proxyTypesRecord)) {
+        options.push({ label: proxyTypesRecords[proxyTypesRecord].attributes.name,
+          value: proxyTypesRecords[proxyTypesRecord].attributes.id });
       }
     }
   }
@@ -27,8 +27,8 @@ export default function RootProxySelectField({ proxyTypes }) {
         id="eholdings-settings-root-proxy-server"
         name="rootProxyServer"
         component={Select}
-        label="Root Proxy Server"
         dataOptions={options}
+        label="Root Proxy Server"
       />
     </div>
   );

--- a/src/components/settings-root-proxy/_fields/root-proxy-select/root-proxy-select-field.js
+++ b/src/components/settings-root-proxy/_fields/root-proxy-select/root-proxy-select-field.js
@@ -5,19 +5,19 @@ import { Field } from 'redux-form';
 import { Select } from '@folio/stripes-components';
 import styles from './root-proxy-select-field.css';
 
-export default function RootProxySelectField({ proxies }) {
-  let rootProxyRecords = proxies.resolver.state.rootProxy.records;
+export default function RootProxySelectField({ proxyTypes }) {
+  let rootProxyRecords = proxyTypes.resolver.state.proxyTypes.records;
   let options = [];
 
   if (rootProxyRecords) {
     for (let rootProxyRecord in rootProxyRecords) {
       if (Object.prototype.hasOwnProperty.call(rootProxyRecords, rootProxyRecord)) {
         options.push({ label: rootProxyRecords[rootProxyRecord].attributes.name,
-          value: rootProxyRecords[rootProxyRecord].attributes.id,
-          selected: rootProxyRecords[rootProxyRecord].attributes.selected });
+          value: rootProxyRecords[rootProxyRecord].attributes.id });
       }
     }
   }
+
   return (
     <div
       data-test-eholdings-root-proxy-select-field
@@ -35,5 +35,5 @@ export default function RootProxySelectField({ proxies }) {
 }
 
 RootProxySelectField.propTypes = {
-  proxies: PropTypes.object.isRequired
+  proxyTypes: PropTypes.object.isRequired
 };

--- a/src/components/settings-root-proxy/settings-root-proxy.js
+++ b/src/components/settings-root-proxy/settings-root-proxy.js
@@ -10,12 +10,12 @@ import RootProxySelectField from './_fields/root-proxy-select';
 
 class SettingsRootProxy extends Component {
   static propTypes = {
-    rootProxies: PropTypes.object.isRequired
+    proxyTypes: PropTypes.object.isRequired
   };
 
   render() {
     let {
-      rootProxies
+      proxyTypes
     } = this.props;
 
     return (
@@ -24,7 +24,7 @@ class SettingsRootProxy extends Component {
       >
         <h3>Root Proxy Setting</h3>
 
-        {rootProxies.isLoading ? (
+        {proxyTypes.isLoading ? (
           <Icon icon="spinner-ellipsis" />
         ) : (
           <form
@@ -35,7 +35,7 @@ class SettingsRootProxy extends Component {
               data-test-eholdings-settings-root-proxy-select
               className={styles['settings-root-proxy-form']}
             >
-              <RootProxySelectField proxies={rootProxies} />
+              <RootProxySelectField proxyTypes={proxyTypes} />
             </div>
           </form>
         )}

--- a/src/components/settings-root-proxy/settings-root-proxy.js
+++ b/src/components/settings-root-proxy/settings-root-proxy.js
@@ -2,26 +2,80 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import {
-  Icon
+  Icon,
+  Button
 } from '@folio/stripes-components';
+import isEqual from 'lodash/isEqual';
+
 import SettingsDetailPane from '../settings-detail-pane';
+import { processErrors } from '../utilities';
+import Toaster from '../toaster';
 import styles from './settings-root-proxy.css';
 import RootProxySelectField from './_fields/root-proxy-select';
 
 class SettingsRootProxy extends Component {
   static propTypes = {
-    proxyTypes: PropTypes.object.isRequired
+    proxyTypes: PropTypes.object.isRequired,
+    rootProxy: PropTypes.object.isRequired,
+    handleSubmit: PropTypes.func,
+    onSubmit: PropTypes.func.isRequired,
+    pristine: PropTypes.bool,
+    reset: PropTypes.func
   };
+
+  static contextTypes = {
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
+  };
+
+  componentWillReceiveProps(nextProps) {
+    let wasPending = this.props.rootProxy.update.isPending && !nextProps.rootProxy.update.isPending;
+    let needsUpdate = !isEqual(this.props.rootProxy, nextProps.rootProxy);
+    let isRejected = nextProps.rootProxy.update.isRejected;
+
+    let { router } = this.context;
+
+    if (wasPending && needsUpdate && !isRejected) {
+      router.history.push({
+        pathname: '/settings/eholdings/root-proxy',
+        state: { eholdings: true, isFreshlySaved: true }
+      });
+    }
+  }
 
   render() {
     let {
-      proxyTypes
+      rootProxy,
+      proxyTypes,
+      handleSubmit,
+      onSubmit,
+      pristine,
+      reset
     } = this.props;
+
+    let { router } = this.context;
+
+    let toasts = processErrors(rootProxy);
+
+    if (router.history.action === 'PUSH' &&
+        router.history.location.state &&
+        router.history.location.state.isFreshlySaved &&
+        rootProxy.update.isResolved) {
+      toasts.push({
+        id: `root-proxy-${rootProxy.update.timestamp}`,
+        message: 'Root Proxy updated',
+        type: 'success'
+      });
+    }
 
     return (
       <SettingsDetailPane
         paneTitle="Root proxy"
       >
+        <Toaster toasts={toasts} position="bottom" />
         <h3>Root Proxy Setting</h3>
 
         {proxyTypes.isLoading ? (
@@ -29,6 +83,7 @@ class SettingsRootProxy extends Component {
         ) : (
           <form
             data-test-eholdings-settings-root-proxy
+            onSubmit={handleSubmit(onSubmit)}
             className={styles['settings-root-proxy-form']}
           >
             <div
@@ -37,6 +92,35 @@ class SettingsRootProxy extends Component {
             >
               <RootProxySelectField proxyTypes={proxyTypes} />
             </div>
+
+            {!pristine && (
+            <div
+              className={styles['settings-root-proxy-form-actions']}
+              data-test-eholdings-settings-root-proxy-actions
+            >
+              <div data-test-eholdings-root-proxy-cancel-button>
+                <Button
+                  disabled={rootProxy.update.isPending}
+                  type="reset"
+                  onClick={reset}
+                >
+                  Cancel
+                </Button>
+              </div>
+              <div data-test-eholdings-root-proxy-save-button>
+                <Button
+                  disabled={rootProxy.update.isPending}
+                  type="submit"
+                  buttonStyle="primary"
+                >
+                  {rootProxy.update.isPending ? 'Saving' : 'Save'}
+                </Button>
+              </div>
+              {rootProxy.update.isPending && (
+                <Icon icon="spinner-ellipsis" />
+              )}
+            </div>
+          )}
           </form>
         )}
 

--- a/src/redux/application.js
+++ b/src/redux/application.js
@@ -23,16 +23,24 @@ export const Configuration = model({
   }
 );
 
-export const RootProxy = model({
-  type: 'root-proxies',
-  // id is 'root-proxies' so it will be appended to this path when
-  // retrieving the configuration
-  path: '/eholdings/root-proxies'
+export const ProxyType = model({
+  type: 'proxyTypes',
+  path: '/eholdings/proxy-types'
 })(
-  class RootProxy {
+  class ProxyType {
     id = '';
     name = '';
     urlMask = '';
-    selected = false;
   }
 );
+
+export const RootProxy = model({
+  type: 'rootProxies',
+  path: '/eholdings/root-proxy'
+})(
+  class RootProxy {
+    id = '';
+    proxyTypeId = '';
+  }
+);
+

--- a/src/redux/application.js
+++ b/src/redux/application.js
@@ -36,7 +36,7 @@ export const ProxyType = model({
 
 export const RootProxy = model({
   type: 'rootProxies',
-  path: '/eholdings/root-proxy'
+  path: '/eholdings'
 })(
   class RootProxy {
     id = '';

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -9,6 +9,7 @@ import ResourceModel from './resource';
 import {
   Status as StatusModel,
   Configuration as ConfigurationModel,
+  ProxyType as ProxyTypeModel,
   RootProxy as RootProxyModel
 } from './application';
 
@@ -25,6 +26,7 @@ export const createResolver = (state) => {
     ResourceModel,
     StatusModel,
     ConfigurationModel,
+    ProxyTypeModel,
     RootProxyModel
   ]);
 };

--- a/src/routes/settings-root-proxy.js
+++ b/src/routes/settings-root-proxy.js
@@ -3,25 +3,25 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { createResolver } from '../redux';
-import { RootProxy } from '../redux/application';
+import { ProxyType } from '../redux/application';
 import View from '../components/settings-root-proxy';
 
 class SettingsRootProxyRoute extends Component {
   static propTypes = {
-    rootProxies: PropTypes.object.isRequired,
-    getRootProxies: PropTypes.func.isRequired
+    proxyTypes: PropTypes.object.isRequired,
+    getProxyTypes: PropTypes.func.isRequired
   };
 
   componentWillMount() {
-    this.props.getRootProxies();
+    this.props.getProxyTypes();
   }
 
   render() {
-    let { rootProxies } = this.props;
+    let { proxyTypes } = this.props;
 
     return (
       <View
-        rootProxies={rootProxies}
+        proxyTypes={proxyTypes}
       />
     );
   }
@@ -29,8 +29,8 @@ class SettingsRootProxyRoute extends Component {
 
 export default connect(
   ({ eholdings: { data } }) => ({
-    rootProxies: createResolver(data).query('root-proxies')
+    proxyTypes: createResolver(data).query('proxyTypes')
   }), {
-    getRootProxies: () => RootProxy.query()
+    getProxyTypes: () => ProxyType.query()
   }
 )(SettingsRootProxyRoute);

--- a/src/routes/settings-root-proxy.js
+++ b/src/routes/settings-root-proxy.js
@@ -3,25 +3,42 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { createResolver } from '../redux';
-import { ProxyType } from '../redux/application';
+import { ProxyType, RootProxy } from '../redux/application';
 import View from '../components/settings-root-proxy';
 
 class SettingsRootProxyRoute extends Component {
   static propTypes = {
     proxyTypes: PropTypes.object.isRequired,
-    getProxyTypes: PropTypes.func.isRequired
+    rootProxy: PropTypes.object.isRequired,
+    getProxyTypes: PropTypes.func.isRequired,
+    getRootProxy: PropTypes.func.isRequired,
+    updateRootProxy: PropTypes.func.isRequired
   };
 
   componentWillMount() {
     this.props.getProxyTypes();
+    this.props.getRootProxy();
+  }
+
+  rootProxySubmitted = (values) => {
+    let { rootProxy, updateRootProxy } = this.props;
+
+    rootProxy.proxyTypeId = values.rootProxyServer;
+
+    updateRootProxy(rootProxy);
   }
 
   render() {
-    let { proxyTypes } = this.props;
+    let { proxyTypes, rootProxy } = this.props;
 
     return (
       <View
+        initialValues={{
+          rootProxyServer: rootProxy.proxyTypeId
+        }}
         proxyTypes={proxyTypes}
+        rootProxy={rootProxy}
+        onSubmit={this.rootProxySubmitted}
       />
     );
   }
@@ -29,8 +46,11 @@ class SettingsRootProxyRoute extends Component {
 
 export default connect(
   ({ eholdings: { data } }) => ({
-    proxyTypes: createResolver(data).query('proxyTypes')
+    proxyTypes: createResolver(data).query('proxyTypes'),
+    rootProxy: createResolver(data).find('rootProxies', 'root-proxy')
   }), {
-    getProxyTypes: () => ProxyType.query()
+    getProxyTypes: () => ProxyType.query(),
+    getRootProxy: () => RootProxy.find('root-proxy'),
+    updateRootProxy: model => RootProxy.save(model)
   }
 )(SettingsRootProxyRoute);

--- a/tests/pages/settings-root-proxy.js
+++ b/tests/pages/settings-root-proxy.js
@@ -1,10 +1,21 @@
 import {
   interactor,
-  value
+  fillable,
+  clickable,
+  value,
+  isPresent
 } from '@bigtest/interactor';
+import Toast from './toast';
 
 @interactor class SettingsRootProxyPage {
   RootProxySelectValue = value('[data-test-eholdings-settings-root-proxy-select] select');
+  hasSaveButton = isPresent('[data-test-eholdings-root-proxy-save-button] button');
+  hasCancelButton = isPresent('[data-test-eholdings-root-proxy-cancel-button] button');
+  chooseRootProxy = fillable('[data-test-eholdings-settings-root-proxy-select] select');
+  save = clickable('[data-test-eholdings-root-proxy-save-button] button');
+  cancel = clickable('[data-test-eholdings-root-proxy-cancel-button] button');
+
+  toast = Toast;
 }
 
 export default new SettingsRootProxyPage('[data-test-eholdings-settings-root-proxy]');

--- a/tests/settings-root-proxy-test.js
+++ b/tests/settings-root-proxy-test.js
@@ -11,8 +11,86 @@ describeApplication('With list of root proxies available to a customer', () => {
       return this.visit('/settings/eholdings/root-proxy', () => expect(SettingsRootProxyPage.$root).to.exist);
     });
 
-    it('has a select field defaulted with selected root proxy', () => {
-      expect(SettingsRootProxyPage.RootProxySelectValue).to.equal('some-selected-value');
+    it('has a select field defaulted with current root proxy', () => {
+      expect(SettingsRootProxyPage.RootProxySelectValue).to.equal('bigTestJS');
+    });
+
+    describe('choosing another root proxy from select', () => {
+      beforeEach(() => {
+        return SettingsRootProxyPage.chooseRootProxy('microstates');
+      });
+
+      it('should display cancel action button', () => {
+        expect(SettingsRootProxyPage.hasCancelButton).to.eq(true);
+      });
+
+      it('should display save action button', () => {
+        expect(SettingsRootProxyPage.hasSaveButton).to.eq(true);
+      });
+
+      describe('clicking save to update Root Proxy', () => {
+        beforeEach(() => {
+          return SettingsRootProxyPage.save();
+        });
+
+        it('should display the updated root proxy', () => {
+          expect(SettingsRootProxyPage.RootProxySelectValue).to.eq('microstates');
+        });
+
+        it('should remove save button', () => {
+          expect(SettingsRootProxyPage.hasSaveButton).to.eq(false);
+        });
+
+        it('should remove cancel button', () => {
+          expect(SettingsRootProxyPage.hasCancelButton).to.eq(false);
+        });
+
+        it('should show a success toast', () => {
+          expect(SettingsRootProxyPage.toast.successText).to.eq('Root Proxy updated');
+        });
+      });
+
+      describe('clicking cancel to cancel updating Root Proxy', () => {
+        beforeEach(() => {
+          return SettingsRootProxyPage.cancel();
+        });
+
+        it('should display the initial root proxy', () => {
+          expect(SettingsRootProxyPage.RootProxySelectValue).to.eq('bigTestJS');
+        });
+
+        it('should remove save button', () => {
+          expect(SettingsRootProxyPage.hasSaveButton).to.eq(false);
+        });
+
+        it('should remove cancel button', () => {
+          expect(SettingsRootProxyPage.hasCancelButton).to.eq(false);
+        });
+      });
+    });
+  });
+
+  describe('encountering a server error when PUTting', () => {
+    beforeEach(function () {
+      this.server.put('/root-proxy', {
+        errors: [{
+          title: 'There was an error'
+        }]
+      }, 500);
+
+      return this.visit('/settings/eholdings/root-proxy', () => {
+        expect(SettingsRootProxyPage.$root).to.exist;
+      });
+    });
+
+    describe('updating root-proxy', () => {
+      beforeEach(() => {
+        return SettingsRootProxyPage.chooseRootProxy('microstates').save();
+      });
+
+      it('should show a error toast', () => {
+        expect(SettingsRootProxyPage.toast.errorText).to.eq('There was an error');
+      });
     });
   });
 });


### PR DESCRIPTION
## Purpose
From the ui-eholdings application a user has the ability to pick from a list of available Root-Proxy and then set it. When a user reaches the settings page a list of available Root-Proxy is populated but when they have to send a request to update the Root-Proxy the request cannot contain the collection but rather a single root-proxy. This work here utilizes two new endpoints in mod-kb-ebsco to facilitate in the updating of what is deemed a singular resource in Root-Proxy. 

## Approach
 - Create two new models:
   - `Proxy-Types`: which is the collection of available of Root-Proxy
   - `Root-Proxy`: which is the Singular Root-Proxy and the Proxy that the user current has set or is trying to set from the UI.
 - Make use of the two new endpoints:
   - `eholdings/proxy-types`: will `GET` return a collection
   - `eholdings/root-proxy`: use to `GET` and `PUT` the user's root-proxy

## Screenshots
![2018-06-07 17 25 50](https://user-images.githubusercontent.com/1953098/41129661-22e93ade-6a81-11e8-82ff-10110f8ce892.gif)

