### PR TITLE
Use intl from react-intl instead of stripes context

### DIFF
--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
+import { FormattedNumber } from 'react-intl';
 
 import styles from './package-list-item.css';
 import Link from '../link';
@@ -16,8 +17,6 @@ export default function PackageListItem({
   packageName,
   onClick,
   headingLevel
-}, {
-  intl
 }) {
   let Heading = headingLevel || 'h3';
 
@@ -62,13 +61,13 @@ export default function PackageListItem({
             &nbsp;&bull;&nbsp;
 
             <span data-test-eholdings-package-list-item-num-titles-selected>
-              {intl.formatNumber(item.selectedCount)}
+              <FormattedNumber value={item.selectedCount} />
             </span>
 
             &nbsp;/&nbsp;
 
             <span data-test-eholdings-package-list-item-num-titles>
-              {intl.formatNumber(item.titleCount)}
+              <FormattedNumber value={item.titleCount} />
             </span>
 
             &nbsp;
@@ -101,8 +100,4 @@ PackageListItem.propTypes = {
   packageName: PropTypes.string,
   onClick: PropTypes.func,
   headingLevel: PropTypes.string
-};
-
-PackageListItem.contextTypes = {
-  intl: PropTypes.object
 };

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -13,7 +13,6 @@ export default class PackageCoverageFields extends Component {
   static propTypes = {
     packageCoverage: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     locale: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
-    intl: PropTypes.object, // eslint-disable-line react/no-unused-prop-types,
     initialValue: PropTypes.array
   };
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -8,7 +8,8 @@ import {
   KeyValue,
   PaneMenu
 } from '@folio/stripes-components';
-import { processErrors, formatISODateWithoutTime } from '../../utilities';
+import { FormattedDate, FormattedNumber } from 'react-intl';
+import { processErrors } from '../../utilities';
 
 import DetailsView from '../../details-view';
 import QueryList from '../../query-list';
@@ -30,7 +31,6 @@ export default class PackageShow extends Component {
   };
 
   static contextTypes = {
-    intl: PropTypes.object,
     router: PropTypes.object,
     queryParams: PropTypes.object
   };
@@ -79,7 +79,7 @@ export default class PackageShow extends Component {
 
   render() {
     let { model, fetchPackageTitles } = this.props;
-    let { intl, router, queryParams } = this.context;
+    let { router, queryParams } = this.context;
     let {
       showSelectionModal,
       packageSelected,
@@ -194,13 +194,13 @@ export default class PackageShow extends Component {
 
                 <KeyValue label="Titles selected">
                   <div data-test-eholdings-package-details-titles-selected>
-                    {intl.formatNumber(model.selectedCount)}
+                    <FormattedNumber value={model.selectedCount} />
                   </div>
                 </KeyValue>
 
                 <KeyValue label="Total titles">
                   <div data-test-eholdings-package-details-titles-total>
-                    {intl.formatNumber(model.titleCount)}
+                    <FormattedNumber value={model.titleCount} />
                   </div>
                 </KeyValue>
               </DetailsViewSection>
@@ -265,7 +265,22 @@ export default class PackageShow extends Component {
                       <div>
                         <KeyValue label="Custom coverage dates">
                           <div data-test-eholdings-package-details-custom-coverage-display>
-                            {formatISODateWithoutTime(model.customCoverage.beginCoverage, intl)} - {formatISODateWithoutTime(model.customCoverage.endCoverage, intl) || 'Present'}
+                            <FormattedDate
+                              value={model.customCoverage.beginCoverage}
+                              timeZone="UTC"
+                              year="numeric"
+                              month="numeric"
+                              day="numeric"
+                            />&nbsp;-&nbsp;
+                            {(model.customCoverage.endCoverage) ? (
+                              <FormattedDate
+                                value={model.customCoverage.endCoverage}
+                                timeZone="UTC"
+                                year="numeric"
+                                month="numeric"
+                                day="numeric"
+                              />
+                            ) : 'Present'}
                           </div>
                         </KeyValue>
                       </div>

--- a/src/components/provider-list-item/provider-list-item.js
+++ b/src/components/provider-list-item/provider-list-item.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
+import { FormattedNumber } from 'react-intl';
 
 import styles from './provider-list-item.css';
 import Link from '../link';
 
 const cx = classNames.bind(styles);
 
-export default function ProviderListItem({ item, link, active, onClick, headingLevel }, { intl }) {
+export default function ProviderListItem({ item, link, active, onClick, headingLevel }) {
   let Heading = headingLevel || 'h3';
 
   return !item ? (
@@ -32,13 +33,13 @@ export default function ProviderListItem({ item, link, active, onClick, headingL
 
       <div data-test-eholdings-provider-list-item-selections>
         <span data-test-eholdings-provider-list-item-num-packages-selected>
-          {intl.formatNumber(item.packagesSelected)}
+          <FormattedNumber value={item.packagesSelected} />
         </span>
 
         &nbsp;/&nbsp;
 
         <span data-test-eholdings-provider-list-item-num-packages-total>
-          {intl.formatNumber(item.packagesTotal)}
+          <FormattedNumber value={item.packagesTotal} />
         </span>
 
         &nbsp;
@@ -58,8 +59,4 @@ ProviderListItem.propTypes = {
   active: PropTypes.bool,
   onClick: PropTypes.func,
   headingLevel: PropTypes.string
-};
-
-ProviderListItem.contextTypes = {
-  intl: PropTypes.object,
 };

--- a/src/components/provider-show/provider-show.js
+++ b/src/components/provider-show/provider-show.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { KeyValue } from '@folio/stripes-components';
+import { FormattedNumber } from 'react-intl';
 
 import { processErrors } from '../utilities';
 import DetailsView from '../details-view';
@@ -17,7 +18,6 @@ export default function ProviderShow({
   searchPackages,
   searchParams
 }, {
-  intl,
   queryParams
 }) {
   let actionMenuItems = [];
@@ -46,13 +46,13 @@ export default function ProviderShow({
           <DetailsViewSection label="Provider information">
             <KeyValue label="Packages selected">
               <div data-test-eholdings-provider-details-packages-selected>
-                {intl.formatNumber(model.packagesSelected)}
+                <FormattedNumber value={model.packagesSelected} />
               </div>
             </KeyValue>
 
             <KeyValue label="Total packages">
               <div data-test-eholdings-provider-details-packages-total>
-                {intl.formatNumber(model.packagesTotal)}
+                <FormattedNumber value={model.packagesTotal} />
               </div>
             </KeyValue>
           </DetailsViewSection>
@@ -95,6 +95,5 @@ ProviderShow.propTypes = {
 
 ProviderShow.contextTypes = {
   router: PropTypes.object,
-  queryParams: PropTypes.object,
-  intl: PropTypes.object
+  queryParams: PropTypes.object
 };

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -27,8 +27,7 @@ export default class ResourceShow extends Component {
 
   static contextTypes = {
     locale: PropTypes.string,
-    router: PropTypes.object,
-    intl: PropTypes.object
+    router: PropTypes.object
   };
 
   state = {

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -23,26 +23,6 @@ export function isBookPublicationType(publicationType) {
   return !!publicationTypeIsBook[publicationType];
 }
 
-export function formatISODateWithoutTime(dateString, intl) {
-  if (!dateString) {
-    return '';
-  }
-  let [year, month, day] = dateString.split('-');
-  let dateObj = new Date();
-  dateObj.setFullYear(year);
-  dateObj.setMonth(parseInt(month, 10) - 1);
-  dateObj.setDate(day);
-  return intl.formatDate(dateObj);
-}
-
-export function formatYear(dateString) {
-  if (!dateString) {
-    return '';
-  }
-  let [year] = dateString.split('-');
-  return year;
-}
-
 export function isValidCoverage(coverageObj) {
   if (coverageObj.beginCoverage) {
     if (!moment(coverageObj.beginCoverage, 'YYYY-MM-DD').isValid()) { return false; }

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,6 @@ export default class EHoldings extends Component {
       path: PropTypes.string.isRequired
     }).isRequired,
     stripes: PropTypes.shape({
-      intl: PropTypes.object.isRequired,
       locale: PropTypes.string.isRequired
     }).isRequired,
     showSettings: PropTypes.bool
@@ -39,13 +38,11 @@ export default class EHoldings extends Component {
   };
 
   static childContextTypes = {
-    intl: PropTypes.object,
     locale: PropTypes.string
   }
 
   getChildContext() {
     return {
-      intl: this.props.stripes.intl,
       locale: this.props.stripes.locale
     };
   }

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -22,7 +22,6 @@ class ResourceEditRoute extends Component {
   };
 
   static contextTypes = {
-    intl: PropTypes.object.isRequired,
     router: PropTypes.shape({
       history: PropTypes.shape({
         replace: PropTypes.func.isRequired
@@ -102,13 +101,12 @@ class ResourceEditRoute extends Component {
 
   render() {
     let { model } = this.props;
-    let { intl, locale } = this.context;
+    let { locale } = this.context;
 
     return (
       <View
         model={model}
         onSubmit={this.resourceEditSubmitted}
-        intl={intl}
         locale={locale}
       />
     );

--- a/tests/custom-package-edit-test.js
+++ b/tests/custom-package-edit-test.js
@@ -93,7 +93,7 @@ describeApplication('CustomPackageEdit', () => {
         });
 
         it('displays new coverage dates', () => {
-          expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
+          expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
         });
 
         it('shows a success toast message', () => {

--- a/tests/custom-resource-edit-custom-coverage-test.js
+++ b/tests/custom-resource-edit-custom-coverage-test.js
@@ -201,10 +201,10 @@ describeApplication('CustomResourceEditCustomCoverage', () => {
 
               it('has messaging that dates overlap', () => {
                 expect(ResourceEditPage.dateRangeRowList(0).beginDate.validationError).to.eq(
-                  'Date range overlaps with 12/18/2018 - 12/19/2018'
+                  'Date range overlaps with 12/18/2018 - 12/19/2018.'
                 );
                 expect(ResourceEditPage.dateRangeRowList(1).beginDate.validationError).to.eq(
-                  'Date range overlaps with 12/16/2018 - 12/20/2018'
+                  'Date range overlaps with 12/16/2018 - 12/20/2018.'
                 );
               });
             });

--- a/tests/managed-package-edit-test.js
+++ b/tests/managed-package-edit-test.js
@@ -85,7 +85,7 @@ describeApplication('ManagedPackageEdit', () => {
         });
 
         it('displays the new coverage dates', () => {
-          expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
+          expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
         });
 
         it('shows a success toast message', () => {

--- a/tests/managed-resource-edit-custom-coverage-test.js
+++ b/tests/managed-resource-edit-custom-coverage-test.js
@@ -199,10 +199,10 @@ describeApplication('ManagedResourceEditCustomCoverage', () => {
 
               it('has messaging that dates overlap', () => {
                 expect(ResourceEditPage.dateRangeRowList(0).beginDate.validationError).to.eq(
-                  'Date range overlaps with 12/18/2018 - 12/19/2018'
+                  'Date range overlaps with 12/18/2018 - 12/19/2018.'
                 );
                 expect(ResourceEditPage.dateRangeRowList(1).beginDate.validationError).to.eq(
-                  'Date range overlaps with 12/16/2018 - 12/20/2018'
+                  'Date range overlaps with 12/16/2018 - 12/20/2018.'
                 );
               });
             });

--- a/tests/package-create-test.js
+++ b/tests/package-create-test.js
@@ -79,7 +79,7 @@ describeApplication('PackageCreate', () => {
 
     it('redirects to the new package with custom coverages', function () {
       expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
-      expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
+      expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
     });
   });
 

--- a/tests/package-custom-coverage-test.js
+++ b/tests/package-custom-coverage-test.js
@@ -54,7 +54,7 @@ describeApplication('PackageCustomCoverage', () => {
     });
 
     it('displays the custom coverage section', () => {
-      expect(PackageShowPage.customCoverage).to.equal('7/16/1969 - 12/19/1972');
+      expect(PackageShowPage.customCoverage).to.equal('7/16/1969 - 12/19/1972');
     });
 
     it.always('should not display a button to add custom coverage', () => {
@@ -81,7 +81,7 @@ describeApplication('PackageCustomCoverage', () => {
       });
 
       it.always('does not remove the custom coverage', () => {
-        expect(PackageShowPage.customCoverage).to.equal('7/16/1969 - 12/19/1972');
+        expect(PackageShowPage.customCoverage).to.equal('7/16/1969 - 12/19/1972');
       });
     });
   });


### PR DESCRIPTION
## Purpose
Now that we know it's on the fast train to deprecation, we want to avoid using the old React context API.

## Approach
Use `react-intl`'s `FormattedDate`, `FormattedNumber`, and `injectIntl` instead of `context.intl` or `stripes.context.intl`. When `react-intl` moves to the new context API under the hood, those abstractions should still work.