### PR TITLE
UIEH-504 Clear contributors and contributorsList before delete requests

### DIFF
--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -66,7 +66,7 @@ class ResourceShowRoute extends Component {
 
     if (model.isSelected === false && model.package.isCustom) {
       destroyResource(model);
-    } else {
+    } else if (model.isSelected === false) {
       // clear out any customizations before sending to server
       model.visibilityData.isHidden = false;
       model.customCoverages = [];
@@ -74,7 +74,11 @@ class ResourceShowRoute extends Component {
       model.customEmbargoPeriod = {};
       model.identifiersList = [];
       model.identifiers = [];
+      model.contributors = [];
+      model.contributorsList = [];
 
+      updateResource(model);
+    } else {
       updateResource(model);
     }
   }


### PR DESCRIPTION

## Purpose
Sending a requests to remove a resource that contains contributors will fail if those elements on the model are not cleared out before the request is sent.

## Approach
 - Ensure that contributors and contributorsList are cleared out and sent in the requests are empty elements.

## Screenshots
*Before:*
![2018-07-19 14 55 47](https://user-images.githubusercontent.com/1953098/42964272-7f55359e-8b64-11e8-8f83-d8b0b96551c4.gif)

*After:*
![2018-07-19 14 56 17](https://user-images.githubusercontent.com/1953098/42964273-7f63b6f0-8b64-11e8-86a8-fe628806536f.gif)

