### PR TITLE
[UIEH-437 ]Change visibility label

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -222,7 +222,7 @@ class CustomPackageEdit extends Component {
                       <Fragment>
                         <div data-test-eholdings-package-visibility-field>
                           <Field
-                            label="Visible to patrons"
+                            label="Show titles in package to patrons"
                             name="isVisible"
                             component={RadioButtonGroup}
                           >

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -211,7 +211,7 @@ class ManagedPackageEdit extends Component {
                       <Fragment>
                         <div data-test-eholdings-package-visibility-field>
                           <Field
-                            label="Visible to patrons"
+                            label="Show titles in package to patrons"
                             name="isVisible"
                             component={RadioButtonGroup}
                           >

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -229,7 +229,7 @@ export default class PackageShow extends Component {
               <DetailsViewSection label="Package settings">
                 {packageSelected ? (
                   <div>
-                    <KeyValue label="Visible to patrons">
+                    <KeyValue label="Show titles in package to patrons">
                       <div data-test-eholdings-package-details-visibility-status>
                         {!model.visibilityData.isHidden ? 'Yes' : `No ${visibilityMessage}`}
                       </div>

--- a/tests/managed-resource-edit-visibility-test.js
+++ b/tests/managed-resource-edit-visibility-test.js
@@ -201,7 +201,7 @@ describeApplication('ManagedResourceEditVisibility', () => {
       });
     });
 
-    it('displays it is not visible to patrons', () => {
+    it('does not show titles in package to patrons', () => {
       expect(ResourceEditPage.isResourceNotSelectedLabelPresent).to.be.true;
     });
   });

--- a/tests/package-visibility-test.js
+++ b/tests/package-visibility-test.js
@@ -51,7 +51,7 @@ describeApplication('PackageVisibility', () => {
       });
     });
 
-    it('displays NO (Hidden from patrons)', () => {
+    it('does not show titles in package to patrons', () => {
       expect(PackageShowPage.isVisibleToPatrons).to.equal('No');
     });
 
@@ -74,7 +74,7 @@ describeApplication('PackageVisibility', () => {
       });
     });
 
-    it('displays YES (Visible to patrons)', () => {
+    it('shows titles in package to patrons', () => {
       expect(PackageShowPage.isVisibleToPatrons).to.equal('Yes');
     });
 

--- a/tests/resource-visibility-test.js
+++ b/tests/resource-visibility-test.js
@@ -27,7 +27,7 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays it is visible to patrons', () => {
+    it('shows titles in package to patrons', () => {
       expect(ResourceShowPage.isResourceVisible).to.be.true;
     });
   });
@@ -45,7 +45,7 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays it is not visible to patrons', () => {
+    it('does not show titles in package to patrons', () => {
       expect(ResourceShowPage.isResourceHidden).to.be.true;
     });
   });
@@ -63,7 +63,7 @@ describeApplication('ResourceVisibility', () => {
       });
     });
 
-    it('displays it is not visible to patrons', () => {
+    it('does not show titles in package to patrons', () => {
       expect(ResourceShowPage.isResourceHidden).to.be.true;
     });
 


### PR DESCRIPTION
## Purpose / Approach
This changes `Visible to patrons` to `Show titles in package to patrons` in package details in order to be consistent with the rest of the app. I also changed the wording in a few tests to meet this as well. 
This resolves [UIEH-437](https://issues.folio.org/browse/UIEH-437).

## Screenshots
![localhost_3000_eholdings_packages_123355-2884739_searchtype packages q carole searchfield title iphone 5_se](https://user-images.githubusercontent.com/25858667/41558425-5d33e166-7306-11e8-9fd3-78ebd366edc9.png)
