### PR TITLE
UIEH-405 Refactor resource-edit page holding status

### DIFF
--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -53,6 +53,12 @@ class ResourceEditCustomTitle extends Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.model.destroy.errors.length) {
+      return {
+        showSelectionModal: false
+      };
+    }
+
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
       return {
         ...prevState,
@@ -102,7 +108,6 @@ class ResourceEditCustomTitle extends Component {
 
   commitSelectionToggle = () => {
     this.setState({
-      showSelectionModal: false,
       allowFormToSubmit: true
     }, () => { this.handleOnSubmit(this.state.formValues); });
   };
@@ -281,8 +286,9 @@ class ResourceEditCustomTitle extends Component {
           footer={(
             <ModalFooter
               primaryButton={{
-                'label': 'Yes, remove',
+                'label': model.destroy.isPending ? 'Removing...' : 'Yes, remove',
                 'onClick': this.commitSelectionToggle,
+                'disabled': model.destroy.isPending,
                 'data-test-eholdings-resource-deselection-confirmation-modal-yes': true
               }}
               secondaryButton={{

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { reduxForm, Field } from 'redux-form';
+import { reduxForm } from 'redux-form';
 import isEqual from 'lodash/isEqual';
 import { intlShape, injectIntl } from 'react-intl';
 
@@ -20,7 +20,6 @@ import CoverageStatementFields, { validate as validateCoverageStatement } from '
 import CustomEmbargoFields, { validate as validateEmbargo } from '../_fields/custom-embargo';
 import DetailsViewSection from '../../details-view-section';
 import NavigationModal from '../../navigation-modal';
-import ToggleSwitch from '../../toggle-switch/toggle-switch';
 import Toaster from '../../toaster';
 import styles from './resource-edit-custom-title.css';
 
@@ -87,6 +86,14 @@ class ResourceEditCustomTitle extends Component {
     );
   }
 
+  handleRemoveResourceFromHoldings = () => {
+    this.setState({
+      formValues: {
+        isSelected: false
+      }
+    }, () => { this.handleOnSubmit(this.state.formValues); });
+  }
+
   handleSelectionToggle = (e) => {
     this.setState({
       resourceSelected: e.target.checked
@@ -149,6 +156,15 @@ class ResourceEditCustomTitle extends Component {
       }
     ];
 
+    if (resourceSelected === true) {
+      actionMenuItems.push({
+        'label': 'Remove title from holdings',
+        'state': { eholdings: true },
+        'onClick': this.handleRemoveResourceFromHoldings,
+        'data-test-eholdings-remove-resource-from-holdings': true
+      });
+    }
+
     let visibilityMessage = model.package.visibilityData.isHidden
       ? '(All titles in this package are hidden)'
       : model.visibilityData.reason && `(${model.visibilityData.reason})`;
@@ -164,6 +180,17 @@ class ResourceEditCustomTitle extends Component {
           actionMenuItems={actionMenuItems}
           bodyContent={(
             <form onSubmit={handleSubmit(this.handleOnSubmit)}>
+              <DetailsViewSection
+                label="Holding status"
+              >
+                <label
+                  data-test-eholdings-resource-holding-status
+                  htmlFor="custom-resource-holding-status"
+                >
+                  <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
+                  <br />
+                </label>
+              </DetailsViewSection>
               <DetailsViewSection label="Resource settings">
                 {resourceSelected ? (
                   <Fragment>
@@ -176,24 +203,7 @@ class ResourceEditCustomTitle extends Component {
                   </p>
                 )}
               </DetailsViewSection>
-              <DetailsViewSection
-                label="Holding status"
-              >
-                <label
-                  data-test-eholdings-resource-holding-status
-                  htmlFor="custom-resource-holding-toggle-switch"
-                >
-                  <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
-                  <br />
-                  <Field
-                    name="isSelected"
-                    component={ToggleSwitch}
-                    checked={resourceSelected}
-                    onChange={this.handleSelectionToggle}
-                    id="custom-resource-holding-toggle-switch"
-                  />
-                </label>
-              </DetailsViewSection>
+
               <DetailsViewSection
                 label="Coverage dates"
               >

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -61,6 +61,12 @@ class ResourceEditManagedTitle extends Component { // eslint-disable-line react/
       });
     }
 
+    if (nextProps.model.update.errors.length) {
+      this.setState({
+        showSelectionModal: false
+      });
+    }
+
     if (wasUnSelected || isCurrentlySelected) {
       if (wasPending && needsUpdate) {
         this.context.router.history.push(
@@ -102,7 +108,6 @@ class ResourceEditManagedTitle extends Component { // eslint-disable-line react/
 
   commitSelectionToggle = () => {
     this.setState({
-      showSelectionModal: false,
       allowFormToSubmit: true
     }, () => { this.handleOnSubmit(this.state.formValues); });
   };
@@ -206,7 +211,7 @@ class ResourceEditManagedTitle extends Component { // eslint-disable-line react/
                     <Button
                       buttonStyle="primary"
                       onClick={this.handleAddResourceToHoldings}
-                      disabled={model.destroy.isPending || isSelectInFlight}
+                      disabled={isSelectInFlight}
                       data-test-eholdings-resource-add-to-holdings-button
                     >
                       Add to holdings
@@ -265,11 +270,11 @@ class ResourceEditManagedTitle extends Component { // eslint-disable-line react/
                     data-test-eholdings-resource-save-button
                   >
                     <Button
-                      disabled={pristine || model.update.isPending || model.destroy.isPending}
+                      disabled={pristine || model.update.isPending}
                       type="submit"
                       buttonStyle="primary"
                     >
-                      {model.update.isPending || model.destroy.isPending ? 'Saving' : 'Save'}
+                      {model.update.isPending ? 'Saving' : 'Save'}
                     </Button>
                   </div>
                   {model.update.isPending && (
@@ -290,8 +295,9 @@ class ResourceEditManagedTitle extends Component { // eslint-disable-line react/
           footer={(
             <ModalFooter
               primaryButton={{
-                'label': 'Yes, remove',
+                'label': model.update.isPending ? 'Removing...' : 'Yes, remove',
                 'onClick': this.commitSelectionToggle,
+                'disabled': model.update.isPending,
                 'data-test-eholdings-resource-deselection-confirmation-modal-yes': true
               }}
               secondaryButton={{

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -77,6 +77,10 @@ class ResourceEditRoute extends Component {
       model.coverageStatement = '';
 
       updateResource(model);
+    } else if (values.isSelected && !values.customCoverages) {
+      model.isSelected = true;
+
+      updateResource(model);
     } else {
       model.customCoverages = customCoverages.map((dateRange) => {
         let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).tz('UTC').format('YYYY-MM-DD');
@@ -95,6 +99,7 @@ class ResourceEditRoute extends Component {
         embargoValue: customEmbargoValue,
         embargoUnit: customEmbargoUnit
       };
+
       updateResource(model);
     }
   }

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -70,7 +70,7 @@ class ResourceEditRoute extends Component {
       model.customCoverages = [];
       model.visibilityData.isHidden = false;
       model.identifiersList = [];
-      model.identifiers = {};
+      model.identifiers = [];
       model.customStatement = '';
       model.customEmbargoPeriod = {};
       model.contributors = [];

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -73,7 +73,7 @@ class ResourceShowRoute extends Component {
       model.coverageStatement = '';
       model.customEmbargoPeriod = {};
       model.identifiersList = [];
-      model.identifiers = {};
+      model.identifiers = [];
 
       updateResource(model);
     }

--- a/tests/custom-resource-edit-embargo-test.js
+++ b/tests/custom-resource-edit-embargo-test.js
@@ -328,17 +328,7 @@ describeApplication('CustomResourceEditEmbargo', () => {
     });
 
     it('displays an indicator that the title package is selected', () => {
-      expect(ResourceEditPage.isSelected).to.equal(true);
-    });
-
-    describe('toggling to deselect a title package', () => {
-      beforeEach(() => {
-        return ResourceEditPage.toggleIsSelected();
-      });
-
-      it('displays a message that custom embargo is not shown', () => {
-        expect(ResourceEditPage.isEmbargoNotShownLabelPresent).to.be.true;
-      });
+      expect(ResourceEditPage.isResourceSelected).to.equal('Selected');
     });
   });
 });

--- a/tests/custom-resource-edit-visibility-test.js
+++ b/tests/custom-resource-edit-visibility-test.js
@@ -204,25 +204,11 @@ describeApplication('CustomResourceEditVisibility', () => {
     });
 
     it('reflects the desired state of holding status', () => {
-      expect(ResourceEditPage.isSelected).to.equal(true);
+      expect(ResourceEditPage.isResourceSelected).to.equal('Selected');
     });
 
     it('disables the save button', () => {
       expect(ResourceEditPage.isSaveDisabled).to.be.true;
-    });
-
-    describe('toggling the selection toggle', () => {
-      beforeEach(() => {
-        return ResourceEditPage.toggleIsSelected();
-      });
-
-      it('cannot toggle visibility', () => {
-        expect(ResourceEditPage.isVisibilityFieldPresent).to.equal(false);
-      });
-
-      it('displays a not selected message for resource settings', () => {
-        expect(ResourceEditPage.isResourceNotSelectedLabelPresent).to.be.true;
-      });
     });
   });
 });

--- a/tests/managed-resource-edit-embargo-test.js
+++ b/tests/managed-resource-edit-embargo-test.js
@@ -302,8 +302,8 @@ describeApplication('ManagedResourceEditEmbargo', () => {
       });
     });
 
-    it('displays a message that custom embargo is not shown', () => {
-      expect(ResourceEditPage.isEmbargoNotShownLabelPresent).to.be.true;
+    it('should not show the embargo section', () => {
+      expect(ResourceEditPage.hasCustomEmbargoSelect).to.be.false;
     });
   });
 
@@ -326,17 +326,7 @@ describeApplication('ManagedResourceEditEmbargo', () => {
     });
 
     it('displays an indicator that the title package is selected', () => {
-      expect(ResourceEditPage.isSelected).to.equal(true);
-    });
-
-    describe('toggling to deselect a title package', () => {
-      beforeEach(() => {
-        return ResourceEditPage.toggleIsSelected();
-      });
-
-      it('displays a message that custom embargo is not shown', () => {
-        expect(ResourceEditPage.isEmbargoNotShownLabelPresent).to.be.true;
-      });
+      expect(ResourceEditPage.isResourceSelected).to.equal('Selected');
     });
   });
 });

--- a/tests/managed-resource-edit-visibility-test.js
+++ b/tests/managed-resource-edit-visibility-test.js
@@ -201,8 +201,8 @@ describeApplication('ManagedResourceEditVisibility', () => {
       });
     });
 
-    it('does not show titles in package to patrons', () => {
-      expect(ResourceEditPage.isResourceNotSelectedLabelPresent).to.be.true;
+    it('does not show visibility section', () => {
+      expect(ResourceEditPage.isVisibilityFieldPresent).to.be.false;
     });
   });
 });

--- a/tests/pages/resource-edit.js
+++ b/tests/pages/resource-edit.js
@@ -25,6 +25,8 @@ import Datepicker from './datepicker';
 @interactor class ResourceEditModal {
   confirmDeselection = clickable('[data-test-eholdings-resource-deselection-confirmation-modal-yes]');
   cancelDeselection = clickable('[data-test-eholdings-resource-deselection-confirmation-modal-no]');
+  confirmButtonText = text('[data-test-eholdings-resource-deselection-confirmation-modal-yes]');
+  confirmButtonIsDisabled = property('[data-test-eholdings-resource-deselection-confirmation-modal-yes]', 'disabled');
 }
 
 @interactor class ResourceEditPage {

--- a/tests/pages/resource-edit.js
+++ b/tests/pages/resource-edit.js
@@ -41,7 +41,6 @@ import Datepicker from './datepicker';
   isPeerReviewed = property('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]', 'checked');
   checkPeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
-  isSelected = property('[data-test-eholdings-resource-holding-status] input', 'checked');
   isResourceSelected = text('[data-test-eholdings-resource-holding-status] h4');
   isResourceVisible = property('[data-test-eholdings-resource-visibility-field] input[value="true"]', 'checked');
   isHiddenMessage = computed(function () {

--- a/tests/pages/resource-edit.js
+++ b/tests/pages/resource-edit.js
@@ -30,14 +30,19 @@ import Datepicker from './datepicker';
 @interactor class ResourceEditPage {
   navigationModal = new ResourceEditNavigationModal('#navigation-modal');
 
+  addToHoldingsButton = isPresent('[data-test-eholdings-resource-add-to-holdings-button]');
+
   clickCancel = clickable('[data-test-eholdings-resource-cancel-button] button');
   clickSave = clickable('[data-test-eholdings-resource-save-button] button');
+  hasSaveButon = isPresent('[data-test-eholdings-resource-save-button] button');
+  hasCancelButton = isPresent('[data-test-eholdings-resource-cancel-button] button');
   isSaveDisabled = property('[data-test-eholdings-resource-save-button] button', 'disabled');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
   isPeerReviewed = property('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]', 'checked');
   checkPeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   isSelected = property('[data-test-eholdings-resource-holding-status] input', 'checked');
+  isResourceSelected = text('[data-test-eholdings-resource-holding-status] h4');
   isResourceVisible = property('[data-test-eholdings-resource-visibility-field] input[value="true"]', 'checked');
   isHiddenMessage = computed(function () {
     let $node = this.$('[data-test-eholdings-resource-visibility-field] input[value="false"] ~ span:last-child');

--- a/tests/pages/resource-show.js
+++ b/tests/pages/resource-show.js
@@ -9,7 +9,6 @@ import {
   text,
   is
 } from '@bigtest/interactor';
-import { hasClassBeginningWith } from './helpers';
 import Toast from './toast';
 
 
@@ -39,7 +38,6 @@ import Toast from './toast';
   descriptionText = text('[data-test-eholdings-description-field]');
   publisherName = text('[data-test-eholdings-resource-show-publisher-name]');
   publicationType = text('[data-test-eholdings-resource-show-publication-type]');
-  isSelected = property('[data-test-eholdings-resource-show-selected] input', 'checked');
   hasPublicationType = isPresent('[data-test-eholdings-resource-show-publication-type]');
   subjectsList = text('[data-test-eholdings-resource-show-subjects-list]');
   providerName = text('[data-test-eholdings-resource-show-provider-name]');
@@ -51,8 +49,6 @@ import Toast from './toast';
   hasContentType = isPresent('[data-test-eholdings-resource-show-content-type]');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
   isResourceSelected = text('[data-test-eholdings-resource-show-selected] h4');
-  isSelected = property('[data-test-eholdings-resource-show-selected] input', 'checked');
-  isSelecting = hasClassBeginningWith('[data-test-eholdings-resource-show-selected] [data-test-toggle-switch]', 'is-pending--');
   isLoading = isPresent('[data-test-eholdings-resource-show-selected] [class*=icon---][class*=iconSpinner]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button] button');
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button] button');

--- a/tests/resource-edit-custom-title-test.js
+++ b/tests/resource-edit-custom-title-test.js
@@ -44,16 +44,31 @@ describeApplication('ResourceEditCustomTitle', () => {
 
   describe('visting the custom resource edit page but the resource is unselected', () => {
     beforeEach(function () {
+      let title = this.server.create('title', {
+        name: 'Best Title Ever',
+        publicationType: 'Streaming Video',
+        publisherName: 'Amazing Publisher',
+        isTitleCustom: true
+      });
+
+      title.save();
+
+      resource = this.server.create('resource', {
+        package: providerPackage,
+        isSelected: false,
+        visibilityData: {
+          isHidden: true
+        },
+        title,
+        url: 'https://frontside.io'
+      });
+
       return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
         expect(ResourceEditPage.$root).to.exist;
       });
     });
 
     describe('with the resource unselected', () => {
-      beforeEach(() => {
-        return ResourceEditPage.toggleIsSelected();
-      });
-
       it('should not display the coverage button', () => {
         expect(ResourceEditPage.hasAddCustomCoverageButton).to.be.false;
       });

--- a/tests/resource-edit-deselection-test.js
+++ b/tests/resource-edit-deselection-test.js
@@ -44,61 +44,23 @@ describeApplication('ResourceEditDeselection', () => {
       });
 
       it('indicates that the resource is selected', () => {
-        expect(ResourceEditPage.isSelected).to.equal(true);
+        expect(ResourceEditPage.isResourceSelected).to.equal('Selected');
       });
 
       describe('deselecting', () => {
         beforeEach(() => {
-          return ResourceEditPage.toggleIsSelected();
+          return ResourceShowPage
+            .dropDown.clickDropDownButton()
+            .dropDownMenu.clickRemoveFromHoldings();
         });
 
-        it('hides custom url field', () => {
-          expect(ResourceEditPage.hasCustomUrlField).to.equal(false);
-        });
-
-        it('hides visibility field', () => {
-          expect(ResourceEditPage.isVisibilityFieldPresent).to.equal(false);
-        });
-
-        it('hides add date range button', () => {
-          expect(ResourceEditPage.hasAddCustomCoverageButton).to.equal(false);
-        });
-
-        it('hides coverage statement input field', () => {
-          expect(ResourceEditPage.hasCoverageStatementArea).to.equal(false);
-        });
-
-        it('hides add embargo period button', () => {
-          expect(ResourceEditPage.hasAddCustomEmbargoButton).to.equal(false);
-        });
-
-        describe('clicking save', () => {
+        describe('clicking yes', () => {
           beforeEach(() => {
-            return ResourceEditPage.clickSave();
+            return ResourceEditPage.modal.confirmDeselection();
           });
 
-          it('displays confirmation modal', () => {
-            expect(ResourceEditPage.modal.$root).to.exist;
-          });
-
-          describe('clicking no', () => {
-            beforeEach(() => {
-              return ResourceEditPage.modal.cancelDeselection();
-            });
-
-            it('returns to the edit page', () => {
-              expect(ResourceEditPage.$root).to.exist;
-            });
-          });
-
-          describe('clicking yes', () => {
-            beforeEach(() => {
-              return ResourceEditPage.modal.confirmDeselection();
-            });
-
-            it('goes to the resource show page', () => {
-              expect(ResourceShowPage.$root).to.exist;
-            });
+          it('goes to the resource show page', () => {
+            expect(ResourceShowPage.$root).to.exist;
           });
         });
       });

--- a/tests/resource-edit-managed-title-in-custom-package-test.js
+++ b/tests/resource-edit-managed-title-in-custom-package-test.js
@@ -1,7 +1,8 @@
-import { beforeEach, afterEach, describe, it } from '@bigtest/mocha';
+import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
 import { describeApplication } from './helpers';
+import ResourcePage from './pages/resource-show';
 import ResourceEditPage from './pages/resource-edit';
 import PackageSearchPage from './pages/package-search';
 
@@ -47,7 +48,7 @@ describeApplication('ResourceEditManagedTitleInCustomPackage', () => {
     });
 
     it('shows the managed resource as selected in my holdings', () => {
-      expect(ResourceEditPage.isSelected).to.equal(true);
+      expect(ResourceEditPage.isResourceSelected).to.equal('Selected');
     });
 
     it('shows save button to be disabled', () => {
@@ -55,73 +56,47 @@ describeApplication('ResourceEditManagedTitleInCustomPackage', () => {
     });
 
 
-    describe('deselecting a managed resource', () => {
-      beforeEach(function () {
-        /*
-         * The expectations in the convergent `it` blocks
-         * get run once every 10ms.  We were seeing test flakiness
-         * when a toggle action dispatched and resolved before an
-         * expectation had the chance to run.  We sidestep this by
-         * temporarily increasing the mirage server's response time
-         * to 50ms.
-         * TODO: control timing directly with Mirage
-         */
-        this.server.timing = 50;
-        return ResourceEditPage.toggleIsSelected();
+    describe('removing a managed resource', () => {
+      beforeEach(() => {
+        return ResourcePage
+          .dropDown.clickDropDownButton()
+          .dropDownMenu.clickRemoveFromHoldings();
       });
 
-      afterEach(function () {
-        this.server.timing = 0;
+      it('shows the confirmation modal', () => {
+        expect(ResourceEditPage.modal.isPresent).to.equal(true);
       });
 
-      it('reflects the desired state (not selected)', () => {
-        expect(ResourceEditPage.isSelected).to.equal(false);
-      });
-
-      describe('clicking save button', () => {
+      describe('confirming the save and continue deselection', () => {
         beforeEach(() => {
-          return ResourceEditPage.clickSave();
+          return ResourceEditPage.modal.confirmDeselection();
         });
 
-        it('shows the confirmation modal', () => {
-          expect(ResourceEditPage.modal.isPresent).to.equal(true);
+        it('transition to package search page', () => {
+          expect(PackageSearchPage.isPresent).to.equal(true);
         });
 
-        describe('confirming the save and continue deselection', () => {
-          beforeEach(() => {
-            return ResourceEditPage.modal.confirmDeselection();
-          });
-
-          it('transition to package search page', () => {
-            expect(PackageSearchPage.isPresent).to.equal(true);
-          });
-
-          it('has search prefilled with package name', () => {
-            expect(PackageSearchPage.searchFieldValue).to.equal('Star Wars Custom Package');
-          });
-
-          it('does not have an association to the above package', () => {
-            expect(PackageSearchPage.packageTitleList().length).to.equal(0);
-          });
-
-          it('has a success Toast notification', () => {
-            expect(PackageSearchPage.toast.successText).to.equal('Title removed from package.');
-          });
+        it('has search prefilled with package name', () => {
+          expect(PackageSearchPage.searchFieldValue).to.equal('Star Wars Custom Package');
         });
 
-        describe('canceling the save and discontinue deselection', () => {
-          beforeEach(() => {
-            return ResourceEditPage.modal.cancelDeselection();
-          });
+        it('does not have an association to the above package', () => {
+          expect(PackageSearchPage.packageTitleList().length).to.equal(0);
+        });
 
-          it('should not transition to title search page', () => {
-            expect(PackageSearchPage.isPresent).to.equal(false);
-            expect(ResourceEditPage.isPresent).to.equal(true);
-          });
+        it('has a success Toast notification', () => {
+          expect(PackageSearchPage.toast.successText).to.equal('Title removed from package.');
+        });
+      });
 
-          it('reverts holding status back to original state', () => {
-            expect(ResourceEditPage.isSelected).to.equal(true);
-          });
+      describe('canceling the save and discontinue deselection', () => {
+        beforeEach(() => {
+          return ResourceEditPage.modal.cancelDeselection();
+        });
+
+        it('should not transition to title search page', () => {
+          expect(PackageSearchPage.isPresent).to.equal(false);
+          expect(ResourceEditPage.isPresent).to.equal(true);
         });
       });
     });
@@ -130,40 +105,26 @@ describeApplication('ResourceEditManagedTitleInCustomPackage', () => {
       beforeEach(function () {
         this.server.delete('/resources/:id', {
           errors: [{
-            title: 'There was an error'
+            title: 'There was an error.'
           }]
         }, 500);
 
-        return ResourceEditPage.toggleIsSelected();
+        return ResourcePage
+          .dropDown.clickDropDownButton()
+          .dropDownMenu.clickRemoveFromHoldings();
       });
 
-      it('reflects the desired state (Unselected)', () => {
-        expect(ResourceEditPage.isSelected).to.equal(false);
-      });
-
-      describe('clicking save', () => {
+      describe('confirming the deselection', () => {
         beforeEach(() => {
-          return ResourceEditPage.clickSave();
+          return ResourceEditPage.modal.confirmDeselection();
         });
 
-        describe('confirm and continue deselection', () => {
-          beforeEach(() => {
-            return ResourceEditPage.modal.confirmDeselection();
-          });
+        it('shows a toasts with an error message', () => {
+          expect(ResourceEditPage.toast.errorText).to.equal('There was an error.');
+        });
 
-          it('cannot be interacted with while the request is in flight', () => {
-            expect(ResourceEditPage.isSaveDisabled).to.equal(true);
-          });
-
-          describe('when the request fails', () => {
-            it('indicates it is no longer working', () => {
-              expect(ResourceEditPage.isSaveDisabled).to.equal(false);
-            });
-
-            it('shows the error as a toast', () => {
-              expect(ResourceEditPage.toast.errorText).to.equal('There was an error');
-            });
-          });
+        it('reflects the desired state was not set)', () => {
+          expect(ResourceEditPage.isResourceSelected).to.equal('Selected');
         });
       });
     });

--- a/tests/resource-edit-managed-title-test.js
+++ b/tests/resource-edit-managed-title-test.js
@@ -5,6 +5,8 @@ import { describeApplication } from './helpers';
 import ResourceShowPage from './pages/resource-show';
 import ResourceEditPage from './pages/resource-edit';
 
+window.ResourceEditPage = ResourceEditPage;
+
 describeApplication('ResourceEditManagedTitleInManagedPackage', () => {
   let provider,
     providerPackage,
@@ -38,32 +40,6 @@ describeApplication('ResourceEditManagedTitleInManagedPackage', () => {
       visibilityData: {
         isHidden: true
       }
-    });
-  });
-
-  describe('visting the managed resource edit page but the resource is unselected', () => {
-    beforeEach(function () {
-      return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
-        expect(ResourceEditPage.$root).to.exist;
-      });
-    });
-
-    describe('with the resource unselected', () => {
-      beforeEach(() => {
-        return ResourceEditPage.toggleIsSelected();
-      });
-
-      it('should not display the coverage button', () => {
-        expect(ResourceEditPage.hasAddCustomCoverageButton).to.be.false;
-      });
-
-      it('should not display the custom embargo button', () => {
-        expect(ResourceEditPage.hasAddCustomEmbargoButton).to.be.false;
-      });
-
-      it('should not display the coverage statement textarea', () => {
-        expect(ResourceEditPage.hasCoverageStatementArea).to.be.false;
-      });
     });
   });
 
@@ -134,7 +110,7 @@ describeApplication('ResourceEditManagedTitleInManagedPackage', () => {
           return ResourceEditPage.clickRemoveCustomEmbargoButton();
         });
 
-        it.always('does not show a message that saving will remove embargo', () => {
+        it('does not show a message that saving will remove embargo', () => {
           expect(ResourceEditPage.hasSavingWillRemoveEmbargoMessage).to.be.false;
         });
       });

--- a/tests/resource-edit-selection-test.js
+++ b/tests/resource-edit-selection-test.js
@@ -7,7 +7,7 @@ import ResourceEditPage from './pages/resource-edit';
 
 window.ResourceEditPage = ResourceEditPage;
 
-describeApplication.only('ResourceEditSelection', () => {
+describeApplication('ResourceEditSelection', () => {
   let provider,
     providerPackage,
     resource;

--- a/tests/resource-edit-selection-test.js
+++ b/tests/resource-edit-selection-test.js
@@ -5,7 +5,9 @@ import { describeApplication } from './helpers';
 import ResourceShowPage from './pages/resource-show';
 import ResourceEditPage from './pages/resource-edit';
 
-describeApplication('ResourceEditSelection', () => {
+window.ResourceEditPage = ResourceEditPage;
+
+describeApplication.only('ResourceEditSelection', () => {
   let provider,
     providerPackage,
     resource;
@@ -33,7 +35,7 @@ describeApplication('ResourceEditSelection', () => {
     });
   });
 
-  describe('visiting the resource edit page', () => {
+  describe('visiting the resource edit page with unselected resource', () => {
     beforeEach(function () {
       return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
         expect(ResourceEditPage.$root).to.exist;
@@ -41,94 +43,58 @@ describeApplication('ResourceEditSelection', () => {
     });
 
     it('indicates that the resource is not yet selected', () => {
-      expect(ResourceEditPage.isSelected).to.equal(false);
+      expect(ResourceEditPage.isResourceSelected).to.equal('Not selected');
     });
 
-    describe('successfully selecting a package title to add to my holdings', () => {
+    it('displays an add to holdings button', () => {
+      expect(ResourceEditPage.addToHoldingsButton).to.equal(true);
+    });
+
+
+    it('should not display the coverage button', () => {
+      expect(ResourceEditPage.hasAddCustomCoverageButton).to.be.false;
+    });
+
+    it('should not display the custom embargo button', () => {
+      expect(ResourceEditPage.hasAddCustomEmbargoButton).to.be.false;
+    });
+
+    it('should not display the coverage statement textarea', () => {
+      expect(ResourceEditPage.hasCoverageStatementArea).to.be.false;
+    });
+
+    describe('successfully adding a resource to holdings using button', () => {
       beforeEach(() => {
-        return ResourceEditPage.toggleIsSelected();
+        return ResourceShowPage.clickAddToHoldingsButton();
       });
 
       it('reflects the desired state (Selected)', () => {
-        expect(ResourceEditPage.isSelected).to.equal(true);
+        expect(ResourceEditPage.isResourceSelected).to.equal('Selected');
       });
 
-      describe('clicking cancel', () => {
-        beforeEach(() => {
-          return ResourceEditPage.clickCancel();
-        });
-
-        it('goes to the resource show page', () => {
-          expect(ResourceShowPage.$root).to.exist;
-        });
-      });
-
-      describe('when the request succeeds', () => {
-        it('reflects the desired state was set', () => {
-          expect(ResourceEditPage.isSelected).to.equal(true);
-        });
-
-        describe('clicking save', () => {
-          beforeEach(() => {
-            return ResourceEditPage.clickSave();
-          });
-
-          it('goes to the resource show page', () => {
-            expect(ResourceShowPage.$root).to.exist;
-          });
-
-          it('reflects the new state', () => {
-            expect(ResourceShowPage.isResourceSelected).to.equal('Selected');
-          });
-        });
+      it('remains on the resource edit page', () => {
+        expect(ResourceEditPage.hasCancelButton).to.equal(true);
+        expect(ResourceEditPage.hasSaveButon).to.equal(true);
       });
     });
 
-    describe('unsuccessfully selecting a package title to add to my holdings', () => {
+    describe('adding a package title to my holdings but request fails', () => {
       beforeEach(function () {
         this.server.put('/resources/:id', {
           errors: [{
             title: 'There was an error'
           }]
         }, 500);
-        return ResourceEditPage.toggleIsSelected();
+        return ResourceShowPage.clickAddToHoldingsButton();
       });
 
-      it('reflects the desired state (Selected)', () => {
-        expect(ResourceEditPage.isSelected).to.equal(true);
-      });
-
-      describe('clicking cancel', () => {
-        beforeEach(() => {
-          return ResourceEditPage.clickCancel();
-        });
-
-        it('goes to the resource show page', () => {
-          expect(ResourceShowPage.$root).to.exist;
-        });
-      });
-
-      describe('when the request succeeds', () => {
+      describe('when the request fails', () => {
         it('reflects the desired state was set', () => {
-          expect(ResourceEditPage.isSelected).to.equal(true);
+          expect(ResourceEditPage.isResourceSelected).to.equal('Not selected');
         });
 
-        describe('clicking save', () => {
-          beforeEach(() => {
-            return ResourceEditPage.clickSave();
-          });
-
-          it('goes to the resource show page', () => {
-            expect(ResourceShowPage.$root).to.exist;
-          });
-
-          it('indicates it is no longer working', () => {
-            expect(ResourceShowPage.isLoading).to.equal(false);
-          });
-
-          it('displays a toast error', () => {
-            expect(ResourceShowPage.toast.errorText).to.equal('There was an error');
-          });
+        it('displays a toast error', () => {
+          expect(ResourceShowPage.toast.errorText).to.equal('There was an error');
         });
       });
     });


### PR DESCRIPTION
## Purpose
eHoldings users are able to manage their holdings by adding or removing a resource from their holdings. Here we are also providing them that ability when in the 'edit' mode of a resource aka package-title. eHoldings has the concept of a managed-resource and a custom-resource and even though the behavior slightly differs between the two types the base is the same -- a user managing the status of their holdings.

Prior this area used a toggle switch but we are refactoring towards a explicit button and action
from the dropdown to conform with the UX from other FOLIO applications.

## Approach
To ensure that the eHoldings UX is inline with other FOLIO applications:
 - Add a button which allows a user to add a resource to their holdings when the resource is unselected.
 - Move the removal of a resource action into the dropdown menu.
## Jira
https://issues.folio.org/browse/UIEH-405

## Screenshots
*Custom Resource:*
![2018-07-19 13 10 43](https://user-images.githubusercontent.com/1953098/42959032-62396b2e-8b55-11e8-930e-400affedaad5.gif)

*Managed Resource:*
![2018-07-19 13 09 43](https://user-images.githubusercontent.com/1953098/42959047-6c94c8c0-8b55-11e8-9425-30968282e09f.gif)

