### PR TITLE
Match padding of other FOLIO New buttons

### DIFF
--- a/src/components/search-paneset/search-paneset.css
+++ b/src/components/search-paneset/search-paneset.css
@@ -74,7 +74,7 @@
 }
 
 .search-new-button {
-  padding: 3px 10px 7px;
+  padding: 0 10px;
   height: 24px;
   text-align: center;
   cursor: pointer;


### PR DESCRIPTION
The "+ New" button on search pages no longer matched other FOLIO modules.

Related: https://issues.folio.org/browse/STCOM-301

### Before
![localhost_3000_eholdings_searchtype packages q e searchfield title iphone 5_se](https://user-images.githubusercontent.com/230597/42005998-dc0bedac-7a3c-11e8-85df-2104044bc239.png)

### After
![localhost_3000_eholdings_searchtype packages iphone 5_se](https://user-images.githubusercontent.com/230597/42006004-e0770e3a-7a3c-11e8-8e0a-375675c9ecb7.png)
