### PR TITLE
UIEH- 496 Fix i8ln naming in custom package edit

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -235,7 +235,7 @@ class CustomPackageEdit extends Component {
                       <Fragment>
                         <div data-test-eholdings-package-visibility-field>
                           <Field
-                            label={<FormattedMessage id="ui-eholdings.package.visbility" />}
+                            label={<FormattedMessage id="ui-eholdings.package.visibility" />}
                             name="isVisible"
                             component={RadioButtonGroup}
                           >
@@ -300,9 +300,9 @@ class CustomPackageEdit extends Component {
                     buttonStyle="primary"
                   >
                     {model.update.isPending ?
-                    (<FormattedMessage id="ui-eholdings.package.saving" />)
+                    (<FormattedMessage id="ui-eholdings.saving" />)
                     :
-                    (<FormattedMessage id="ui-eholdings.package.save" />)}
+                    (<FormattedMessage id="ui-eholdings.save" />)}
                   </Button>
                 </div>
                 {model.update.isPending && (


### PR DESCRIPTION
## Purpose
The i8ln translations pull from a file and in order for the translation to match up with their respective location in the DOM the naming conventions have to match.

## Approach
 - Update and match naming conventions

## Screenshots

#### Before
<img width="1918" alt="screen shot 2018-07-11 at 4 52 09 pm" src="https://user-images.githubusercontent.com/1953098/42598777-3220389e-852b-11e8-9522-2e962a791092.png">

#### After
<img width="1919" alt="screen shot 2018-07-11 at 4 52 17 pm" src="https://user-images.githubusercontent.com/1953098/42598791-3d77a038-852b-11e8-94bd-6f43e05b56cc.png">

