### PR TITLE
Upgrade eslint-config-stripes to 2.0.2

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+/artifacts
+/dist
+/node_modules

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.3.3",
     "@bigtest/react": "^0.1.1",
-    "@folio/eslint-config-stripes": "^1.1.0",
+    "@folio/eslint-config-stripes": "^2.0.2",
     "@folio/stripes-cli": "^1.2.1",
     "@folio/stripes-connect": "^3.1.3",
     "@folio/stripes-core": "^2.10.0",

--- a/src/components/impagination.js
+++ b/src/components/impagination.js
@@ -133,11 +133,6 @@ export default class Impagination extends Component {
     readOffset: 0
   };
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    const dataset = updateDataset(nextProps, prevState);
-    return { collection: nextProps.collection, dataset };
-  }
-
   // we can't set this directly as the state object because it will
   // lose getters and other prototype methods
   state = {
@@ -151,6 +146,11 @@ export default class Impagination extends Component {
       stats: { totalPages: this.props.collection.totalPages }
     })
   };
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const dataset = updateDataset(nextProps, prevState);
+    return { collection: nextProps.collection, dataset };
+  }
 
   // We treat `children` as a render prop and call it with the dataset
   // state. Notice we do not import React because we are not using any

--- a/src/components/navigation-modal/navigation-modal.js
+++ b/src/components/navigation-modal/navigation-modal.js
@@ -19,12 +19,6 @@ export default class NavigationModal extends Component {
     ])
   };
 
-  static defaultProps = {
-    modalLabel: 'Confirm navigation',
-    continueLabel: 'Continue without saving',
-    dismissLabel: 'Keep editing'
-  };
-
   static contextTypes = {
     router: PropTypes.shape({
       history: PropTypes.shape({
@@ -32,6 +26,12 @@ export default class NavigationModal extends Component {
         push: PropTypes.func.isRequired
       }).isRequired
     }).isRequired
+  };
+
+  static defaultProps = {
+    modalLabel: 'Confirm navigation',
+    continueLabel: 'Continue without saving',
+    dismissLabel: 'Keep editing'
   };
 
   constructor(props) {

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -44,6 +44,16 @@ class CustomPackageEdit extends Component {
     queryParams: PropTypes.object
   };
 
+  state = {
+    showSelectionModal: false,
+    allowFormToSubmit: false,
+    packageSelected: this.props.initialValues.isSelected,
+    formValues: {},
+    // these are used above in getDerivedStateFromProps
+    packageVisible: this.props.initialValues.isVisible, // eslint-disable-line react/no-unused-state
+    initialValues: this.props.initialValues // eslint-disable-line react/no-unused-state
+  }
+
   static getDerivedStateFromProps(nextProps, prevState) {
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
       return {
@@ -56,16 +66,6 @@ class CustomPackageEdit extends Component {
       };
     }
     return prevState;
-  }
-
-  state = {
-    showSelectionModal: false,
-    allowFormToSubmit: false,
-    packageSelected: this.props.initialValues.isSelected,
-    formValues: {},
-    // these are used above in getDerivedStateFromProps
-    packageVisible: this.props.initialValues.isVisible, // eslint-disable-line react/no-unused-state
-    initialValues: this.props.initialValues // eslint-disable-line react/no-unused-state
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -41,6 +41,16 @@ class ManagedPackageEdit extends Component {
     queryParams: PropTypes.object
   };
 
+  state = {
+    showSelectionModal: false,
+    allowFormToSubmit: false,
+    packageSelected: this.props.initialValues.isSelected,
+    formValues: {},
+    // these are used above in getDerivedStateFromProps
+    packageVisible: this.props.initialValues.isVisible, // eslint-disable-line react/no-unused-state
+    initialValues: this.props.initialValues // eslint-disable-line react/no-unused-state
+  }
+
   static getDerivedStateFromProps(nextProps, prevState) {
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
       return {
@@ -53,16 +63,6 @@ class ManagedPackageEdit extends Component {
       };
     }
     return prevState;
-  }
-
-  state = {
-    showSelectionModal: false,
-    allowFormToSubmit: false,
-    packageSelected: this.props.initialValues.isSelected,
-    formValues: {},
-    // these are used above in getDerivedStateFromProps
-    packageVisible: this.props.initialValues.isVisible, // eslint-disable-line react/no-unused-state
-    initialValues: this.props.initialValues // eslint-disable-line react/no-unused-state
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -35,6 +35,13 @@ export default class PackageShow extends Component {
     queryParams: PropTypes.object
   };
 
+  state = {
+    showSelectionModal: false,
+    packageSelected: this.props.model.isSelected,
+    packageAllowedToAddTitles: this.props.model.allowKbToAddTitles,
+    isCoverageEditable: false
+  };
+
   static getDerivedStateFromProps(nextProps, prevState) {
     const { model: { allowKbToAddTitles, isSaving, isSelected } } = nextProps;
     if (!isSaving) {
@@ -46,13 +53,6 @@ export default class PackageShow extends Component {
     }
     return prevState;
   }
-
-  state = {
-    showSelectionModal: false,
-    packageSelected: this.props.model.isSelected,
-    packageAllowedToAddTitles: this.props.model.allowKbToAddTitles,
-    isCoverageEditable: false
-  };
 
   handleSelectionToggle = () => {
     this.setState({ packageSelected: !this.props.model.isSelected });

--- a/src/components/query-list/query-list.js
+++ b/src/components/query-list/query-list.js
@@ -9,6 +9,10 @@ import Impagination from '../impagination';
 const cx = classnames.bind(styles);
 
 export default class QueryList extends Component {
+  static getDerivedPropsFromState({ offset }, prevState) {
+    return offset !== prevState.offset ? { offset } : prevState;
+  }
+
   static propTypes = {
     type: PropTypes.string.isRequired,
     offset: PropTypes.number,
@@ -26,10 +30,6 @@ export default class QueryList extends Component {
 
   static defaultProps = {
     notFoundMessage: 'Not found'
-  }
-
-  static getDerivedPropsFromState({ offset }, prevState) {
-    return offset !== prevState.offset ? { offset } : prevState;
   }
 
   state = {

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -42,6 +42,16 @@ class ResourceEditCustomTitle extends Component {
     }).isRequired
   };
 
+  state = {
+    resourceSelected: this.props.initialValues.isSelected,
+    showSelectionModal: false,
+    allowFormToSubmit: false,
+    formValues: {},
+    // this is used above in getDerivedStateFromProps
+    // eslint-disable-next-line react/no-unused-state
+    initialValues: this.props.initialValues
+  }
+
   static getDerivedStateFromProps(nextProps, prevState) {
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
       return {
@@ -54,16 +64,6 @@ class ResourceEditCustomTitle extends Component {
       };
     }
     return prevState;
-  }
-
-  state = {
-    resourceSelected: this.props.initialValues.isSelected,
-    showSelectionModal: false,
-    allowFormToSubmit: false,
-    formValues: {},
-    // this is used above in getDerivedStateFromProps
-    // eslint-disable-next-line react/no-unused-state
-    initialValues: this.props.initialValues
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -22,7 +22,7 @@ import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 import styles from './resource-edit-managed-title.css';
 
-class ResourceEditManagedTitle extends Component {
+class ResourceEditManagedTitle extends Component { // eslint-disable-line react/no-deprecated
   static propTypes = {
     model: PropTypes.object.isRequired,
     initialValues: PropTypes.object.isRequired,

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -252,7 +252,7 @@ export default class ResourceShow extends Component {
                 {model.url && (
                   <KeyValue label={`${model.title.isTitleCustom ? 'Custom' : 'Managed'} URL`}>
                     <div data-test-eholdings-resource-show-url>
-                      <a href={model.url} target="_blank">{model.url}</a>
+                      <a href={model.url} target="_blank" rel="noopener noreferrer">{model.url}</a>
                     </div>
                   </KeyValue>
                 )}

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -29,16 +29,16 @@ export default class ResourceShow extends Component {
     router: PropTypes.object
   };
 
+  state = {
+    showSelectionModal: false,
+    resourceSelected: this.props.model.isSelected
+  };
+
   static getDerivedStateFromProps({ model }, prevState) {
     return !model.isSaving ?
       { ...prevState, resourceSelected: model.isSelected } :
       prevState;
   }
-
-  state = {
-    showSelectionModal: false,
-    resourceSelected: this.props.model.isSelected
-  };
 
   handleHoldingStatus = () => {
     if (this.props.model.isSelected) {

--- a/src/components/scroll-view/scroll-view.js
+++ b/src/components/scroll-view/scroll-view.js
@@ -9,6 +9,10 @@ import List from '../list';
 const cx = classNames.bind(styles);
 
 export default class ScrollView extends Component {
+  static getDerivedPropsFromState({ offset }, prevState) {
+    return offset !== prevState.offset ? { offset } : prevState;
+  }
+
   static propTypes = {
     items: PropTypes.shape({
       length: PropTypes.number.isRequired,
@@ -26,10 +30,6 @@ export default class ScrollView extends Component {
     offset: 0,
     scrollable: true
   };
-
-  static getDerivedPropsFromState({ offset }, prevState) {
-    return offset !== prevState.offset ? { offset } : prevState;
-  }
 
   constructor(props) {
     super(props);

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -43,6 +43,13 @@ export default class SearchForm extends Component {
     displaySearchTypeSwitcher: true
   };
 
+  state = {
+    searchString: this.props.searchString || '',
+    filter: this.props.filter || {},
+    searchfield: this.props.searchfield || 'title', // last attr actually used in getDerivedStateFromProps
+    sort: this.props.sort || 'relevance' // eslint-disable-line react/no-unused-state
+  };
+
   static getDerivedStateFromProps({ searchString = '', filter = {}, searchfield, sort }, state) {
     const newSearchfield = searchfield !== state.searchfield ? searchfield : state.searchfield;
     const newSearchString = searchString !== state.searchString ? searchString : state.searchString;
@@ -65,13 +72,6 @@ export default class SearchForm extends Component {
       sort: newSort,
     };
   }
-
-  state = {
-    searchString: this.props.searchString || '',
-    filter: this.props.filter || {},
-    searchfield: this.props.searchfield || 'title', // last attr actually used in getDerivedStateFromProps
-    sort: this.props.sort || 'relevance' // eslint-disable-line react/no-unused-state
-  };
 
   submitSearch = () => {
     let { sort, ...searchfilter } = this.state.filter;

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -32,14 +32,14 @@ export default class SearchPaneset extends React.Component {
     }).isRequired
   };
 
-  static defaultProps = {
-    totalResults: 0
-  };
-
   static contextTypes = {
     router: PropTypes.shape({
       history: PropTypes.object
     })
+  };
+
+  static defaultProps = {
+    totalResults: 0
   };
 
   state = {

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -17,7 +17,7 @@ import SearchPaneVignette from '../search-pane-vignette';
 import Link from '../link';
 import styles from './search-paneset.css';
 
-export default class SearchPaneset extends React.Component {
+export default class SearchPaneset extends React.Component { // eslint-disable-line react/no-deprecated
   static propTypes = {
     searchForm: PropTypes.node,
     hideFilters: PropTypes.bool,

--- a/src/components/toaster/toaster.js
+++ b/src/components/toaster/toaster.js
@@ -36,18 +36,18 @@ class Toaster extends Component {
     position: 'bottom'
   };
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    return nextProps.toasts ?
-      { ...prevState, toasts: nextProps.toasts } :
-      prevState;
-  }
-
   constructor(props) {
     super(props);
 
     this.state = {
       toasts: props.toasts
     };
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    return nextProps.toasts ?
+      { ...prevState, toasts: nextProps.toasts } :
+      prevState;
   }
 
   destroyToast = (toastId) => {

--- a/src/components/toggle-switch/toggle-switch.js
+++ b/src/components/toggle-switch/toggle-switch.js
@@ -16,16 +16,16 @@ export default class ToggleSwitch extends Component {
     isPending: PropTypes.bool
   }
 
+  state = {
+    inputChecked: this.props.checked, // isPending is actually used in getDerivedStateFromProps
+    isPending: this.props.isPending // eslint-disable-line react/no-unused-state
+  }
+
   static getDerivedStateFromProps({ checked, isPending }, state) {
     const wasPending = state.isPending && !isPending;
     const needsUpdate = state.inputChecked !== checked;
     const inputChecked = wasPending || needsUpdate ? checked : state.inputChecked;
     return { inputChecked, isPending };
-  }
-
-  state = {
-    inputChecked: this.props.checked, // isPending is actually used in getDerivedStateFromProps
-    isPending: this.props.isPending // eslint-disable-line react/no-unused-state
   }
 
   toggle = (e) => {

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -13,7 +13,7 @@ import TitleSearchList from '../components/title-search-list';
 import SearchPaneset from '../components/search-paneset';
 import SearchForm from '../components/search-form';
 
-class SearchRoute extends Component {
+class SearchRoute extends Component { // eslint-disable-line react/no-deprecated
   static propTypes = {
     location: PropTypes.shape({
       pathname: PropTypes.string.isRequired,

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,16 +117,16 @@
   dependencies:
     history "^4.7.2"
 
-"@folio/eslint-config-stripes@^1.1.0":
-  version "1.1.100026"
-  resolved "https://repository.folio.org/repository/npm-folioci/@folio/eslint-config-stripes/-/eslint-config-stripes-1.1.100026.tgz#4a31f3d85f2bb31600c860999ea5f3374f481542"
+"@folio/eslint-config-stripes@^2.0.2":
+  version "2.0.200030"
+  resolved "https://repository.folio.org/repository/npm-folioci/@folio/eslint-config-stripes/-/eslint-config-stripes-2.0.200030.tgz#3111ef08e5cf6c6bc6c8039bf3715b18204cab4e"
   dependencies:
     eslint-config-airbnb "^16.1.0"
     eslint-import-resolver-webpack "^0.8.3"
     eslint-plugin-babel "^4.1.2"
     eslint-plugin-import "^2.8.0"
     eslint-plugin-jsx-a11y "^6.0.3"
-    eslint-plugin-react "^7.6.0"
+    eslint-plugin-react "7.9.1"
 
 "@folio/react-intl-safe-html@^1.0.1":
   version "1.0.10008"
@@ -2886,7 +2886,7 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.2, doctrine@^2.1.0:
+doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
@@ -3402,14 +3402,14 @@ eslint-plugin-jsx-a11y@^6.0.3:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^2.0.0"
 
-eslint-plugin-react@^7.6.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz#f606c719dbd8a1a2b3d25c16299813878cca0160"
+eslint-plugin-react@7.9.1:
+  version "7.9.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.9.1.tgz#101aadd15e7c7b431ed025303ac7b421a8e3dc15"
   dependencies:
-    doctrine "^2.0.2"
-    has "^1.0.1"
+    doctrine "^2.1.0"
+    has "^1.0.2"
     jsx-ast-utils "^2.0.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.1"
 
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"
@@ -4411,6 +4411,12 @@ has@^1.0.1:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
+
+has@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
 
 hash-base@^3.0.0:
   version "3.0.4"


### PR DESCRIPTION
- Cleans up some component declaration ordering.
- Disables the warnings for the remaining lifecycle hook deprecations.
- Adds `.eslintignore` to improve linting performance.