### PR TITLE
[UIEH-388] Custom title adding identifiers and contributors

### DIFF
--- a/src/components/contributors-list.js
+++ b/src/components/contributors-list.js
@@ -24,7 +24,9 @@ export default function ContributorsList({ data }) {
         return (
           <div key={key} data-test-eholdings-contributors-list-item>
             <KeyValue label={capitalizedKey}>
-              {names.join('; ')}
+              <div data-test-eholdings-contributor-names>
+                {names.join('; ')}
+              </div>
             </KeyValue>
           </div>
         );

--- a/src/components/identifiers-list.js
+++ b/src/components/identifiers-list.js
@@ -33,7 +33,9 @@ export default function IdentifiersList({ data }) {
       {Object.keys(identifiersByType).map(key => (
         <div key={key} data-test-eholdings-identifiers-list-item>
           <KeyValue label={key}>
-            {identifiersByType[key].join(', ')}
+            <div data-test-eholdings-identifier-id>
+              {identifiersByType[key].join(', ')}
+            </div>
           </KeyValue>
         </div>
       ))}

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -65,7 +65,7 @@ class TitleShowRoute extends Component {
       let mergedTypeIndex = 0;
 
       if (type && subtype) {
-        mergedTypeIndex = this.flattenedIdentifiers.filter(row =>
+        mergedTypeIndex = this.flattenedIdentifiers.findIndex(row =>
           row.type === type && row.subtype === subtype);
       }
 

--- a/tests/custom-title-edit-test.js
+++ b/tests/custom-title-edit-test.js
@@ -35,6 +35,13 @@ describeApplication('CustomTitleEdit', () => {
           type: 'author'
         }
       ],
+      identifiers: [
+        {
+          type: 'ISBN',
+          subtype: 'Online',
+          id: '11133394'
+        }
+      ],
       isTitleCustom: true
     });
 
@@ -115,8 +122,32 @@ describeApplication('CustomTitleEdit', () => {
           expect(TitleShowPage.$root).to.exist;
         });
 
-        it('displays new author', () => {
-          expect(TitleShowPage.contributorsList(1).text).to.contain('Ron');
+        it('displays new editor', () => {
+          expect(TitleShowPage.contributorsList(1).contributorName).to.equal('Ron');
+          expect(TitleShowPage.contributorsList(1).contributorType).to.equal('Editor');
+        });
+      });
+    });
+
+    describe('adding a second identifier', () => {
+      beforeEach(() => {
+        return TitleEditPage.clickAddIdentifiersRowButton()
+          .secondIdentifierType('0')
+          .secondIdentifierId('81803');
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return TitleEditPage.clickSave();
+        });
+
+        it('goes to the title show page', () => {
+          expect(TitleShowPage.$root).to.exist;
+        });
+
+        it('displays the new identifier', () => {
+          expect(TitleShowPage.identifiersList(1).identifierType).to.equal('ISSN (Online)');
+          expect(TitleShowPage.identifiersList(1).identifierId).to.equal('81803');
         });
       });
     });
@@ -216,7 +247,7 @@ describeApplication('CustomTitleEdit', () => {
           .fillContributor('Awesome Author')
           .selectContributorType('Editor')
           .clickAddIdentifiersRowButton()
-          .identifiersRowList(0).id('1111') // eslint-disable-line newline-per-chained-call
+          .identifiersRowList(1).id('1111') // eslint-disable-line newline-per-chained-call
           .fillDescription('What a super helpful description. Wow.')
           .checkPeerReviewed();
       });
@@ -253,7 +284,8 @@ describeApplication('CustomTitleEdit', () => {
         });
 
         it('shows the new ISSN', () => {
-          expect(TitleShowPage.identifiersList(0).text).to.equal('ISSN (Online)1111');
+          expect(TitleShowPage.identifiersList(1).identifierType).to.equal('ISSN (Online)');
+          expect(TitleShowPage.identifiersList(1).identifierId).to.equal('1111');
         });
 
         it('shows the new description', () => {

--- a/tests/custom-title-edit-test.js
+++ b/tests/custom-title-edit-test.js
@@ -73,8 +73,16 @@ describeApplication('CustomTitleEdit', () => {
       expect(TitleEditPage.contributorType).to.equal('author');
     });
 
+    it('shows add contributor button', () => {
+      expect(TitleEditPage.hasContributorBtn).to.be.true;
+    });
+
     it('shows unchecked peer review box', () => {
       expect(TitleEditPage.isPeerReviewed).to.be.false;
+    });
+
+    it('shows add identifier button', () => {
+      expect(TitleEditPage.hasIdentifiersBtn).to.be.true;
     });
 
     it('disables the save button', () => {
@@ -88,6 +96,28 @@ describeApplication('CustomTitleEdit', () => {
 
       it('goes to the title show page', () => {
         expect(TitleShowPage.$root).to.exist;
+      });
+    });
+
+    describe('adding a second contributor', () => {
+      beforeEach(() => {
+        return TitleEditPage.clickAddContributor()
+          .secondContributorType('editor')
+          .secondContributorName('Ron');
+      });
+
+      describe('clicking save', () => {
+        beforeEach(() => {
+          return TitleEditPage.clickSave();
+        });
+
+        it('goes to the title show page', () => {
+          expect(TitleShowPage.$root).to.exist;
+        });
+
+        it('displays new author', () => {
+          expect(TitleShowPage.contributorsList(1).text).to.contain('Ron');
+        });
       });
     });
 

--- a/tests/pages/title-edit.js
+++ b/tests/pages/title-edit.js
@@ -51,11 +51,17 @@ import Toast from './toast';
   contributorHasError = hasClassBeginningWith('[data-test-eholdings-contributor-contributor] input', 'hasError--');
   contributorError = text('[data-test-eholdings-contributor-contributor] [class^="feedbackError--"]');
 
+  hasContributorBtn = isPresent('[data-test-eholdings-contributor-fields-add-row-button]');
+  clickAddContributor = clickable('[data-test-eholdings-contributor-fields-add-row-button] button');
+  secondContributorType = fillable('[data-test-eholdings-contributor-type] select[id="contributors[1]-type"]');
+  secondContributorName = fillable('[data-test-eholdings-contributor-contributor] input[id="contributors[1]-input"]');
+
   removeContributorCollection = collection('[data-test-eholdings-contributor-fields-remove-row-button]', {
     remove: clickable('button')
   });
   contributorsWillBeRemoved = text('[data-test-eholdings-contributors-fields-saving-will-remove]');
 
+  hasIdentifiersBtn = isPresent('[data-test-eholdings-identifiers-fields-add-row-button]');
   clickAddIdentifiersRowButton = clickable('[data-test-eholdings-identifiers-fields-add-row-button] button');
   identifiersRowList = collection('[data-test-eholdings-identifiers-fields-row]', {
     type: fillable('[data-test-eholdings-identifiers-fields-type] select'),

--- a/tests/pages/title-edit.js
+++ b/tests/pages/title-edit.js
@@ -63,6 +63,8 @@ import Toast from './toast';
 
   hasIdentifiersBtn = isPresent('[data-test-eholdings-identifiers-fields-add-row-button]');
   clickAddIdentifiersRowButton = clickable('[data-test-eholdings-identifiers-fields-add-row-button] button');
+  secondIdentifierType = fillable('[data-test-eholdings-identifiers-fields-type] select[name="identifiers[1].flattenedType"]');
+  secondIdentifierId = fillable('[data-test-eholdings-identifiers-fields-id] input[name="identifiers[1].id"]');
   identifiersRowList = collection('[data-test-eholdings-identifiers-fields-row]', {
     type: fillable('[data-test-eholdings-identifiers-fields-type] select'),
     id: fillable('[data-test-eholdings-identifiers-fields-id] input'),

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -77,11 +77,13 @@ import Toast from './toast';
   });
 
   identifiersList = collection('[data-test-eholdings-identifiers-list-item]', {
-    identifierText: text()
+    identifierId: text('[data-test-eholdings-identifier-id]'),
+    identifierType: text('[data-test-eholdings-identifiers-list-item] [class^="kvLabel--"]')
   });
 
   contributorsList = collection('[data-test-eholdings-contributors-list-item]', {
-    contributorText: text()
+    contributorName: text('[data-test-eholdings-contributor-names]'),
+    contributorType: text('[data-test-eholdings-contributors-list-item] [class^="kvLabel--"]')
   });
 
   clickAddToCustomPackageButton = clickable('[data-test-eholdings-add-to-custom-package-button]');


### PR DESCRIPTION
## Purpose
This change fixes the bug, outlined in [UIEH-388](https://issues.folio.org/browse/UIEH-388), that prevented the user from adding additional contributors and identifiers to a custom title. 

## Approach / Learning
Where I was hung up the most was in the tests. For the longest time I was unable to get the values of the _type_ of contributor and the _name_ of the contributor separately, as they appear to the user.
To do this, I ended up having to modify the components a touch to give the `type` and `name/id` separate data attributes as there wasn't a way to differentiate them in the test otherwise. 
Before, the test would return the text value of both the type and name combined for contributor, as the page object was looking for just any text in that row:
` expect(TitleShowPage.identifiersList(0).text).to.equal('ISSN (Online)1111'); `
 Now you can check for them separately.

## Screenshots
![2018-06-13 13 58 30](https://user-images.githubusercontent.com/25858667/41372303-867886dc-6f12-11e8-9405-0980d5329168.gif)
