### PR TITLE
Use ReduxForm format() on Datepickers

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "webpack": "^4.0.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "3.0.1000441",
+    "@folio/stripes-components": "3.0.1000442",
     "classnames": "^2.2.5",
     "funcadelic": "^0.4.0",
     "impagination": "^1.0.0-alpha.3",

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Field, FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { injectIntl, intlShape } from 'react-intl';
 
 import Datepicker from '@folio/stripes-components/lib/Datepicker';
 import Button from '@folio/stripes-components/lib/Button';
@@ -9,9 +10,10 @@ import IconButton from '@folio/stripes-components/lib/IconButton';
 
 import styles from './package-coverage-fields.css';
 
-export default class PackageCoverageFields extends Component {
+class PackageCoverageFields extends Component {
   static propTypes = {
-    initialValue: PropTypes.array
+    initialValue: PropTypes.array,
+    intl: intlShape.isRequired
   };
 
   static defaultProps = {
@@ -19,7 +21,7 @@ export default class PackageCoverageFields extends Component {
   };
 
   renderCoverageFields = ({ fields }) => {
-    let { initialValue } = this.props;
+    let { initialValue, intl } = this.props;
 
     return (
       <div className={styles['coverage-fields']}>
@@ -61,6 +63,7 @@ export default class PackageCoverageFields extends Component {
                     type="text"
                     component={Datepicker}
                     label="Start date"
+                    format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
                   />
                 </div>
                 <div
@@ -72,6 +75,7 @@ export default class PackageCoverageFields extends Component {
                     type="text"
                     component={Datepicker}
                     label="End date"
+                    format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
                   />
                 </div>
 
@@ -99,6 +103,8 @@ export default class PackageCoverageFields extends Component {
     );
   }
 }
+
+export default injectIntl(PackageCoverageFields);
 
 export function validate(values, props) {
   moment.locale(props.intl.locale);

--- a/src/components/resource/_fields/custom-coverage/resource-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/resource-coverage-fields.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Field, FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { FormattedDate } from 'react-intl';
+import { injectIntl, intlShape, FormattedDate } from 'react-intl';
 
 import {
   Button,
@@ -12,9 +12,10 @@ import {
 
 import styles from './resource-coverage-fields.css';
 
-export default class ResourceCoverageFields extends Component {
+class ResourceCoverageFields extends Component {
   static propTypes = {
-    initialValue: PropTypes.array
+    initialValue: PropTypes.array,
+    intl: intlShape.isRequired
   };
 
   static defaultProps = {
@@ -22,7 +23,7 @@ export default class ResourceCoverageFields extends Component {
   };
 
   renderCoverageFields = ({ fields }) => {
-    let { initialValue } = this.props;
+    let { initialValue, intl } = this.props;
     return (
       <div className={styles['coverage-fields']}>
         {fields.length === 0
@@ -52,6 +53,7 @@ export default class ResourceCoverageFields extends Component {
                     component={Datepicker}
                     label="Start date"
                     id="begin-coverage"
+                    format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
                   />
                 </div>
                 <div
@@ -64,6 +66,7 @@ export default class ResourceCoverageFields extends Component {
                     component={Datepicker}
                     label="End date"
                     id="end-coverage"
+                    format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
                   />
                 </div>
 
@@ -103,6 +106,8 @@ export default class ResourceCoverageFields extends Component {
     );
   }
 }
+
+export default injectIntl(ResourceCoverageFields);
 
 /**
  * Validator to ensure start date comes before end date chronologically

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,9 +175,9 @@
     webpack-bundle-analyzer "^2.9.1"
     yargs "^10.0.3"
 
-"@folio/stripes-components@3.0.1000441":
-  version "3.0.1000441"
-  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-components/-/stripes-components-3.0.1000441.tgz#08d2b5adac0d718624126de0b578fea271f07b27"
+"@folio/stripes-components@3.0.1000442":
+  version "3.0.1000442"
+  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-components/-/stripes-components-3.0.1000442.tgz#21170f1ae965f73a7f6955909a246f2355ff66e5"
   dependencies:
     "@folio/stripes-connect" "^3.1.3"
     "@folio/stripes-form" "^0.8.2"


### PR DESCRIPTION
## Purpose
Changes in https://github.com/folio-org/stripes-components/pull/487 needed these updates to `Datepicker` usage.

## Approach
The `format()` prop on Redux Form `<Field>` takes care of the date transformation we need to do from `YYYY-MM-DD` to whatever the user's locale is.

Seems to work with the current iteration of the `Datepicker` as well, so might as well get it in.

## Learning
https://redux-form.com/7.4.2/docs/api/field.md/#-code-format-value-name-gt-formattedvalue-code-optional-
