### PR TITLE
UIEH-502: Remove 'All' as publication type for titles create/edit

### DIFF
--- a/mirage/factories/title.js
+++ b/mirage/factories/title.js
@@ -4,7 +4,6 @@ export default Factory.extend({
   name: () => faker.company.catchPhrase(),
   publisherName: () => faker.company.companyName(),
   publicationType: () => faker.random.arrayElement([
-    'All',
     'Audiobook',
     'Book',
     'Book Series',

--- a/src/components/title/_fields/publication-type/publication-type.js
+++ b/src/components/title/_fields/publication-type/publication-type.js
@@ -15,7 +15,6 @@ export default function PublicationTypeField() {
         component={Select}
         label="Publication type"
         dataOptions={[
-          { value: 'All', label: 'All' },
           { value: 'Audio Book', label: 'Audio Book' },
           { value: 'Book', label: 'Book' },
           { value: 'Book Series', label: 'Book Series' },


### PR DESCRIPTION
https://issues.folio.org/browse/UIEH-502

## Purpose
Remove 'All' from Publication Type dropdown selection which is present on both Titles Create and Resource Edit pages (for a Custom Title). This option is not available from RM API and results in an HTTP 400 error (if selected)

## Approach
Removed 'All' as option for publication type field (used for both title create and update)
Removed 'All' as option from mirage title publication types.

## Learning
RM API documentation for custom title payload notes the values which are valid for pubType
https://developer.ebsco.com/reference/rmapi#customtitlepayload

## Screenshots
<img width="1657" alt="screen shot 2018-07-18 at 5 50 11 pm" src="https://user-images.githubusercontent.com/19415226/42910166-76ca665c-8ab4-11e8-9b28-7d0f2be6729c.png">
