### PR TITLE
Use locale from react-intl instead of stripes context

### DIFF
--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -11,8 +11,6 @@ import styles from './package-coverage-fields.css';
 
 export default class PackageCoverageFields extends Component {
   static propTypes = {
-    packageCoverage: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
-    locale: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
     initialValue: PropTypes.array
   };
 
@@ -103,7 +101,7 @@ export default class PackageCoverageFields extends Component {
 }
 
 export function validate(values, props) {
-  moment.locale(props.locale);
+  moment.locale(props.intl.locale);
   let dateFormat = moment.localeData()._longDateFormat.L;
   const errors = {};
 

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
+import { intlShape, injectIntl } from 'react-intl';
 
 import {
   Button,
@@ -23,7 +24,8 @@ class PackageCreate extends Component {
     request: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
-    pristine: PropTypes.bool.isRequired
+    pristine: PropTypes.bool.isRequired,
+    intl: intlShape.isRequired // eslint-disable-line react/no-unused-prop-types
   };
 
   static contextTypes = {
@@ -122,9 +124,9 @@ const validate = (values, props) => {
   return Object.assign({}, validatePackageName(values), validateCoverageDates(values, props));
 };
 
-export default reduxForm({
+export default injectIntl(reduxForm({
   validate,
   enableReinitialize: true,
   form: 'PackageCreate',
   destroyOnUnmount: false
-})(PackageCreate);
+})(PackageCreate));

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import isEqual from 'lodash/isEqual';
+import { intlShape, injectIntl } from 'react-intl';
 
 import {
   Button,
@@ -29,6 +30,7 @@ class CustomPackageEdit extends Component {
     model: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
+    intl: intlShape.isRequired // eslint-disable-line react/no-unused-prop-types
   };
 
   static contextTypes = {
@@ -330,9 +332,9 @@ const validate = (values, props) => {
   return Object.assign({}, validatePackageName(values), validateCoverageDates(values, props));
 };
 
-export default reduxForm({
+export default injectIntl(reduxForm({
   validate,
   form: 'CustomPackageEdit',
   enableReinitialize: true,
   destroyOnUnmount: false,
-})(CustomPackageEdit);
+})(CustomPackageEdit));

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import isEqual from 'lodash/isEqual';
+import { intlShape, injectIntl } from 'react-intl';
 
 import {
   Button,
@@ -27,7 +28,8 @@ class ManagedPackageEdit extends Component {
     initialValues: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
-    pristine: PropTypes.bool
+    pristine: PropTypes.bool,
+    intl: intlShape.isRequired // eslint-disable-line react/no-unused-prop-types
   };
 
   static contextTypes = {
@@ -351,9 +353,9 @@ const validate = (values, props) => {
   return validateCoverageDates(values, props);
 };
 
-export default reduxForm({
+export default injectIntl(reduxForm({
   validate,
   enableReinitialize: true,
   form: 'ManagedPackageEdit',
   destroyOnUnmount: false,
-})(ManagedPackageEdit);
+})(ManagedPackageEdit));

--- a/src/components/resource/_fields/custom-coverage/resource-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/resource-coverage-fields.js
@@ -14,7 +14,6 @@ import styles from './resource-coverage-fields.css';
 
 export default class ResourceCoverageFields extends Component {
   static propTypes = {
-    locale: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
     initialValue: PropTypes.array
   };
 
@@ -266,7 +265,7 @@ const validateNoRangeOverlaps = (dateRange, customCoverages, index) => {
 
 export function validate(values, props) {
   let errors = [];
-  let { locale, model } = props;
+  let { intl, model } = props;
 
   let packageCoverage = model.package.customCoverage;
 
@@ -274,7 +273,7 @@ export function validate(values, props) {
     let dateRangeErrors = {};
 
     dateRangeErrors =
-      validateDateFormat(dateRange, locale) ||
+      validateDateFormat(dateRange, intl.locale) ||
       validateStartDateBeforeEndDate(dateRange) ||
       validateNoRangeOverlaps(dateRange, values.customCoverages, index) ||
       validateWithinPackageRange(dateRange, packageCoverage);

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import isEqual from 'lodash/isEqual';
+import { intlShape, injectIntl } from 'react-intl';
 
 import {
   Button,
@@ -29,7 +30,8 @@ class ResourceEditCustomTitle extends Component {
     handleSubmit: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    change: PropTypes.func
+    change: PropTypes.func,
+    intl: intlShape.isRequired // eslint-disable-line react/no-unused-prop-types
   };
 
   static contextTypes = {
@@ -306,9 +308,9 @@ const validate = (values, props) => {
     validateEmbargo(values));
 };
 
-export default reduxForm({
+export default injectIntl(reduxForm({
   validate,
   enableReinitialize: true,
   form: 'ResourceEditCustomTitle',
   destroyOnUnmount: false,
-})(ResourceEditCustomTitle);
+})(ResourceEditCustomTitle));

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import isEqual from 'lodash/isEqual';
+import { intlShape, injectIntl } from 'react-intl';
 
 import {
   Button,
@@ -28,7 +29,8 @@ class ResourceEditManagedTitle extends Component {
     handleSubmit: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    change: PropTypes.func
+    change: PropTypes.func,
+    intl: intlShape.isRequired // eslint-disable-line react/no-unused-prop-types
   };
 
   static contextTypes = {
@@ -277,9 +279,9 @@ const validate = (values, props) => {
   return Object.assign({}, validateCoverageDates(values, props), validateCoverageStatement(values), validateEmbargo(values));
 };
 
-export default reduxForm({
+export default injectIntl(reduxForm({
   validate,
   enableReinitialize: true,
   form: 'ResourceEditManagedTitle',
   destroyOnUnmount: false,
-})(ResourceEditManagedTitle);
+})(ResourceEditManagedTitle));

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -26,7 +26,6 @@ export default class ResourceShow extends Component {
   };
 
   static contextTypes = {
-    locale: PropTypes.string,
     router: PropTypes.object
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,9 +25,6 @@ export default class EHoldings extends Component {
     match: PropTypes.shape({
       path: PropTypes.string.isRequired
     }).isRequired,
-    stripes: PropTypes.shape({
-      locale: PropTypes.string.isRequired
-    }).isRequired,
     showSettings: PropTypes.bool
   };
 
@@ -36,16 +33,6 @@ export default class EHoldings extends Component {
     addEpic: PropTypes.func.isRequired,
     router: PropTypes.object
   };
-
-  static childContextTypes = {
-    locale: PropTypes.string
-  }
-
-  getChildContext() {
-    return {
-      locale: this.props.stripes.locale
-    };
-  }
 
   componentWillMount() {
     this.context.addReducer('eholdings', reducer);

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -101,13 +101,11 @@ class ResourceEditRoute extends Component {
 
   render() {
     let { model } = this.props;
-    let { locale } = this.context;
 
     return (
       <View
         model={model}
         onSubmit={this.resourceEditSubmitted}
-        locale={locale}
       />
     );
   }


### PR DESCRIPTION
## Purpose
Now that we know it's on the fast train to deprecation, we want to avoid using the old React context API.

## Approach
Use `locale` from the `intl` prop injected by `react-intl` rather than `context.intl` or `stripes.context.intl`. When react-intl moves to the new context API under the hood, those abstractions should still work.

I don't love the way the `injectIntl` pattern plays with our `redux-form` `validate()` organization (ESLint picks up some "unused" props), but this means we're now not retrieving `context.stripes` at all. :tada: