### PR TITLE
UIEH-314: Change modal message when deleting a custom package from holdings

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -293,7 +293,7 @@ class CustomPackageEdit extends Component {
         <Modal
           open={showSelectionModal}
           size="small"
-          label="Remove package from holdings?"
+          label="Delete custom package"
           scope="root"
           id="eholdings-package-confirmation-modal"
           footer={(
@@ -303,18 +303,18 @@ class CustomPackageEdit extends Component {
                 onClick={this.commitSelectionToggle}
                 data-test-eholdings-package-deselection-confirmation-modal-yes
               >
-                Yes, remove
+                Yes, delete
               </Button>
               <Button
                 onClick={this.cancelSelectionToggle}
                 data-test-eholdings-package-deselection-confirmation-modal-no
               >
-                No, do not remove
+                No, do not delete
               </Button>
             </div>
           )}
         >
-           Are you sure you want to remove this package and all its titles from your holdings? All customizations will be lost.
+          Are you sure you want to delete this package? By deleting this package it will no longer be available for selection and all customization will be lost. If a title only appears in this package it will no longer be available for selection.
         </Modal>
       </div>
     );

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -91,6 +91,21 @@ export default class PackageShow extends Component {
     } = this.state;
 
     let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
+    let modalMessage = model.isCustom ?
+      {
+        header: 'Delete custom package',
+        body: `Are you sure you want to delete this package?
+          By deleting this package it will no longer be available for selection and all customization will be lost.
+          If a title only appears in this package it will no longer be available for selection.`,
+        buttonConfirm: 'Yes, delete',
+        buttonCancel: 'No, do not delete'
+      } :
+      {
+        header: 'Remove package from holdings?',
+        body: 'Are you sure you want to remove this package and all its titles from your holdings? All customizations will be lost.',
+        buttonConfirm: 'Yes, remove',
+        buttonCancel: 'No, do not remove'
+      };
 
     let actionMenuItems = [
       {
@@ -323,7 +338,7 @@ export default class PackageShow extends Component {
         <Modal
           open={showSelectionModal}
           size="small"
-          label="Remove package from holdings?"
+          label={modalMessage.header}
           scope="root"
           id="eholdings-package-confirmation-modal"
           footer={(
@@ -333,18 +348,18 @@ export default class PackageShow extends Component {
                 onClick={this.commitSelectionToggle}
                 data-test-eholdings-package-deselection-confirmation-modal-yes
               >
-                Yes, remove
+                {modalMessage.buttonConfirm}
               </Button>
               <Button
                 onClick={this.cancelSelectionToggle}
                 data-test-eholdings-package-deselection-confirmation-modal-no
               >
-                No, do not remove
+                {modalMessage.buttonCancel}
               </Button>
             </div>
           )}
         >
-           Are you sure you want to remove this package and all its titles from your holdings? All customizations will be lost.
+          {modalMessage.body}
         </Modal>
 
         <NavigationModal when={isCoverageEditable} />


### PR DESCRIPTION
## Purpose
Simply a change to the modal messaging when deleting a custom package to better reflect that the consequence of deselecting a custom package is to DELETE it.

## Screenshots
![2018-06-21 16 00 08](https://user-images.githubusercontent.com/15052791/41745585-02fafc70-756d-11e8-90f6-035e2938a5e1.gif)
