### PR TITLE
Use Accordions on detail record pages

### DIFF
--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -86,7 +86,7 @@ class PackageCreate extends Component {
               <NameField />
               <ContentTypeField />
             </DetailsViewSection>
-            <DetailsViewSection label="Coverage dates">
+            <DetailsViewSection label="Coverage settings">
               <CoverageFields />
             </DetailsViewSection>
             <div className={styles['package-create-action-buttons']}>

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -198,6 +198,21 @@ class CustomPackageEdit extends Component {
           bodyContent={(
             <form onSubmit={handleSubmit(this.handleOnSubmit)}>
               <DetailsViewSection
+                label={intl.formatMessage({ id: 'ui-eholdings.package.holdingStatus' })}
+              >
+                <label
+                  data-test-eholdings-package-details-selected
+                  htmlFor="custom-package-details-toggle-switch"
+                >
+                  <h4>
+                    {packageSelected ?
+                      (<FormattedMessage id="ui-eholdings.selected" />) :
+                      (<FormattedMessage id="ui-eholdings.notSelected" />)
+                    }
+                  </h4>
+                </label>
+              </DetailsViewSection>
+              <DetailsViewSection
                 label={intl.formatMessage({ id: 'ui-eholdings.packageInformation' })}
               >
                 {packageSelected ? (
@@ -219,21 +234,6 @@ class CustomPackageEdit extends Component {
                    </div>
                  </KeyValue>
                )}
-              </DetailsViewSection>
-              <DetailsViewSection
-                label={intl.formatMessage({ id: 'ui-eholdings.package.holdingStatus' })}
-              >
-                <label
-                  data-test-eholdings-package-details-selected
-                  htmlFor="custom-package-details-toggle-switch"
-                >
-                  <h4>
-                    {packageSelected ?
-                      (<FormattedMessage id="ui-eholdings.selected" />) :
-                      (<FormattedMessage id="ui-eholdings.notSelected" />)
-                    }
-                  </h4>
-                </label>
               </DetailsViewSection>
               <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}>
                 {packageSelected ? (
@@ -275,7 +275,7 @@ class CustomPackageEdit extends Component {
               </DetailsViewSection>
 
               <DetailsViewSection
-                label={intl.formatMessage({ id: 'ui-eholdings.package.coverageDates' })}
+                label={intl.formatMessage({ id: 'ui-eholdings.package.coverageSettings' })}
               >
                 {packageSelected ? (
                   <CoverageFields

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -312,7 +312,7 @@ class ManagedPackageEdit extends Component {
                     </div>
                   </DetailsViewSection>
                   <DetailsViewSection
-                    label={intl.formatMessage({ id: 'ui-eholdings.package.coverageDates' })}
+                    label={intl.formatMessage({ id: 'ui-eholdings.package.coverageSettings' })}
                   >
                     <CoverageFields
                       initialValue={initialValues.customCoverages}

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import {
+  Accordion,
   Icon,
   IconButton,
   KeyValue,
@@ -17,7 +18,6 @@ import QueryList from '../../query-list';
 import Link from '../../link';
 import TitleListItem from '../../title-list-item';
 import NavigationModal from '../../navigation-modal';
-import DetailsViewSection from '../../details-view-section';
 import Toaster from '../../toaster';
 
 import SelectionStatus from './selection-status';
@@ -211,7 +211,15 @@ class PackageShow extends Component {
           )}
           bodyContent={(
             <div>
-              <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.packageInformation' })}>
+              <Accordion label={intl.formatMessage({ id: 'ui-eholdings.package.holdingStatus' })}>
+                <SelectionStatus
+                  model={model}
+                  isPending={packageSelectionPending}
+                  isSelectedInParentComponentState={packageSelected}
+                  onAddToHoldings={this.props.addPackageToHoldings}
+                />
+              </Accordion>
+              <Accordion label={intl.formatMessage({ id: 'ui-eholdings.packageInformation' })}>
                 <KeyValue label={<FormattedMessage id="ui-eholdings.package.provider" />}>
                   <div data-test-eholdings-package-details-provider>
                     <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
@@ -245,16 +253,8 @@ class PackageShow extends Component {
                     <FormattedNumber value={model.titleCount} />
                   </div>
                 </KeyValue>
-              </DetailsViewSection>
-              <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.packageInformation' })}>
-                <SelectionStatus
-                  model={model}
-                  isPending={packageSelectionPending}
-                  isSelectedInParentComponentState={packageSelected}
-                  onAddToHoldings={this.props.addPackageToHoldings}
-                />
-              </DetailsViewSection>
-              <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}>
+              </Accordion>
+              <Accordion label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}>
                 {packageSelected ? (
                   <div>
                     <KeyValue label={<FormattedMessage id="ui-eholdings.package.visibility" />}>
@@ -294,9 +294,9 @@ class PackageShow extends Component {
                 ) : (
                   <p><FormattedMessage id="ui-eholdings.package.visibility.notSelected" /></p>
                 )}
-              </DetailsViewSection>
-              <DetailsViewSection
-                label={intl.formatMessage({ id: 'ui-eholdings.package.coverageDates' })}
+              </Accordion>
+              <Accordion
+                label={intl.formatMessage({ id: 'ui-eholdings.package.coverageSettings' })}
                 closedByDefault={!packageSelected}
               >
                 {packageSelected ? (
@@ -331,7 +331,7 @@ class PackageShow extends Component {
                 ) : (
                   <p><FormattedMessage id="ui-eholdings.package.customCoverage.notSelected" /></p>
                 )}
-              </DetailsViewSection>
+              </Accordion>
             </div>
           )}
           listType="titles"

--- a/src/components/provider-show/provider-show.js
+++ b/src/components/provider-show/provider-show.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { KeyValue } from '@folio/stripes-components';
+import {
+  Accordion,
+  KeyValue
+} from '@folio/stripes-components';
 import { FormattedNumber, FormattedMessage } from 'react-intl';
 
 import { processErrors } from '../utilities';
 import DetailsView from '../details-view';
 import QueryList from '../query-list';
 import PackageListItem from '../package-list-item';
-import DetailsViewSection from '../details-view-section';
 import Toaster from '../toaster';
 import styles from './provider-show.css';
 
@@ -44,7 +46,7 @@ export default function ProviderShow({
         paneTitle={model.name}
         actionMenuItems={actionMenuItems}
         bodyContent={(
-          <DetailsViewSection label={<FormattedMessage id="ui-eholdings.provider.providerInformation" />}>
+          <Accordion label={<FormattedMessage id="ui-eholdings.provider.providerInformation" />}>
             <KeyValue label={<FormattedMessage id="ui-eholdings.provider.packagesSelected" />}>
               <div data-test-eholdings-provider-details-packages-selected>
                 <FormattedNumber value={model.packagesSelected} />
@@ -56,7 +58,7 @@ export default function ProviderShow({
                 <FormattedNumber value={model.packagesTotal} />
               </div>
             </KeyValue>
-          </DetailsViewSection>
+          </Accordion>
         )}
         enableListSearch
         listType="packages"

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -210,39 +210,32 @@ class ResourceEditCustomTitle extends Component {
               </DetailsViewSection>
 
               <DetailsViewSection
-                label="Coverage dates"
+                label="Coverage settings"
               >
                 {resourceSelected ? (
-                  <CustomCoverageFields
-                    initialValue={initialValues.customCoverages}
-                  />
-                  ) : (
-                    <p>Add the resource to holdings to set custom coverage dates.</p>
-                )}
-              </DetailsViewSection>
-              <DetailsViewSection
-                label="Coverage statement"
-              >
-                {resourceSelected ? (
-                  <CoverageStatementFields />
-                  ) : (
-                    <p>Add the resource to holdings to set coverage statement.</p>
-                  )}
-              </DetailsViewSection>
-              <DetailsViewSection
-                label="Embargo period"
-              >
-                {resourceSelected ? (
-                  <CustomEmbargoFields
-                    change={change}
-                    showInputs={(initialValues.customEmbargoValue > 0)}
-                    initialValue={{
-                      customEmbargoValue: initialValues.customEmbargoValue,
-                      customEmbargoUnit: initialValues.customEmbargoUnit
-                  }}
-                  />
+                  <Fragment>
+                    <h4>Coverage dates</h4>
+                    <CustomCoverageFields
+                      initialValue={initialValues.customCoverages}
+                    />
+
+                    <h4>Coverage statement</h4>
+                    <CoverageStatementFields />
+
+                    <h4>Embargo period</h4>
+                    <CustomEmbargoFields
+                      change={change}
+                      showInputs={(initialValues.customEmbargoValue > 0)}
+                      initialValue={{
+                        customEmbargoValue: initialValues.customEmbargoValue,
+                        customEmbargoUnit: initialValues.customEmbargoUnit
+                      }}
+                    />
+                  </Fragment>
                 ) : (
-                  <p data-test-eholdings-resource-embargo-not-shown-label>Add the resource to holdings to set custom embargo.</p>
+                  <p data-test-eholdings-resource-edit-settings-message>
+                    Add the resource to holdings to customize coverage.
+                  </p>
                 )}
 
               </DetailsViewSection>

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -225,24 +225,17 @@ class ResourceEditManagedTitle extends Component { // eslint-disable-line react/
               )}
               {managedResourceSelected && (
                 <DetailsViewSection
-                  label="Coverage dates"
+                  label="Coverage settings"
                 >
+                  <h4>Coverage dates</h4>
                   <CustomCoverageFields
                     initialValue={initialValues.customCoverages}
                   />
-                </DetailsViewSection>
-              )}
-              {managedResourceSelected && (
-                <DetailsViewSection
-                  label="Coverage statement"
-                >
+
+                  <h4>Coverage statement</h4>
                   <CoverageStatementFields />
-                </DetailsViewSection>
-               )}
-              {managedResourceSelected && (
-                <DetailsViewSection
-                  label="Embargo period"
-                >
+
+                  <h4>Embargo period</h4>
                   <CustomEmbargoFields
                     change={change}
                     showInputs={(initialValues.customEmbargoValue > 0)}

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -1,7 +1,8 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import {
+  Accordion,
   Button,
   IconButton,
   Icon,
@@ -18,7 +19,6 @@ import IdentifiersList from '../identifiers-list';
 import ContributorsList from '..//contributors-list';
 import CoverageDateList from '../coverage-date-list';
 import { isBookPublicationType, isValidCoverageList, processErrors } from '../utilities';
-import DetailsViewSection from '../details-view-section';
 import Toaster from '../toaster';
 
 
@@ -157,7 +157,32 @@ export default class ResourceShow extends Component {
           )}
           bodyContent={(
             <div>
-              <DetailsViewSection label="Title information">
+              <Accordion label="Holding status">
+                <label
+                  data-test-eholdings-resource-show-selected
+                  htmlFor="resource-show-toggle-switch"
+                >
+                  {
+                    model.update.isPending ? (
+                      <Icon icon='spinner-ellipsis' />
+                    ) : (
+                      <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
+                    )
+                  }
+                  <br />
+                  { ((!resourceSelected && !isSelectInFlight) || (!this.props.model.isSelected && isSelectInFlight)) && (
+                    <Button
+                      buttonStyle="primary"
+                      onClick={this.handleHoldingStatus}
+                      disabled={model.destroy.isPending || isSelectInFlight}
+                      data-test-eholdings-resource-add-to-holdings-button
+                    >
+                      Add to holdings
+                    </Button>)}
+                </label>
+              </Accordion>
+
+              <Accordion label="Resource information">
                 <KeyValue label="Title">
                   <Link to={`/eholdings/titles/${model.titleId}`}>
                     {model.title.name}
@@ -219,9 +244,7 @@ export default class ResourceShow extends Component {
                     </div>
                   </KeyValue>
                 )}
-              </DetailsViewSection>
 
-              <DetailsViewSection label="Package information">
                 <KeyValue label="Package">
                   <div data-test-eholdings-resource-show-package-name>
                     <Link to={`/eholdings/packages/${model.packageId}`}>{model.package.name}</Link>
@@ -235,15 +258,15 @@ export default class ResourceShow extends Component {
                 </KeyValue>
 
                 {model.package.contentType && (
-                  <KeyValue label="Content type">
+                  <KeyValue label="Package content type">
                     <div data-test-eholdings-resource-show-content-type>
                       {model.package.contentType}
                     </div>
                   </KeyValue>
                 )}
-              </DetailsViewSection>
+              </Accordion>
 
-              <DetailsViewSection label="Resource settings">
+              <Accordion label="Resource settings">
                 <KeyValue label="Show to patrons">
                   <div data-test-eholdings-resource-show-visibility>
                     {model.visibilityData.isHidden || !resourceSelected
@@ -263,112 +286,83 @@ export default class ResourceShow extends Component {
                     </div>
                   </KeyValue>
                 )}
-              </DetailsViewSection>
+              </Accordion>
 
-              <DetailsViewSection label="Holding status">
-                <label
-                  data-test-eholdings-resource-show-selected
-                  htmlFor="resource-show-toggle-switch"
-                >
-                  {
-                    model.update.isPending ? (
-                      <Icon icon='spinner-ellipsis' />
-                    ) : (
-                      <h4>{resourceSelected ? 'Selected' : 'Not selected'}</h4>
-                    )
-                  }
-                  <br />
-                  { ((!resourceSelected && !isSelectInFlight) || (!this.props.model.isSelected && isSelectInFlight)) && (
-                    <Button
-                      buttonStyle="primary"
-                      onClick={this.handleHoldingStatus}
-                      disabled={model.destroy.isPending || isSelectInFlight}
-                      data-test-eholdings-resource-add-to-holdings-button
-                    >
-                      Add to holdings
-                    </Button>)}
-                </label>
-              </DetailsViewSection>
-
-              <DetailsViewSection
-                label="Coverage dates"
-                closedByDefault={!hasManagedCoverages && !resourceSelected}
-              >
-                {hasManagedCoverages && (
-                  <KeyValue label="Managed coverage dates">
-                    <div data-test-eholdings-resource-show-managed-coverage-list>
-                      <CoverageDateList
-                        coverageArray={model.managedCoverages}
-                        isYearOnly={isBookPublicationType(model.publicationType)}
-                      />
-                    </div>
-                  </KeyValue>
-                )}
-
-                {(resourceSelected && !isSelectInFlight) && (
-                <div>
-                  {hasCustomCoverages && (
-                  <KeyValue label="Custom coverage dates">
-                    <span data-test-eholdings-resource-show-custom-coverage-list>
-                      <CoverageDateList
-                        coverageArray={model.customCoverages}
-                        isYearOnly={isBookPublicationType(model.publicationType)}
-                      />
-                    </span>
-                  </KeyValue>
-                  )}
-                </div>)}
-
-                {!hasManagedCoverages && !hasCustomCoverages && (
-                  <p data-test-eholdings-resource-no-coverage-date-label>No coverage date has been set.</p>
-                )}
-
-              </DetailsViewSection>
-              <DetailsViewSection
-                label="Coverage statement"
+              <Accordion
+                label="Coverage settings"
+                closedByDefault={!resourceSelected}
               >
                 {(resourceSelected && !isSelectInFlight) ? (
-                  <div>
-                    {model.coverageStatement ? (
-                      <span data-test-eholdings-resource-coverage-statement-display>
-                        {model.coverageStatement}
-                      </span>
-                   ) : (<p data-test-eholdings-resource-no-coverage-label>No coverage statement has been set.</p>
-                   )}
-                  </div>
-                ) : (
-                  <p data-test-eholdings-resource-coverage-not-shown-label>Add the resource to holdings to set a coverage statement.</p>
-                )}
-              </DetailsViewSection>
+                  <Fragment>
+                    <h4>Coverage dates</h4>
+                    {!hasManagedCoverages && !hasCustomCoverages && (
+                      <p data-test-eholdings-resource-no-coverage-date-label>No coverage dates have been set.</p>
+                    )}
 
-              <DetailsViewSection
-                label="Embargo period"
-                closedByDefault={!hasManagedEmbargoPeriod && !resourceSelected}
-              >
-                {hasManagedEmbargoPeriod && (
-                  <KeyValue label="Managed embargo period">
-                    <div data-test-eholdings-resource-show-managed-embargo-period>
-                      {model.managedEmbargoPeriod.embargoValue} {model.managedEmbargoPeriod.embargoUnit}
-                    </div>
-                  </KeyValue>
-                )}
+                    {hasManagedCoverages && (
+                      <KeyValue label="Managed coverage dates">
+                        <div data-test-eholdings-resource-show-managed-coverage-list>
+                          <CoverageDateList
+                            coverageArray={model.managedCoverages}
+                            isYearOnly={isBookPublicationType(model.publicationType)}
+                          />
+                        </div>
+                      </KeyValue>
+                    )}
 
-                {(resourceSelected && !isSelectInFlight) && (
-                  <div>
-                    {hasCustomEmbargoPeriod && (
-                      <KeyValue label="Custom">
-                        <span data-test-eholdings-resource-custom-embargo-display>
-                          {customEmbargoValue} {customEmbargoUnit}
+                    {(resourceSelected && !isSelectInFlight) && (
+                    <div>
+                      {hasCustomCoverages && (
+                      <KeyValue label="Custom coverage dates">
+                        <span data-test-eholdings-resource-show-custom-coverage-list>
+                          <CoverageDateList
+                            coverageArray={model.customCoverages}
+                            isYearOnly={isBookPublicationType(model.publicationType)}
+                          />
                         </span>
                       </KeyValue>
-                   )}
-                  </div>
-                 )}
+                      )}
+                    </div>)}
 
-                {!hasManagedEmbargoPeriod && !hasCustomEmbargoPeriod && (
-                <p data-test-eholdings-resource-no-embargo-label>No embargo period has been set.</p>
+                    <h4>Coverage statement</h4>
+                    <div>
+                      {model.coverageStatement ? (
+                        <span data-test-eholdings-resource-coverage-statement-display>
+                          {model.coverageStatement}
+                        </span>
+                     ) : (<p data-test-eholdings-resource-no-coverage-label>No coverage statement has been set.</p>
+                     )}
+                    </div>
+
+                    <h4>Embargo period</h4>
+                    {hasManagedEmbargoPeriod && (
+                      <KeyValue label="Managed embargo period">
+                        <div data-test-eholdings-resource-show-managed-embargo-period>
+                          {model.managedEmbargoPeriod.embargoValue} {model.managedEmbargoPeriod.embargoUnit}
+                        </div>
+                      </KeyValue>
+                    )}
+
+                    {(resourceSelected && !isSelectInFlight) && (
+                      <div>
+                        {hasCustomEmbargoPeriod && (
+                          <KeyValue label="Custom">
+                            <span data-test-eholdings-resource-custom-embargo-display>
+                              {customEmbargoValue} {customEmbargoUnit}
+                            </span>
+                          </KeyValue>
+                       )}
+                      </div>
+                     )}
+
+                    {!hasManagedEmbargoPeriod && !hasCustomEmbargoPeriod && (
+                    <p data-test-eholdings-resource-no-embargo-label>No embargo period has been set.</p>
+                    )}
+                  </Fragment>
+                ) : (
+                  <p data-test-eholdings-resource-not-selected-coverage-message>Add the resource to holdings to customize coverage.</p>
                 )}
-              </DetailsViewSection>
+              </Accordion>
             </div>
           )}
         />

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import {
+  Accordion,
   Button,
   IconButton,
   KeyValue,
@@ -16,7 +17,6 @@ import ScrollView from '../../scroll-view';
 import PackageListItem from '../../package-list-item';
 import IdentifiersList from '../../identifiers-list';
 import ContributorsList from '../../contributors-list';
-import DetailsViewSection from '../../details-view-section';
 import AddToPackageForm from '../_forms/add-to-package';
 import Toaster from '../../toaster';
 import styles from './title-show.css';
@@ -167,7 +167,7 @@ class TitleShow extends Component {
           actionMenuItems={this.actionMenuItems}
           lastMenu={this.lastMenu}
           bodyContent={(
-            <DetailsViewSection label={<FormattedMessage id="ui-eholdings.title.titleInformation" />}>
+            <Accordion label={<FormattedMessage id="ui-eholdings.title.titleInformation" />}>
               <ContributorsList data={model.contributors} />
 
               {model.edition && (
@@ -232,7 +232,7 @@ class TitleShow extends Component {
                   <FormattedMessage id="ui-eholdings.title.addToCustomPackage" />
                 </Button>
               </div>
-            </DetailsViewSection>
+            </Accordion>
           )}
           listType="packages"
           renderList={scrollable => (

--- a/tests/custom-resource-edit-embargo-test.js
+++ b/tests/custom-resource-edit-embargo-test.js
@@ -290,25 +290,6 @@ describeApplication('CustomResourceEditEmbargo', () => {
     });
   });
 
-  describe('visiting the resource edit page with title package not selected', () => {
-    beforeEach(function () {
-      resource.isSelected = false;
-      resource.customEmbargoPeriod = this.server.create('embargo-period', {
-        embargoUnit: 'Weeks',
-        embargoValue: null
-      }).toJSON();
-
-      resource.save();
-      return this.visit(`/eholdings/resources/${resource.id}/edit`, () => {
-        expect(ResourceEditPage.$root).to.exist;
-      });
-    });
-
-    it('displays a message that custom embargo is not shown', () => {
-      expect(ResourceEditPage.isEmbargoNotShownLabelPresent).to.be.true;
-    });
-  });
-
   describe('visiting the resource edit page with title package selected', () => {
     beforeEach(function () {
       resource.customEmbargoPeriod = this.server.create('embargo-period', {

--- a/tests/pages/resource-show.js
+++ b/tests/pages/resource-show.js
@@ -99,6 +99,8 @@ import Toast from './toast';
   hasCustomCoverageList = isPresent('[data-test-eholdings-resource-show-custom-coverage-list]');
   hasNoCoverageDate = isPresent('[data-test-eholdings-resource-no-coverage-date-label]');
 
+  isNotSelectedCoverageMessagePresent = isPresent('[data-test-eholdings-resource-not-selected-coverage-message]');
+
   identifiersList = collection('[data-test-eholdings-identifiers-list-item]', {
     indentifierText: text()
   });

--- a/tests/resource-coverage-statement-test.js
+++ b/tests/resource-coverage-statement-test.js
@@ -63,8 +63,8 @@ describeApplication('ResourceCoverageStatement', () => {
       expect(ResourceShowPage.hasCoverageStatement).to.be.false;
     });
 
-    it('displays a message that coverage statement is not shown ', () => {
-      expect(ResourceShowPage.hasCoverageNotShownStatement).to.be.true;
+    it('displays a message that coverage cannot be edited on an unselected resource', () => {
+      expect(ResourceShowPage.isNotSelectedCoverageMessagePresent).to.be.true;
     });
   });
 });

--- a/tests/resource-custom-coverage-test.js
+++ b/tests/resource-custom-coverage-test.js
@@ -34,8 +34,8 @@ describeApplication('ResourceCustomCoverage', () => {
       });
     });
 
-    it('displays message that no coverage date has been set', () => {
-      expect(ResourcePage.hasNoCoverageDate).to.be.true;
+    it('displays message that resource needs to be selected', () => {
+      expect(ResourcePage.isNotSelectedCoverageMessagePresent).to.be.true;
     });
 
     it('does not display custom coverage dates', () => {

--- a/tests/resource-embargo-test.js
+++ b/tests/resource-embargo-test.js
@@ -140,8 +140,8 @@ describeApplication('ResourceEmbargo', () => {
       expect(ResourceShowPage.hasCustomEmbargoPeriod).to.be.false;
     });
 
-    it('displays a message that no embargo period has been set', () => {
-      expect(ResourceShowPage.hasNoEmbargoPeriod).to.be.true;
+    it('displays a message that embargo period cannot be edited on an unselected resource', () => {
+      expect(ResourceShowPage.isNotSelectedCoverageMessagePresent).to.be.true;
     });
   });
 
@@ -182,8 +182,8 @@ describeApplication('ResourceEmbargo', () => {
           expect(ResourceShowPage.hasCustomEmbargoPeriod).to.be.false;
         });
 
-        it('displays a message that embargo period is not shown', () => {
-          expect(ResourceShowPage.hasNoEmbargoPeriod).to.be.true;
+        it('displays a message that embargo period cannot be edited on an unselected resource', () => {
+          expect(ResourceShowPage.isNotSelectedCoverageMessagePresent).to.be.true;
         });
       });
 

--- a/tests/resource-managed-coverage-test.js
+++ b/tests/resource-managed-coverage-test.js
@@ -18,7 +18,8 @@ describeApplication('ResourceManagedCoverage', () => {
 
     resource = this.server.create('resource', {
       package: pkg,
-      title
+      title,
+      isSelected: true
     });
   });
 

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -2,7 +2,7 @@
     "meta.title": "eHoldings",
     "package.addToHoldings": "Add to holdings",
     "package.contentType": "Content type",
-    "package.coverageDates": "Coverage dates",
+    "package.coverageSettings": "Coverage settings",
     "package.customCoverageDates": "Custom coverage dates",
     "package.deletePackage": "Delete package",
     "package.holdingStatus": "Holding status",


### PR DESCRIPTION
## Purpose
To apply the same organizational strategy to detail records that other FOLIO modules have, use the `stripes-components` `<Accordion>`.

## Approach
- Accordions only applied to show routes, not edit routes. It's recommended we keep it that way, so fields that have a validation error can't end up being hidden within a closed accordion.
- Accordions not applied to infinitely scrolling lists yet.
- Show routes and their accompanying edit routes always have the same order of headlines/sections.
- "Holding status" is always first.
- Does not include expand all / collapse all functionality for accordions.

### Sections
#### Provider
- Provider information
- Packages

#### Title
- Title information
- Packages

#### Package
- Holding status
- Package information
- Package settings
- Coverage settings
- Titles

#### Resource
- Holding status
- Resource information
- Resource settings
- Coverage settings

## Next Steps
- Address expand all / collapse all design.
- Redesign "Coverage settings" section (https://issues.folio.org/browse/UIEH-188).
- Redesign "Holding status" section.
- Put padding on the bottom of `<Accordion>`s?

## Screenshots
### Package show
![localhost_3000_eholdings_packages_1 iphone 5_se](https://user-images.githubusercontent.com/230597/43107810-45c9b65e-8ea4-11e8-85b0-4553d5fef759.png)

### Package edit
![localhost_3000_eholdings_packages_1_edit iphone 5_se](https://user-images.githubusercontent.com/230597/43107804-3f98bf50-8ea4-11e8-901e-ea2a77868dcd.png)


### Resource show
_"Title information" on this one is now "Resource information"
![localhost_3000_eholdings_resources_1 iphone 5_se](https://user-images.githubusercontent.com/230597/43107828-57bf0594-8ea4-11e8-9a85-8c80c5e8e9a2.png)

![localhost_3000_eholdings_resources_1 iphone 5_se -2](https://user-images.githubusercontent.com/230597/43107820-52c09d82-8ea4-11e8-92d3-ac29e021db4d.png)


### Resource edit
![localhost_3000_eholdings_resources_1_edit iphone 5_se](https://user-images.githubusercontent.com/230597/43107817-4d5ad560-8ea4-11e8-9f96-04a5392d44c1.png)

![localhost_3000_eholdings_resources_2_edit iphone 5_se](https://user-images.githubusercontent.com/230597/43107833-5fc345ca-8ea4-11e8-93ac-a3ca7e96c213.png)

