### PR TITLE
UIEH-404 Refactor holding status away from ToggleSwitch

### DIFF
--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -117,14 +117,14 @@ export default class ResourceShow extends Component {
 
     if (resourceSelected === true) {
       actionMenuItems.push({
-        'label': 'Remove title from Holdings',
+        'label': 'Remove title from holdings',
         'state': { eholdings: true },
         'onClick': this.handleHoldingStatus,
         'data-test-eholdings-remove-resource-from-holdings': true
       });
     } else if (resourceSelected === false) {
       actionMenuItems.push({
-        'label': 'Add to Holdings',
+        'label': 'Add to holdings',
         'state': { eholdings: true },
         'onClick': this.handleHoldingStatus,
         'data-test-eholdings-add-resource-to-holdings': true

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {
   Button,
   IconButton,
+  Icon,
   KeyValue,
   PaneMenu
 } from '@folio/stripes-components';
@@ -12,7 +13,6 @@ import DetailsView from '../details-view';
 import Link from '../link';
 import IdentifiersList from '../identifiers-list';
 import ContributorsList from '..//contributors-list';
-import ToggleSwitch from '../toggle-switch';
 import CoverageDateList from '../coverage-date-list';
 import { isBookPublicationType, isValidCoverageList, processErrors } from '../utilities';
 import Modal from '../modal';
@@ -42,8 +42,7 @@ export default class ResourceShow extends Component {
     }
   }
 
-  handleSelectionToggle = () => {
-    this.setState({ resourceSelected: !this.props.model.isSelected });
+  handleHoldingStatus = () => {
     if (this.props.model.isSelected) {
       this.setState({ showSelectionModal: true });
     } else {
@@ -113,6 +112,22 @@ export default class ResourceShow extends Component {
         id: `success-package-creation-${model.id}`,
         message: 'Title was updated.',
         type: 'success'
+      });
+    }
+
+    if (resourceSelected === true) {
+      actionMenuItems.push({
+        'label': 'Remove title from Holdings',
+        'state': { eholdings: true },
+        'onClick': this.handleHoldingStatus,
+        'data-test-eholdings-remove-resource-from-holdings': true
+      });
+    } else if (resourceSelected === false) {
+      actionMenuItems.push({
+        'label': 'Add to Holdings',
+        'state': { eholdings: true },
+        'onClick': this.handleHoldingStatus,
+        'data-test-eholdings-add-resource-to-holdings': true
       });
     }
 
@@ -250,14 +265,23 @@ export default class ResourceShow extends Component {
                   data-test-eholdings-resource-show-selected
                   htmlFor="resource-show-toggle-switch"
                 >
-                  <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
+                  {
+                    model.update.isPending ? (
+                      <Icon icon='spinner-ellipsis' />
+                    ) : (
+                      <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
+                    )
+                  }
                   <br />
-                  <ToggleSwitch
-                    onChange={this.handleSelectionToggle}
-                    checked={model.destroy.isPending ? false : resourceSelected}
-                    isPending={model.destroy.isPending || isSelectInFlight}
-                    id="resource-show-toggle-switch"
-                  />
+                  { ((!resourceSelected && !isSelectInFlight) || (!this.props.model.isSelected && isSelectInFlight)) && (
+                    <Button
+                      buttonStyle="primary"
+                      onClick={this.handleHoldingStatus}
+                      disabled={model.destroy.isPending || isSelectInFlight}
+                      data-test-eholdings-resource-add-to-holdings-button
+                    >
+                      Add to holdings
+                    </Button>)}
                 </label>
               </DetailsViewSection>
 

--- a/tests/pages/resource-show.js
+++ b/tests/pages/resource-show.js
@@ -5,6 +5,7 @@ import {
   isPresent,
   interactor,
   property,
+  attribute,
   text
 } from '@bigtest/interactor';
 import { hasClassBeginningWith } from './helpers';
@@ -18,6 +19,16 @@ import Toast from './toast';
   hasDeselectFinalTitleWarning = isPresent('[data-test-eholdings-deselect-final-title-warning]');
 }
 
+@interactor class ResourceShowDropDown {
+  clickDropDownButton = clickable('button');
+  isExpanded = attribute('button', 'aria-expanded');
+}
+
+@interactor class ResourceShowDropDownMenu {
+  clickRemoveFromHoldings = clickable('.tether-element [data-test-eholdings-remove-resource-from-holdings]');
+  clickAddToHoldings = clickable('.tether-element [data-test-eholdings-add-resource-to-holdings]');
+}
+
 @interactor class ResourceShowNavigationModal {}
 
 @interactor class ResourceShowPage {
@@ -26,6 +37,7 @@ import Toast from './toast';
   descriptionText = text('[data-test-eholdings-description-field]');
   publisherName = text('[data-test-eholdings-resource-show-publisher-name]');
   publicationType = text('[data-test-eholdings-resource-show-publication-type]');
+  isSelected = property('[data-test-eholdings-resource-show-selected] input', 'checked');
   hasPublicationType = isPresent('[data-test-eholdings-resource-show-publication-type]');
   subjectsList = text('[data-test-eholdings-resource-show-subjects-list]');
   providerName = text('[data-test-eholdings-resource-show-provider-name]');
@@ -36,16 +48,22 @@ import Toast from './toast';
   contentType = text('[data-test-eholdings-resource-show-content-type]');
   hasContentType = isPresent('[data-test-eholdings-resource-show-content-type]');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
+  isResourceSelected = text('[data-test-eholdings-resource-show-selected] h4');
   isSelected = property('[data-test-eholdings-resource-show-selected] input', 'checked');
   isSelecting = hasClassBeginningWith('[data-test-eholdings-resource-show-selected] [data-test-toggle-switch]', 'is-pending--');
+  isLoading = isPresent('[data-test-eholdings-resource-show-selected] [class*=icon---][class*=iconSpinner]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button] button');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   paneSub = text('[data-test-eholdings-details-view-pane-sub]');
   isSelectedToggleDisabled = property('[data-test-eholdings-resource-show-selected] input[type=checkbox]', 'disabled');
-  toggleIsSelected = clickable('[data-test-eholdings-resource-show-selected] input');
+  toggleIsSelected = clickable('[data-test-eholdings-resource-show-holding-status] input');
   isEditingCustomEmbargo = isPresent('[data-test-eholdings-embargo-form] form');
   clickPackage = clickable('[data-test-eholdings-resource-show-package-name] a');
+  clickAddToHoldingsButton = clickable('[data-test-eholdings-resource-add-to-holdings-button]');
+  isAddToHoldingsButtonDisabled = property('[data-test-eholdings-resource-add-to-holdings-button]', 'disabled');
+  dropDown= new ResourceShowDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  dropDownMenu = new ResourceShowDropDownMenu();
   deselectionModal = new ResourceShowDeselectionModal('#eholdings-resource-deselection-confirmation-modal');
   navigationModal = new ResourceShowNavigationModal('#navigation-modal');
   resourceVisibilityLabel = text('[data-test-eholdings-resource-show-visibility]');
@@ -62,7 +80,7 @@ import Toast from './toast';
   clickEditButton = clickable('[data-test-eholdings-resource-edit-link]');
   peerReviewedStatus = text('[data-test-eholdings-peer-reviewed-field]');
 
-  toast = Toast
+  toast = Toast;
 
   managedEmbargoPeriod = text('[data-test-eholdings-resource-show-managed-embargo-period]');
   hasManagedEmbargoPeriod = isPresent('[data-test-eholdings-resource-show-managed-embargo-period]');

--- a/tests/resource-deselection-test.js
+++ b/tests/resource-deselection-test.js
@@ -44,12 +44,12 @@ describeApplication('ResourceDeselection', () => {
       });
 
       it('indicates that the resource is selected', () => {
-        expect(ResourcePage.isSelected).to.equal(true);
+        expect(ResourcePage.isResourceSelected).to.equal('Selected');
       });
 
       describe('deselecting', () => {
         beforeEach(() => {
-          return ResourcePage.toggleIsSelected();
+          return ResourcePage.dropDownMenu.clickRemoveFromHoldings();
         });
 
         it('warns the user they are deselecting the final title in the package', () => {
@@ -69,20 +69,18 @@ describeApplication('ResourceDeselection', () => {
       });
 
       it('indicates that the resource is selected', () => {
-        expect(ResourcePage.isSelected).to.equal(true);
+        expect(ResourcePage.isResourceSelected).to.equal('Selected');
       });
 
       describe('deselecting', () => {
         beforeEach(() => {
-          return ResourcePage.toggleIsSelected();
+          return ResourcePage
+            .dropDown.clickDropDownButton()
+            .dropDownMenu.clickRemoveFromHoldings();
         });
 
         it('warns the user they are deselecting', () => {
           expect(ResourcePage.deselectionModal.hasDeselectTitleWarning).to.be.true;
-        });
-
-        it('reflects the desired state (not selected)', () => {
-          expect(ResourcePage.isSelected).to.equal(false);
         });
 
         describe('canceling the deselection', () => {
@@ -91,7 +89,7 @@ describeApplication('ResourceDeselection', () => {
           });
 
           it('reverts back to the selected state', () => {
-            expect(ResourcePage.isSelected).to.equal(true);
+            expect(ResourcePage.isResourceSelected).to.equal('Selected');
           });
         });
 
@@ -102,6 +100,10 @@ describeApplication('ResourceDeselection', () => {
 
           it('remains on Resource Page', () => {
             expect(ResourcePage.isPresent).to.be.true;
+          });
+
+          it('set and displayes the selected state', () => {
+            expect(ResourcePage.isResourceSelected).to.equal('Not selected');
           });
 
           describe('when the request succeeds', () => {

--- a/tests/resource-edit-selection-test.js
+++ b/tests/resource-edit-selection-test.js
@@ -78,7 +78,7 @@ describeApplication('ResourceEditSelection', () => {
           });
 
           it('reflects the new state', () => {
-            expect(ResourceShowPage.isSelected).to.equal(true);
+            expect(ResourceShowPage.isResourceSelected).to.equal('Selected');
           });
         });
       });
@@ -123,7 +123,7 @@ describeApplication('ResourceEditSelection', () => {
           });
 
           it('indicates it is no longer working', () => {
-            expect(ResourceShowPage.isSelecting).to.equal(false);
+            expect(ResourceShowPage.isLoading).to.equal(false);
           });
 
           it('displays a toast error', () => {

--- a/tests/resource-embargo-test.js
+++ b/tests/resource-embargo-test.js
@@ -163,12 +163,14 @@ describeApplication('ResourceEmbargo', () => {
     });
 
     it('displays whether the title package is selected', () => {
-      expect(ResourceShowPage.isSelected).to.equal(true);
+      expect(ResourceShowPage.isResourceSelected).to.equal('Selected');
     });
 
-    describe('toggling to deselect a title package', () => {
+    describe('removing the title package via drop down', () => {
       beforeEach(() => {
-        return ResourceShowPage.toggleIsSelected();
+        return ResourceShowPage
+          .dropDown.clickDropDownButton()
+          .dropDownMenu.clickRemoveFromHoldings();
       });
 
       describe('and confirming deselection', () => {

--- a/tests/resource-show-test.js
+++ b/tests/resource-show-test.js
@@ -140,7 +140,7 @@ describeApplication('ResourceShow', () => {
     });
 
     it('indicates that the resource is not yet selected', () => {
-      expect(ResourcePage.isSelected).to.equal(false);
+      expect(ResourcePage.isResourceSelected).to.equal('Not selected');
     });
 
     it.always('should not display the back button', () => {
@@ -155,7 +155,7 @@ describeApplication('ResourceShow', () => {
           }]
         }, 500);
 
-        return ResourcePage.toggleIsSelected();
+        return ResourcePage.clickAddToHoldingsButton();
       });
 
       it('displays the correct error text', () => {
@@ -183,7 +183,7 @@ describeApplication('ResourceShow', () => {
           }]
         }, 500);
 
-        return ResourcePage.toggleIsSelected();
+        return ResourcePage.clickAddToHoldingsButton();
       });
 
       it('has two errors', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,7 +175,7 @@
     webpack-bundle-analyzer "^2.9.1"
     yargs "^10.0.3"
 
-"@folio/stripes-components@^2.0.0", "@folio/stripes-components@^2.0.12", "@folio/stripes-components@^2.0.28":
+"@folio/stripes-components@2.0.28000389", "@folio/stripes-components@^2.0.0", "@folio/stripes-components@^2.0.12":
   version "2.0.28000389"
   resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-components/-/stripes-components-2.0.28000389.tgz#8e7343273184cebf05f9206b9fd5d11b898c7175"
   dependencies:
@@ -341,7 +341,7 @@
     mousetrap "^1.6.1"
     prop-types "^15.5.10"
 
-"@folio/ui-testing@github:folio-org/ui-testing#framework-only":
+"@folio/ui-testing@folio-org/ui-testing#framework-only":
   version "4.0.0"
   resolved "https://codeload.github.com/folio-org/ui-testing/tar.gz/4599a415d27bbd0fc02c9cf6e8c04c6649af9c8e"
   dependencies:


### PR DESCRIPTION
## Purpose
UI-eHoldings users are able to add and remove `titles` also referred to as `resources` to their holdings. Here we are refactoring from using a toggle-switch to rather use a button to add and then removing is done from the action menu in the dropdown. This change and UX is more in line with what the rest FOLIO applications are doing so we conforming to ensure users have the same experience across the the various FOLIO applications. 

## Approach
 - Replace the ToggleSwitch component with Button component
 - Add the actions to the drop-down within the Resource Page header

## Screenshots
![2018-06-26 16 13 38](https://user-images.githubusercontent.com/1953098/41936913-cca3f4c6-795c-11e8-9b9a-a14693cb9da4.gif)
