### PR TITLE
[UIEH-440] More Accessible Routing

### DIFF
--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -60,12 +60,27 @@ export default class DetailsView extends Component {
     showSearchModal: false
   };
 
+  // used to focus the heading when the model loads
+  $heading = React.createRef(); // eslint-disable-line react/sort-comp
+
   componentDidMount() {
     window.addEventListener('resize', this.handleLayout);
     this.handleLayout();
+
+    // if the heading exists on mount, focus it
+    if (this.$heading.current) {
+      this.$heading.current.focus();
+    }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    let { model } = this.props;
+
+    // if the model just finished loading focus the heading
+    if (!prevProps.model.isLoaded && model.isLoaded) {
+      this.$heading.current.focus();
+    }
+
     this.handleLayout();
   }
 
@@ -248,7 +263,11 @@ export default class DetailsView extends Component {
         >
           {model.isLoaded ? [
             <div key="header" className={styles.header}>
-              <h2 data-test-eholdings-details-view-name={type}>
+              <h2
+                tabIndex={-1}
+                ref={this.$heading}
+                data-test-eholdings-details-view-name={type}
+              >
                 {paneTitle}
               </h2>
               {paneSub && (

--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { FormattedNumber } from 'react-intl';
 
+import shouldFocus from '../should-focus';
 import styles from './package-list-item.css';
 import Link from '../link';
 
 const cx = classNames.bind(styles);
 
-export default function PackageListItem({
+function PackageListItem({
   item,
   link,
   active,
@@ -101,3 +102,7 @@ PackageListItem.propTypes = {
   onClick: PropTypes.func,
   headingLevel: PropTypes.string
 };
+
+// this HOC adds a prop, `shouldFocus` that will focus the component's
+// rendered DOM node on mount and update (when the prop is toggled)
+export default shouldFocus(PackageListItem);

--- a/src/components/package-search-list.js
+++ b/src/components/package-search-list.js
@@ -7,13 +7,12 @@ import PackageListItem from './package-list-item';
 export default function PackageSearchList({
   location,
   params,
+  activeId,
+  shouldFocusItem,
   collection,
   fetch,
   onUpdateOffset
 }, { router }) {
-  let { params: routeParams } = router.route.match;
-  let isPackagePage = routeParams.type === 'packages';
-
   return (
     <QueryList
       type="packages"
@@ -30,7 +29,8 @@ export default function PackageSearchList({
           link={item.content && {
             pathname: `/eholdings/packages/${item.content.id}`
           }}
-          active={item.content && isPackagePage && routeParams.id === item.content.id}
+          active={item.content && activeId && item.content.id === activeId}
+          shouldFocus={item.content && shouldFocusItem && item.content.id === shouldFocusItem}
           onClick={() => {
             router.history.push(
               `/eholdings/packages/${item.content.id}${location.search}`
@@ -45,6 +45,8 @@ export default function PackageSearchList({
 PackageSearchList.propTypes = {
   location: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired,
+  activeId: PropTypes.string,
+  shouldFocusItem: PropTypes.string,
   collection: PropTypes.object.isRequired,
   fetch: PropTypes.func.isRequired,
   onUpdateOffset: PropTypes.func.isRequired

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -171,6 +171,7 @@ export default class PackageShow extends Component {
         <DetailsView
           type="package"
           model={model}
+          key={model.id}
           paneTitle={model.name}
           actionMenuItems={actionMenuItems}
           lastMenu={(

--- a/src/components/provider-list-item/provider-list-item.js
+++ b/src/components/provider-list-item/provider-list-item.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { FormattedNumber } from 'react-intl';
 
+import shouldFocus from '../should-focus';
 import styles from './provider-list-item.css';
 import Link from '../link';
 
 const cx = classNames.bind(styles);
 
-export default function ProviderListItem({ item, link, active, onClick, headingLevel }) {
+function ProviderListItem({ item, link, active, onClick, headingLevel }) {
   let Heading = headingLevel || 'h3';
 
   return !item ? (
@@ -60,3 +61,7 @@ ProviderListItem.propTypes = {
   onClick: PropTypes.func,
   headingLevel: PropTypes.string
 };
+
+// this HOC adds a prop, `shouldFocus` that will focus the component's
+// rendered DOM node on mount and update (when the prop is toggled)
+export default shouldFocus(ProviderListItem);

--- a/src/components/provider-search-list.js
+++ b/src/components/provider-search-list.js
@@ -7,13 +7,12 @@ import ProviderListItem from './provider-list-item';
 export default function ProviderSearchList({
   location,
   params,
+  activeId,
+  shouldFocusItem,
   collection,
   fetch,
   onUpdateOffset,
 }, { router }) {
-  let { params: routeParams } = router.route.match;
-  let isProviderPage = routeParams.type === 'providers';
-
   return (
     <QueryList
       type="providers"
@@ -29,7 +28,8 @@ export default function ProviderSearchList({
           link={item.content && {
             pathname: `/eholdings/providers/${item.content.id}`
           }}
-          active={item.content && isProviderPage && routeParams.id === item.content.id}
+          active={item.content && activeId && item.content.id === activeId}
+          shouldFocus={item.content && shouldFocusItem && item.content.id === shouldFocusItem}
           onClick={() => {
             router.history.push(
               `/eholdings/providers/${item.content.id}${location.search}`
@@ -44,6 +44,8 @@ export default function ProviderSearchList({
 ProviderSearchList.propTypes = {
   location: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired,
+  activeId: PropTypes.string,
+  shouldFocusItem: PropTypes.string,
   collection: PropTypes.object.isRequired,
   fetch: PropTypes.func.isRequired,
   onUpdateOffset: PropTypes.func.isRequired

--- a/src/components/provider-show/provider-show.js
+++ b/src/components/provider-show/provider-show.js
@@ -40,6 +40,7 @@ export default function ProviderShow({
       <DetailsView
         type="provider"
         model={model}
+        key={model.id}
         paneTitle={model.name}
         actionMenuItems={actionMenuItems}
         bodyContent={(

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -49,10 +49,9 @@ export default class SearchPaneset extends React.Component {
   // used to focus the pane title when a new search happens
   $title = React.createRef(); // eslint-disable-line react/sort-comp
 
-  // focus the pane title if we mounted with an existing search
+  // focus the pane title if we mounted with existing search results and no details view
   componentDidMount() {
-    // this is only defined when there is an existing search
-    if (this.props.resultsView) {
+    if (this.props.resultsView && !this.props.detailsView) {
       this.$title.current.focus();
     }
   }

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -46,6 +46,17 @@ export default class SearchPaneset extends React.Component {
     hideFilters: this.props.hideFilters
   };
 
+  // used to focus the pane title when a new search happens
+  $title = React.createRef(); // eslint-disable-line react/sort-comp
+
+  // focus the pane title if we mounted with an existing search
+  componentDidMount() {
+    // this is only defined when there is an existing search
+    if (this.props.resultsView) {
+      this.$title.current.focus();
+    }
+  }
+
   componentWillReceiveProps({ resultsType, location }) {
     let isSameLocation = location.search === this.props.location.search;
 
@@ -64,6 +75,16 @@ export default class SearchPaneset extends React.Component {
           this.setState({ hideFilters: false });
         }
       }
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    let isNewSearch = prevProps.location.search !== this.props.location.search;
+    let isSameSearchType = prevProps.resultsType === this.props.resultsType;
+
+    // focus the pane title when a new search happens within the same search type
+    if (isNewSearch && isSameSearchType) {
+      this.$title.current.focus();
     }
   }
 
@@ -157,6 +178,7 @@ export default class SearchPaneset extends React.Component {
                 }}
                 paneTitle={capitalize(resultsType)}
                 paneSub={resultsPaneSub}
+                paneTitleRef={this.$title}
                 firstMenu={
                   <div className={styles['results-pane-search-toggle']}>
                     <PaneMenu>

--- a/src/components/should-focus.js
+++ b/src/components/should-focus.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { findDOMNode } from 'react-dom';
+
+/**
+ * Higher order component that, when given the prop
+ * `shouldFocus={true}`, will focus the component's DOM node on mount
+ * and on update when the prop is toggled from `false` to `true`.
+ */
+export default function shouldFocus(Focusable) {
+  return class extends Component {
+    static propTypes = {
+      shouldFocus: PropTypes.bool
+    };
+
+    componentDidMount() {
+      if (this.props.shouldFocus) {
+        this.focusable.focus();
+      }
+    }
+
+    componentDidUpdate(prevProps) {
+      if (this.props.shouldFocus && !prevProps.shouldFocus) {
+        this.focusable.focus();
+      }
+    }
+
+    get focusable() {
+      // eslint-disable-next-line react/no-find-dom-node
+      return findDOMNode(this);
+    }
+
+    render() {
+      return (
+        <Focusable {...this.props} />
+      );
+    }
+  };
+}

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 
+import shouldFocus from '../should-focus';
 import styles from './title-list-item.css';
 import Link from '../link';
 
 const cx = classNames.bind(styles);
 
-export default function TitleListItem({
+function TitleListItem({
   item,
   link,
   active,
@@ -89,3 +90,7 @@ TitleListItem.propTypes = {
   onClick: PropTypes.func,
   headingLevel: PropTypes.string
 };
+
+// this HOC adds a prop, `shouldFocus` that will focus the component's
+// rendered DOM node on mount and update (when the prop is toggled)
+export default shouldFocus(TitleListItem);

--- a/src/components/title-search-list.js
+++ b/src/components/title-search-list.js
@@ -7,13 +7,12 @@ import TitleListItem from './title-list-item';
 export default function TitleSearchList({
   location,
   params,
+  activeId,
+  shouldFocusItem,
   collection,
   fetch,
   onUpdateOffset
 }, { router }) {
-  let { params: routeParams } = router.route.match;
-  let isTitlePage = routeParams.type === 'titles';
-
   return (
     <QueryList
       type="titles"
@@ -30,7 +29,8 @@ export default function TitleSearchList({
           link={item.content && {
             pathname: `/eholdings/titles/${item.content.id}`
           }}
-          active={item.content && isTitlePage && routeParams.id === item.content.id}
+          active={item.content && activeId && item.content.id === activeId}
+          shouldFocus={item.content && shouldFocusItem && item.content.id === shouldFocusItem}
           onClick={() => {
             router.history.push(
               `/eholdings/titles/${item.content.id}${location.search}`
@@ -45,6 +45,8 @@ export default function TitleSearchList({
 TitleSearchList.propTypes = {
   location: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired,
+  activeId: PropTypes.string,
+  shouldFocusItem: PropTypes.string,
   collection: PropTypes.object.isRequired,
   fetch: PropTypes.func.isRequired,
   onUpdateOffset: PropTypes.func.isRequired

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -153,6 +153,7 @@ export default class TitleShow extends Component {
         <DetailsView
           type="title"
           model={model}
+          key={model.id}
           paneTitle={model.name}
           actionMenuItems={this.actionMenuItems}
           lastMenu={this.lastMenu}

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -55,7 +55,11 @@ class SearchRoute extends Component {
       this.path[searchType] = props.location.pathname;
     }
 
-    this.state = { params, searchType };
+    this.state = {
+      hideDetails: /^\/eholdings\/?$/.test(props.location.pathname),
+      searchType,
+      params
+    };
   }
 
   getChildContext() {
@@ -71,6 +75,7 @@ class SearchRoute extends Component {
   componentWillReceiveProps(nextProps) {
     let { location, match } = nextProps;
     let { searchType, ...params } = qs.parse(location.search);
+    let hideDetails = /^\/eholdings\/?$/.test(location.pathname);
     let shouldFocusItem = null;
 
     // cache the query so it can be restored via the search type
@@ -79,13 +84,15 @@ class SearchRoute extends Component {
       this.path[searchType] = location.pathname;
     }
 
-    // we need to focus the last active list item as determined by the `id` URL param
-    if (this.props.match.params.id && this.props.match.params.id !== match.params.id) {
-      shouldFocusItem = this.props.match.params.id;
+    // when details are not visible, we need to focus the last active
+    // list item as determined by the `id` URL param
+    if (hideDetails && this.props.match.params.id !== match.params.id) {
+      shouldFocusItem = this.props.match.params.id || null;
     }
 
     // always update the results state
     this.setState({
+      hideDetails,
       shouldFocusItem,
       searchType,
       params
@@ -260,10 +267,9 @@ class SearchRoute extends Component {
    */
   render() {
     let { location, children } = this.props;
-    let { searchType, params } = this.state;
+    let { searchType, params, hideDetails } = this.state;
 
     if (searchType) {
-      let hideDetails = /^\/eholdings\/?$/.test(location.pathname);
       let results = this.getResults();
 
       return (

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -24,6 +24,11 @@ class SearchRoute extends Component {
       replace: PropTypes.func.isRequired,
       location: PropTypes.object
     }).isRequired,
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        id: PropTypes.string
+      }).isRequired
+    }).isRequired,
     searchProviders: PropTypes.func.isRequired,
     searchPackages: PropTypes.func.isRequired,
     searchTitles: PropTypes.func.isRequired,
@@ -64,8 +69,9 @@ class SearchRoute extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    let { location } = nextProps;
+    let { location, match } = nextProps;
     let { searchType, ...params } = qs.parse(location.search);
+    let shouldFocusItem = null;
 
     // cache the query so it can be restored via the search type
     if (searchType) {
@@ -73,8 +79,17 @@ class SearchRoute extends Component {
       this.path[searchType] = location.pathname;
     }
 
+    // we need to focus the last active list item as determined by the `id` URL param
+    if (this.props.match.params.id && this.props.match.params.id !== match.params.id) {
+      shouldFocusItem = this.props.match.params.id;
+    }
+
     // always update the results state
-    this.setState({ searchType, params });
+    this.setState({
+      shouldFocusItem,
+      searchType,
+      params
+    });
   }
 
   /**
@@ -213,9 +228,13 @@ class SearchRoute extends Component {
    * Renders the search component specific to the current search type
    */
   renderResults() {
-    let { searchType, params } = this.state;
+    let { searchType, params, shouldFocusItem } = this.state;
+    let { match: { params: { id } } } = this.props;
+
     let props = {
       params,
+      activeId: id,
+      shouldFocusItem,
       location: this.props.location,
       collection: this.getResults(),
       onUpdateOffset: this.handleOffset,

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -48,6 +48,10 @@ describeApplication('PackageSearch', () => {
       expect(PackageSearchPage.hasPreSearchPane).to.equal(false);
     });
 
+    it('focuses on the search pane title', () => {
+      expect(PackageSearchPage.paneTitleHasFocus).to.be.true;
+    });
+
     it("displays package entries related to 'Package'", () => {
       expect(PackageSearchPage.packageList()).to.have.lengthOf(3);
     });
@@ -83,6 +87,10 @@ describeApplication('PackageSearch', () => {
 
       it('shows the preview pane', () => {
         expect(PackageSearchPage.packagePreviewPaneIsPresent).to.be.true;
+      });
+
+      it('focuses the package name', () => {
+        expect(PackageShowPage.nameHasFocus).to.be.true;
       });
 
       it.always('should not display button in UI', () => {
@@ -151,6 +159,11 @@ describeApplication('PackageSearch', () => {
         it('displays the original search results', () => {
           expect(PackageSearchPage.packageList()).to.have.lengthOf(3);
         });
+
+        it('focuses the last active item', () => {
+          expect(PackageSearchPage.packageList(0).isActive).to.be.false;
+          expect(PackageSearchPage.packageList(0).hasFocus).to.be.true;
+        });
       });
 
       describe('clicking an item within the preview pane', () => {
@@ -160,6 +173,10 @@ describeApplication('PackageSearch', () => {
 
         it('hides the search ui', () => {
           expect(PackageSearchPage.isPresent).to.be.false;
+        });
+
+        it('focuses the resource name', () => {
+          expect(ResourceShowPage.nameHasFocus).to.be.true;
         });
 
         describe('and clicking the back button', () => {
@@ -173,6 +190,10 @@ describeApplication('PackageSearch', () => {
 
           it('displays the original search results', () => {
             expect(PackageSearchPage.packageList()).to.have.lengthOf(3);
+          });
+
+          it('focuses the package name', () => {
+            expect(PackageShowPage.nameHasFocus).to.be.true;
           });
         });
       });

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -37,8 +37,9 @@ describeApplication('PackageShow', () => {
       expect(PackageShowPage.paneTitle).to.equal('Cool Package');
     });
 
-    it('displays the package name', () => {
+    it('displays and focuses on the package name', () => {
       expect(PackageShowPage.name).to.equal('Cool Package');
+      expect(PackageShowPage.nameHasFocus).to.be.true;
     });
 
     it('displays whether or not the package is selected', () => {

--- a/tests/pages/package-search.js
+++ b/tests/pages/package-search.js
@@ -24,6 +24,7 @@ import Toast from './toast';
   titleSearchFieldValue = value('[data-test-title-search-field] input[name="search"]');
   hasResults = isPresent('[data-test-eholdings-search-results-header]');
   totalResults = text('[data-test-eholdings-search-results-header] p');
+  paneTitleHasFocus = is('[data-test-eholdings-search-results-header] h2 [tabindex]', ':focus');
   packagePreviewPaneIsPresent = isPresent('[data-test-preview-pane="packages"]');
   titlePreviewPaneIsPresent = isPresent('[data-test-preview-pane="titles"]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
@@ -81,6 +82,7 @@ import Toast from './toast';
       return this.isSelectedText === 'Selected';
     }),
     isActive: is('[class*="is-selected"]'),
+    hasFocus: is(':focus'),
     clickThrough: clickable()
   });
 

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -8,7 +8,8 @@ import {
   property,
   action,
   text,
-  triggerable
+  triggerable,
+  is
 } from '@bigtest/interactor';
 import { getComputedStyle, hasClassBeginningWith } from './helpers';
 import Datepicker from './datepicker';
@@ -31,6 +32,7 @@ import Toast from './toast';
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   contentType = text('[data-test-eholdings-package-details-content-type]');
   name = text('[data-test-eholdings-details-view-name="package"]');
+  nameHasFocus = is('[data-test-eholdings-details-view-name="package"]', ':focus');
   numTitles = text('[data-test-eholdings-package-details-titles-total]');
   numTitlesSelected = text('[data-test-eholdings-package-details-titles-selected]');
   packageType = text('[data-test-eholdings-package-details-type');

--- a/tests/pages/provider-search.js
+++ b/tests/pages/provider-search.js
@@ -20,6 +20,7 @@ import { hasClassBeginningWith } from './helpers';
   hasSearchFilters = isPresent('[data-test-eholdings-search-filters="providers"]');
   searchFieldValue = value('[data-test-search-field] input[name="search"]');
   totalResults = text('[data-test-eholdings-search-results-header] p');
+  paneTitleHasFocus = is('[data-test-eholdings-search-results-header] h2 [tabindex]', ':focus');
   providerPreviewPaneIsPresent = isPresent('[data-test-preview-pane="providers"]');
   packagePreviewPaneIsPresent = isPresent('[data-test-preview-pane="packages"]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
@@ -72,6 +73,7 @@ import { hasClassBeginningWith } from './helpers';
     providerName: text('[data-test-eholdings-package-list-item-provider-name]'),
     numPackagesSelected: text('[data-test-eholdings-provider-list-item-num-packages-selected]'),
     isActive: is('[class*="is-selected"]'),
+    hasFocus: is(':focus'),
     clickThrough: clickable()
   });
 

--- a/tests/pages/provider-show.js
+++ b/tests/pages/provider-show.js
@@ -5,7 +5,8 @@ import {
   isPresent,
   interactor,
   text,
-  clickable
+  clickable,
+  is
 } from '@bigtest/interactor';
 
 import Toast from './toast';
@@ -14,6 +15,7 @@ import SearchModal from './search-modal';
 @interactor class ProviderShowPage {
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   name = text('[data-test-eholdings-details-view-name="provider"]');
+  nameHasFocus = is('[data-test-eholdings-details-view-name="provider"]', ':focus');
   numPackages = text('[data-test-eholdings-provider-details-packages-total]');
   numPackagesSelected = text('[data-test-eholdings-provider-details-packages-selected]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');

--- a/tests/pages/resource-show.js
+++ b/tests/pages/resource-show.js
@@ -6,7 +6,8 @@ import {
   interactor,
   property,
   attribute,
-  text
+  text,
+  is
 } from '@bigtest/interactor';
 import { hasClassBeginningWith } from './helpers';
 import Toast from './toast';
@@ -33,6 +34,7 @@ import Toast from './toast';
 
 @interactor class ResourceShowPage {
   titleName = text('[data-test-eholdings-details-view-name="resource"]');
+  nameHasFocus = is('[data-test-eholdings-details-view-name="resource"]', ':focus');
   edition = text('[data-test-eholdings-resource-show-edition]');
   descriptionText = text('[data-test-eholdings-description-field]');
   publisherName = text('[data-test-eholdings-resource-show-publisher-name]');

--- a/tests/pages/title-search.js
+++ b/tests/pages/title-search.js
@@ -25,6 +25,7 @@ import { hasClassBeginningWith } from './helpers';
   searchFieldSelectValue = value('[data-test-title-search-field] select');
   hasSearchFilters = isPresent('[data-test-eholdings-search-filters="titles"]');
   totalResults = text('[data-test-eholdings-search-results-header] p');
+  paneTitleHasFocus = is('[data-test-eholdings-search-results-header] h2 [tabindex]', ':focus');
   titlePreviewPaneIsPresent = isPresent('[data-test-preview-pane="titles"]');
   providerPreviewPaneIsPresent = isPresent('[data-test-preview-pane="providers"]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
@@ -85,7 +86,8 @@ import { hasClassBeginningWith } from './helpers';
     publisherName: text('[data-test-eholdings-title-list-item-publisher-name]'),
     publicationType: text('[data-test-eholdings-title-list-item-publication-type]'),
     clickThrough: clickable(),
-    isActive: is('[class*="is-selected--"]')
+    isActive: is('[class*="is-selected--"]'),
+    hasFocus: is(':focus')
   });
 
   packageTitleList = collection('[data-test-query-list="title-packages"] li', {

--- a/tests/pages/title-show.js
+++ b/tests/pages/title-show.js
@@ -7,7 +7,8 @@ import {
   property,
   interactor,
   fillable,
-  text
+  text,
+  is
 } from '@bigtest/interactor';
 
 import {
@@ -40,6 +41,7 @@ import Toast from './toast';
 @interactor class TitleShowPage {
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   titleName = text('[data-test-eholdings-details-view-name="title"]');
+  nameHasFocus = is('[data-test-eholdings-details-view-name="title"]', ':focus');
   edition = text('[data-test-eholdings-title-show-edition]');
   publisherName = text('[data-test-eholdings-title-show-publisher-name]');
   publicationType = text('[data-test-eholdings-title-show-publication-type]');

--- a/tests/provider-search-test.js
+++ b/tests/provider-search-test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 
 import { describeApplication } from './helpers';
 import ProviderSearchPage from './pages/provider-search';
+import ProviderShowPage from './pages/provider-show';
 import PackageShowPage from './pages/package-show';
 
 describeApplication('ProviderSearch', () => {
@@ -41,6 +42,10 @@ describeApplication('ProviderSearch', () => {
 
     it('removes the pre-results pane', () => {
       expect(ProviderSearchPage.hasPreSearchPane).to.equal(false);
+    });
+
+    it('focuses on the search pane title', () => {
+      expect(ProviderSearchPage.paneTitleHasFocus).to.be.true;
     });
 
     it("displays provider entries related to 'Provider'", () => {
@@ -82,6 +87,10 @@ describeApplication('ProviderSearch', () => {
 
       it('shows the preview pane', () => {
         expect(ProviderSearchPage.providerPreviewPaneIsPresent).to.be.true;
+      });
+
+      it('focuses the provider name', () => {
+        expect(ProviderShowPage.nameHasFocus).to.be.true;
       });
 
       it('should not display back button in UI', () => {
@@ -139,8 +148,12 @@ describeApplication('ProviderSearch', () => {
         it('displays the original search results', () => {
           expect(ProviderSearchPage.providerList()).to.have.lengthOf(3);
         });
-      });
 
+        it('focuses the last active item', () => {
+          expect(ProviderSearchPage.providerList(0).isActive).to.be.false;
+          expect(ProviderSearchPage.providerList(0).hasFocus).to.be.true;
+        });
+      });
 
       describe('clicking an item within the preview pane', () => {
         beforeEach(() => {
@@ -149,6 +162,10 @@ describeApplication('ProviderSearch', () => {
 
         it('hides the search UI', () => {
           expect(ProviderSearchPage.isPresent).to.be.false;
+        });
+
+        it('focuses the package name', () => {
+          expect(PackageShowPage.nameHasFocus).to.be.true;
         });
 
         describe('and clicking the back button', () => {
@@ -162,6 +179,10 @@ describeApplication('ProviderSearch', () => {
 
           it('displays the original search results', () => {
             expect(ProviderSearchPage.providerList()).to.have.lengthOf(3);
+          });
+
+          it('focuses the provider name', () => {
+            expect(ProviderShowPage.nameHasFocus).to.be.true;
           });
         });
       });

--- a/tests/provider-show-test.js
+++ b/tests/provider-show-test.js
@@ -29,8 +29,9 @@ describeApplication('ProviderShow', () => {
       expect(ProviderShowPage.paneTitle).to.equal('League of Ordinary Men');
     });
 
-    it('displays the provider name', () => {
+    it('displays and focuses the provider name', () => {
       expect(ProviderShowPage.name).to.equal('League of Ordinary Men');
+      expect(ProviderShowPage.nameHasFocus).to.be.true;
     });
 
     it('displays the total number of packages', () => {

--- a/tests/resource-show-test.js
+++ b/tests/resource-show-test.js
@@ -72,8 +72,9 @@ describeApplication('ResourceShow', () => {
       expect(ResourcePage.paneSub).to.equal('Cool Package');
     });
 
-    it('displays the title name', () => {
+    it('displays and focuses the title name', () => {
       expect(ResourcePage.titleName).to.equal('Best Title Ever');
+      expect(ResourcePage.nameHasFocus).to.be.true;
     });
 
     it('displays the edition', () => {

--- a/tests/title-search-test.js
+++ b/tests/title-search-test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 
 import { describeApplication } from './helpers';
 import TitleSearchPage from './pages/title-search';
+import TitleShowPage from './pages/title-show';
 import ResourceShowPage from './pages/resource-show';
 
 describeApplication('TitleSearch', () => {
@@ -84,6 +85,10 @@ describeApplication('TitleSearch', () => {
       expect(TitleSearchPage.hasPreSearchPane).to.equal(false);
     });
 
+    it('focuses on the search pane title', () => {
+      expect(TitleSearchPage.paneTitleHasFocus).to.be.true;
+    });
+
     it('has enabled search button', () => {
       expect(TitleSearchPage.isSearchButtonDisabled).to.be.false;
     });
@@ -127,6 +132,10 @@ describeApplication('TitleSearch', () => {
 
       it('shows the preview pane', () => {
         expect(TitleSearchPage.titlePreviewPaneIsPresent).to.be.true;
+      });
+
+      it('focuses the title name', () => {
+        expect(TitleShowPage.nameHasFocus).to.be.true;
       });
 
       it('should not display back button in UI', () => {
@@ -184,6 +193,11 @@ describeApplication('TitleSearch', () => {
         it('displays the original search results', () => {
           expect(TitleSearchPage.titleList()).to.have.lengthOf(3);
         });
+
+        it('focuses the last active item', () => {
+          expect(TitleSearchPage.titleList(0).isActive).to.be.false;
+          expect(TitleSearchPage.titleList(0).hasFocus).to.be.true;
+        });
       });
 
       describe('clicking an item within the preview pane', () => {
@@ -193,6 +207,10 @@ describeApplication('TitleSearch', () => {
 
         it('hides the search ui', () => {
           expect(TitleSearchPage.isPresent).to.be.false;
+        });
+
+        it('focuses the resource name', () => {
+          expect(ResourceShowPage.nameHasFocus).to.be.true;
         });
 
         describe('and clicking the back button', () => {
@@ -206,6 +224,10 @@ describeApplication('TitleSearch', () => {
 
           it('displays the original search results', () => {
             expect(TitleSearchPage.titleList()).to.have.lengthOf(3);
+          });
+
+          it('focuses the title name', () => {
+            expect(TitleShowPage.nameHasFocus).to.be.true;
           });
         });
       });

--- a/tests/title-show-test.js
+++ b/tests/title-show-test.js
@@ -52,8 +52,9 @@ describeApplication('TitleShow', () => {
       expect(TitleShowPage.paneTitle).to.equal('Cool Title');
     });
 
-    it('displays the title name', () => {
+    it('displays and focuses the title name', () => {
       expect(TitleShowPage.titleName).to.equal('Cool Title');
+      expect(TitleShowPage.nameHasFocus).to.be.true;
     });
 
     it('displays the edition', () => {


### PR DESCRIPTION
## Purpose

[[UIEH-440]](https://issues.folio.org/browse/UIEH-440)

This initially started as a spike to see how accessible routing looked in eholdings. This cleans up that POC and adds tests.

## Approach

As it turned out, this POC has little to do with the actual routing or routes. 

- **Focus the pane title when a new search is conducted**

  This was done in the `SearchPaneset` component. When the component updates with a new search within the same search type, the results pane title will receive focus. Similarly, when navigating directly to an existing search (via external link), the results pane title is also focused on mount (as long as the details view is not also visible).

- **Focus the search results list item when a details pane is closed**

  The search route knows which element is currently, and was previously active, so the active item logic was moved into the `getResults()` method of that route. Since this route also knows the previous active item, when the details view is closed the previously active item will receive focus.

  This is done via a `shouldFocusItem` prop which reflects the previous item ID that will be sent to all list items. When the list item ID matches, it is made focused via an HOC designed specifically to focus elements on mount and update. This was made into an HOC in case this pattern is needed again in the future.

- **Focus the details pane heading when it becomes active**

  For this, the details view is one of the deepest navigation points in our app. So whenever that component is mounted, it should receive focus. Since the heading sometimes is not visible while loading, on update after it is finished loading it will focus the heading.

#### TODOs

- This only covers three primary areas of eholdings. Still to be done is search form focus management in all places where we can conduct searches, and most likely some other areas as well.

## Screenshots

![a11y-routing](https://user-images.githubusercontent.com/5005153/42048961-4047f0ee-7aca-11e8-9f06-be417bc55098.gif)

Not sure why this gif looks weird but ¯\_(ツ)_/¯ 