### PR TITLE
UIEH-407: Change holding status toggle into a button on package-edit

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -21,7 +21,6 @@ import CoverageFields, { validate as validateCoverageDates } from '../_fields/cu
 import ContentTypeField from '../_fields/content-type';
 import DetailsViewSection from '../../details-view-section';
 import NavigationModal from '../../navigation-modal';
-import ToggleSwitch from '../../toggle-switch/toggle-switch';
 import Toaster from '../../toaster';
 import styles from './custom-package-edit.css';
 
@@ -93,10 +92,12 @@ class CustomPackageEdit extends Component {
     });
   }
 
-  handleSelectionToggle = (e) => {
+  handleDeleteAction = () => {
     this.setState({
-      packageSelected: e.target.checked
-    });
+      formValues: {
+        isSelected: false
+      }
+    }, () => this.handleOnSubmit(this.state.formValues));
   }
 
   commitSelectionToggle = () => {
@@ -174,6 +175,15 @@ class CustomPackageEdit extends Component {
       });
     }
 
+    if (packageSelected) {
+      actionMenuItems.push({
+        'label': 'Delete package',
+        'state': { eholdings: true },
+        'data-test-eholdings-package-remove-from-holdings-action': true,
+        'onClick': this.handleDeleteAction
+      });
+    }
+
     return (
       <div>
         <Toaster toasts={processErrors(model)} position="bottom" />
@@ -214,20 +224,12 @@ class CustomPackageEdit extends Component {
                   data-test-eholdings-package-details-selected
                   htmlFor="custom-package-details-toggle-switch"
                 >
-                  <h4>{packageSelected ?
-                    (<FormattedMessage id="ui-eholdings.selected" />)
-                    :
-                    (<FormattedMessage id="ui-eholdings.notSelected" />)}
+                  <h4>
+                    {packageSelected ?
+                      (<FormattedMessage id="ui-eholdings.selected" />) :
+                      (<FormattedMessage id="ui-eholdings.notSelected" />)
+                    }
                   </h4>
-                  <br />
-
-                  <Field
-                    name="isSelected"
-                    component={ToggleSwitch}
-                    checked={packageSelected}
-                    onChange={this.handleSelectionToggle}
-                    id="custom-package-details-toggle-switch"
-                  />
                 </label>
               </DetailsViewSection>
               <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}>

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -55,6 +55,10 @@ class CustomPackageEdit extends Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.model.destroy.errors.length) {
+      return { showSelectionModal: false };
+    }
+
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
       return {
         ...prevState,
@@ -102,7 +106,6 @@ class CustomPackageEdit extends Component {
 
   commitSelectionToggle = () => {
     this.setState({
-      showSelectionModal: false,
       allowFormToSubmit: true
     }, () => { this.handleOnSubmit(this.state.formValues); });
   };
@@ -155,7 +158,7 @@ class CustomPackageEdit extends Component {
 
     let actionMenuItems = [
       {
-        label: <FormattedMessage id="ui-eholdings.package.actionMenu.cancelEditing" />,
+        label: intl.formatMessage({ id: 'ui-eholdings.package.actionMenu.cancelEditing' }),
         to: {
           pathname: `/eholdings/packages/${model.id}`,
           search: router.route.location.search,
@@ -166,7 +169,7 @@ class CustomPackageEdit extends Component {
 
     if (queryParams.searchType) {
       actionMenuItems.push({
-        label: <FormattedMessage id="ui-eholdings.actionMenu.fullView" />,
+        label: intl.formatMessage({ id: 'ui-eholdings.actionMenu.fullView' }),
         to: {
           pathname: `/eholdings/packages/${model.id}/edit`,
           state: { eholdings: true }
@@ -177,7 +180,7 @@ class CustomPackageEdit extends Component {
 
     if (packageSelected) {
       actionMenuItems.push({
-        'label': 'Delete package',
+        'label': intl.formatMessage({ id: 'ui-eholdings.package.deletePackage' }),
         'state': { eholdings: true },
         'data-test-eholdings-package-remove-from-holdings-action': true,
         'onClick': this.handleDeleteAction
@@ -200,7 +203,7 @@ class CustomPackageEdit extends Component {
                 {packageSelected ? (
                   <NameField />
                ) : (
-                 <KeyValue label={<FormattedMessage id="ui-eholdings.package.name" />}>
+                 <KeyValue label={intl.formatMessage({ id: 'ui-eholdings.package.name' })}>
                    <div data-test-eholdings-package-readonly-name-field>
                      {model.name}
                    </div>
@@ -210,7 +213,7 @@ class CustomPackageEdit extends Component {
                 {packageSelected ? (
                   <ContentTypeField />
                ) : (
-                 <KeyValue label={<FormattedMessage id="ui-eholdings.package.contentType" />}>
+                 <KeyValue label={intl.formatMessage({ id: 'ui-eholdings.package.contentType' })}>
                    <div data-test-eholdings-package-details-readonly-content-type>
                      {model.contentType}
                    </div>
@@ -317,7 +320,6 @@ class CustomPackageEdit extends Component {
           )}
         />
 
-
         <Modal
           open={showSelectionModal}
           size="small"
@@ -326,8 +328,11 @@ class CustomPackageEdit extends Component {
           footer={(
             <ModalFooter
               primaryButton={{
-                'label': intl.formatMessage({ id: 'ui-eholdings.package.modalMessageButtonConfirm.isCustom' }),
+                'label': model.destroy.isPending ?
+                intl.formatMessage({ id: 'ui-eholdings.package.modalMessageButtonWorking.isCustom' }) :
+                intl.formatMessage({ id: 'ui-eholdings.package.modalMessageButtonConfirm.isCustom' }),
                 'onClick': this.commitSelectionToggle,
+                'disabled': model.destroy.isPending,
                 'data-test-eholdings-package-deselection-confirmation-modal-yes': true
               }}
               secondaryButton={{

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -70,7 +70,10 @@ class ManagedPackageEdit extends Component {
     let needsUpdate = !isEqual(prevProps.model, this.props.model);
     let { router } = this.context;
 
-    if (wasPending && needsUpdate) {
+    let wasUnSelected = prevProps.model.isSelected && !this.props.model.isSelected;
+    let isCurrentlySelected = prevProps.model.isSelected && this.props.model.isSelected;
+
+    if (wasPending && needsUpdate && (wasUnSelected || isCurrentlySelected)) {
       router.history.push({
         pathname: `/eholdings/packages/${this.props.model.id}`,
         search: router.route.location.search,
@@ -96,7 +99,7 @@ class ManagedPackageEdit extends Component {
         allowKbToAddTitles: true,
         isSelected: true
       }
-    });
+    }, () => this.handleOnSubmit(this.state.formValues));
   }
 
   handleDeselectionAction = () => {

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -52,6 +52,10 @@ class ManagedPackageEdit extends Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.model.update.errors.length) {
+      return { showSelectionModal: false };
+    }
+
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
       return {
         ...prevState,
@@ -112,7 +116,6 @@ class ManagedPackageEdit extends Component {
 
   commitSelectionToggle = () => {
     this.setState({
-      showSelectionModal: false,
       allowFormToSubmit: true
     }, () => { this.handleOnSubmit(this.state.formValues); });
   };
@@ -162,8 +165,7 @@ class ManagedPackageEdit extends Component {
     } = this.context;
 
     let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
-    let packageSelectionPending = model.destroy.isPending ||
-      (model.update.isPending && 'isSelected' in model.update.changedAttributes);
+    let packageSelectionPending = model.update.isPending && 'isSelected' in model.update.changedAttributes;
 
     let actionMenuItems = [
       {
@@ -248,25 +250,22 @@ class ManagedPackageEdit extends Component {
               </DetailsViewSection>
               {packageSelected && (
                 <div>
-                  <DetailsViewSection label={<FormattedMessage id="ui-eholdings.package.packageSettings" />}>
+                  <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}>
                     <div className={styles['visibility-radios']}>
                       {this.props.initialValues.isVisible != null ? (
                         <Fragment>
                           <div data-test-eholdings-package-visibility-field>
                             <Field
-                              label={<FormattedMessage id="ui-eholdings.package.visibility" />}
+                              label={intl.formatMessage({ id: 'ui-eholdings.package.visibility' })}
                               name="isVisible"
                               component={RadioButtonGroup}
                             >
-                              <RadioButton label={<FormattedMessage id="ui-eholdings.yes" />} value="true" />
+                              <RadioButton label={intl.formatMessage({ id: 'ui-eholdings.yes' })} value="true" />
                               <RadioButton
-                                label={
-                                  <FormattedMessage
-                                    id="ui-eholdings.package.visibility.no"
-                                    values={{
-                                      visibilityMessage
-                                    }}
-                                  />}
+                                label={intl.formatMessage(
+                                  { id: 'ui-eholdings.package.visibility.no' },
+                                  { visibilityMessage }
+                                )}
                                 value="false"
                               />
                             </Field>
@@ -285,18 +284,18 @@ class ManagedPackageEdit extends Component {
                       {this.props.initialValues.allowKbToAddTitles != null ? (
                         <Fragment>
                           <Field
-                            label={<FormattedMessage id="ui-eholdings.package.packageAllowToAddTitles" />}
+                            label={intl.formatMessage({ id: 'ui-eholdings.package.packageAllowToAddTitles' })}
                             name="allowKbToAddTitles"
                             data-test-eholdings-allow-kb-to-add-titles-radios
                             component={RadioButtonGroup}
                           >
                             <RadioButton
-                              label={<FormattedMessage id="ui-eholdings.yes" />}
+                              label={intl.formatMessage({ id: 'ui-eholdings.yes' })}
                               value="true"
                               data-test-eholdings-allow-kb-to-add-titles-radio-yes
                             />
                             <RadioButton
-                              label={<FormattedMessage id="ui-eholdings.no" />}
+                              label={intl.formatMessage({ id: 'ui-eholdings.no' })}
                               value="false"
                               data-test-eholdings-allow-kb-to-add-titles-radio-no
                             />
@@ -313,7 +312,7 @@ class ManagedPackageEdit extends Component {
                     </div>
                   </DetailsViewSection>
                   <DetailsViewSection
-                    label="Coverage dates"
+                    label={intl.formatMessage({ id: 'ui-eholdings.package.coverageDates' })}
                   >
                     <CoverageFields
                       initialValue={initialValues.customCoverages}
@@ -365,8 +364,11 @@ class ManagedPackageEdit extends Component {
           footer={(
             <ModalFooter
               primaryButton={{
-                'label': intl.formatMessage({ id: 'ui-eholdings.package.modalMessageButtonConfirm' }),
+                'label': model.update.isPending ?
+                  intl.formatMessage({ id: 'ui-eholdings.package.modalMessageButtonWorking' }) :
+                  intl.formatMessage({ id: 'ui-eholdings.package.modalMessageButtonConfirm' }),
                 'onClick': this.commitSelectionToggle,
+                'disabled': model.update.isPending,
                 'data-test-eholdings-package-deselection-confirmation-modal-yes': true
               }}
               secondaryButton={{

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -246,116 +246,114 @@ class ManagedPackageEdit extends Component {
                   }
                 </label>
               </DetailsViewSection>
-              <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}>
-                {packageSelected ? (
-                  <div className={styles['visibility-radios']}>
-                    {this.props.initialValues.isVisible != null ? (
-                      <Fragment>
-                        <div data-test-eholdings-package-visibility-field>
+              {packageSelected && (
+                <div>
+                  <DetailsViewSection label={<FormattedMessage id="ui-eholdings.package.packageSettings" />}>
+                    <div className={styles['visibility-radios']}>
+                      {this.props.initialValues.isVisible != null ? (
+                        <Fragment>
+                          <div data-test-eholdings-package-visibility-field>
+                            <Field
+                              label={<FormattedMessage id="ui-eholdings.package.visibility" />}
+                              name="isVisible"
+                              component={RadioButtonGroup}
+                            >
+                              <RadioButton label={<FormattedMessage id="ui-eholdings.yes" />} value="true" />
+                              <RadioButton
+                                label={
+                                  <FormattedMessage
+                                    id="ui-eholdings.package.visibility.no"
+                                    values={{
+                                      visibilityMessage
+                                    }}
+                                  />}
+                                value="false"
+                              />
+                            </Field>
+                          </div>
+                        </Fragment>
+                      ) : (
+                        <label
+                          data-test-eholdings-package-details-visibility
+                          htmlFor="managed-package-details-visibility-switch"
+                        >
+                          <Icon icon="spinner-ellipsis" />
+                        </label>
+                      )}
+                    </div>
+                    <div className={styles['title-management-radios']}>
+                      {this.props.initialValues.allowKbToAddTitles != null ? (
+                        <Fragment>
                           <Field
-                            label={intl.formatMessage({ id: 'ui-eholdings.package.visibility' })}
-                            name="isVisible"
+                            label={<FormattedMessage id="ui-eholdings.package.packageAllowToAddTitles" />}
+                            name="allowKbToAddTitles"
+                            data-test-eholdings-allow-kb-to-add-titles-radios
                             component={RadioButtonGroup}
                           >
-                            <RadioButton label={intl.formatMessage({ id: 'ui-eholdings.yes' })} value="true" />
                             <RadioButton
-                              label={intl.formatMessage(
-                                { id: 'ui-eholdings.package.visibility.no' },
-                                { visibilityMessage }
-                              )}
+                              label={<FormattedMessage id="ui-eholdings.yes" />}
+                              value="true"
+                              data-test-eholdings-allow-kb-to-add-titles-radio-yes
+                            />
+                            <RadioButton
+                              label={<FormattedMessage id="ui-eholdings.no" />}
                               value="false"
+                              data-test-eholdings-allow-kb-to-add-titles-radio-no
                             />
                           </Field>
-                        </div>
-                      </Fragment>
-                    ) : (
-                      <label
-                        data-test-eholdings-package-details-visibility
-                        htmlFor="managed-package-details-visibility-switch"
-                      >
-                        <Icon icon="spinner-ellipsis" />
-                      </label>
-                    )}
-                  </div>
-                ) : (
-                  <p><FormattedMessage id="ui-eholdings.package.packageSettings.notSelected" /></p>
-                )}
-                {packageSelected ? (
-                  <div className={styles['title-management-radios']}>
-                    {this.props.initialValues.allowKbToAddTitles != null ? (
-                      <Fragment>
-                        <Field
-                          label={intl.formatMessage({ id: 'ui-eholdings.package.packageAllowToAddTitles' })}
-                          name="allowKbToAddTitles"
-                          data-test-eholdings-allow-kb-to-add-titles-radios
-                          component={RadioButtonGroup}
+                        </Fragment>
+                      ) : (
+                        <label
+                          data-test-eholdings-package-details-allow-add-new-titles
+                          htmlFor="managed-package-details-toggle-allow-add-new-titles-switch"
                         >
-                          <RadioButton
-                            label={intl.formatMessage({ id: 'ui-eholdings.yes' })}
-                            value="true"
-                            data-test-eholdings-allow-kb-to-add-titles-radio-yes
-                          />
-                          <RadioButton
-                            label={intl.formatMessage({ id: 'ui-eholdings.no' })}
-                            value="false"
-                            data-test-eholdings-allow-kb-to-add-titles-radio-no
-                          />
-                        </Field>
-                      </Fragment>
-                    ) : (
-                      <label
-                        data-test-eholdings-package-details-allow-add-new-titles
-                        htmlFor="managed-package-details-toggle-allow-add-new-titles-switch"
-                      >
-                        <Icon icon="spinner-ellipsis" />
-                      </label>
-                    )}
+                          <Icon icon="spinner-ellipsis" />
+                        </label>
+                      )}
+                    </div>
+                  </DetailsViewSection>
+                  <DetailsViewSection
+                    label="Coverage dates"
+                  >
+                    <CoverageFields
+                      initialValue={initialValues.customCoverages}
+                    />
+                  </DetailsViewSection>
+                </div>
+              )}
+              <div>
+                <div className={styles['package-edit-action-buttons']}>
+                  <div
+                    data-test-eholdings-package-cancel-button
+                  >
+                    <Button
+                      disabled={model.update.isPending}
+                      type="button"
+                      onClick={this.handleCancel}
+                    >
+                      Cancel
+                    </Button>
                   </div>
-                  ) : (
-                    <p><FormattedMessage id="ui-eholdings.package.packageAllowToAddTitles.notSelected" /></p>
+                  <div
+                    data-test-eholdings-package-save-button
+                  >
+                    <Button
+                      disabled={pristine || model.update.isPending}
+                      type="submit"
+                      buttonStyle="primary"
+                    >
+                      {model.update.isPending ?
+                        (<FormattedMessage id="ui-eholdings.saving" />)
+                          :
+                        (<FormattedMessage id="ui-eholdings.save" />)}
+                    </Button>
+                  </div>
+                  {model.update.isPending && (
+                    <Icon icon="spinner-ellipsis" />
                   )}
-              </DetailsViewSection>
-              <DetailsViewSection
-                label={intl.formatMessage({ id: 'ui-eholdings.package.coverageDates' })}
-              >
-                {packageSelected ? (
-                  <CoverageFields
-                    initialValue={initialValues.customCoverages}
-                  />) : (
-                    <p><FormattedMessage id="ui-eholdings.package.customCoverage.notSelected" /></p>
-                )}
-              </DetailsViewSection>
-              <div className={styles['package-edit-action-buttons']}>
-                <div
-                  data-test-eholdings-package-cancel-button
-                >
-                  <Button
-                    disabled={model.update.isPending}
-                    type="button"
-                    onClick={this.handleCancel}
-                  >
-                    Cancel
-                  </Button>
                 </div>
-                <div
-                  data-test-eholdings-package-save-button
-                >
-                  <Button
-                    disabled={pristine || model.update.isPending}
-                    type="submit"
-                    buttonStyle="primary"
-                  >
-                    {model.update.isPending ?
-                      (<FormattedMessage id="ui-eholdings.saving" />)
-                        :
-                      (<FormattedMessage id="ui-eholdings.save" />)}
-                  </Button>
-                </div>
-                {model.update.isPending && (
-                  <Icon icon="spinner-ellipsis" />
-                )}
+                <NavigationModal when={!pristine && !model.update.isPending} />
               </div>
-              <NavigationModal when={!pristine && !model.update.isPending} />
             </form>
           )}
         />

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -79,6 +79,10 @@ class PackageEditRoute extends Component {
       model.customCoverage = {};
       model.allowKbToAddTitles = false;
       updatePackage(model);
+    } else if (values.isSelected && !values.customCoverages) {
+      model.isSelected = true;
+      model.allowKbToAddTitles = true;
+      updatePackage(model);
     } else {
       let beginCoverage = '';
       let endCoverage = '';

--- a/tests/custom-package-edit-selection-test.js
+++ b/tests/custom-package-edit-selection-test.js
@@ -48,98 +48,48 @@ describeApplication('CustomPackageEditSelection', () => {
       });
     });
 
-    describe('toggling the selection toggle (OFF)', () => {
+    describe('deleting the custom package', () => {
       beforeEach(() => {
-        return PackageEditPage.toggleIsSelected();
+        return PackageEditPage
+          .dropDown.clickDropDownButton()
+          .dropDownMenu.clickRemoveFromHoldings();
       });
 
-      it('cannot toggle visibility', () => {
-        expect(PackageEditPage.isVisibilityFieldPresent).to.equal(false);
+      it('shows the deletion confirmation modal', () => {
+        expect(PackageEditPage.modal.isPresent).to.equal(true);
       });
 
-      it('cannot edit coverage', () => {
-        expect(PackageEditPage.hasCoverageDatesPresent).to.equal(false);
-      });
-
-      it('cannot edit package name', () => {
-        expect(PackageEditPage.hasReadOnlyNameFieldPresent).to.equal(true);
-        expect(PackageEditPage.hasNameFieldPresent).to.equal(false);
-      });
-
-      it('cannot edit content type', () => {
-        expect(PackageEditPage.hasReadOnlyContentTypeFieldPresent).to.equal(true);
-        expect(PackageEditPage.hasContentTypeFieldPresent).to.equal(false);
-      });
-
-      describe('clicking save', () => {
+      describe('clicking cancel', () => {
         beforeEach(() => {
-          return PackageEditPage.clickSave();
+          return PackageEditPage.modal.cancelDeselection();
         });
 
-        it('shows the modal', () => {
-          expect(PackageEditPage.modal.isPresent).to.equal(true);
+        it('should stay on the edit page', () => {
+          expect(PackageEditPage.isPresent).to.equal(true);
         });
 
-        it('reflects the desired state of holding status', () => {
-          expect(PackageEditPage.isSelected).to.equal(false);
-        });
-
-        describe('clicking confirm', () => {
-          beforeEach(() => {
-            return PackageEditPage.modal.confirmDeselection();
-          });
-
-          it('transitions to the package search page', function () {
-            expect(this.app.history.location.search).to.include('?searchType=packages');
-          });
-
-          describe('searching for package after confirming', () => {
-            beforeEach(() => {
-              return PackageSearchPage.search('Cool Package');
-            });
-
-            it('does not find package', () => {
-              expect(PackageSearchPage.noResultsMessage).to.equal('No packages found for "Cool Package".');
-            });
-          });
-        });
-
-        describe('clicking cancel', () => {
-          beforeEach(() => {
-            return PackageEditPage.modal.cancelDeselection();
-          });
-
-          it('removes the modal', () => {
-            expect(PackageEditPage.modal.isPresent).to.equal(false);
-          });
-
-          it('reflects the correct holding status', () => {
-            expect(PackageEditPage.isSelected).to.equal(true);
-          });
+        it('reflects that the package is still selected', () => {
+          expect(PackageEditPage.isSelected).to.equal(true);
         });
       });
 
-      describe('toggling the selection toggle ON', () => {
+      describe('clicking confirm', () => {
         beforeEach(() => {
-          return PackageEditPage.toggleIsSelected();
+          return PackageEditPage.modal.confirmDeselection();
         });
 
-        it('can toggle visibility', () => {
-          expect(PackageEditPage.isVisibilityFieldPresent).to.equal(true);
+        it('transitions to the package search page', function () {
+          expect(this.app.history.location.search).to.include('?searchType=packages');
         });
 
-        it('can edit coverage', () => {
-          expect(PackageEditPage.hasCoverageDatesPresent).to.equal(true);
-        });
+        describe('searching for package after confirming', () => {
+          beforeEach(() => {
+            return PackageSearchPage.search('Cool Package');
+          });
 
-        it('can edit package name', () => {
-          expect(PackageEditPage.hasReadOnlyNameFieldPresent).to.equal(false);
-          expect(PackageEditPage.hasNameFieldPresent).to.equal(true);
-        });
-
-        it('can edit content type', () => {
-          expect(PackageEditPage.hasReadOnlyContentTypeFieldPresent).to.equal(false);
-          expect(PackageEditPage.hasContentTypeFieldPresent).to.equal(true);
+          it('does not find package', () => {
+            expect(PackageSearchPage.noResultsMessage).to.equal('No packages found for "Cool Package".');
+          });
         });
       });
     });

--- a/tests/custom-package-edit-visibility-test.js
+++ b/tests/custom-package-edit-visibility-test.js
@@ -190,15 +190,5 @@ describeApplication('CustomPackageEditVisibility', () => {
     it('disables the save button', () => {
       expect(PackageEditPage.isSaveDisabled).to.be.true;
     });
-
-    describe('toggling the selection toggle', () => {
-      beforeEach(() => {
-        return PackageEditPage.toggleIsSelected();
-      });
-
-      it('cannot toggle visibility', () => {
-        expect(PackageEditPage.isVisibilityFieldPresent).to.equal(false);
-      });
-    });
   });
 });

--- a/tests/managed-package-edit-add-new-titles-test.js
+++ b/tests/managed-package-edit-add-new-titles-test.js
@@ -166,7 +166,7 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
 
     describe('toggling the selected toggle', () => {
       beforeEach(() => {
-        return PackageEditPage.toggleIsSelected();
+        return PackageEditPage.clickAddButton();
       });
 
       it('reflects the desired state (Selected)', () => {

--- a/tests/managed-package-edit-add-new-titles-test.js
+++ b/tests/managed-package-edit-add-new-titles-test.js
@@ -160,8 +160,8 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
       expect(PackageEditPage.hasRadioForAllowKbToAddTitles).to.equal(false);
     });
 
-    it('disables the save button', () => {
-      expect(PackageEditPage.isSaveDisabled).to.be.true;
+    it('hides the save button', () => {
+      expect(PackageEditPage.isSavePresent).to.equal(false);
     });
 
     describe('toggling the selected toggle', () => {

--- a/tests/managed-package-edit-selection-test.js
+++ b/tests/managed-package-edit-selection-test.js
@@ -49,7 +49,7 @@ describeApplication('ManagedPackageEditSelection', () => {
     });
 
     it('disables the save button', () => {
-      expect(PackageEditPage.isSaveDisabled).to.be.true;
+      expect(PackageEditPage.isSavePresent).to.equal(false);
     });
 
     describe('clicking cancel', () => {

--- a/tests/managed-package-edit-selection-test.js
+++ b/tests/managed-package-edit-selection-test.js
@@ -32,6 +32,10 @@ describeApplication('ManagedPackageEditSelection', () => {
       expect(PackageEditPage.isSelected).to.equal(false);
     });
 
+    it('shows "Add to holdings" button', () => {
+      expect(PackageEditPage.hasAddButton).to.equal(true);
+    });
+
     it('cannot toggle visibility', () => {
       expect(PackageEditPage.isVisibilityFieldPresent).to.equal(false);
     });
@@ -58,55 +62,42 @@ describeApplication('ManagedPackageEditSelection', () => {
       });
     });
 
-    describe('toggling the selection toggle', () => {
-      beforeEach(() => {
-        return PackageEditPage.toggleIsSelected();
-      });
-
-      describe('clicking cancel', () => {
+    describe('selecting the package', () => {
+      describe('via "Add to holdings" button', () => {
         beforeEach(() => {
-          return PackageEditPage.clickCancel();
+          return PackageEditPage.clickAddButton();
         });
 
-        it('shows a navigation confirmation modal', () => {
-          expect(PackageEditPage.navigationModal.$root).to.exist;
+        it('stays on the edit page', () => {
+          expect(PackageEditPage.isPresent).to.equal(true);
         });
 
-        describe('confirming to continue without saving', () => {
-          beforeEach(() => {
-            return PackageEditPage.navigationModal.confirmNavigation();
-          });
-
-          it('navigates from editing page', () => {
-            expect(PackageShowPage.isPresent).to.eq(true);
-          });
-
-          it('reflects the desired state of holding status', () => {
-            expect(PackageEditPage.isSelected).to.equal(false);
-          });
+        it('reflects that the package has been selected', () => {
+          expect(PackageEditPage.isSelected).to.equal(true);
         });
-        describe('confirming to keep editing', () => {
-          beforeEach(() => {
-            return PackageEditPage.navigationModal.cancelNavigation();
-          });
 
-          it('remains on the editing page', () => {
-            expect(PackageEditPage.isPresent).to.eq(true);
-          });
+        it('should not need the form to be submitted', () => {
+          expect(PackageEditPage.isSaveDisabled).to.equal(true);
         });
       });
 
-      describe('clicking save', () => {
+      describe('via dropdown action', () => {
         beforeEach(() => {
-          return PackageEditPage.clickSave();
+          return PackageEditPage
+            .dropDown.clickDropDownButton()
+            .dropDownMenu.clickAddToHoldings();
         });
 
-        it('goes to the package show page', () => {
-          expect(PackageShowPage.$root).to.exist;
+        it('stays on the edit page', () => {
+          expect(PackageEditPage.isPresent).to.equal(true);
         });
 
-        it('displays the new holding status', () => {
-          expect(PackageShowPage.isSelected).to.equal(true);
+        it('reflects that the package has been selected', () => {
+          expect(PackageEditPage.isSelected).to.equal(true);
+        });
+
+        it('should not need the form to be submitted', () => {
+          expect(PackageEditPage.isSaveDisabled).to.equal(true);
         });
       });
     });
@@ -127,6 +118,10 @@ describeApplication('ManagedPackageEditSelection', () => {
 
     it('reflects the desired state of holding status', () => {
       expect(PackageEditPage.isSelected).to.equal(true);
+    });
+
+    it('hides "Add to holdings" button', () => {
+      expect(PackageEditPage.hasAddButton).to.equal(false);
     });
 
     it('can toggle visibility', () => {
@@ -155,95 +150,38 @@ describeApplication('ManagedPackageEditSelection', () => {
       });
     });
 
-    describe('toggling the selection toggle', () => {
+    describe('deselecting the package', () => {
       beforeEach(() => {
-        return PackageEditPage.toggleIsSelected();
+        return PackageEditPage
+          .dropDown.clickDropDownButton()
+          .dropDownMenu.clickRemoveFromHoldings();
+      });
+
+      it('shows the deselection confirmation modal', () => {
+        expect(PackageEditPage.modal.isPresent).to.equal(true);
       });
 
       describe('clicking cancel', () => {
         beforeEach(() => {
-          return PackageEditPage.clickCancel();
+          return PackageEditPage.modal.cancelDeselection();
         });
 
-        it('shows a navigation confirmation modal', () => {
-          expect(PackageEditPage.navigationModal.$root).to.exist;
-        });
-
-        describe('confirming to continue without saving', () => {
-          beforeEach(() => {
-            return PackageEditPage.navigationModal.confirmNavigation();
-          });
-
-          it('navigates from editing page', () => {
-            expect(PackageShowPage.isPresent).to.eq(true);
-          });
-
-          it('reflects the desired state of holding status', () => {
-            expect(PackageEditPage.isSelected).to.equal(true);
-          });
-        });
-        describe('confirming to keep editing', () => {
-          beforeEach(() => {
-            return PackageEditPage.navigationModal.cancelNavigation();
-          });
-
-          it('remains on the editing page', () => {
-            expect(PackageEditPage.isPresent).to.eq(true);
-          });
-        });
-      });
-
-      describe('clicking save', () => {
-        beforeEach(() => {
-          return PackageEditPage.clickSave();
-        });
-
-        it('shows the modal', () => {
-          expect(PackageEditPage.modal.isPresent).to.equal(true);
+        it('should stay on the edit page', () => {
+          expect(PackageEditPage.isPresent).to.equal(true);
         });
 
         it('reflects the desired state of holding status', () => {
-          expect(PackageEditPage.isSelected).to.equal(false);
+          expect(PackageEditPage.isSelected).to.equal(true);
+        });
+      });
+
+      describe('clicking confirm', () => {
+        beforeEach(() => {
+          return PackageEditPage.modal.confirmDeselection();
         });
 
-        describe('clicking confirm', () => {
-          beforeEach(() => {
-            return PackageEditPage.modal.confirmDeselection();
-          });
-
-          it('removes the modal', () => {
-            expect(PackageEditPage.modal.isPresent).to.equal(false);
-          });
-
-          it('reflects the correct holding status', () => {
-            expect(PackageEditPage.isSelected).to.equal(false);
-          });
-
-          it('goes to the package show page', () => {
-            expect(PackageShowPage.$root).to.exist;
-          });
-
-          it('reflects the correct holding status', () => {
-            expect(PackageEditPage.isSelected).to.equal(false);
-          });
-
-          it('shows a success toast message', () => {
-            expect(PackageShowPage.toast.successText).to.equal('Package saved.');
-          });
-        });
-
-        describe('clicking cancel', () => {
-          beforeEach(() => {
-            return PackageEditPage.modal.cancelDeselection();
-          });
-
-          it('removes the modal', () => {
-            expect(PackageEditPage.modal.isPresent).to.equal(false);
-          });
-
-          it('reflects the correct holding status', () => {
-            expect(PackageEditPage.isSelected).to.equal(true);
-          });
+        it('should navigate to the show page', () => {
+          expect(PackageShowPage.isPresent).to.equal(true);
         });
       });
     });

--- a/tests/managed-package-edit-selection-test.js
+++ b/tests/managed-package-edit-selection-test.js
@@ -176,12 +176,40 @@ describeApplication('ManagedPackageEditSelection', () => {
       });
 
       describe('clicking confirm', () => {
-        beforeEach(() => {
+        let resolveRequest;
+
+        beforeEach(function () {
+          this.server.put('/packages/:id', () => {
+            return new Promise((resolve) => {
+              resolveRequest = resolve;
+            });
+          });
+
           return PackageEditPage.modal.confirmDeselection();
         });
 
-        it('should navigate to the show page', () => {
-          expect(PackageShowPage.isPresent).to.equal(true);
+        it('should keep confirmation modal on screen until requests responds', () => {
+          expect(PackageEditPage.modal.isPresent).to.equal(true);
+        });
+
+        it('confirmation button now reads "removing"', () => {
+          expect(PackageEditPage.modal.confirmButtonText).to.equal('Removing...');
+          resolveRequest();
+        });
+
+        it('confirmation button is disabled', () => {
+          expect(PackageEditPage.modal.confirmButtonIsDisabled).to.equal(true);
+        });
+
+        describe('when request resolves', () => {
+          beforeEach(() => {
+            return resolveRequest();
+          });
+
+          it('goes to the resource show page', () => {
+            expect(PackageShowPage.$root).to.exist;
+            expect(PackageShowPage.hasTitleList).to.equal(true);
+          });
         });
       });
     });

--- a/tests/managed-package-edit-visibility-test.js
+++ b/tests/managed-package-edit-visibility-test.js
@@ -183,6 +183,7 @@ describeApplication('ManagedPackageEditVisibility', () => {
         expect(PackageEditPage.$root).to.exist;
       });
     });
+
     it('reflects the desired state of holding status', () => {
       expect(PackageEditPage.isSelected).to.equal(false);
     });
@@ -192,7 +193,7 @@ describeApplication('ManagedPackageEditVisibility', () => {
     });
 
     it('disables the save button', () => {
-      expect(PackageEditPage.isSaveDisabled).to.be.true;
+      expect(PackageEditPage.isSavePresent).to.equal(false);
     });
 
     describe('clicking cancel', () => {

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -1,4 +1,5 @@
 import {
+  attribute,
   clickable,
   collection,
   computed,
@@ -23,6 +24,16 @@ import Datepicker from './datepicker';
   confirmDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-yes]');
 }
 
+@interactor class PackageEditDropDown {
+  clickDropDownButton = clickable('button');
+  isExpanded = attribute('button', 'aria-expanded');
+}
+
+@interactor class PackageEditDropDownMenu {
+  clickRemoveFromHoldings = clickable('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
+  clickAddToHoldings = clickable('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
+}
+
 @interactor class PackageEditPage {
   navigationModal = new PackageEditNavigationModal('#navigation-modal');
 
@@ -36,6 +47,8 @@ import Datepicker from './datepicker';
   isSelected = computed(function () {
     return this.selectionText === 'Selected';
   });
+  hasAddButton = isPresent('[data-test-eholdings-package-add-to-holdings-button]');
+  clickAddButton = clickable('[data-test-eholdings-package-add-to-holdings-button]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   isHiddenMessage = text('[data-test-eholdings-package-details-is-hidden-reason]');
   isHiddenMessagePresent = isPresent('[data-test-eholdings-package-details-is-hidden-reason]');
@@ -62,6 +75,8 @@ import Datepicker from './datepicker';
   hasReadOnlyNameFieldPresent = isPresent('[data-test-eholdings-package-readonly-name-field]');
   hasContentTypeFieldPresent = isPresent('[data-test-eholdings-package-content-type-field]');
   hasReadOnlyContentTypeFieldPresent = isPresent('[data-test-eholdings-package-details-readonly-content-type]');
+  dropDown = new PackageEditDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  dropDownMenu = new PackageEditDropDownMenu();
 
   toast = Toast;
 

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -22,6 +22,8 @@ import Datepicker from './datepicker';
 @interactor class PackageEditModal {
   cancelDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-no]');
   confirmDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-yes]');
+  confirmButtonText = text('[data-test-eholdings-package-deselection-confirmation-modal-yes]');
+  confirmButtonIsDisabled = property('[data-test-eholdings-package-deselection-confirmation-modal-yes]', 'disabled');
 }
 
 @interactor class PackageEditDropDown {

--- a/tests/pages/package-edit.js
+++ b/tests/pages/package-edit.js
@@ -39,6 +39,7 @@ import Datepicker from './datepicker';
 
   clickCancel = clickable('[data-test-eholdings-package-cancel-button] button');
   clickSave = clickable('[data-test-eholdings-package-save-button] button');
+  isSavePresent = isPresent('[data-test-eholdings-package-save-button]');
   isSaveDisabled = property('[data-test-eholdings-package-save-button] button', 'disabled');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="package"]');
   toggleIsSelected = clickable('[data-test-eholdings-package-details-selected] input');

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -77,6 +77,7 @@ import Toast from './toast';
     return !!this.titleList().length && this.titleList().every(title => title.isSelected);
   });
 
+  hasTitleList = isPresent('[data-test-query-list="package-titles"]');
   titleList = collection('[data-test-query-list="package-titles"] li a', {
     name: text('[data-test-eholdings-title-list-item-title-name]'),
     isSelectedLabel: text('[data-test-eholdings-title-list-item-title-selected]'),

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -27,11 +27,13 @@
     "package.modalMessageHeader.isCustom": "Delete custom package",
     "package.modalMessageBody.isCustom": "Are you sure you want to delete this package? By deleting this package it will no longer be available for selection and all customization will be lost. If a title only appears in this package it will no longer be available for selection.",
     "package.modalMessageButtonConfirm.isCustom": "Yes, delete",
+    "package.modalMessageButtonWorking.isCustom": "Deleting...",
     "package.modalMessageButtonCancel.isCustom": "No, do not delete",
 
     "package.modalMessageHeader": "Remove package from holdings?",
     "package.modalMessageBody": "Are you sure you want to remove this package and all its titles from your holdings? All customizations will be lost.",
     "package.modalMessageButtonConfirm": "Yes, remove",
+    "package.modalMessageButtonWorking": "Removing...",
     "package.modalMessageButtonCancel": "No, do not remove",
 
     "package.actionMenu.edit": "Edit",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -4,6 +4,7 @@
     "package.contentType": "Content type",
     "package.coverageDates": "Coverage dates",
     "package.customCoverageDates": "Custom coverage dates",
+    "package.deletePackage": "Delete package",
     "package.holdingStatus": "Holding status",
     "package.name": "Name",
     "package.name.isRequired": "Name *",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -1,5 +1,6 @@
 {
     "meta.title": "eHoldings",
+    "package.addToHoldings": "Add to holdings",
     "package.contentType": "Content type",
     "package.coverageDates": "Coverage dates",
     "package.customCoverageDates": "Custom coverage dates",


### PR DESCRIPTION
## Purpose
The "Select / Deselect" toggle switch is totally out of place now on the edit page, so this PR is to bring the edit page back in line with the pattern already on the show page. This replaces the toggle with an "add" button when deselected and a set of actions in the pane header.

#### TODOS
- [x] manged package edit page
- [x] custom package edit page

## Screenshots
*Before*
![2018-07-16 11 55 08](https://user-images.githubusercontent.com/15052791/42775573-54045972-88fa-11e8-9aaa-78fb91393210.gif)

*After*
![2018-07-16 11 33 36](https://user-images.githubusercontent.com/15052791/42775572-53ef2160-88fa-11e8-9600-54c97c8378cb.gif)

