### PR TITLE
Remove outdated assertion

### DIFF
--- a/tests/package-selection-test.js
+++ b/tests/package-selection-test.js
@@ -48,10 +48,6 @@ describeApplication('PackageSelection', () => {
         this.server.timing = 0;
       });
 
-      it('reflects the desired state (Selected)', () => {
-        expect(PackageShowPage.isSelected).to.equal(true);
-      });
-
       it('indicates it is working to get to desired state', () => {
         expect(PackageShowPage.isSelecting).to.equal(true);
       });


### PR DESCRIPTION
## Purpose
The package selection tests relying on the timing of mirage responses have been flaking lately, which was probably inevitable. We want to refactor those to have complete control over when the mirage response resolves.

## Approach
I noticed one incorrectly placed assertion. It checks to see if the package now shows up as selected, which now shouldn't happen until after the endpoint resolves.

Hopefully this will cut down the flakiness until we can solve the root problem.