### PR TITLE
UIEH-129: External Link Component in Resource Show

### DIFF
--- a/src/components/external-link/external-link.css
+++ b/src/components/external-link/external-link.css
@@ -1,0 +1,3 @@
+.external-link-icon {
+  vertical-align: middle;
+}

--- a/src/components/external-link/external-link.js
+++ b/src/components/external-link/external-link.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon } from '@folio/stripes-components';
+import classNames from 'classnames/bind';
+import styles from './external-link.css';
+
+classNames.bind(styles);
+
+export default function ExternalLink(props) {
+  return (
+    <a href={props.href} target={props.target} rel={props.rel}>{props.href}{' '}
+      <span data-test-eholdings-resource-show-external-link-icon className={styles['external-link-icon']}>
+        <Icon icon="external-link" size="small" color="currentColor" />
+      </span>
+    </a>
+  );
+}
+
+ExternalLink.propTypes = {
+  href: PropTypes.string,
+  target: PropTypes.string,
+  rel: PropTypes.string
+};

--- a/src/components/external-link/index.js
+++ b/src/components/external-link/index.js
@@ -1,0 +1,1 @@
+export { default } from './external-link';

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -13,12 +13,14 @@ import {
 
 import DetailsView from '../details-view';
 import Link from '../link';
+import ExternalLink from '../external-link/external-link';
 import IdentifiersList from '../identifiers-list';
 import ContributorsList from '..//contributors-list';
 import CoverageDateList from '../coverage-date-list';
 import { isBookPublicationType, isValidCoverageList, processErrors } from '../utilities';
 import DetailsViewSection from '../details-view-section';
 import Toaster from '../toaster';
+
 
 export default class ResourceShow extends Component {
   static propTypes = {
@@ -253,7 +255,11 @@ export default class ResourceShow extends Component {
                 {model.url && (
                   <KeyValue label={`${model.title.isTitleCustom ? 'Custom' : 'Managed'} URL`}>
                     <div data-test-eholdings-resource-show-url>
-                      <a href={model.url} target="_blank" rel="noopener noreferrer">{model.url}</a>
+                      <ExternalLink
+                        href={model.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      />
                     </div>
                   </KeyValue>
                 )}

--- a/tests/pages/resource-show.js
+++ b/tests/pages/resource-show.js
@@ -45,6 +45,7 @@ import Toast from './toast';
   packageName = text('[data-test-eholdings-resource-show-package-name]');
   isUrlPresent = isPresent('[data-test-eholdings-resource-show-url]');
   url = text('[data-test-eholdings-resource-show-url]');
+  isExternalLinkIconPresent = isPresent('[data-test-eholdings-resource-show-external-link-icon]');
   contentType = text('[data-test-eholdings-resource-show-content-type]');
   hasContentType = isPresent('[data-test-eholdings-resource-show-content-type]');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');

--- a/tests/resource-show-test.js
+++ b/tests/resource-show-test.js
@@ -129,6 +129,10 @@ describeApplication('ResourceShow', () => {
       expect(ResourcePage.url).to.equal('https://frontside.io');
     });
 
+    it('displays the external link icon', () => {
+      expect(ResourcePage.isExternalLinkIconPresent).to.be.true;
+    });
+
     describe.skip('clicking the managed url opens link in new tab', () => {
       beforeEach(() => {
         ResourcePage.clickManagedURL();


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-129, we are supposed to display an external link icon next to managed/custom url in resource show page. Implement that functionality.

## Approach
- Create a functional component named `ExternalLink`
- Use Stripes-components Icon component within the anchor link
- Add associated unit tests

#### TODOS and Open Questions
- [x] Icon size "small" supports size 16x16 where as our font size is 14x14. Per @cherewaty  suggestion, reached out to @filipjakobsen and @rasmuswoelk to find out if that is intentional or something that we can change to 14x14. Waiting on @rasmuswoelk response. 
- [x] Based on the above response, decide whether we need external-link.css for styling the icon with padding etc. because currently, since the size is bigger, it is not aesthetically pleasing.
- [x] Added a unit test to check if the icon is present on page, thought of adding one more to ensure that once its clicked, it opens link in a new tab but looks that the existing test for that is being skipped. Should we add any more tests?
- [ ] Ticket also mentions about contributing this component back to stripes, do we need to make any changes to be able to do that?

## Screenshots
![updated_css](https://user-images.githubusercontent.com/33662516/42963629-c4f1781c-8b62-11e8-815a-b5c30a476320.gif)

