### PR TITLE
UIEH-410 - Package Titles header is bleeding into first package/title in list

### DIFF
--- a/src/components/details-view/details-view.css
+++ b/src/components/details-view/details-view.css
@@ -13,6 +13,7 @@
     border-bottom: 1px solid #eee;
     border-top: 1px solid var(--minor-divider-color);
     justify-content: space-between;
+    flex-shrink: 0;
 
     & p {
       color: var(--secondary);


### PR DESCRIPTION
[UIEH-410- Detail Record: List of Packages / Titles header is bleeding into first package/title on list](https://issues.folio.org/browse/UIEH-410) 

## Purpose
Under certain conditions, we are seeing result list header text overlap with the first item in a result list.  The overlap condition was found to happen in cases when screen size is adjusted/scaled or when testing in responsive mode and adjusting height. This condition was also happening in some windows installations. All cases were observed with Chrome Browser.

## Approach
Thanks to consult with @wwilsman for css fix which resolves this issue. Added flex-shrink setting of 0.

`What was happening, is by default `flex-shrink` is `1`. Which means it's allowed to shrink by that "factor". When the list didn't have a height, it was causing the header to shrink to try to let the list fit.
By setting it to `0`, we tell it that it isn't allowed to shrink and we don't get overlapping`

#### TODOS and Open Questions
- [ ] Add a separate Jira issue for current scroll behavior as observed in this image. Research and  make scrolling more reliable - scrolling jumps between detail record and results list. https://issues.folio.org/secure/attachment/12329/2018-06-11%2009.27.29.gif

## Learning

https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink

## Screenshots
Before - bleeding of text observed when zooming browser
![2018-06-11 16 18 40](https://user-images.githubusercontent.com/19415226/41255238-dd9ff844-6d93-11e8-9bb6-2806511ef6df.gif)

After - the list header text does not over lap with list items
![2018-06-11 16 18 04](https://user-images.githubusercontent.com/19415226/41255273-fdb2889a-6d93-11e8-8df9-5dbac4cd8ef1.gif)


