### PR TITLE
[UIEH-354] Clean up managed package view & labeling

### DIFF
--- a/src/components/package/edit-managed/managed-package-edit.css
+++ b/src/components/package/edit-managed/managed-package-edit.css
@@ -21,6 +21,7 @@
 
 .title-management-radios {
   max-width: 50em;
+  margin-top: 2em;
 
   & fieldset {
     padding: 0;

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -209,7 +209,7 @@ class ManagedPackageEdit extends Component {
                   />
                 </label>
               </DetailsViewSection>
-              <DetailsViewSection label="Visibility">
+              <DetailsViewSection label="Package Settings">
                 {packageSelected ? (
                   <div>
                     <label
@@ -240,8 +240,6 @@ class ManagedPackageEdit extends Component {
                 ) : (
                   <p>Not shown to patrons.</p>
                 )}
-              </DetailsViewSection>
-              <DetailsViewSection label="Title management">
                 {packageSelected ? (
                   <div className={styles['title-management-radios']}>
                     {this.props.initialValues.allowKbToAddTitles != null ? (

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -236,7 +236,7 @@ export default class PackageShow extends Component {
                       )}
                     </KeyValue>
                     {!model.isCustom && (
-                      <KeyValue label="Allow knowledge base to automatically select new titles">
+                      <KeyValue label="Automatically select new titles">
                         <div>
                           {packageAllowedToAddTitles != null ? (
                             <div data-test-eholdings-package-details-allow-add-new-titles>


### PR DESCRIPTION
## Purpose

To clean up the managed packaged edit and show view to have the right copy. 

## Screenshots
![image](https://user-images.githubusercontent.com/2072894/41236436-be0de492-6d56-11e8-82e2-4834e8d51da2.png)

![image](https://user-images.githubusercontent.com/2072894/41236447-c7a2b0be-6d56-11e8-9268-99ff75be3506.png)
