### PR TITLE
UIEH-239 Generate stylelint JUnit-style report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,15 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Set up artifacts directory
+          command: mkdir -p artifacts/stylelint
+      - run:
           name: Lint CSS
-          command: yarn stylelint
+          command: yarn --silent stylelint --custom-formatter './node_modules/stylelint-junit-formatter' > ./artifacts/stylelint/stylelint.xml
+      - store_test_results:
+          path: ./artifacts
+      - store_artifacts:
+          path: ./artifacts
 
   build:
     docker:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-trigger-change": "^1.0.2",
     "stylelint": "^8.2.0",
     "stylelint-config-standard": "^17.0.0",
+    "stylelint-junit-formatter": "^0.2.1",
     "webpack": "^3.0.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9160,6 +9160,12 @@ stylelint-config-standard@^17.0.0:
   dependencies:
     stylelint-config-recommended "^1.0.0"
 
+stylelint-junit-formatter@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/stylelint-junit-formatter/-/stylelint-junit-formatter-0.2.1.tgz#8cddde6b3d3a93189f5b3b1b419dcf3c338038ab"
+  dependencies:
+    xmlbuilder "^10.0.0"
+
 stylelint@^8.2.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-8.4.0.tgz#c2dbaeb17236917819f9206e1c0df5fddf6f83c3"
@@ -10173,6 +10179,10 @@ xml@^1.0.1:
 xmlbuilder@8.2.2:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
+
+xmlbuilder@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-10.0.0.tgz#c64e52f8ae097fe5fd46d1c38adaade071ee1b55"
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"


### PR DESCRIPTION
## Purpose
CircleCI has nicer test summary UI when results are reported in JUnit-style XML.

Resolves https://issues.folio.org/browse/UIEH-239

## Approach
Use `stylelint-junit-formatter` reporter.

## Screenshots
![screen shot 2018-07-09 at 10 38 38 am](https://user-images.githubusercontent.com/230597/42460781-636c37d6-8364-11e8-8e5c-3e3d450e0e4c.png)