### PR TITLE
STCOR-228 Add translation for module title

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "stripes": {
     "type": "app",
-    "displayName": "eHoldings",
+    "displayName": "ui-eholdings.meta.title",
     "route": "/eholdings",
     "hasSettings": true,
     "icons": [

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -1,3 +1,4 @@
 {
+  "meta.title": "eHoldings",
   "resultCount": "{count, number} {count, plural, one {search result} other {search results}}"
 }


### PR DESCRIPTION
We now have a way to provide translations for the module name. Upstream changes: https://github.com/folio-org/stripes-core/pull/327
