### PR TITLE
Add document titles

### DIFF
--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import Package from '../redux/package';
@@ -56,15 +57,17 @@ class PackageCreateRoute extends Component {
 
   render() {
     return (
-      <View
-        request={this.props.createRequest}
-        onSubmit={this.packageCreateSubmitted}
-        initialValues={{
-          name: '',
-          contentType: 'Unknown',
-          customCoverages: []
-        }}
-      />
+      <TitleManager record="New custom package">
+        <View
+          request={this.props.createRequest}
+          onSubmit={this.packageCreateSubmitted}
+          initialValues={{
+            name: '',
+            contentType: 'Unknown',
+            customCoverages: []
+          }}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import Package from '../redux/package';
@@ -120,10 +121,12 @@ class PackageEditRoute extends Component {
     let { model } = this.props;
 
     return (
-      <View
-        model={model}
-        onSubmit={this.packageEditSubmitted}
-      />
+      <TitleManager record={`Edit ${this.props.model.name}`}>
+        <View
+          model={model}
+          onSubmit={this.packageEditSubmitted}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import Package from '../redux/package';
@@ -97,14 +98,16 @@ class PackageShowRoute extends Component {
 
   render() {
     return (
-      <View
-        model={this.props.model}
-        fetchPackageTitles={this.fetchPackageTitles}
-        toggleSelected={this.toggleSelected}
-        toggleHidden={this.toggleHidden}
-        customCoverageSubmitted={this.customCoverageSubmitted}
-        toggleAllowKbToAddTitles={this.toggleAllowKbToAddTitles}
-      />
+      <TitleManager record={this.props.model.name}>
+        <View
+          model={this.props.model}
+          fetchPackageTitles={this.fetchPackageTitles}
+          toggleSelected={this.toggleSelected}
+          toggleHidden={this.toggleHidden}
+          customCoverageSubmitted={this.customCoverageSubmitted}
+          toggleAllowKbToAddTitles={this.toggleAllowKbToAddTitles}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import Provider from '../redux/provider';
@@ -65,13 +66,15 @@ class ProviderShowRoute extends Component {
 
   render() {
     return (
-      <View
-        model={this.props.model}
-        packages={this.getPkgResults()}
-        fetchPackages={this.fetchPackages}
-        searchPackages={this.searchPackages}
-        searchParams={this.state.pkgSearchParams}
-      />
+      <TitleManager record={this.props.model.name}>
+        <View
+          model={this.props.model}
+          packages={this.getPkgResults()}
+          fetchPackages={this.fetchPackages}
+          searchPackages={this.searchPackages}
+          searchParams={this.state.pkgSearchParams}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import Resource from '../redux/resource';
@@ -102,10 +103,12 @@ class ResourceEditRoute extends Component {
     let { model } = this.props;
 
     return (
-      <View
-        model={model}
-        onSubmit={this.resourceEditSubmitted}
-      />
+      <TitleManager record={`Edit ${this.props.model.name}`}>
+        <View
+          model={model}
+          onSubmit={this.resourceEditSubmitted}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import Resource from '../redux/resource';
@@ -80,10 +81,12 @@ class ResourceShowRoute extends Component {
 
   render() {
     return (
-      <View
-        model={this.props.model}
-        toggleSelected={this.toggleSelected}
-      />
+      <TitleManager record={this.props.model.name}>
+        <View
+          model={this.props.model}
+          toggleSelected={this.toggleSelected}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import capitalize from 'lodash/capitalize';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
+
 import { qs } from '../components/utilities';
 import { createResolver } from '../redux';
 import Provider from '../redux/provider';
@@ -273,29 +276,31 @@ class SearchRoute extends Component { // eslint-disable-line react/no-deprecated
       let results = this.getResults();
 
       return (
-        <div data-test-eholdings>
-          <SearchPaneset
-            location={location}
-            hideFilters={!!params.q}
-            resultsType={searchType}
-            resultsView={this.renderResults()}
-            detailsView={!hideDetails && children}
-            totalResults={results.length}
-            isLoading={!results.hasLoaded}
-            searchForm={(
-              <SearchForm
-                searchType={searchType}
-                searchString={params.q}
-                filter={params.filter}
-                searchfield={params.searchfield}
-                sort={params.sort}
-                searchTypeUrls={this.getSearchTypeUrls()}
-                onSearch={this.handleSearch}
-                isLoading={params.q && !results.hasLoaded}
-              />
-            )}
-          />
-        </div>
+        <TitleManager record={capitalize(searchType)}>
+          <div data-test-eholdings>
+            <SearchPaneset
+              location={location}
+              hideFilters={!!params.q}
+              resultsType={searchType}
+              resultsView={this.renderResults()}
+              detailsView={!hideDetails && children}
+              totalResults={results.length}
+              isLoading={!results.hasLoaded}
+              searchForm={(
+                <SearchForm
+                  searchType={searchType}
+                  searchString={params.q}
+                  filter={params.filter}
+                  searchfield={params.searchfield}
+                  sort={params.sort}
+                  searchTypeUrls={this.getSearchTypeUrls()}
+                  onSearch={this.handleSearch}
+                  isLoading={params.q && !results.hasLoaded}
+                />
+              )}
+            />
+          </div>
+        </TitleManager>
       );
     } else {
       return children;

--- a/src/routes/settings-knowledge-base.js
+++ b/src/routes/settings-knowledge-base.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import { Configuration } from '../redux/application';
@@ -32,14 +33,16 @@ class SettingsKnowledgeBaseRoute extends Component {
     let { config } = this.props;
 
     return (
-      <View
-        model={config}
-        onSubmit={this.updateConfig}
-        initialValues={{
-          customerId: config.customerId,
-          apiKey: config.apiKey
-        }}
-      />
+      <TitleManager page="eHoldings settings" record="Knowledge base">
+        <View
+          model={config}
+          onSubmit={this.updateConfig}
+          initialValues={{
+            customerId: config.customerId,
+            apiKey: config.apiKey
+          }}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/routes/settings-root-proxy.js
+++ b/src/routes/settings-root-proxy.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import { ProxyType, RootProxy } from '../redux/application';
@@ -33,14 +34,16 @@ class SettingsRootProxyRoute extends Component {
     let { proxyTypes, rootProxy } = this.props;
 
     return (
-      <View
-        initialValues={{
-          rootProxyServer: rootProxy.proxyTypeId
-        }}
-        proxyTypes={proxyTypes}
-        rootProxy={rootProxy}
-        onSubmit={this.rootProxySubmitted}
-      />
+      <TitleManager page="eHoldings settings" record="Root proxy">
+        <View
+          initialValues={{
+            rootProxyServer: rootProxy.proxyTypeId
+          }}
+          proxyTypes={proxyTypes}
+          rootProxy={rootProxy}
+          onSubmit={this.rootProxySubmitted}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
-import View from '@folio/stripes-components/lib/Settings';
+import { Settings as View } from '@folio/stripes-components';
 import ApplicationRoute from './application';
 
 export default class SettingsRoute extends Component {
@@ -25,13 +26,15 @@ export default class SettingsRoute extends Component {
 
     return (
       <ApplicationRoute showSettings>
-        <View
-          paneTitle="eHoldings"
-          activeLink={router.route.location.pathname}
-          match={router.route.match}
-          location={router.route.location}
-          pages={pages}
-        />
+        <TitleManager page="eHoldings settings">
+          <View
+            paneTitle="eHoldings"
+            activeLink={router.route.location.pathname}
+            match={router.route.match}
+            location={router.route.location}
+            pages={pages}
+          />
+        </TitleManager>
       </ApplicationRoute>
     );
   }

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import Title from '../redux/title';
@@ -69,22 +70,24 @@ class TitleCreateRoute extends Component {
     } = this.props;
 
     return (
-      <View
-        request={createRequest}
-        customPackages={customPackages}
-        onSubmit={this.createTitle}
-        initialValues={{
-          name: '',
-          edition: '',
-          publisherName: '',
-          publicationType: 'Unspecified',
-          isPeerReviewed: false,
-          contributors: [],
-          identifiers: [],
-          description: '',
-          packageId: ''
-        }}
-      />
+      <TitleManager record="New custom title">
+        <View
+          request={createRequest}
+          customPackages={customPackages}
+          onSubmit={this.createTitle}
+          initialValues={{
+            name: '',
+            edition: '',
+            publisherName: '',
+            publicationType: 'Unspecified',
+            isPeerReviewed: false,
+            contributors: [],
+            identifiers: [],
+            description: '',
+            packageId: ''
+          }}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import Title from '../redux/title';
@@ -98,21 +99,23 @@ class TitleEditRoute extends Component {
     } = this.props;
 
     return (
-      <View
-        model={model}
-        onSubmit={this.titleEditSubmitted}
-        updateRequest={updateRequest}
-        initialValues={{
-          name: model.name,
-          edition: model.edition,
-          isPeerReviewed: model.isPeerReviewed,
-          publicationType: model.publicationType,
-          publisherName: model.publisherName,
-          description: model.description,
-          contributors: model.contributors,
-          identifiers: this.mergeIdentifiers(model.identifiers)
-        }}
-      />
+      <TitleManager record={`Edit ${this.props.model.name}`}>
+        <View
+          model={model}
+          onSubmit={this.titleEditSubmitted}
+          updateRequest={updateRequest}
+          initialValues={{
+            name: model.name,
+            edition: model.edition,
+            isPeerReviewed: model.isPeerReviewed,
+            publicationType: model.publicationType,
+            publisherName: model.publisherName,
+            description: model.description,
+            contributors: model.contributors,
+            identifiers: this.mergeIdentifiers(model.identifiers)
+          }}
+        />
+      </TitleManager>
     );
   }
 }

--- a/src/routes/title-show.js
+++ b/src/routes/title-show.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
 import { createResolver } from '../redux';
 import Title from '../redux/title';
@@ -70,12 +71,14 @@ class TitleShowRoute extends Component {
     let { model, customPackages, createRequest } = this.props;
 
     return (
-      <View
-        request={createRequest}
-        model={model}
-        customPackages={customPackages}
-        addCustomPackage={this.createResource}
-      />
+      <TitleManager record={this.props.model.name}>
+        <View
+          request={createRequest}
+          model={model}
+          customPackages={customPackages}
+          addCustomPackage={this.createResource}
+        />
+      </TitleManager>
     );
   }
 }


### PR DESCRIPTION
## Purpose
Document titles are part of the essential UX for any browser-based app.

## Approach
Use `TitleManager` introduced in https://github.com/folio-org/stripes-core/pull/324

I don't love reaching into the `stripes-core` directory structure, but `stripes-core` doesn't have an `index.js` that exports anything.