### PR TITLE
UIEH-382: Refactor out React17 deprecated lifecycle hooks

### DIFF
--- a/src/components/navigation-modal/navigation-modal.js
+++ b/src/components/navigation-modal/navigation-modal.js
@@ -34,21 +34,23 @@ export default class NavigationModal extends Component {
     }).isRequired
   };
 
+  constructor(props) {
+    super(props);
+
+    if (props.when) {
+      this.enable();
+    }
+  }
+
   state = {
     showModal: false,
     nextLocation: null
   };
 
-  componentWillMount() {
-    if (this.props.when) {
+  componentDidUpdate({ when }) {
+    if (this.props.when && !when) {
       this.enable();
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.when && !this.props.when) {
-      this.enable();
-    } else if (!nextProps.when) {
+    } else if (!this.props.when) {
       this.disable();
     }
   }

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -44,25 +44,34 @@ class CustomPackageEdit extends Component {
     queryParams: PropTypes.object
   };
 
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
+      return {
+        ...prevState,
+        initialValues: {
+          ...prevState.initialValues,
+          isSelected: nextProps.initialValues.isSelected
+        },
+        packageSelected: nextProps.initialValues.isSelected
+      };
+    }
+    return prevState;
+  }
+
   state = {
     showSelectionModal: false,
     allowFormToSubmit: false,
     packageSelected: this.props.initialValues.isSelected,
-    packageVisible: this.props.initialValues.isVisible,
-    formValues: {}
+    formValues: {},
+    // these are used above in getDerivedStateFromProps
+    packageVisible: this.props.initialValues.isVisible, // eslint-disable-line react/no-unused-state
+    initialValues: this.props.initialValues // eslint-disable-line react/no-unused-state
   }
 
-  componentWillReceiveProps(nextProps) {
-    let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
-    let needsUpdate = !isEqual(this.props.model, nextProps.model);
+  componentDidUpdate(prevProps) {
+    let wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
+    let needsUpdate = !isEqual(prevProps.model, this.props.model);
     let { router } = this.context;
-
-    if (nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) {
-      this.setState({
-        ...this.state,
-        packageSelected: nextProps.initialValues.isSelected
-      });
-    }
 
     if (wasPending && needsUpdate) {
       router.history.push({

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -41,25 +41,34 @@ class ManagedPackageEdit extends Component {
     queryParams: PropTypes.object
   };
 
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
+      return {
+        ...prevState,
+        initialValues: {
+          ...prevState.initialValues,
+          isSelected: nextProps.initialValues.isSelected
+        },
+        packageSelected: nextProps.initialValues.isSelected
+      };
+    }
+    return prevState;
+  }
+
   state = {
     showSelectionModal: false,
     allowFormToSubmit: false,
     packageSelected: this.props.initialValues.isSelected,
-    packageVisible: this.props.initialValues.isVisible,
-    formValues: {}
+    formValues: {},
+    // these are used above in getDerivedStateFromProps
+    packageVisible: this.props.initialValues.isVisible, // eslint-disable-line react/no-unused-state
+    initialValues: this.props.initialValues // eslint-disable-line react/no-unused-state
   }
 
-  componentWillReceiveProps(nextProps) {
-    let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
-    let needsUpdate = !isEqual(this.props.model, nextProps.model);
+  componentDidUpdate(prevProps) {
+    let wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
+    let needsUpdate = !isEqual(prevProps.model, this.props.model);
     let { router } = this.context;
-
-    if (nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) {
-      this.setState({
-        ...this.state,
-        packageSelected: nextProps.initialValues.isSelected
-      });
-    }
 
     if (wasPending && needsUpdate) {
       router.history.push({

--- a/src/components/query-list/query-list.js
+++ b/src/components/query-list/query-list.js
@@ -28,16 +28,13 @@ export default class QueryList extends Component {
     notFoundMessage: 'Not found'
   }
 
+  static getDerivedPropsFromState({ offset }, prevState) {
+    return offset !== prevState.offset ? { offset } : prevState;
+  }
+
   state = {
     offset: this.props.offset || 0
   };
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.offset !== this.props.offset &&
-        nextProps.offset !== this.state.offset) {
-      this.setState({ offset: nextProps.offset });
-    }
-  }
 
   updateOffset = (offset) => {
     this.setState({ offset });

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -42,26 +42,37 @@ class ResourceEditCustomTitle extends Component {
     }).isRequired
   };
 
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
+      return {
+        ...prevState,
+        initialValues: {
+          ...prevState.initialValues,
+          isSelected: nextProps.initialValues.isSelected
+        },
+        resourceSelected: nextProps.initialValues.isSelected
+      };
+    }
+    return prevState;
+  }
+
   state = {
     resourceSelected: this.props.initialValues.isSelected,
     showSelectionModal: false,
     allowFormToSubmit: false,
-    formValues: {}
+    formValues: {},
+    // this is used above in getDerivedStateFromProps
+    // eslint-disable-next-line react/no-unused-state
+    initialValues: this.props.initialValues
   }
 
-  componentWillReceiveProps(nextProps) {
-    let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
-    let needsUpdate = !isEqual(this.props.model, nextProps.model);
-
-    if ((nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) ||
-        (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
-      this.setState({
-        resourceSelected: nextProps.initialValues.isSelected
-      });
-    }
+  componentDidUpdate(prevProps) {
+    let wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
+    let needsUpdate = !isEqual(prevProps.model, this.props.model);
+    let { router } = this.context;
 
     if (wasPending && needsUpdate) {
-      this.context.router.history.push(
+      router.history.push(
         `/eholdings/resources/${this.props.model.id}`,
         { eholdings: true, isFreshlySaved: true }
       );

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -52,10 +52,9 @@ class ResourceEditManagedTitle extends Component {
     let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
     let needsUpdate = !isEqual(this.props.model, nextProps.model);
 
-    if ((nextProps.initialValues.isSelected !== this.props.initialValues.isSelected) ||
-        (nextProps.initialValues.isVisible !== this.props.initialValues.isVisible)) {
+    if (nextProps.initialValues.isSelected !== this.state.managedResourceSelected) {
       this.setState({
-        managedResourceSelected: nextProps.initialValues.isSelected
+        managedResourceSelected: nextProps.initialValues.isSelected,
       });
     }
 

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -29,18 +29,16 @@ export default class ResourceShow extends Component {
     router: PropTypes.object
   };
 
+  static getDerivedStateFromProps({ model }, prevState) {
+    return !model.isSaving ?
+      { ...prevState, resourceSelected: model.isSelected } :
+      prevState;
+  }
+
   state = {
     showSelectionModal: false,
     resourceSelected: this.props.model.isSelected
   };
-
-  componentWillReceiveProps({ model }) {
-    if (!model.isSaving) {
-      this.setState({
-        resourceSelected: model.isSelected
-      });
-    }
-  }
 
   handleHoldingStatus = () => {
     if (this.props.model.isSelected) {

--- a/src/components/scroll-view/scroll-view.js
+++ b/src/components/scroll-view/scroll-view.js
@@ -27,12 +27,12 @@ export default class ScrollView extends Component {
     scrollable: true
   };
 
-  state = {
-    offset: this.props.offset,
-    visibleItems: 0
-  };
+  static getDerivedPropsFromState({ offset }, prevState) {
+    return offset !== prevState.offset ? { offset } : prevState;
+  }
 
-  componentDidMount() {
+  constructor(props) {
+    super(props);
     // update the DOM element's scrollTop position with our offset
     this.setScrollOffset();
     // adjust the amount of visible items on resize
@@ -40,12 +40,10 @@ export default class ScrollView extends Component {
     this.handleListLayout();
   }
 
-  componentWillReceiveProps({ offset }) {
-    // new offset that's different from the state
-    if (offset !== this.props.offset && offset !== this.state.offset) {
-      this.setState({ offset });
-    }
-  }
+  state = {
+    offset: this.props.offset,
+    visibleItems: 0
+  };
 
   componentDidUpdate(prevProps, prevState) {
     // did the state update

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -43,34 +43,35 @@ export default class SearchForm extends Component {
     displaySearchTypeSwitcher: true
   };
 
+  static getDerivedStateFromProps({ searchString = '', filter = {}, searchfield, sort }, state) {
+    const newSearchfield = searchfield !== state.searchfield ? searchfield : state.searchfield;
+    const newSearchString = searchString !== state.searchString ? searchString : state.searchString;
+    const newSort = sort !== state.sort ? sort : state.sort;
+    let newFilter = state.filter;
+
+    if (sort) {
+      const displayfilter = { ...filter, sort };
+      if (!isEqual(displayfilter, state.filter)) {
+        newFilter = displayfilter;
+      }
+    } else if (!isEqual(filter, state.filter)) {
+      newFilter = filter;
+    }
+
+    return {
+      filter: newFilter,
+      searchfield: newSearchfield,
+      searchString: newSearchString,
+      sort: newSort,
+    };
+  }
+
   state = {
     searchString: this.props.searchString || '',
     filter: this.props.filter || {},
-    searchfield: this.props.searchfield || 'title',
-    sort: this.props.sort || 'relevance'
+    searchfield: this.props.searchfield || 'title', // last attr actually used in getDerivedStateFromProps
+    sort: this.props.sort || 'relevance' // eslint-disable-line react/no-unused-state
   };
-
-  componentWillReceiveProps({ searchString = '', filter = {}, searchfield, sort }) {
-    if (searchString !== this.state.searchString) {
-      this.setState({ searchString });
-    }
-
-    if (sort !== this.state.sort) {
-      this.setState({ sort });
-    }
-
-    if (sort) {
-      let displayfilter = { ...filter, sort };
-      if (!isEqual(displayfilter, this.state.filter)) {
-        this.setState({ filter: displayfilter });
-      }
-    } else if (!isEqual(filter, this.state.filter)) {
-      this.setState({ filter });
-    }
-    if (searchfield !== this.state.searchfield) {
-      this.setState({ searchfield });
-    }
-  }
 
   submitSearch = () => {
     let { sort, ...searchfilter } = this.state.filter;

--- a/src/components/settings-root-proxy/settings-root-proxy.js
+++ b/src/components/settings-root-proxy/settings-root-proxy.js
@@ -31,10 +31,10 @@ class SettingsRootProxy extends Component {
     }).isRequired
   };
 
-  componentWillReceiveProps(nextProps) {
-    let wasPending = this.props.rootProxy.update.isPending && !nextProps.rootProxy.update.isPending;
-    let needsUpdate = !isEqual(this.props.rootProxy, nextProps.rootProxy);
-    let isRejected = nextProps.rootProxy.update.isRejected;
+  componentDidUpdate(prevProps) {
+    let wasPending = prevProps.rootProxy.update.isPending && !this.props.rootProxy.update.isPending;
+    let needsUpdate = !isEqual(prevProps.rootProxy, this.props.rootProxy);
+    let isRejected = this.props.rootProxy.update.isRejected;
 
     let { router } = this.context;
 

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -41,14 +41,14 @@ class TitleEdit extends Component {
     queryParams: PropTypes.object
   };
 
-  componentWillReceiveProps(nextProps) {
-    let wasPending = this.props.model.update.isPending && !nextProps.model.update.isPending;
-    let needsUpdate = !isEqual(this.props.initialValues, nextProps.initialValues);
+  componentDidUpdate(prevProps) {
+    let wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
+    let needsUpdate = !isEqual(prevProps.initialValues, this.props.initialValues);
     let { router } = this.context;
 
     if (wasPending && needsUpdate) {
       router.history.push({
-        pathname: `/eholdings/titles/${this.props.model.id}`,
+        pathname: `/eholdings/titles/${prevProps.model.id}`,
         search: router.route.location.search,
         state: { eholdings: true }
       });

--- a/src/components/toaster/toaster.js
+++ b/src/components/toaster/toaster.js
@@ -36,18 +36,18 @@ class Toaster extends Component {
     position: 'bottom'
   };
 
+  static getDerivedStateFromProps(nextProps, prevState) {
+    return nextProps.toasts ?
+      { ...prevState, toasts: nextProps.toasts } :
+      prevState;
+  }
+
   constructor(props) {
     super(props);
 
     this.state = {
       toasts: props.toasts
     };
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.toasts) {
-      this.setState({ toasts: nextProps.toasts });
-    }
   }
 
   destroyToast = (toastId) => {

--- a/src/components/toggle-switch/toggle-switch.js
+++ b/src/components/toggle-switch/toggle-switch.js
@@ -16,17 +16,16 @@ export default class ToggleSwitch extends Component {
     isPending: PropTypes.bool
   }
 
-  state = {
-    inputChecked: this.props.checked
+  static getDerivedStateFromProps({ checked, isPending }, state) {
+    const wasPending = state.isPending && !isPending;
+    const needsUpdate = state.inputChecked !== checked;
+    const inputChecked = wasPending || needsUpdate ? checked : state.inputChecked;
+    return { inputChecked, isPending };
   }
 
-  componentWillReceiveProps(nextProps) {
-    let wasPending = this.props.isPending && !nextProps.isPending;
-    let needsUpdate = this.props.checked !== nextProps.checked;
-
-    if (wasPending || needsUpdate) {
-      this.setState({ inputChecked: nextProps.checked });
-    }
+  state = {
+    inputChecked: this.props.checked, // isPending is actually used in getDerivedStateFromProps
+    isPending: this.props.isPending // eslint-disable-line react/no-unused-state
   }
 
   toggle = (e) => {

--- a/src/index.js
+++ b/src/index.js
@@ -34,9 +34,10 @@ export default class EHoldings extends Component {
     router: PropTypes.object
   };
 
-  componentWillMount() {
-    this.context.addReducer('eholdings', reducer);
-    this.context.addEpic('eholdings', epics);
+  constructor(props, context) {
+    super(props);
+    context.addReducer('eholdings', reducer);
+    context.addEpic('eholdings', epics);
   }
 
   render() {

--- a/src/routes/application/application.js
+++ b/src/routes/application/application.js
@@ -19,8 +19,9 @@ class ApplicationRoute extends Component {
     getBackendStatus: PropTypes.func.isRequired
   }
 
-  componentWillMount() {
-    this.props.getBackendStatus();
+  constructor(props) {
+    super(props);
+    props.getBackendStatus();
   }
 
   render() {

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -31,26 +31,17 @@ class PackageEditRoute extends Component {
     }).isRequired
   };
 
-  componentWillMount() {
-    let { packageId } = this.props.match.params;
-    this.props.getPackage(packageId);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    let { model: next, match, getPackage, unloadResources } = nextProps;
-    let { model: old, match: oldMatch } = this.props;
-    let { packageId } = match.params;
-
-    if (packageId !== oldMatch.params.packageId) {
-      getPackage(packageId);
-
-    // if an update just resolved, unfetch the package titles
-    } else if (next.update.isResolved && old.update.isPending) {
-      unloadResources(next.resources);
-    }
+  constructor(props) {
+    super(props);
+    let { packageId } = props.match.params;
+    props.getPackage(packageId);
   }
 
   componentDidUpdate(prevProps) {
+    let { model: next, match, getPackage, unloadResources } = this.props;
+    let { model: old, match: oldMatch } = prevProps;
+    let { packageId } = match.params;
+
     if (!prevProps.model.destroy.isResolved && this.props.model.destroy.isResolved) {
       // if package was reached based on search
       if (this.context.router.history.location.search) {
@@ -62,6 +53,13 @@ class PackageEditRoute extends Component {
       } else {
         this.context.router.history.replace('/eholdings?searchType=packages', { eholdings: true });
       }
+    }
+
+    if (packageId !== oldMatch.params.packageId) {
+      getPackage(packageId);
+    // if an update just resolved, unfetch the package titles
+    } else if (next.update.isResolved && old.update.isPending) {
+      unloadResources(next.resources);
     }
   }
 

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -31,26 +31,17 @@ class PackageShowRoute extends Component {
     }).isRequired
   };
 
-  componentWillMount() {
-    let { packageId } = this.props.match.params;
-    this.props.getPackage(packageId);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    let { model: next, match, getPackage, unloadResources } = nextProps;
-    let { model: old, match: oldMatch } = this.props;
-    let { packageId } = match.params;
-
-    if (packageId !== oldMatch.params.packageId) {
-      getPackage(packageId);
-
-    // if an update just resolved, unfetch the package titles
-    } else if (next.update.isResolved && old.update.isPending) {
-      unloadResources(next.resources);
-    }
+  constructor(props) {
+    super(props);
+    let { packageId } = props.match.params;
+    props.getPackage(packageId);
   }
 
   componentDidUpdate(prevProps) {
+    let { model: next, match, getPackage, unloadResources } = this.props;
+    let { model: old, match: oldMatch } = prevProps;
+    let { packageId } = match.params;
+
     if (!prevProps.model.destroy.isResolved && this.props.model.destroy.isResolved) {
       // if package was reached based on search
       if (this.context.router.history.location.search) {
@@ -62,6 +53,13 @@ class PackageShowRoute extends Component {
       } else {
         this.context.router.history.replace('/eholdings?searchType=packages', { eholdings: true });
       }
+    }
+
+    if (packageId !== oldMatch.params.packageId) {
+      getPackage(packageId);
+      // if an update just resolved, unfetch the package titles
+    } else if (next.update.isResolved && old.update.isPending) {
+      unloadResources(next.resources);
     }
   }
 

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -20,13 +20,14 @@ class ProviderShowRoute extends Component {
     getPackages: PropTypes.func.isRequired
   };
 
-  state = {
-    pkgSearchParams: {}
+  constructor(props) {
+    super(props);
+    let { providerId } = props.match.params;
+    props.getProvider(providerId);
   }
 
-  componentWillMount() {
-    let { providerId } = this.props.match.params;
-    this.props.getProvider(providerId);
+  state = {
+    pkgSearchParams: {}
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -29,26 +29,25 @@ class ResourceEditRoute extends Component {
     }).isRequired
   };
 
-  componentWillMount() {
-    let { match, getResource } = this.props;
+  constructor(props) {
+    super(props);
+    let { match, getResource } = props;
     let { id } = match.params;
     getResource(id);
   }
 
-  componentWillReceiveProps(nextProps) {
-    let { match, getResource } = nextProps;
-    let { id } = match.params;
-
-    if (id !== this.props.match.params.id) {
-      getResource(id);
-    }
-  }
-
   componentDidUpdate(prevProps) {
     let { packageName, packageId } = prevProps.model;
+    let { match, getResource } = this.props;
+    let { id } = match.params;
+
     if (!prevProps.model.destroy.isResolved && this.props.model.destroy.isResolved) {
       this.context.router.history.replace(`/eholdings/packages/${packageId}?searchType=packages&q=${packageName}`,
         { eholdings: true, isDestroyed: true });
+    }
+
+    if (id !== prevProps.match.params.id) {
+      getResource(id);
     }
   }
 

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -27,23 +27,18 @@ class ResourceShowRoute extends Component {
     }).isRequired
   };
 
-  componentWillMount() {
-    let { match, getResource } = this.props;
+  constructor(props) {
+    super(props);
+    let { match, getResource } = props;
     let { id } = match.params;
     getResource(id);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    let { match, getResource } = nextProps;
-    let { id } = match.params;
-    if (id !== this.props.match.params.id) {
-      getResource(id);
-    }
   }
 
   componentDidUpdate(prevProps) {
     let wasUpdated = !this.props.model.update.isPending && prevProps.model.update.isPending && (!this.props.model.update.errors.length > 0);
     let { router } = this.context;
+    let { match, getResource } = this.props;
+    let { id } = match.params;
 
     let { packageName, packageId } = prevProps.model;
     if (!prevProps.model.destroy.isResolved && this.props.model.destroy.isResolved) {
@@ -57,6 +52,10 @@ class ResourceShowRoute extends Component {
         search: router.route.location.search,
         state: { eholdings: true, isFreshlySaved: true }
       });
+    }
+
+    if (id !== prevProps.match.params.id) {
+      getResource(id);
     }
   }
 

--- a/src/routes/settings-knowledge-base.js
+++ b/src/routes/settings-knowledge-base.js
@@ -14,8 +14,9 @@ class SettingsKnowledgeBaseRoute extends Component {
     updateBackendConfig: PropTypes.func.isRequired
   };
 
-  componentWillMount() {
-    this.props.getBackendConfig();
+  constructor(props) {
+    super(props);
+    props.getBackendConfig();
   }
 
   updateConfig = ({ customerId, apiKey }) => {

--- a/src/routes/settings-root-proxy.js
+++ b/src/routes/settings-root-proxy.js
@@ -15,9 +15,10 @@ class SettingsRootProxyRoute extends Component {
     updateRootProxy: PropTypes.func.isRequired
   };
 
-  componentWillMount() {
-    this.props.getProxyTypes();
-    this.props.getRootProxy();
+  constructor(props) {
+    super(props);
+    props.getProxyTypes();
+    props.getRootProxy();
   }
 
   rootProxySubmitted = (values) => {

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -8,7 +8,7 @@ import Resource from '../redux/resource';
 
 import View from '../components/title/edit';
 
-class TitleShowRoute extends Component {
+class TitleEditRoute extends Component {
   static propTypes = {
     match: PropTypes.shape({
       params: PropTypes.shape({
@@ -29,27 +29,26 @@ class TitleShowRoute extends Component {
     }).isRequired
   };
 
-  componentWillMount() {
-    let { match, getTitle } = this.props;
+  constructor(props) {
+    super(props);
+    let { match, getTitle } = props;
     let { titleId } = match.params;
     getTitle(titleId);
   }
 
-  componentWillReceiveProps(nextProps) {
-    let { match, getTitle } = nextProps;
+  componentDidUpdate(prevProps) {
+    let { match, getTitle } = this.props;
     let { titleId } = match.params;
 
-    if (titleId !== this.props.match.params.titleId) {
-      getTitle(titleId);
-    }
-  }
-
-  componentDidUpdate(prevProps) {
     if (!prevProps.updateRequest.isResolved && this.props.updateRequest.isResolved) {
       this.context.router.history.push(
         `/eholdings/titles/${this.props.model.id}`,
         { eholdings: true, isFreshlySaved: true }
       );
+    }
+
+    if (titleId !== prevProps.match.params.titleId) {
+      getTitle(titleId);
     }
   }
 
@@ -126,4 +125,4 @@ export default connect(
     getTitle: id => Title.find(id, { include: 'resources' }),
     updateResource: model => Resource.save(model)
   }
-)(TitleShowRoute);
+)(TitleEditRoute);

--- a/tests/harness.js
+++ b/tests/harness.js
@@ -29,7 +29,8 @@ const actionNames = gatherActions();
  * for interacting with the custom history.
  */
 export default class TestHarness extends Component {
-  componentWillMount() {
+  constructor() {
+    super();
     this.logger = configureLogger(config);
     this.epics = configureEpics();
     this.store = configureStore({ okapi }, this.logger, this.epics);


### PR DESCRIPTION
## Purpose
Among the changes that React 17 brings to the table, several problematic component lifecycle hooks are now deprecated and need to be removed from the codebase. In order to adopt the latest version of the AirBnB eslint rule-set we need to go through the code and convert away from these old lifecycle hooks to make sure our builds are not failing on a big ol' pile of deprecation warnings.

## Approach
The deprecated hooks are: 
```
componentWillMount
componentWillReceiveProps
componentWillUpdate
```
According to the react documentation and a few helpful [blog posts](https://hackernoon.com/problematic-react-lifecycle-methods-are-going-away-in-react-17-4216acc7d58b) there are some new methods to use to avoid using the old stuff.
The new hooks are:
```
UNSAFE_componentWillMount
UNSAFE_componentWillRecieveProps
UNSAFE_componentWillUpdate
getDerivedStateFromProps
getSnapshotBeforeUpdate
```

#### TODOS and Open Questions
These files contain the old hooks I haven't been able to solve for yet
- [x] src/components/impagination.js
- [x] src/components/navigation-modal/navigation-modal.js
- [x] src/components/package/edit-custom/custom-package-edit.js
- [x] src/components/package/edit-managed/managed-package-edit.js
- [x] src/components/resource/edit-custom-title/resource-edit-custom-title.js
- [ ] src/components/resource/edit-managed-title/resource-edit-managed-title.js
- [x] src/components/search-form/search-form.js
- [ ] src/components/search-paneset/search-paneset.js
- [x] src/components/toggle-switch/toggle-switch.js
- [ ] src/routes/search.js