### PR TITLE
UIEH-238 Generate ESLint JUnit-style report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ jobs:
       - store_test_results:
           path: ./artifacts
       - store_artifacts:
-          name: Store report
           path: ./artifacts
 
   stylelint:
@@ -66,14 +65,7 @@ jobs:
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:
-          name: Store junit test report
-          path: ./artifacts/junit
-      - store_artifacts:
-          name: Store lcov.info
-          path: ./artifacts/coverage/lcov.info
-      - store_artifacts:
-          name: Store HTML code coverage report
-          path: ./artifacts/coverage/lcov-report
+          path: ./artifacts
 
   test-safari:
     docker:
@@ -87,8 +79,7 @@ jobs:
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:
-          name: Store junit test report
-          path: ./artifacts/junit
+          path: ./artifacts
 
   test-firefox:
     docker:
@@ -108,8 +99,7 @@ jobs:
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:
-          name: Store junit test report
-          path: ./artifacts/junit
+          path: ./artifacts
 
   test-edge:
     docker:
@@ -123,8 +113,7 @@ jobs:
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:
-          name: Store junit test report
-          path: ./artifacts/junit
+          path: ./artifacts
 
   test-ie:
     docker:
@@ -138,8 +127,7 @@ jobs:
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:
-          name: Store junit test report
-          path: ./artifacts/junit
+          path: ./artifacts
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,12 @@ jobs:
           at: ~/
       - run:
           name: Lint JS
-          command: yarn eslint --max-warnings=0
+          command: yarn eslint --max-warnings=0 --format junit --output-file ./artifacts/eslint/eslint.xml
+      - store_test_results:
+          path: ./artifacts
+      - store_artifacts:
+          name: Store report
+          path: ./artifacts
 
   stylelint:
     docker:


### PR DESCRIPTION
## Purpose
CircleCI has nicer test summary UI when results are reported in JUnit-style XML.

Resolves https://issues.folio.org/browse/UIEH-238

## Approach
Use `eslint`'s built-in `junit` reporter.

## Screenshots
<img width="973" alt="screen shot 2018-07-05 at 11 42 02 am" src="https://user-images.githubusercontent.com/230597/42336299-e2e9f030-8048-11e8-8fe0-7f4b21552899.png">