### PR TITLE
UIEH-448: Add * for certain required fields in custom packages and custom titles

### DIFF
--- a/src/components/package/_fields/name/package-name-field.js
+++ b/src/components/package/_fields/name/package-name-field.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Field } from 'redux-form';
+import { FormattedMessage } from 'react-intl';
 
 import { TextField } from '@folio/stripes-components';
 import styles from './package-name-field.css';
@@ -15,7 +16,7 @@ export default class PackageNameField extends Component {
           name="name"
           type="text"
           component={TextField}
-          label="Name"
+          label={<FormattedMessage id="ui-eholdings.package.name.isRequired" />}
         />
       </div>
     );

--- a/src/components/title/_fields/name/title-name-field.js
+++ b/src/components/title/_fields/name/title-name-field.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Field } from 'redux-form';
+import { FormattedMessage } from 'react-intl';
 
 import { TextField } from '@folio/stripes-components';
 import styles from './title-name-field.css';
@@ -15,7 +16,7 @@ export default class TitleNameField extends Component {
           name="name"
           type="text"
           component={TextField}
-          label="Name"
+          label={<FormattedMessage id="ui-eholdings.title.name.isRequired" />}
         />
       </div>
     );

--- a/src/components/title/_fields/package-select/package-select-field.js
+++ b/src/components/title/_fields/package-select/package-select-field.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
+import { FormattedMessage } from 'react-intl';
 
 import { Select } from '@folio/stripes-components';
 import styles from './package-select-field.css';
@@ -20,7 +21,7 @@ export default function PackageSelectField({ options }) {
       <Field
         name="packageId"
         component={Select}
-        label="Package"
+        label={<FormattedMessage id="ui-eholdings.title.package.isRequired" />}
         dataOptions={optionsWithPlaceholder}
       />
     </div>

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -5,6 +5,7 @@
     "package.customCoverageDates": "Custom coverage dates",
     "package.holdingStatus": "Holding status",
     "package.name": "Name",
+    "package.name.isRequired": "Name *",
     "package.packageInformation": "Package information",
     "package.packageType": "Package type",
     "package.provider": "Provider",
@@ -38,6 +39,9 @@
     "package.toast.isNewRecord": "Custom package created.",
     "package.toast.isDestroyed": "Title removed from package.",
     "package.toast.isFreshlySaved": "Package saved.",
+
+    "title.name.isRequired": "Name *",
+    "title.package.isRequired": "Package *",
 
     "selected": "Selected",
     "notSelected": "Not selected",


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-448, we are supposed to indicate that certain fields are required while creating or editing custom packages and custom titles.

## Approach
- We tried using the *required* prop in Stripes Components TextField and Select but they did not work per our expectations. We figured that setting those props had nothing to do with the needed asterisk. Moreover, if we set those props, we figured that the browser validation was superseding our redux-form validations.
- We modified our approach to just add an asterisk next to the label referring to what ui-inventory module does.
- I was able to verify the change locally for custom packages and new custom title creation but not edit page of custom title since there seems to be a different error in loading custom titles at the time of this PR.

#### TODOS and Open Questions
[ ] - I see that *Name* label is available in translations/ui-eholdings/en.json. Do we hav to use that in place of these labels to support i8ln? Even so, I would think we need to create two separate entries for names because these asterisks only need to appear on certain labels and not all *Name* labels. I am not sure if there is a separate story for that.

## Learning
- Usage of react dev tools for debugging
- A bit of insight into ui-inventory

## Screenshots
![adding_asterisk](https://user-images.githubusercontent.com/33662516/42641811-634188ae-85c3-11e8-8d21-13b531319a1f.gif)

