### PR TITLE
UIEH-477: Add null checks to avoid trying to focus search results when there are none

### DIFF
--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -82,7 +82,7 @@ export default class SearchPaneset extends React.Component { // eslint-disable-l
     let isSameSearchType = prevProps.resultsType === this.props.resultsType;
 
     // focus the pane title when a new search happens within the same search type
-    if (isNewSearch && isSameSearchType) {
+    if (isNewSearch && isSameSearchType && this.$title.current) {
       this.$title.current.focus();
     }
   }

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -296,7 +296,7 @@ class SearchRoute extends Component { // eslint-disable-line react/no-deprecated
                   searchTypeUrls={this.getSearchTypeUrls()}
                   onSearch={this.handleSearch}
                   onFilterChange={this.handleSearch}
-                  isLoading={params.q && !results.hasLoaded}
+                  isLoading={!!params.q && !results.hasLoaded}
                 />
               )}
             />

--- a/tests/provider-search-test.js
+++ b/tests/provider-search-test.js
@@ -405,6 +405,28 @@ describeApplication('ProviderSearch', () => {
         expect(ProviderSearchPage.isSearchButtonDisabled).to.equal(true);
       });
     });
+
+    describe('selecting a filter without a value in the search field', () => {
+      beforeEach(() => {
+        return ProviderSearchPage.clickFilter('sort', 'name');
+      });
+
+      it('should not perform an empty search', () => {
+        expect(ProviderSearchPage.hasPreSearchPane).to.be.true;
+      });
+
+      describe('then adding a search term', () => {
+        beforeEach(() => {
+          return ProviderSearchPage.search('health');
+        });
+
+        it('should apply selected filter to the results', () => {
+          expect(ProviderSearchPage.providerList(0).name).to.equal('Health Associations');
+          expect(ProviderSearchPage.providerList(1).name).to.equal('My Health Analytics 2');
+          expect(ProviderSearchPage.providerList(2).name).to.equal('My Health Analytics 10');
+        });
+      });
+    });
   });
 
   describe('with multiple pages of providers', () => {


### PR DESCRIPTION
## Purpose
There is currently a bug wherein selecting a search filter without having a query string in the "Search" field will cause the UI to blow up, showing an uncaught error to the user.

## Approach
It turns out that there is one place where we should be doing a null check to ensure we're not accessing properties on an object that is not there. In addition I found a spot where a boolean property was being coerced into a string somehow.

## Todos
- [x] I have an open question about the intended behavior in this particular case here:  https://issues.folio.org/browse/UIEH-477?focusedCommentId=33268&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-33268