### PR TITLE
UIEH-393 Default content type to 'Unknown'

### DIFF
--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -61,7 +61,7 @@ class PackageCreateRoute extends Component {
         onSubmit={this.packageCreateSubmitted}
         initialValues={{
           name: '',
-          contentType: '',
+          contentType: 'Unknown',
           customCoverages: []
         }}
       />

--- a/tests/package-create-test.js
+++ b/tests/package-create-test.js
@@ -21,6 +21,10 @@ describeApplication('PackageCreate', () => {
     expect(PackageCreatePage.hasContentType).to.be.true;
   });
 
+  it('content-type field is "Unknown" by default', () => {
+    expect(PackageCreatePage.contentTypeValue).to.eq('Unknown');
+  });
+
   it('has an add coverage button', () => {
     expect(PackageCreatePage.hasAddCoverageButton).to.be.true;
   });

--- a/tests/pages/package-create.js
+++ b/tests/pages/package-create.js
@@ -5,7 +5,8 @@ import {
   clickable,
   collection,
   scoped,
-  property
+  property,
+  value
 } from '@bigtest/interactor';
 import Datepicker from './datepicker';
 
@@ -14,6 +15,7 @@ import Datepicker from './datepicker';
   fillName = fillable('[data-test-eholdings-package-name-field] input');
   hasContentType = isPresent('[data-test-eholdings-package-content-type-field]');
   chooseContentType = fillable('[data-test-eholdings-package-content-type-field] select');
+  contentTypeValue = value('[data-test-eholdings-package-content-type-field] select');
   hasAddCoverageButton = isPresent('[data-test-eholdings-coverage-fields-add-row-button]');
   addCoverage = clickable('[data-test-eholdings-coverage-fields-add-row-button] button');
   save = clickable('[data-test-eholdings-package-create-save-button] button');


### PR DESCRIPTION
## Purpose
Within the eholdings application users have the ability to create a custom package that has a 'contentType' selection that is required when creating a custom-package. Upon the initial intent to create a custom-package we are going to set the default content type to 'Unknown'. If the user does not explicitly change this default the custom package they create will have the content-type of Unknown.

## Approach
 - Pass an initialValue to the content-type field in the form

## Screenshots
![2018-06-08 19 34 27](https://user-images.githubusercontent.com/1953098/41185429-43f4e43c-6b56-11e8-8928-f8f2c73bcf7a.gif)
