### PR TITLE
UIEH-352: Change package visibility toggle to radio inputs

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.css
+++ b/src/components/package/edit-custom/custom-package-edit.css
@@ -18,3 +18,13 @@
     display: block;
   }
 }
+
+.visibility-radios {
+  max-width: 50em;
+  margin-top: 2em;
+
+  & fieldset {
+    padding: 0;
+  }
+}
+

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import isEqual from 'lodash/isEqual';
@@ -7,7 +7,9 @@ import { intlShape, injectIntl } from 'react-intl';
 import {
   Button,
   Icon,
-  KeyValue
+  KeyValue,
+  RadioButton,
+  RadioButtonGroup
 } from '@folio/stripes-components';
 import { processErrors } from '../../utilities';
 
@@ -55,12 +57,10 @@ class CustomPackageEdit extends Component {
     let needsUpdate = !isEqual(this.props.model, nextProps.model);
     let { router } = this.context;
 
-    if ((nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) ||
-    (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
+    if (nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) {
       this.setState({
         ...this.state,
-        packageSelected: nextProps.initialValues.isSelected,
-        packageVisible: nextProps.initialValues.isVisible
+        packageSelected: nextProps.initialValues.isSelected
       });
     }
 
@@ -105,12 +105,6 @@ class CustomPackageEdit extends Component {
     });
   };
 
-  handleVisibilityToggle = (e) => {
-    this.setState({
-      packageVisible: e.target.checked
-    });
-  }
-
   handleOnSubmit = (values) => {
     if (this.state.allowFormToSubmit === false && values.isSelected === false) {
       this.setState({
@@ -137,14 +131,15 @@ class CustomPackageEdit extends Component {
 
     let {
       showSelectionModal,
-      packageSelected,
-      packageVisible
+      packageSelected
     } = this.state;
 
     let {
       queryParams,
       router
     } = this.context;
+
+    let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
 
     let actionMenuItems = [
       {
@@ -220,32 +215,30 @@ class CustomPackageEdit extends Component {
                   />
                 </label>
               </DetailsViewSection>
-              <DetailsViewSection label="Visibility">
+              <DetailsViewSection label="Package settings">
                 {packageSelected ? (
-                  <div>
-                    <label
-                      data-test-eholdings-package-details-visible
-                      htmlFor="custom-package-details-toggle-visible-switch"
-                    >
-                      <h4>
-                        {packageVisible
-                          ? 'Visible to patrons'
-                          : 'Hidden from patrons'}
-                      </h4>
-                      <br />
-                      <Field
-                        name="isVisible"
-                        component={ToggleSwitch}
-                        checked={packageVisible}
-                        onChange={this.handleVisibilityToggle}
-                        id="custom-package-details-toggle-visible-switch"
-                      />
-                    </label>
+                  <div className={styles['visibility-radios']}>
+                    {this.props.initialValues.isVisible != null ? (
+                      <Fragment>
+                        <div data-test-eholdings-package-visibility-field>
+                          <Field
+                            label="Visible to patrons"
+                            name="isVisible"
+                            component={RadioButtonGroup}
+                          >
+                            <RadioButton label="Yes" value="true" />
+                            <RadioButton label={`No ${visibilityMessage}`} value="false" />
+                          </Field>
+                        </div>
+                      </Fragment>
+                    ) : (
+                      <label
+                        data-test-eholdings-package-details-visibility
+                        htmlFor="managed-package-details-visibility-switch"
+                      >
+                        <Icon icon="spinner-ellipsis" />
+                      </label>
 
-                    {!packageVisible && (
-                      <div data-test-eholdings-package-details-is-hidden-reason>
-                        {model.visibilityData.reason}
-                      </div>
                     )}
                   </div>
                 ) : (

--- a/src/components/package/edit-managed/managed-package-edit.css
+++ b/src/components/package/edit-managed/managed-package-edit.css
@@ -19,6 +19,7 @@
   }
 }
 
+.visibility-radios,
 .title-management-radios {
   max-width: 50em;
   margin-top: 2em;

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -8,7 +8,7 @@ import {
   Button,
   Icon,
   RadioButton,
-  RadioButtonGroup,
+  RadioButtonGroup
 } from '@folio/stripes-components';
 import { processErrors } from '../../utilities';
 
@@ -54,12 +54,10 @@ class ManagedPackageEdit extends Component {
     let needsUpdate = !isEqual(this.props.model, nextProps.model);
     let { router } = this.context;
 
-    if ((nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) ||
-    (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
+    if (nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) {
       this.setState({
         ...this.state,
-        packageSelected: nextProps.initialValues.isSelected,
-        packageVisible: nextProps.initialValues.isVisible
+        packageSelected: nextProps.initialValues.isSelected
       });
     }
 
@@ -118,12 +116,6 @@ class ManagedPackageEdit extends Component {
     });
   };
 
-  handleVisibilityToggle = (e) => {
-    this.setState({
-      packageVisible: e.target.checked
-    });
-  }
-
   handleOnSubmit = (values) => {
     if (this.state.allowFormToSubmit === false && values.isSelected === false) {
       this.setState({
@@ -151,14 +143,15 @@ class ManagedPackageEdit extends Component {
 
     let {
       showSelectionModal,
-      packageSelected,
-      packageVisible
+      packageSelected
     } = this.state;
 
     let {
       queryParams,
       router
     } = this.context;
+
+    let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
 
     let actionMenuItems = [
       {
@@ -213,30 +206,27 @@ class ManagedPackageEdit extends Component {
               </DetailsViewSection>
               <DetailsViewSection label="Package Settings">
                 {packageSelected ? (
-                  <div>
-                    <label
-                      data-test-eholdings-package-details-visible
-                      htmlFor="managed-package-details-toggle-visible-switch"
-                    >
-                      <h4>
-                        {packageVisible
-                          ? 'Visible to patrons'
-                          : 'Hidden from patrons'}
-                      </h4>
-                      <br />
-                      <Field
-                        name="isVisible"
-                        component={ToggleSwitch}
-                        checked={packageVisible}
-                        onChange={this.handleVisibilityToggle}
-                        id="managed-package-details-toggle-visible-switch"
-                      />
-                    </label>
-
-                    {!packageVisible && (
-                      <div data-test-eholdings-package-details-is-hidden-reason>
-                        {model.visibilityData.reason}
-                      </div>
+                  <div className={styles['visibility-radios']}>
+                    {this.props.initialValues.isVisible != null ? (
+                      <Fragment>
+                        <div data-test-eholdings-package-visibility-field>
+                          <Field
+                            label="Visible to patrons"
+                            name="isVisible"
+                            component={RadioButtonGroup}
+                          >
+                            <RadioButton label="Yes" value="true" />
+                            <RadioButton label={`No ${visibilityMessage}`} value="false" />
+                          </Field>
+                        </div>
+                      </Fragment>
+                    ) : (
+                      <label
+                        data-test-eholdings-package-details-visibility
+                        htmlFor="managed-package-details-visibility-switch"
+                      >
+                        <Icon icon="spinner-ellipsis" />
+                      </label>
                     )}
                   </div>
                 ) : (

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -35,21 +35,24 @@ export default class PackageShow extends Component {
     queryParams: PropTypes.object
   };
 
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const { model: { allowKbToAddTitles, isSaving, isSelected } } = nextProps;
+    if (!isSaving) {
+      return {
+        ...prevState,
+        packageSelected: isSelected,
+        packageAllowedToAddTitles: allowKbToAddTitles
+      };
+    }
+    return prevState;
+  }
+
   state = {
     showSelectionModal: false,
     packageSelected: this.props.model.isSelected,
     packageAllowedToAddTitles: this.props.model.allowKbToAddTitles,
     isCoverageEditable: false
   };
-
-  componentWillReceiveProps({ model }) {
-    if (!model.isSaving) {
-      this.setState({
-        packageSelected: model.isSelected,
-        packageAllowedToAddTitles: model.allowKbToAddTitles
-      });
-    }
-  }
 
   handleSelectionToggle = () => {
     this.setState({ packageSelected: !this.props.model.isSelected });
@@ -86,6 +89,8 @@ export default class PackageShow extends Component {
       packageAllowedToAddTitles,
       isCoverageEditable
     } = this.state;
+
+    let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
 
     let actionMenuItems = [
       {
@@ -226,7 +231,7 @@ export default class PackageShow extends Component {
                   <div>
                     <KeyValue label="Visible to patrons">
                       <div data-test-eholdings-package-details-visibility-status>
-                        {!model.visibilityData.isHidden ? 'Yes' : 'No'}
+                        {!model.visibilityData.isHidden ? 'Yes' : `No ${visibilityMessage}`}
                       </div>
 
                       {model.visibilityData.isHidden && (

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -99,7 +99,7 @@ class PackageEditRoute extends Component {
       }
 
       if ('isVisible' in values) {
-        model.visibilityData.isHidden = !values.isVisible;
+        model.visibilityData.isHidden = !(values.isVisible === 'true'); // turn string into boolean
       }
 
       if ('allowKbToAddTitles' in values) {

--- a/tests/custom-package-edit-selection-test.js
+++ b/tests/custom-package-edit-selection-test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { describe, beforeEach, afterEach, it } from '@bigtest/mocha';
+import { describe, beforeEach, it } from '@bigtest/mocha';
 
 import { describeApplication } from './helpers';
 import PackageShowPage from './pages/package-show';
@@ -49,26 +49,12 @@ describeApplication('CustomPackageEditSelection', () => {
     });
 
     describe('toggling the selection toggle (OFF)', () => {
-      beforeEach(function () {
-        /*
-         * The expectations in the convergent `it` blocks
-         * get run once every 10ms.  We were seeing test flakiness
-         * when a toggle action dispatched and resolved before an
-         * expectation had the chance to run.  We sidestep this by
-         * temporarily increasing the mirage server's response time
-         * to 50ms.
-         * TODO: control timing directly with Mirage
-         */
-        this.server.timing = 50;
+      beforeEach(() => {
         return PackageEditPage.toggleIsSelected();
       });
 
-      afterEach(function () {
-        this.server.timing = 0;
-      });
-
       it('cannot toggle visibility', () => {
-        expect(PackageEditPage.isVisibleTogglePresent).to.equal(false);
+        expect(PackageEditPage.isVisibilityFieldPresent).to.equal(false);
       });
 
       it('cannot edit coverage', () => {
@@ -134,26 +120,12 @@ describeApplication('CustomPackageEditSelection', () => {
       });
 
       describe('toggling the selection toggle ON', () => {
-        beforeEach(function () {
-          /*
-           * The expectations in the convergent `it` blocks
-           * get run once every 10ms.  We were seeing test flakiness
-           * when a toggle action dispatched and resolved before an
-           * expectation had the chance to run.  We sidestep this by
-           * temporarily increasing the mirage server's response time
-           * to 50ms.
-           * TODO: control timing directly with Mirage
-           */
-          this.server.timing = 50;
+        beforeEach(() => {
           return PackageEditPage.toggleIsSelected();
         });
 
-        afterEach(function () {
-          this.server.timing = 0;
-        });
-
         it('can toggle visibility', () => {
-          expect(PackageEditPage.isVisibleTogglePresent).to.equal(true);
+          expect(PackageEditPage.isVisibilityFieldPresent).to.equal(true);
         });
 
         it('can edit coverage', () => {

--- a/tests/custom-package-edit-visibility-test.js
+++ b/tests/custom-package-edit-visibility-test.js
@@ -29,7 +29,7 @@ describeApplication('CustomPackageEditVisibility', () => {
     });
 
     it('displays the correct visibility status', () => {
-      expect(PackageEditPage.isVisibleToPatrons).to.equal(false);
+      expect(PackageEditPage.isVisibleToPatrons).to.be.false;
     });
 
     it('displays the hidden/reason section', () => {
@@ -50,7 +50,7 @@ describeApplication('CustomPackageEditVisibility', () => {
       });
     });
 
-    describe('toggling the visiblity toggle', () => {
+    describe('toggling the visiblity field', () => {
       beforeEach(() => {
         return PackageEditPage.toggleIsVisible();
       });
@@ -139,7 +139,7 @@ describeApplication('CustomPackageEditVisibility', () => {
       });
     });
 
-    describe('toggling the visiblity toggle', () => {
+    describe('toggling the visiblity field', () => {
       beforeEach(() => {
         return PackageEditPage.toggleIsVisible();
       });
@@ -197,7 +197,7 @@ describeApplication('CustomPackageEditVisibility', () => {
       });
 
       it('cannot toggle visibility', () => {
-        expect(PackageEditPage.isVisibleTogglePresent).to.equal(false);
+        expect(PackageEditPage.isVisibilityFieldPresent).to.equal(false);
       });
     });
   });

--- a/tests/managed-package-edit-selection-test.js
+++ b/tests/managed-package-edit-selection-test.js
@@ -33,7 +33,7 @@ describeApplication('ManagedPackageEditSelection', () => {
     });
 
     it('cannot toggle visibility', () => {
-      expect(PackageEditPage.isVisibleTogglePresent).to.equal(false);
+      expect(PackageEditPage.isVisibilityFieldPresent).to.equal(false);
     });
 
     it('cannot select allow kb to add titles', () => {
@@ -130,7 +130,7 @@ describeApplication('ManagedPackageEditSelection', () => {
     });
 
     it('can toggle visibility', () => {
-      expect(PackageEditPage.isVisibleTogglePresent).to.equal(true);
+      expect(PackageEditPage.isVisibilityFieldPresent).to.equal(true);
     });
 
     it('can select allow kb to add titles', () => {

--- a/tests/managed-package-edit-visibility-test.js
+++ b/tests/managed-package-edit-visibility-test.js
@@ -50,7 +50,7 @@ describeApplication('ManagedPackageEditVisibility', () => {
       });
     });
 
-    describe('toggling the visiblity toggle', () => {
+    describe('toggling the visiblity field', () => {
       beforeEach(() => {
         return PackageEditPage.toggleIsVisible();
       });
@@ -139,7 +139,7 @@ describeApplication('ManagedPackageEditVisibility', () => {
       });
     });
 
-    describe('toggling the visiblity toggle', () => {
+    describe('toggling the visiblity field', () => {
       beforeEach(() => {
         return PackageEditPage.toggleIsVisible();
       });
@@ -187,8 +187,8 @@ describeApplication('ManagedPackageEditVisibility', () => {
       expect(PackageEditPage.isSelected).to.equal(false);
     });
 
-    it('visible toggle is not present', () => {
-      expect(PackageEditPage.isVisibleTogglePresent).to.equal(false);
+    it('visibility field is not present', () => {
+      expect(PackageEditPage.isVisibilityFieldPresent).to.equal(false);
     });
 
     it('disables the save button', () => {

--- a/tests/package-visibility-test.js
+++ b/tests/package-visibility-test.js
@@ -29,7 +29,7 @@ describeApplication('PackageVisibility', () => {
     });
 
     it('displays NO (Hidden from patrons)', () => {
-      expect(PackageShowPage.isVisibleToPatrons).to.equal('No');
+      expect(PackageShowPage.isVisibleToPatrons).to.contain('No');
     });
 
     it('displays the hidden/reason section', () => {

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -1,6 +1,7 @@
 import {
   clickable,
   collection,
+  computed,
   scoped,
   fillable,
   isPresent,
@@ -33,14 +34,22 @@ import Datepicker from './datepicker';
   isSelected = property('[data-test-eholdings-package-details-selected] input', 'checked');
   modal = new PackageEditModal('#eholdings-package-confirmation-modal');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
-  toggleIsVisible = clickable('[data-test-eholdings-package-details-visible] input');
-  isVisibleToPatrons = property('[data-test-eholdings-package-details-visible] input', 'checked');
   isHiddenMessage = text('[data-test-eholdings-package-details-is-hidden-reason]');
   isHiddenMessagePresent = isPresent('[data-test-eholdings-package-details-is-hidden-reason]');
-  isVisibleTogglePresent = isPresent('[data-test-eholdings-package-details-visible] input');
+  isVisibilityFieldPresent = isPresent('[data-test-eholdings-package-visibility-field]');
+  isVisibleToPatrons = property('[data-test-eholdings-package-visibility-field] input[value="true"]', 'checked');
+  toggleIsVisible() {
+    let isVisible = (!this.isVisibleToPatrons).toString();
+    return this.click(`[data-test-eholdings-package-visibility-field] input[value="${isVisible}"]`);
+  }
+  isHiddenMessage = computed(function () {
+    let $node = this.$('[data-test-eholdings-package-visibility-field] input[value="false"] ~ span:last-child');
+    return $node.textContent.replace(/^No(\s\((.*)\))?$/, '$2');
+  });
+  isHiddenMessagePresent = computed(function () {
+    try { return !!this.isHiddenMessage; } catch (e) { return false; }
+  });
   hasRadioForAllowKbToAddTitles = isPresent('[data-test-eholdings-allow-kb-to-add-titles-radios]');
-  toggleAllowKbToAddTitles = clickable('[data-test-eholdings-package-details-allow-add-new-titles] input');
-  allowKbToAddTitles = property('[data-test-eholdings-package-details-allow-add-new-titles] input', 'checked');
   disallowKbToAddTitlesRadio = property('[data-test-eholdings-allow-kb-to-add-titles-radio-no]', 'checked')
   allowKbToAddTitlesRadio = property('[data-test-eholdings-allow-kb-to-add-titles-radio-yes]', 'checked');
   clickAllowKbToAddTitlesRadio = clickable('[data-test-eholdings-allow-kb-to-add-titles-radio-yes]');


### PR DESCRIPTION
## Purpose
To be consistent with other Folio apps, we are changing the Visibility toggle to radio buttons.

This resolves [UIEH-352](https://issues.folio.org/browse/UIEH-352)

## Approach
There was some great work done for changing the visibility toggles in resources that helped guide my approach here for packages. 

## Screenshots
*_Before_*
![2018-06-12 16 13 22](https://user-images.githubusercontent.com/15052791/41318134-ff50d1e2-6e5c-11e8-93c3-6adcf8c96bc8.gif)
*_After_*
![2018-06-12 16 16 58](https://user-images.githubusercontent.com/15052791/41318135-ff6933c2-6e5c-11e8-8e3c-7cace9fef40d.gif)
