### PR TITLE
Allow DetailsViewSection label to be React element

### DIFF
--- a/src/components/details-view-section/details-view-section.js
+++ b/src/components/details-view-section/details-view-section.js
@@ -17,9 +17,12 @@ export default function DetailsViewSection(props) {
 }
 
 DetailsViewSection.propTypes = {
-  label: PropTypes.string,
-  separator: PropTypes.bool,
-  children: PropTypes.node
+  children: PropTypes.node,
+  label: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.string
+  ]).isRequired,
+  separator: PropTypes.bool
 };
 
 DetailsViewSection.defaultProps = {


### PR DESCRIPTION
Allows `<FormattedMessage>` to be passed into `label`, so `label` acts the same way as a `stripes-components` `Accordion`.