### PR TITLE
UIEH-406: Holding status: package show page: Ability to add/remove the entire package

### DIFF
--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -15,7 +15,6 @@ import DetailsView from '../../details-view';
 import QueryList from '../../query-list';
 import Link from '../../link';
 import TitleListItem from '../../title-list-item';
-import ToggleSwitch from '../../toggle-switch';
 import Modal from '../../modal';
 import NavigationModal from '../../navigation-modal';
 import DetailsViewSection from '../../details-view-section';
@@ -91,6 +90,9 @@ export default class PackageShow extends Component {
     } = this.state;
 
     let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
+    let packageSelectionPending = model.destroy.isPending ||
+        (model.update.isPending && 'isSelected' in model.update.changedAttributes);
+
     let modalMessage = model.isCustom ?
       {
         header: 'Delete custom package',
@@ -126,6 +128,22 @@ export default class PackageShow extends Component {
           state: { eholdings: true }
         },
         className: styles['full-view-link']
+      });
+    }
+
+    if (packageSelected) {
+      actionMenuItems.push({
+        'label': 'Remove from Holdings',
+        'state': { eholdings: true },
+        'data-test-eholdings-package-remove-from-holdings-action': true,
+        'onClick': this.handleSelectionToggle
+      });
+    } else {
+      actionMenuItems.push({
+        'label': 'Add to Holdings',
+        'state': { eholdings: true },
+        'data-test-eholdings-package-add-to-holdings-action': true,
+        'onClick': this.handleSelectionToggle
       });
     }
 
@@ -230,16 +248,25 @@ export default class PackageShow extends Component {
                   data-test-eholdings-package-details-selected
                   htmlFor="package-details-toggle-switch"
                 >
-                  <h4>{packageSelected ? 'Selected' : 'Not selected'}</h4>
+                  { packageSelectionPending ? (
+                    <Icon icon="spinner-ellipsis" />
+                  ) : (
+                    <h4>{packageSelected ? 'Selected' : 'Not selected'}</h4>
+                  ) }
                   <br />
-                  <ToggleSwitch
-                    onChange={this.handleSelectionToggle}
-                    // if destroying selection status is always false
-                    checked={model.destroy.isPending ? false : packageSelected}
-                    isPending={model.destroy.isPending ||
-                      (model.update.isPending && 'isSelected' in model.update.changedAttributes)}
-                    id="package-details-toggle-switch"
-                  />
+                  {(
+                    (!packageSelected && !packageSelectionPending) ||
+                    (!this.props.model.isSelected && packageSelectionPending)) &&
+                    <Button
+                      type="button"
+                      buttonStyle="primary"
+                      disabled={packageSelectionPending}
+                      onClick={this.handleSelectionToggle}
+                      data-test-eholdings-package-add-to-holdings-button
+                    >
+                    Add to Holdings
+                    </Button>
+                  }
                 </label>
               </DetailsViewSection>
               <DetailsViewSection label="Package settings">

--- a/tests/custom-package-show-selection-test.js
+++ b/tests/custom-package-show-selection-test.js
@@ -49,15 +49,13 @@ describeApplication('CustomPackageShowSelection', () => {
          * TODO: control timing directly with Mirage
          */
         this.server.timing = 50;
-        return PackageShowPage.toggleIsSelected();
+        return PackageShowPage
+          .dropDown.clickDropDownButton()
+          .dropDownMenu.clickRemoveFromHoldings();
       });
 
       afterEach(function () {
         this.server.timing = 0;
-      });
-
-      it('reflects the desired state (not selected)', () => {
-        expect(PackageShowPage.isSelected).to.equal(false);
       });
 
       describe('canceling the deselection', () => {
@@ -80,21 +78,14 @@ describeApplication('CustomPackageShowSelection', () => {
           this.server.timing = 0;
         });
 
-        it('reflects the desired state (Unselected)', () => {
-          expect(PackageShowPage.isSelected).to.equal(false);
-        });
-
         it('indicates it is working to get to desired state', () => {
           expect(PackageShowPage.isSelecting).to.equal(true);
         });
 
-        it('cannot be interacted with while the request is in flight', () => {
-          expect(PackageShowPage.isSelectedToggleDisabled).to.equal(true);
-        });
-
         describe('when the request succeeds', () => {
-          it('reflect the desired state was set', () => {
-            expect(PackageShowPage.isSelected).to.equal(false);
+          beforeEach(() => {
+            return PackageShowPage
+              .when(() => !PackageShowPage.isSelecting);
           });
 
           it('removes package detail pane', () => {
@@ -115,20 +106,14 @@ describeApplication('CustomPackageShowSelection', () => {
           }]
         }, 500);
 
-        return PackageShowPage.toggleIsSelected();
-      });
-
-      it('reflects the desired state (Unselected)', () => {
-        expect(PackageShowPage.isSelected).to.equal(false);
+        return PackageShowPage
+          .dropDown.clickDropDownButton()
+          .dropDownMenu.clickRemoveFromHoldings();
       });
 
       describe('confirming the deselection', () => {
         beforeEach(() => {
           return PackageShowPage.modal.confirmDeselection();
-        });
-
-        it('cannot be interacted with while the request is in flight', () => {
-          expect(PackageShowPage.isSelectedToggleDisabled).to.equal(true);
         });
 
         describe('when the request fails', () => {

--- a/tests/package-add-new-titles-test.js
+++ b/tests/package-add-new-titles-test.js
@@ -94,7 +94,7 @@ describeApplication('PackageShowAllowKbToAddTitles', () => {
 
     describe('selecting a package', () => {
       beforeEach(() => {
-        return PackageShowPage.toggleIsSelected();
+        return PackageShowPage.selectPackage();
       });
 
       it('reflects the desired state (Selected)', () => {
@@ -128,9 +128,7 @@ describeApplication('PackageShowAllowKbToAddTitles', () => {
 
     describe('toggling to deselect a package and confirming deselection', () => {
       beforeEach(() => {
-        return PackageShowPage
-          .toggleIsSelected()
-          .modal.confirmDeselection();
+        return PackageShowPage.deselectAndConfirmPackage();
       });
 
       it('removes allow KB to add titles toggle switch', () => {
@@ -140,9 +138,7 @@ describeApplication('PackageShowAllowKbToAddTitles', () => {
 
     describe('toggling to deselect a package and canceling deselection', () => {
       beforeEach(() => {
-        return PackageShowPage
-          .toggleIsSelected()
-          .modal.cancelDeselection();
+        return PackageShowPage.deselectAndCancelPackage();
       });
 
       it('displays YES for allowing kb to select new titles', () => {

--- a/tests/package-search-test.js
+++ b/tests/package-search-test.js
@@ -124,7 +124,7 @@ describeApplication('PackageSearch', () => {
 
       describe('selecting a package', () => {
         beforeEach(() => {
-          return PackageShowPage.toggleIsSelected();
+          return PackageShowPage.selectPackage();
         });
 
         it('reflects the selection in the results list', () => {

--- a/tests/package-selection-test.js
+++ b/tests/package-selection-test.js
@@ -41,7 +41,7 @@ describeApplication('PackageSelection', () => {
          * TODO: control timing directly with Mirage
          */
         this.server.timing = 50;
-        return PackageShowPage.toggleIsSelected();
+        return PackageShowPage.selectPackage();
       });
 
       afterEach(function () {
@@ -54,10 +54,6 @@ describeApplication('PackageSelection', () => {
 
       it('indicates it is working to get to desired state', () => {
         expect(PackageShowPage.isSelecting).to.equal(true);
-      });
-
-      it('cannot be interacted with while the request is in flight', () => {
-        expect(PackageShowPage.isSelectedToggleDisabled).to.equal(true);
       });
 
       describe('when the request succeeds', () => {
@@ -80,17 +76,12 @@ describeApplication('PackageSelection', () => {
 
       describe('and deselecting the package', () => {
         beforeEach(() => {
+          // many thanks to elrick for catching the need for
+          // the `when` here
           return PackageShowPage
-            .when(() => !PackageShowPage.isSelectedToggleDisabled)
-            .toggleIsSelected();
-        });
-
-        it('reflects the desired state (not selected)', () => {
-          expect(PackageShowPage.isSelected).to.equal(false);
-        });
-
-        it('should show all package titles are not selected', () => {
-          expect(PackageShowPage.allTitlesSelected).to.equal(false);
+            .when(() => !PackageShowPage.isSelecting)
+            .dropDown.clickDropDownButton()
+            .dropDownMenu.clickRemoveFromHoldings();
         });
 
         describe('canceling the deselection', () => {
@@ -98,7 +89,11 @@ describeApplication('PackageSelection', () => {
             return PackageShowPage.modal.cancelDeselection();
           });
 
-          it('reverts back to the selected state', () => {
+          it('does not show a loading indicator', () => {
+            expect(PackageShowPage.isSelecting).to.equal(false);
+          });
+
+          it('remains selected', () => {
             expect(PackageShowPage.isSelected).to.equal(true);
           });
         });
@@ -113,16 +108,8 @@ describeApplication('PackageSelection', () => {
             this.server.timing = 0;
           });
 
-          it('reflects the desired state (Unselected)', () => {
-            expect(PackageShowPage.isSelected).to.equal(false);
-          });
-
-          it('indicates it is working to get to desired state', () => {
+          it('indicates it is working', () => {
             expect(PackageShowPage.isSelecting).to.equal(true);
-          });
-
-          it('cannot be interacted with while the request is in flight', () => {
-            expect(PackageShowPage.isSelectedToggleDisabled).to.equal(true);
           });
 
           describe('when the request succeeds', () => {
@@ -159,23 +146,15 @@ describeApplication('PackageSelection', () => {
         }, 500);
 
         this.server.timing = 50;
-        return PackageShowPage.toggleIsSelected();
+        return PackageShowPage.selectPackage();
       });
 
       afterEach(function () {
         this.server.timing = 0;
       });
 
-      it('reflects the desired state (Selected)', () => {
-        expect(PackageShowPage.isSelected).to.equal(true);
-      });
-
       it('indicates it working to get to desired state', () => {
         expect(PackageShowPage.isSelecting).to.equal(true);
-      });
-
-      it('cannot be interacted with while the request is in flight', () => {
-        expect(PackageShowPage.isSelectedToggleDisabled).to.equal(true);
       });
 
       describe('when the request fails', () => {

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -31,8 +31,11 @@ import Datepicker from './datepicker';
   isSaveDisabled = property('[data-test-eholdings-package-save-button] button', 'disabled');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="package"]');
   toggleIsSelected = clickable('[data-test-eholdings-package-details-selected] input');
-  isSelected = property('[data-test-eholdings-package-details-selected] input', 'checked');
   modal = new PackageEditModal('#eholdings-package-confirmation-modal');
+  selectionText = text('[data-test-eholdings-package-details-selected] h4');
+  isSelected = computed(function () {
+    return this.selectionText === 'Selected';
+  });
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   isHiddenMessage = text('[data-test-eholdings-package-details-is-hidden-reason]');
   isHiddenMessagePresent = isPresent('[data-test-eholdings-package-details-is-hidden-reason]');

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -9,7 +9,8 @@ import {
   action,
   text,
   triggerable,
-  is
+  is,
+  attribute
 } from '@bigtest/interactor';
 import { getComputedStyle, hasClassBeginningWith } from './helpers';
 import Datepicker from './datepicker';
@@ -20,13 +21,26 @@ import Toast from './toast';
   cancelDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-no]');
 }
 
+@interactor class PackageShowDropDown {
+  clickDropDownButton = clickable('button');
+  isExpanded = attribute('button', 'aria-expanded');
+}
+
+@interactor class PackageShowDropDownMenu {
+  clickRemoveFromHoldings = clickable('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
+  clickAddToHoldings = clickable('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
+}
+
 @interactor class PackageShowPage {
   allowKbToAddTitles = text('[data-test-eholdings-package-details-allow-add-new-titles]');
   hasAllowKbToAddTitles = isPresent('[data-test-eholdings-package-details-toggle-allow-add-new-titles] input');
   hasAllowKbToAddTitlesToggle = isPresent('[package-details-toggle-allow-add-new-titles-switch]');
-  isSelected = property('[data-test-eholdings-package-details-selected] input', 'checked');
-  isSelecting = hasClassBeginningWith('[data-test-eholdings-package-details-selected] [data-test-toggle-switch]', 'is-pending--');
-  isSelectedToggleDisabled = property('[data-test-eholdings-package-details-selected] input[type=checkbox]', 'disabled');
+
+  selectionText = text('[data-test-eholdings-package-details-selected] h4');
+  isSelected = computed(function () {
+    return this.selectionText === 'Selected';
+  });
+  isSelecting = isPresent('[data-test-eholdings-package-details-selected] [class*=icon---][class*=iconSpinner]');
   modal = new PackageShowModal('#eholdings-package-confirmation-modal');
   toggleIsSelected = clickable('[data-test-eholdings-package-details-selected] input');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
@@ -41,6 +55,12 @@ import Toast from './toast';
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button] button');
   detailsPaneContentScrollHeight = property('[data-test-eholdings-detail-pane-contents]', 'scrollHeight');
   clickEditButton = clickable('[data-test-eholdings-package-edit-link]');
+
+  clickAddToHoldingsButton = clickable('[data-test-eholdings-package-add-to-holdings-button]');
+  isAddToHoldingsButtonDisabled = property('[data-test-eholdings-package-add-to-holdings-button]', 'disabled');
+  isAddToHoldingsButtonPresent = isPresent('[data-test-eholdings-package-add-to-holdings-button]');
+  dropDown= new PackageShowDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  dropDownMenu = new PackageShowDropDownMenu();
 
   detailPaneMouseWheel = triggerable('[data-test-eholdings-detail-pane-contents]', 'wheel', {
     bubbles: true,
@@ -97,15 +117,25 @@ import Toast from './toast';
   beginDate = scoped('[data-test-eholdings-coverage-fields-date-range-begin]', Datepicker);
   endDate = scoped('[data-test-eholdings-coverage-fields-date-range-end]', Datepicker);
 
-  toast = Toast
+  toast = Toast;
+
+  selectPackage() {
+    return this
+      .dropDown.clickDropDownButton()
+      .dropDownMenu.clickAddToHoldings();
+  }
 
   deselectAndConfirmPackage() {
-    return this.toggleIsSelected()
+    return this
+      .dropDown.clickDropDownButton()
+      .dropDownMenu.clickRemoveFromHoldings()
       .modal.confirmDeselection();
   }
 
   deselectAndCancelPackage() {
-    return this.toggleIsSelected()
+    return this
+      .dropDown.clickDropDownButton()
+      .dropDownMenu.clickRemoveFromHoldings()
       .modal.cancelDeselection();
   }
 }


### PR DESCRIPTION


## Purpose
The "Select / Deselect" toggle switch was increasingly out of place in
the current UI so we're abandoning it in favor of an action in the
pane header.  Additionally we're adding a button inline with the field
if the package is not in the librarian's holdings.  This latter piece
should eliminate any ambiguity if a new user is approaching a package
and unsure how to select it.

## Approach
This changed the flow on the page fairly significantly.  Altering the page required some business logic changes that were led by @cherewaty and coordinated with @elrickvm so the resource show page and package show page are in parity.  Combing through the tests was more challenging - many tests were no longer relevant and were dropped and in one case a test required some structural realignment.  The interactor also required tweaks but I think ultimately this led to a cleaner version.

#### TODOS and Open Questions
- [x] Lint

## Screenshots
_incoming_
