### PR TITLE
UIEH-442 Add partially selected packages to holdings

### DIFF
--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -94,7 +94,7 @@ class PackageShow extends Component {
 
     let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
     let packageSelectionPending = model.destroy.isPending ||
-        (model.update.isPending && 'isSelected' in model.update.changedAttributes);
+        (model.update.isPending && ('selectedCount' in model.update.changedAttributes));
 
     let modalMessage = model.isCustom ?
       {

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -21,6 +21,7 @@ import NavigationModal from '../../navigation-modal';
 import DetailsViewSection from '../../details-view-section';
 import Toaster from '../../toaster';
 
+import SelectionStatus from './selection-status';
 import styles from './package-show.css';
 
 class PackageShow extends Component {
@@ -244,36 +245,13 @@ class PackageShow extends Component {
                 </KeyValue>
               </DetailsViewSection>
               <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageInformation' })}>
-                <label
-                  data-test-eholdings-package-details-selected
-                  htmlFor="package-details-toggle-switch"
-                >
-                  { packageSelectionPending ? (
-                    <Icon icon="spinner-ellipsis" />
-                  ) : (
-                    <h4>{packageSelected ?
-                    (<FormattedMessage id="ui-eholdings.selected" />)
-                    :
-                    (<FormattedMessage id="ui-eholdings.notSelected" />)}
-                    </h4>
-                  ) }
-
-                  <br />
-                  {(
-                    (!packageSelected && !packageSelectionPending) ||
-                    (!this.props.model.isSelected && packageSelectionPending)) &&
-                    <Button
-                      type="button"
-                      buttonStyle="primary"
-                      disabled={packageSelectionPending}
-                      onClick={this.handleSelectionToggle}
-                      data-test-eholdings-package-add-to-holdings-button
-                    >
-                    Add to holdings
-                    </Button>
-                  }
-                </label>
-              </DetailsViewSection>
+                <SelectionStatus
+                  model={model}
+                  isPending={packageSelectionPending}
+                  isSelectedInParentComponentState={packageSelected}
+                  onAddToHoldings={this.handleSelectionToggle}
+                />
+                </DetailsViewSection>
               <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}>
                 {packageSelected ? (
                   <div>

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -141,8 +141,9 @@ class PackageShow extends Component {
       });
     }
     if (!packageSelected || model.isPartiallySelected) {
+      let messageId = model.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings';
       actionMenuItems.push({
-        'label': `Add${model.isPartiallySelected ? ' all ' : ''}to holdings`,
+        'label': intl.formatMessage({ id: `ui-eholdings.${messageId}` }),
         'state': { eholdings: true },
         'data-test-eholdings-package-add-to-holdings-action': true,
         'onClick': this.props.addPackageToHoldings

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  Button,
   Icon,
   IconButton,
   KeyValue,
@@ -29,7 +28,8 @@ class PackageShow extends Component {
     model: PropTypes.object.isRequired,
     fetchPackageTitles: PropTypes.func.isRequired,
     intl: intlShape.isRequired,
-    toggleSelected: PropTypes.func.isRequired
+    toggleSelected: PropTypes.func.isRequired,
+    addPackageToHoldings: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -253,7 +253,7 @@ class PackageShow extends Component {
                   isSelectedInParentComponentState={packageSelected}
                   onAddToHoldings={this.props.addPackageToHoldings}
                 />
-                </DetailsViewSection>
+              </DetailsViewSection>
               <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}>
                 {packageSelected ? (
                   <div>

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -144,7 +144,7 @@ class PackageShow extends Component {
         'label': 'Add to holdings',
         'state': { eholdings: true },
         'data-test-eholdings-package-add-to-holdings-action': true,
-        'onClick': this.handleSelectionToggle
+        'onClick': this.props.addPackageToHoldings
       });
     }
 
@@ -249,7 +249,7 @@ class PackageShow extends Component {
                   model={model}
                   isPending={packageSelectionPending}
                   isSelectedInParentComponentState={packageSelected}
-                  onAddToHoldings={this.handleSelectionToggle}
+                  onAddToHoldings={this.props.addPackageToHoldings}
                 />
                 </DetailsViewSection>
               <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}>

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -139,6 +139,14 @@ class PackageShow extends Component {
         'data-test-eholdings-package-remove-from-holdings-action': true,
         'onClick': this.handleSelectionToggle
       });
+      if (model.isPartiallySelected) {
+        actionMenuItems.push({
+          'label': 'Add all to holdings',
+          'state': { eholdings: true },
+          'data-test-eholdings-package-add-to-holdings-action': true,
+          'onClick': this.props.addPackageToHoldings
+        });
+      }
     } else {
       actionMenuItems.push({
         'label': 'Add to holdings',

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -139,17 +139,10 @@ class PackageShow extends Component {
         'data-test-eholdings-package-remove-from-holdings-action': true,
         'onClick': this.handleSelectionToggle
       });
-      if (model.isPartiallySelected) {
-        actionMenuItems.push({
-          'label': 'Add all to holdings',
-          'state': { eholdings: true },
-          'data-test-eholdings-package-add-to-holdings-action': true,
-          'onClick': this.props.addPackageToHoldings
-        });
-      }
-    } else {
+    }
+    if (!packageSelected || model.isPartiallySelected) {
       actionMenuItems.push({
-        'label': 'Add to holdings',
+        'label': `Add${model.isPartiallySelected ? ' all ' : ''}to holdings`,
         'state': { eholdings: true },
         'data-test-eholdings-package-add-to-holdings-action': true,
         'onClick': this.props.addPackageToHoldings

--- a/src/components/package/show/selection-status.js
+++ b/src/components/package/show/selection-status.js
@@ -3,9 +3,7 @@ import React from 'react';
 import { Icon, Button } from '@folio/stripes-components';
 import { FormattedMessage } from 'react-intl';
 
-export default function SelectionStatus({ model, isPending, isSelectedInParentComponentState, onAddToHoldings }) {
-  let packageSelectionPending = isPending;
-  let packageSelected = isSelectedInParentComponentState;
+export default function SelectionStatus({ model, isPending, onAddToHoldings }) {
   return (<label data-test-eholdings-package-details-selected>
           <SelectionStatusMessage isPending={isPending} model={model} />
           <br />
@@ -24,16 +22,15 @@ function SelectionStatusMessage({ model, isPending }) {
 }
 
 function SelectionStatusButton({ model, isPending, onAddToHoldings }) {
-  let packageSelectionPending = isPending;
-  if (!model.isSelected || packageSelectionPending) {
+  let message = `Add${ model.isPartiallySelected ? ' all ' : ''} to holdings`;
+  if (model.isPartiallySelected || !model.isSelected || isPending) {
     return <Button
-        type="button"
-        buttonStyle="primary"
-        disabled={packageSelectionPending}
-        onClick={onAddToHoldings}
-        data-test-eholdings-package-add-to-holdings-button
-      >
-        Add to holdings
+      type="button"
+      buttonStyle="primary"
+      disabled={isPending}
+      onClick={onAddToHoldings}
+      data-test-eholdings-package-add-to-holdings-button
+      > {message}
     </Button>;
   } else {
     return null;
@@ -42,9 +39,15 @@ function SelectionStatusButton({ model, isPending, onAddToHoldings }) {
 
 
 function messageFor(model) {
+  if (model.isPartiallySelected) {
+    return {
+      id: 'ui-eholdings.package.partiallySelected',
+      values: { selectedCount: model.selectedCount, titleCount: model.titleCount }
+    };
+  }
   if (model.isSelected) {
-    return { id: "ui-eholdings.selected" };
+    return { id: 'ui-eholdings.selected' };
   } else {
-    return { id: "ui-eholdings.notSelected" };
+    return { id: 'ui-eholdings.notSelected'};
   }
 }

--- a/src/components/package/show/selection-status.js
+++ b/src/components/package/show/selection-status.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { Icon, Button } from '@folio/stripes-components';
+import { FormattedMessage } from 'react-intl';
+
+export default function SelectionStatus({ model, isPending, isSelectedInParentComponentState, onAddToHoldings }) {
+  let packageSelectionPending = isPending;
+  let packageSelected = isSelectedInParentComponentState;
+  return (<label data-test-eholdings-package-details-selected>
+          { packageSelectionPending ? (
+            <Icon icon="spinner-ellipsis" />
+          ) : (
+            <h4>{packageSelected ?
+                 (<FormattedMessage id="ui-eholdings.selected" />)
+                 :
+                 (<FormattedMessage id="ui-eholdings.notSelected" />)}
+            </h4>
+          ) }
+
+          <br />
+          {(
+            (!packageSelected && !packageSelectionPending) ||
+              (!model.isSelected && packageSelectionPending)) &&
+           <Button
+           type="button"
+           buttonStyle="primary"
+           disabled={packageSelectionPending}
+           onClick={onAddToHoldings}
+           data-test-eholdings-package-add-to-holdings-button
+           >
+           Add to holdings
+           </Button>
+          }
+  </label>);
+}

--- a/src/components/package/show/selection-status.js
+++ b/src/components/package/show/selection-status.js
@@ -1,37 +1,49 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { Icon, Button } from '@folio/stripes-components';
 import { FormattedMessage } from 'react-intl';
 
 export default function SelectionStatus({ model, isPending, onAddToHoldings }) {
-  return (<label data-test-eholdings-package-details-selected>
-          <SelectionStatusMessage isPending={isPending} model={model} />
-          <br />
-          <SelectionStatusButton
-          model={model}
-          isPending={isPending}
-          onAddToHoldings={onAddToHoldings} />
-  </label>);
+  return (
+    <label data-test-eholdings-package-details-selected>
+      <SelectionStatusMessage isPending={isPending} model={model} />
+      <br />
+      <SelectionStatusButton
+        model={model}
+        isPending={isPending}
+        onAddToHoldings={onAddToHoldings}
+      />
+    </label>);
 }
+SelectionStatus.propTypes = {
+  model: PropTypes.object.isRequired,
+  isPending: PropTypes.bool.isRequired,
+  onAddToHoldings: PropTypes.func.isRequired
+};
 
 function SelectionStatusMessage({ model, isPending }) {
   if (isPending) {
     return <Icon icon="spinner-ellipsis" />;
-  } else
-    return <h4><FormattedMessage {...messageFor(model)} /></h4>;
+  } else {
+    return <h4><FormattedMessage {...messageFor(model)} /></h4>; // eslint-disable-line no-use-before-define
+  }
 }
 
 function SelectionStatusButton({ model, isPending, onAddToHoldings }) {
   if (model.isPartiallySelected || !model.isSelected || isPending) {
     let messageId = model.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings';
-    return <Button
-      type="button"
-      buttonStyle="primary"
-      disabled={isPending}
-      onClick={onAddToHoldings}
-      data-test-eholdings-package-add-to-holdings-button
-      > <FormattedMessage id={`ui-eholdings.${messageId}`} />
-    </Button>;
+    return (
+      <Button
+        type="button"
+        buttonStyle="primary"
+        disabled={isPending}
+        onClick={onAddToHoldings}
+        data-test-eholdings-package-add-to-holdings-button
+      >
+        <FormattedMessage id={`ui-eholdings.${messageId}`} />
+      </Button>
+    );
   } else {
     return null;
   }
@@ -48,6 +60,6 @@ function messageFor(model) {
   if (model.isSelected) {
     return { id: 'ui-eholdings.selected' };
   } else {
-    return { id: 'ui-eholdings.notSelected'};
+    return { id: 'ui-eholdings.notSelected' };
   }
 }

--- a/src/components/package/show/selection-status.js
+++ b/src/components/package/show/selection-status.js
@@ -7,29 +7,44 @@ export default function SelectionStatus({ model, isPending, isSelectedInParentCo
   let packageSelectionPending = isPending;
   let packageSelected = isSelectedInParentComponentState;
   return (<label data-test-eholdings-package-details-selected>
-          { packageSelectionPending ? (
-            <Icon icon="spinner-ellipsis" />
-          ) : (
-            <h4>{packageSelected ?
-                 (<FormattedMessage id="ui-eholdings.selected" />)
-                 :
-                 (<FormattedMessage id="ui-eholdings.notSelected" />)}
-            </h4>
-          ) }
-
+          <SelectionStatusMessage isPending={isPending} model={model} />
           <br />
-          {(
-            (!packageSelected && !packageSelectionPending) ||
-              (!model.isSelected && packageSelectionPending)) &&
-           <Button
-           type="button"
-           buttonStyle="primary"
-           disabled={packageSelectionPending}
-           onClick={onAddToHoldings}
-           data-test-eholdings-package-add-to-holdings-button
-           >
-           Add to holdings
-           </Button>
-          }
+          <SelectionStatusButton
+          model={model}
+          isPending={isPending}
+          onAddToHoldings={onAddToHoldings} />
   </label>);
+}
+
+function SelectionStatusMessage({ model, isPending }) {
+  if (isPending) {
+    return <Icon icon="spinner-ellipsis" />;
+  } else
+    return <h4><FormattedMessage {...messageFor(model)} /></h4>;
+}
+
+function SelectionStatusButton({ model, isPending, onAddToHoldings }) {
+  let packageSelectionPending = isPending;
+  if (!model.isSelected || packageSelectionPending) {
+    return <Button
+        type="button"
+        buttonStyle="primary"
+        disabled={packageSelectionPending}
+        onClick={onAddToHoldings}
+        data-test-eholdings-package-add-to-holdings-button
+      >
+        Add to holdings
+    </Button>;
+  } else {
+    return null;
+  }
+}
+
+
+function messageFor(model) {
+  if (model.isSelected) {
+    return { id: "ui-eholdings.selected" };
+  } else {
+    return { id: "ui-eholdings.notSelected" };
+  }
 }

--- a/src/components/package/show/selection-status.js
+++ b/src/components/package/show/selection-status.js
@@ -22,15 +22,15 @@ function SelectionStatusMessage({ model, isPending }) {
 }
 
 function SelectionStatusButton({ model, isPending, onAddToHoldings }) {
-  let message = `Add${ model.isPartiallySelected ? ' all ' : ''} to holdings`;
   if (model.isPartiallySelected || !model.isSelected || isPending) {
+    let messageId = model.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings';
     return <Button
       type="button"
       buttonStyle="primary"
       disabled={isPending}
       onClick={onAddToHoldings}
       data-test-eholdings-package-add-to-holdings-button
-      > {message}
+      > <FormattedMessage id={`ui-eholdings.${messageId}`} />
     </Button>;
   } else {
     return null;

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -14,6 +14,10 @@ class Package {
   resources = hasMany();
   isCustom = false;
   packageType = '';
+
+  get isPartiallySelected() {
+    return this.selectedCount > 0 && this.selectedCount !== this.titleCount;
+  }
 }
 
 export default model({

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -64,6 +64,14 @@ class PackageShowRoute extends Component {
     }
   }
 
+  addPackageToHoldings = () => {
+    let { model, updatePackage } = this.props;
+    model.isSelected = true;
+    model.selectedCount = model.titleCount;
+    model.allowKbToAddTitles = true;
+    updatePackage(model);
+  };
+
   toggleSelected = () => {
     let { model, updatePackage, destroyPackage } = this.props;
     // if the package is custom setting the holding status to false
@@ -103,6 +111,7 @@ class PackageShowRoute extends Component {
           model={this.props.model}
           fetchPackageTitles={this.fetchPackageTitles}
           toggleSelected={this.toggleSelected}
+          addPackageToHoldings={this.addPackageToHoldings}
           toggleHidden={this.toggleHidden}
           customCoverageSubmitted={this.customCoverageSubmitted}
           toggleAllowKbToAddTitles={this.toggleAllowKbToAddTitles}

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -127,8 +127,15 @@ describeApplication('PackageShow', () => {
     it('has a button to add all of the remaining titles by selecting the entire package directly in the detail record', () => {
       expect(PackageShowPage.selectionStatus.buttonText).to.equal('Add all to holdings');
     });
-    it('has menu item to add all remaining titles from this packages');
-    it('has menu item to remove the entire package from holdings just like a completely selected packages');
+    describe('inspecting the menu', function() {
+      beforeEach(function() {
+        return PackageShowPage.dropDown.clickDropDownButton();
+      });
+
+      it('has menu item to add all remaining titles from this packages');
+
+      it('has menu item to remove the entire package from holdings just like a completely selected packages');
+    });
   });
 
   describe('viewing a custom package details page', () => {

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -127,8 +127,8 @@ describeApplication('PackageShow', () => {
     it('has a button to add all of the remaining titles by selecting the entire package directly in the detail record', () => {
       expect(PackageShowPage.selectionStatus.buttonText).to.equal('Add all to holdings');
     });
-    describe('inspecting the menu', function () {
-      beforeEach(function () {
+    describe('inspecting the menu', () => {
+      beforeEach(() => {
         return PackageShowPage.dropDown.clickDropDownButton();
       });
 

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -102,6 +102,30 @@ describeApplication('PackageShow', () => {
     });
   });
 
+  describe('viewing a partially selected package', () => {
+    let pkg;
+    beforeEach(function () {
+      pkg = this.server.create('package', {
+        provider,
+        name: 'Partial Package',
+        titleCount: 10
+      });
+      this.server.createList('resource', 5, 'withTitle', {
+        package: pkg,
+        isSelected: true
+      });
+      this.server.createList('resource', 5, 'withTitle', {
+        package: pkg,
+        isSelected: false
+      });
+      return this.visit(`/eholdings/packages/${pkg.id}`);
+    });
+    it('shows the selected # of titles and the total # of titles in the package');
+    it('has a button to add all of the remaining titles by selecting the entire package directly in the detail record');
+    it('has menu item to add all remaining titles from this packages');
+    it('has menu item to remove the entire package from holdings just like a completely selected packages');
+  });
+
   describe('viewing a custom package details page', () => {
     beforeEach(function () {
       providerPackage.isCustom = true;

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -127,14 +127,18 @@ describeApplication('PackageShow', () => {
     it('has a button to add all of the remaining titles by selecting the entire package directly in the detail record', () => {
       expect(PackageShowPage.selectionStatus.buttonText).to.equal('Add all to holdings');
     });
-    describe('inspecting the menu', function() {
-      beforeEach(function() {
+    describe('inspecting the menu', function () {
+      beforeEach(function () {
         return PackageShowPage.dropDown.clickDropDownButton();
       });
 
-      it('has menu item to add all remaining titles from this packages');
+      it.skip('has menu item to add all remaining titles from this packages', () => {
+        expect(PackageShowPage.dropDownMenu.addToHoldings.text).to.equal('Add all to holdings');
+      });
 
-      it('has menu item to remove the entire package from holdings just like a completely selected packages');
+      it('has menu item to remove the entire package from holdings just like a completely selected packages', () => {
+        expect(PackageShowPage.dropDownMenu.removeFromHoldings.isVisible).to.equal(true);
+      });
     });
   });
 

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -108,6 +108,7 @@ describeApplication('PackageShow', () => {
       pkg = this.server.create('package', {
         provider,
         name: 'Partial Package',
+        selectedCount: 5,
         titleCount: 10
       });
       this.server.createList('resource', 5, 'withTitle', {
@@ -120,8 +121,12 @@ describeApplication('PackageShow', () => {
       });
       return this.visit(`/eholdings/packages/${pkg.id}`);
     });
-    it('shows the selected # of titles and the total # of titles in the package');
-    it('has a button to add all of the remaining titles by selecting the entire package directly in the detail record');
+    it('shows the selected # of titles and the total # of titles in the package', () => {
+      expect(PackageShowPage.selectionStatus.text).to.equal('5 of 10 titles selected');
+    });
+    it('has a button to add all of the remaining titles by selecting the entire package directly in the detail record', () => {
+      expect(PackageShowPage.selectionStatus.buttonText).to.equal('Add all to holdings');
+    });
     it('has menu item to add all remaining titles from this packages');
     it('has menu item to remove the entire package from holdings just like a completely selected packages');
   });

--- a/tests/package-show-test.js
+++ b/tests/package-show-test.js
@@ -132,7 +132,7 @@ describeApplication('PackageShow', () => {
         return PackageShowPage.dropDown.clickDropDownButton();
       });
 
-      it.skip('has menu item to add all remaining titles from this packages', () => {
+      it('has menu item to add all remaining titles from this packages', () => {
         expect(PackageShowPage.dropDownMenu.addToHoldings.text).to.equal('Add all to holdings');
       });
 

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -1,4 +1,5 @@
 import {
+  Interactor,
   clickable,
   collection,
   scoped,
@@ -33,6 +34,8 @@ import Toast from './toast';
 }
 
 @interactor class PackageShowDropDownMenu {
+  addToHoldings = new Interactor('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
+  removeFromHoldings = new Interactor('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
   clickRemoveFromHoldings = clickable('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
   clickAddToHoldings = clickable('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
 }

--- a/tests/pages/package-show.js
+++ b/tests/pages/package-show.js
@@ -16,6 +16,12 @@ import { getComputedStyle, hasClassBeginningWith } from './helpers';
 import Datepicker from './datepicker';
 import Toast from './toast';
 
+@interactor class PackageSelectionStatus {
+  static defaultScope = '[data-test-eholdings-package-details-selected]';
+  text = text('label h4');
+  buttonText = text('button');
+}
+
 @interactor class PackageShowModal {
   confirmDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-yes]');
   cancelDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-no]');
@@ -35,6 +41,9 @@ import Toast from './toast';
   allowKbToAddTitles = text('[data-test-eholdings-package-details-allow-add-new-titles]');
   hasAllowKbToAddTitles = isPresent('[data-test-eholdings-package-details-toggle-allow-add-new-titles] input');
   hasAllowKbToAddTitlesToggle = isPresent('[package-details-toggle-allow-add-new-titles-switch]');
+
+
+  selectionStatus = new PackageSelectionStatus();
 
   selectionText = text('[data-test-eholdings-package-details-selected] h4');
   isSelected = computed(function () {

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -46,6 +46,8 @@
 
     "selected": "Selected",
     "notSelected": "Not selected",
+    "addToHoldings": "Add to holdings",
+    "addAllToHoldings": "Add all to holdings",
     "saving": "Saving",
     "save": "Save",
     "yes": "Yes",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -8,6 +8,7 @@
     "package.name.isRequired": "Name *",
     "package.packageInformation": "Package information",
     "package.packageType": "Package type",
+    "package.partiallySelected": "{ selectedCount } of { titleCount } titles selected",
     "package.provider": "Provider",
     "package.titlesSelected": "Titles selected",
     "package.totalTitles": "Total titles",


### PR DESCRIPTION
## Purpose

The answer to the question "is a package selected?" Is not a simple binary yes or no. All of the titles in a package can be selected, none of the titles in a package can be selected, or some of the titles in the package can be selected. However, packages where _some_ of the titles are selected can only be removed entirely and added entirely in order to make that package _completely_ selected.

This PR introduces the ability to take a package that has some titles selected and select all of the package in one interaction.

See https://issues.folio.org/browse/UIEH-442 for details.

## Approach

To accomplish this we add two new interactions:

1. We now differentiate between "selected" and and "x of total selected" in the holdings status of a package. In the case where only some of the titles in a package are selected, there is now a button to add all the remaining titles.
2. For packages with only some of the titles selected, there is a menu item in the package actions to "add all to holdings"

We had already moved away from toggles for this portion of the UI, but the route actions were (and to some degree still are) based on toggles.

This PR slices off one half of the toggle. We know which action to call based on which button got clicked.

## Open Questions / TODOS

- [ ] Convert the PackageShow tests to use the plain dropdown menu interactors instead of the custom click actions
- [ ] Get rid of the concept of toggling from the route and the view, and only have a `removePackageFromHoldings` action bound directly to the remove buttons and menu items.

## Learning

#### Where should state live?

1. Too much state is happening in our view components. As a 99/1 rule, any component that is not a route should be a pure function:

```js
function MyComponent(props) {
  // render cool stuff.
}
```

vs

```js
class MyComponent extends React.Component {
  render() {
    // render cool stuff.
  }
}
```

If this isn't the case, then something is up and we should be asking why. For example, the `PackageShow` component is doing way too much state management and probably indicates a weakness at our route/model level.

#### Plain Interactors are 👌 

There are a standard set of methods on the base interactor class. Instead of defining an action on your interactor, consider just using a simple interactor

instead of 

```js
@interactor class PackageShowDropDownMenu {
  clickRemoveFromHoldings = clickable('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
  clickAddToHoldings = clickable('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
}
```

go with:

```js
@interactor class PackageShowDropDownMenu {
  addToHoldings = new Interactor('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
  removeFromHoldings = new Interactor('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
}
```

Now, instead of only having only one click action, you have all of the actions and properties that come with a standard Interactor:

```js
menu.addToHoldings.isVisible //=> true
menu.addToHoldings.text //=> Add all to holdings
menu.addToHoldings.click() // click it!
```

## Screenshots

![2018-07-19 15 11 51](https://user-images.githubusercontent.com/4205/42971584-1903d786-8b6a-11e8-8da3-7302263d02d6.gif)
