### PR TITLE
UIEH-476 - Package Edit Page - Partially Selected Package Handling

### DIFF
--- a/bigtest/interactors/package-edit.js
+++ b/bigtest/interactors/package-edit.js
@@ -1,4 +1,5 @@
 import {
+  Interactor,
   action,
   attribute,
   clickable,
@@ -14,6 +15,7 @@ import {
 import { hasClassBeginningWith } from './helpers';
 import Toast from './toast';
 import Datepicker from './datepicker';
+import PackageSelectionStatus from './selection-status';
 
 @interactor class PackageEditNavigationModal {
   cancelNavigation = clickable('[data-test-navigation-modal-dismiss]');
@@ -33,9 +35,9 @@ import Datepicker from './datepicker';
 }
 
 @interactor class PackageEditDropDownMenu {
-  clickRemoveFromHoldings = clickable('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
-  clickAddToHoldings = clickable('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
-  clickCancel = clickable('.tether-element [data-test-eholdings-package-cancel-action]');
+  addToHoldings = new Interactor('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
+  removeFromHoldings = new Interactor('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
+  cancel = new Interactor('.tether-element [data-test-eholdings-package-cancel-action]');
 }
 
 @interactor class PackageEditPage {
@@ -44,19 +46,14 @@ import Datepicker from './datepicker';
   clickCancel= action(function () {
     return this
       .dropDown.clickDropDownButton()
-      .dropDownMenu.clickCancel();
+      .dropDownMenu.cancel.click();
   });
   clickSave = clickable('[data-test-eholdings-package-save-button]');
   isSavePresent = isPresent('[data-test-eholdings-package-save-button]');
   isSaveDisabled = property('[data-test-eholdings-package-save-button]', 'disabled');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="package"]');
-  toggleIsSelected = clickable('[data-test-eholdings-package-details-selected] input');
   modal = new PackageEditModal('#eholdings-package-confirmation-modal');
-  selectionText = text('[data-test-eholdings-package-details-selected] h4');
-  isSelected = computed(function () {
-    return this.selectionText === 'Selected';
-  });
-  hasAddButton = isPresent('[data-test-eholdings-package-add-to-holdings-button]');
+  selectionStatus = new PackageSelectionStatus();
   clickAddButton = clickable('[data-test-eholdings-package-add-to-holdings-button]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button]');
   isHiddenMessage = text('[data-test-eholdings-package-details-is-hidden-reason]');
@@ -88,6 +85,26 @@ import Datepicker from './datepicker';
   dropDownMenu = new PackageEditDropDownMenu();
 
   toast = Toast;
+
+  selectPackage() {
+    return this
+      .dropDown.clickDropDownButton()
+      .dropDownMenu.addToHoldings.click();
+  }
+
+  deselectAndConfirmPackage() {
+    return this
+      .dropDown.clickDropDownButton()
+      .dropDownMenu.removeFromHoldings.click()
+      .modal.confirmDeselection();
+  }
+
+  deselectAndCancelPackage() {
+    return this
+      .dropDown.clickDropDownButton()
+      .dropDownMenu.removeFromHoldings.click()
+      .modal.cancelDeselection();
+  }
 
   name = fillable('[data-test-eholdings-package-name-field] input');
   contentType = fillable('[data-test-eholdings-package-content-type-field] select');

--- a/bigtest/interactors/package-show.js
+++ b/bigtest/interactors/package-show.js
@@ -16,12 +16,7 @@ import {
 import { getComputedStyle, hasClassBeginningWith } from './helpers';
 import Datepicker from './datepicker';
 import Toast from './toast';
-
-@interactor class PackageSelectionStatus {
-  static defaultScope = '[data-test-eholdings-package-details-selected]';
-  text = text('label h4');
-  buttonText = text('button');
-}
+import PackageSelectionStatus from './selection-status';
 
 @interactor class PackageShowModal {
   confirmDeselection = clickable('[data-test-eholdings-package-deselection-confirmation-modal-yes]');
@@ -36,25 +31,14 @@ import Toast from './toast';
 @interactor class PackageShowDropDownMenu {
   addToHoldings = new Interactor('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
   removeFromHoldings = new Interactor('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
-  clickRemoveFromHoldings = clickable('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
-  clickAddToHoldings = clickable('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
 }
 
 @interactor class PackageShowPage {
   allowKbToAddTitles = text('[data-test-eholdings-package-details-allow-add-new-titles]');
   hasAllowKbToAddTitles = isPresent('[data-test-eholdings-package-details-toggle-allow-add-new-titles] input');
   hasAllowKbToAddTitlesToggle = isPresent('[package-details-toggle-allow-add-new-titles-switch]');
-
-
   selectionStatus = new PackageSelectionStatus();
-
-  selectionText = text('[data-test-eholdings-package-details-selected] h4');
-  isSelected = computed(function () {
-    return this.selectionText === 'Selected';
-  });
-  isSelecting = isPresent('[data-test-eholdings-package-details-selected] [class*=icon---][class*=iconSpinner]');
   modal = new PackageShowModal('#eholdings-package-confirmation-modal');
-  toggleIsSelected = clickable('[data-test-eholdings-package-details-selected] input');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   contentType = text('[data-test-eholdings-package-details-content-type]');
   name = text('[data-test-eholdings-details-view-name="package"]');
@@ -67,10 +51,6 @@ import Toast from './toast';
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button]');
   detailsPaneContentScrollHeight = property('[data-test-eholdings-detail-pane-contents]', 'scrollHeight');
   clickEditButton = clickable('[data-test-eholdings-package-edit-link]');
-
-  clickAddToHoldingsButton = clickable('[data-test-eholdings-package-add-to-holdings-button]');
-  isAddToHoldingsButtonDisabled = property('[data-test-eholdings-package-add-to-holdings-button]', 'disabled');
-  isAddToHoldingsButtonPresent = isPresent('[data-test-eholdings-package-add-to-holdings-button]');
   dropDown= new PackageShowDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   dropDownMenu = new PackageShowDropDownMenu();
 
@@ -135,20 +115,20 @@ import Toast from './toast';
   selectPackage() {
     return this
       .dropDown.clickDropDownButton()
-      .dropDownMenu.clickAddToHoldings();
+      .dropDownMenu.addToHoldings.click();
   }
 
   deselectAndConfirmPackage() {
     return this
       .dropDown.clickDropDownButton()
-      .dropDownMenu.clickRemoveFromHoldings()
+      .dropDownMenu.removeFromHoldings.click()
       .modal.confirmDeselection();
   }
 
   deselectAndCancelPackage() {
     return this
       .dropDown.clickDropDownButton()
-      .dropDownMenu.clickRemoveFromHoldings()
+      .dropDownMenu.removeFromHoldings.click()
       .modal.cancelDeselection();
   }
 }

--- a/bigtest/interactors/selection-status.js
+++ b/bigtest/interactors/selection-status.js
@@ -1,0 +1,18 @@
+import {
+  interactor,
+  computed,
+  text,
+  isPresent
+} from '@bigtest/interactor';
+
+export default @interactor class PackageSelectionStatus {
+  static defaultScope = '[data-test-eholdings-package-details-selected]';
+  text = text('label h4');
+  buttonText = text('button');
+  selectionText = text('[data-test-eholdings-package-details-selected] h4');
+  isSelected = computed(function () {
+    return this.selectionText === 'Selected';
+  });
+  isSelecting = isPresent('[data-test-eholdings-package-details-selected] [class*=icon---][class*=iconSpinner]');
+  hasAddButton = isPresent('[data-test-eholdings-package-add-to-holdings-button]');
+}

--- a/bigtest/tests/custom-package-edit-selection-test.js
+++ b/bigtest/tests/custom-package-edit-selection-test.js
@@ -30,7 +30,7 @@ describeApplication('CustomPackageEditSelection', () => {
     });
 
     it('displays the correct holdings status (ON)', () => {
-      expect(PackageEditPage.isSelected).to.equal(true);
+      expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
     });
 
     it('disables the save button', () => {
@@ -51,7 +51,7 @@ describeApplication('CustomPackageEditSelection', () => {
       beforeEach(() => {
         return PackageEditPage
           .dropDown.clickDropDownButton()
-          .dropDownMenu.clickRemoveFromHoldings();
+          .dropDownMenu.removeFromHoldings.click();
       });
 
       it('shows the deletion confirmation modal', () => {
@@ -68,7 +68,7 @@ describeApplication('CustomPackageEditSelection', () => {
         });
 
         it('reflects that the package is still selected', () => {
-          expect(PackageEditPage.isSelected).to.equal(true);
+          expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
         });
       });
 

--- a/bigtest/tests/custom-package-edit-test.js
+++ b/bigtest/tests/custom-package-edit-test.js
@@ -30,7 +30,7 @@ describeApplication('CustomPackageEdit', () => {
     });
 
     it('displays the correct holdings status', () => {
-      expect(PackageEditPage.isSelected).to.equal(true);
+      expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
     });
 
     it('shows blank datepicker fields', () => {

--- a/bigtest/tests/custom-package-edit-visibility-test.js
+++ b/bigtest/tests/custom-package-edit-visibility-test.js
@@ -184,7 +184,7 @@ describeApplication('CustomPackageEditVisibility', () => {
       });
     });
     it('reflects the desired state of holding status', () => {
-      expect(PackageEditPage.isSelected).to.equal(true);
+      expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
     });
 
     it('disables the save button', () => {

--- a/bigtest/tests/custom-package-show-selection-test.js
+++ b/bigtest/tests/custom-package-show-selection-test.js
@@ -34,14 +34,14 @@ describeApplication('CustomPackageShowSelection', () => {
     });
 
     it('automatically has the custom package in my holdings', () => {
-      expect(PackageShowPage.isSelected).to.equal(true);
+      expect(PackageShowPage.selectionStatus.isSelected).to.equal(true);
     });
 
     describe('deselecting a custom package', () => {
       beforeEach(() => {
         return PackageShowPage
           .dropDown.clickDropDownButton()
-          .dropDownMenu.clickRemoveFromHoldings();
+          .dropDownMenu.removeFromHoldings.click();
       });
 
       describe('canceling the deselection', () => {
@@ -50,7 +50,7 @@ describeApplication('CustomPackageShowSelection', () => {
         });
 
         it('reverts back to the selected state', () => {
-          expect(PackageShowPage.isSelected).to.equal(true);
+          expect(PackageShowPage.selectionStatus.isSelected).to.equal(true);
         });
       });
 
@@ -61,7 +61,7 @@ describeApplication('CustomPackageShowSelection', () => {
         });
 
         it('indicates it is working to get to desired state', () => {
-          expect(PackageShowPage.isSelecting).to.equal(true);
+          expect(PackageShowPage.selectionStatus.isSelecting).to.equal(true);
         });
 
         describe('when the request succeeds', () => {
@@ -91,7 +91,7 @@ describeApplication('CustomPackageShowSelection', () => {
 
         return PackageShowPage
           .dropDown.clickDropDownButton()
-          .dropDownMenu.clickRemoveFromHoldings();
+          .dropDownMenu.removeFromHoldings.click();
       });
 
       it('shows a confirmation dialog', () => {
@@ -104,11 +104,11 @@ describeApplication('CustomPackageShowSelection', () => {
         });
 
         it('reflect the desired state was not set', () => {
-          expect(PackageShowPage.isSelected).to.equal(true);
+          expect(PackageShowPage.selectionStatus.isSelected).to.equal(true);
         });
 
         it('indicates it is no longer working', () => {
-          expect(PackageShowPage.isSelecting).to.equal(false);
+          expect(PackageShowPage.selectionStatus.isSelecting).to.equal(false);
         });
 
         it('shows the error as a toast', () => {

--- a/bigtest/tests/managed-package-edit-add-new-titles-test.js
+++ b/bigtest/tests/managed-package-edit-add-new-titles-test.js
@@ -170,7 +170,7 @@ describeApplication('ManagedPackageEditAllowKbToAddTitles', () => {
       });
 
       it('reflects the desired state (Selected)', () => {
-        expect(PackageEditPage.isSelected).to.be.true;
+        expect(PackageEditPage.selectionStatus.isSelected).to.be.true;
       });
 
       it('allow KB to add titles is selected true', () => {

--- a/bigtest/tests/managed-package-edit-selection-test.js
+++ b/bigtest/tests/managed-package-edit-selection-test.js
@@ -29,11 +29,11 @@ describeApplication('ManagedPackageEditSelection', () => {
     });
 
     it('reflects the desired state of holding status', () => {
-      expect(PackageEditPage.isSelected).to.equal(false);
+      expect(PackageEditPage.selectionStatus.isSelected).to.equal(false);
     });
 
     it('shows "Add to holdings" button', () => {
-      expect(PackageEditPage.hasAddButton).to.equal(true);
+      expect(PackageEditPage.selectionStatus.hasAddButton).to.equal(true);
     });
 
     it('cannot toggle visibility', () => {
@@ -73,7 +73,7 @@ describeApplication('ManagedPackageEditSelection', () => {
         });
 
         it('reflects that the package has been selected', () => {
-          expect(PackageEditPage.isSelected).to.equal(true);
+          expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
         });
 
         it('should not need the form to be submitted', () => {
@@ -85,7 +85,7 @@ describeApplication('ManagedPackageEditSelection', () => {
         beforeEach(() => {
           return PackageEditPage
             .dropDown.clickDropDownButton()
-            .dropDownMenu.clickAddToHoldings();
+            .dropDownMenu.addToHoldings.click();
         });
 
         it('stays on the edit page', () => {
@@ -93,7 +93,7 @@ describeApplication('ManagedPackageEditSelection', () => {
         });
 
         it('reflects that the package has been selected', () => {
-          expect(PackageEditPage.isSelected).to.equal(true);
+          expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
         });
 
         it('should not need the form to be submitted', () => {
@@ -103,7 +103,7 @@ describeApplication('ManagedPackageEditSelection', () => {
     });
   });
 
-  describe('visiting the package edit page with a selected package', () => {
+  describe('visiting the package edit page with a totally selected package', () => {
     beforeEach(function () {
       providerPackage = this.server.create('package', {
         provider,
@@ -117,11 +117,11 @@ describeApplication('ManagedPackageEditSelection', () => {
     });
 
     it('reflects the desired state of holding status', () => {
-      expect(PackageEditPage.isSelected).to.equal(true);
+      expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
     });
 
     it('hides "Add to holdings" button', () => {
-      expect(PackageEditPage.hasAddButton).to.equal(false);
+      expect(PackageEditPage.selectionStatus.hasAddButton).to.equal(false);
     });
 
     it('can toggle visibility', () => {
@@ -154,7 +154,7 @@ describeApplication('ManagedPackageEditSelection', () => {
       beforeEach(() => {
         return PackageEditPage
           .dropDown.clickDropDownButton()
-          .dropDownMenu.clickRemoveFromHoldings();
+          .dropDownMenu.removeFromHoldings.click();
       });
 
       it('shows the deselection confirmation modal', () => {
@@ -171,7 +171,7 @@ describeApplication('ManagedPackageEditSelection', () => {
         });
 
         it('reflects the desired state of holding status', () => {
-          expect(PackageEditPage.isSelected).to.equal(true);
+          expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
         });
       });
 
@@ -209,6 +209,100 @@ describeApplication('ManagedPackageEditSelection', () => {
           it('goes to the resource show page', () => {
             expect(PackageShowPage.$root).to.exist;
             expect(PackageShowPage.hasTitleList).to.equal(true);
+          });
+        });
+      });
+    });
+  });
+
+  describe('visiting the package edit page with a partially selected package', () => {
+    let pkg;
+    beforeEach(function () {
+      pkg = this.server.create('package', {
+        provider,
+        name: 'Partial Package',
+        selectedCount: 5,
+        titleCount: 10
+      });
+      this.server.createList('resource', 5, 'withTitle', {
+        package: pkg,
+        isSelected: true
+      });
+      this.server.createList('resource', 5, 'withTitle', {
+        package: pkg,
+        isSelected: false
+      });
+      return this.visit(`/eholdings/packages/${pkg.id}/edit`);
+    });
+    it('shows the selected # of titles and the total # of titles in the package', () => {
+      expect(PackageEditPage.selectionStatus.text).to.equal('5 of 10 titles selected');
+    });
+    it('shows add all to holdings button', () => {
+      expect(PackageEditPage.selectionStatus.buttonText).to.equal('Add all to holdings');
+    });
+    describe('inspecting the menu', () => {
+      beforeEach(() => {
+        return PackageEditPage.dropDown.clickDropDownButton();
+      });
+      it('has menu item to add all remaining titles from this packages', () => {
+        expect(PackageEditPage.dropDownMenu.addToHoldings.text).to.equal('Add all to holdings');
+      });
+      it('has menu item to remove the entire package from holdings just like a completely selected packages', () => {
+        expect(PackageEditPage.dropDownMenu.removeFromHoldings.isVisible).to.equal(true);
+      });
+    });
+    describe('clicking the menu item to add all to holdings', () => {
+      beforeEach(function () {
+        this.server.block();
+        return PackageEditPage.selectPackage();
+      });
+      it.skip('indicates it is working to get to desired state', () => {
+        expect(PackageEditPage.selectionStatus.isSelecting).to.equal(true);
+      });
+      describe('when the request succeeds', () => {
+        beforeEach(function () {
+          return this.server.unblock();
+        });
+        it('reflects that the package has been selected', () => {
+          expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
+        });
+        describe('inspecting the menu', () => {
+          beforeEach(() => {
+            return PackageEditPage.dropDown.clickDropDownButton();
+          });
+          it('does not have menu item to add all to holdings', () => {
+            expect(PackageEditPage.dropDownMenu.addToHoldings.isPresent).to.equal(false);
+          });
+          it('has menu item to remove the entire package from holdings', () => {
+            expect(PackageEditPage.dropDownMenu.removeFromHoldings.isVisible).to.equal(true);
+          });
+        });
+      });
+    });
+    describe('clicking the "Add all to holdings" button', () => {
+      beforeEach(function () {
+        this.server.block();
+        return PackageEditPage.selectPackage();
+      });
+      it.skip('indicates it is working to get to desired state', () => {
+        expect(PackageEditPage.selectionStatus.isSelecting).to.equal(true);
+      });
+      describe('when the request succeeds', () => {
+        beforeEach(function () {
+          return this.server.unblock();
+        });
+        it('reflects that the package has been selected', () => {
+          expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
+        });
+        describe('inspecting the menu', () => {
+          beforeEach(() => {
+            return PackageEditPage.dropDown.clickDropDownButton();
+          });
+          it('does not have menu item to add all to holdings', () => {
+            expect(PackageEditPage.dropDownMenu.addToHoldings.isPresent).to.equal(false);
+          });
+          it('has menu item to remove the entire package from holdings', () => {
+            expect(PackageEditPage.dropDownMenu.removeFromHoldings.isVisible).to.equal(true);
           });
         });
       });

--- a/bigtest/tests/managed-package-edit-visibility-test.js
+++ b/bigtest/tests/managed-package-edit-visibility-test.js
@@ -185,7 +185,7 @@ describeApplication('ManagedPackageEditVisibility', () => {
     });
 
     it('reflects the desired state of holding status', () => {
-      expect(PackageEditPage.isSelected).to.equal(false);
+      expect(PackageEditPage.selectionStatus.isSelected).to.equal(false);
     });
 
     it('visibility field is not present', () => {

--- a/bigtest/tests/package-add-new-titles-test.js
+++ b/bigtest/tests/package-add-new-titles-test.js
@@ -98,7 +98,7 @@ describeApplication('PackageShowAllowKbToAddTitles', () => {
       });
 
       it('reflects the desired state (Selected)', () => {
-        expect(PackageShowPage.isSelected).to.be.true;
+        expect(PackageShowPage.selectionStatus.isSelected).to.be.true;
       });
 
       it('displays YES for allowing kb to select new titles', () => {

--- a/bigtest/tests/package-custom-coverage-test.js
+++ b/bigtest/tests/package-custom-coverage-test.js
@@ -62,7 +62,7 @@ describeApplication('PackageCustomCoverage', () => {
     });
 
     it('displays whether or not the package is selected', () => {
-      expect(PackageShowPage.isSelected).to.equal(true);
+      expect(PackageShowPage.selectionStatus.isSelected).to.equal(true);
     });
 
     describe('clicking to toggle and deselect package and confirming deselection', () => {

--- a/bigtest/tests/package-selection-test.js
+++ b/bigtest/tests/package-selection-test.js
@@ -37,7 +37,7 @@ describeApplication('PackageSelection', () => {
       });
 
       it.skip('indicates it is working to get to desired state', () => {
-        expect(PackageShowPage.isSelecting).to.equal(true);
+        expect(PackageShowPage.selectionStatus.isSelecting).to.equal(true);
       });
 
       describe('when the request succeeds', () => {
@@ -46,11 +46,11 @@ describeApplication('PackageSelection', () => {
         });
 
         it('reflect the desired state was set', () => {
-          expect(PackageShowPage.isSelected).to.equal(true);
+          expect(PackageShowPage.selectionStatus.isSelected).to.equal(true);
         });
 
         it('indicates it is no longer working', () => {
-          expect(PackageShowPage.isSelecting).to.equal(false);
+          expect(PackageShowPage.selectionStatus.isSelecting).to.equal(false);
         });
 
         it('should show the package titles are all selected', () => {
@@ -70,7 +70,7 @@ describeApplication('PackageSelection', () => {
           return PackageShowPage
             .when(() => !PackageShowPage.isSelecting)
             .dropDown.clickDropDownButton()
-            .dropDownMenu.clickRemoveFromHoldings();
+            .dropDownMenu.removeFromHoldings.click();
         });
 
         describe('canceling the deselection', () => {
@@ -79,11 +79,11 @@ describeApplication('PackageSelection', () => {
           });
 
           it('does not show a loading indicator', () => {
-            expect(PackageShowPage.isSelecting).to.equal(false);
+            expect(PackageShowPage.selectionStatus.isSelecting).to.equal(false);
           });
 
           it('remains selected', () => {
-            expect(PackageShowPage.isSelected).to.equal(true);
+            expect(PackageShowPage.selectionStatus.isSelected).to.equal(true);
           });
         });
 
@@ -94,7 +94,7 @@ describeApplication('PackageSelection', () => {
           });
 
           it('indicates it is working', () => {
-            expect(PackageShowPage.isSelecting).to.equal(true);
+            expect(PackageShowPage.selectionStatus.isSelecting).to.equal(true);
           });
 
           describe('when the request succeeds', () => {
@@ -103,11 +103,11 @@ describeApplication('PackageSelection', () => {
             });
 
             it('reflect the desired state was set', () => {
-              expect(PackageShowPage.isSelected).to.equal(false);
+              expect(PackageShowPage.selectionStatus.isSelected).to.equal(false);
             });
 
             it('indicates it is no longer working', () => {
-              expect(PackageShowPage.isSelecting).to.equal(false);
+              expect(PackageShowPage.selectionStatus.isSelecting).to.equal(false);
             });
 
             it('should show the package titles are not all selected', () => {
@@ -152,11 +152,11 @@ describeApplication('PackageSelection', () => {
         });
 
         it('reflect the desired state was not set', () => {
-          expect(PackageShowPage.isSelected).to.equal(false);
+          expect(PackageShowPage.selectionStatus.isSelected).to.equal(false);
         });
 
         it('indicates it is no longer working', () => {
-          expect(PackageShowPage.isSelecting).to.equal(false);
+          expect(PackageShowPage.selectionStatus.isSelecting).to.equal(false);
         });
 
         it('shows the error as a toast', () => {

--- a/bigtest/tests/package-show-test.js
+++ b/bigtest/tests/package-show-test.js
@@ -43,7 +43,7 @@ describeApplication('PackageShow', () => {
     });
 
     it('displays whether or not the package is selected', () => {
-      expect(PackageShowPage.isSelected).to.equal(false);
+      expect(PackageShowPage.selectionStatus.isSelected).to.equal(false);
     });
 
     it('displays the content type', () => {

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -22,6 +22,7 @@ import DetailsViewSection from '../../details-view-section';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 import PaneHeaderButton from '../../pane-header-button';
+import SelectionStatus from '../selection-status';
 import styles from './custom-package-edit.css';
 
 class CustomPackageEdit extends Component {
@@ -32,7 +33,8 @@ class CustomPackageEdit extends Component {
     model: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    intl: intlShape.isRequired
+    intl: intlShape.isRequired,
+    addPackageToHoldings: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -220,17 +222,10 @@ class CustomPackageEdit extends Component {
                 <DetailsViewSection
                   label={intl.formatMessage({ id: 'ui-eholdings.label.holdingStatus' })}
                 >
-                  <label
-                    data-test-eholdings-package-details-selected
-                    htmlFor="custom-package-details-toggle-switch"
-                  >
-                    <h4>
-                      {packageSelected ?
-                        (<FormattedMessage id="ui-eholdings.selected" />) :
-                        (<FormattedMessage id="ui-eholdings.notSelected" />)
-                      }
-                    </h4>
-                  </label>
+                  <SelectionStatus
+                    model={model}
+                    onAddToHoldings={this.props.addPackageToHoldings}
+                  />
                 </DetailsViewSection>
                 <DetailsViewSection
                   label={intl.formatMessage({ id: 'ui-eholdings.label.packageInformation' })}

--- a/src/components/package/selection-status.js
+++ b/src/components/package/selection-status.js
@@ -4,40 +4,38 @@ import PropTypes from 'prop-types';
 import { Icon, Button } from '@folio/stripes-components';
 import { FormattedMessage } from 'react-intl';
 
-export default function SelectionStatus({ model, isPending, onAddToHoldings }) {
+export default function SelectionStatus({ model, onAddToHoldings }) {
   return (
     <label data-test-eholdings-package-details-selected>
-      <SelectionStatusMessage isPending={isPending} model={model} />
+      <SelectionStatusMessage model={model} />
       <br />
       <SelectionStatusButton
         model={model}
-        isPending={isPending}
         onAddToHoldings={onAddToHoldings}
       />
     </label>);
 }
 SelectionStatus.propTypes = {
   model: PropTypes.object.isRequired,
-  isPending: PropTypes.bool.isRequired,
   onAddToHoldings: PropTypes.func.isRequired
 };
 
-function SelectionStatusMessage({ model, isPending }) {
-  if (isPending) {
+function SelectionStatusMessage({ model }) {
+  if (model.isInFlight) {
     return <Icon icon="spinner-ellipsis" />;
   } else {
     return <h4><FormattedMessage {...messageFor(model)} /></h4>; // eslint-disable-line no-use-before-define
   }
 }
 
-function SelectionStatusButton({ model, isPending, onAddToHoldings }) {
-  if (model.isPartiallySelected || !model.isSelected || isPending) {
+function SelectionStatusButton({ model, onAddToHoldings }) {
+  if (model.isPartiallySelected || !model.isSelected || model.isInFlight) {
     let messageId = model.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings';
     return (
       <Button
         type="button"
         buttonStyle="primary"
-        disabled={isPending}
+        disabled={model.isInFlight}
         onClick={onAddToHoldings}
         data-test-eholdings-package-add-to-holdings-button
       >

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -19,7 +19,7 @@ import TitleListItem from '../../title-list-item';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 
-import SelectionStatus from './selection-status';
+import SelectionStatus from '../selection-status';
 import styles from './package-show.css';
 
 class PackageShow extends Component {
@@ -92,8 +92,6 @@ class PackageShow extends Component {
     } = this.state;
 
     let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
-    let packageSelectionPending = model.destroy.isPending ||
-        (model.update.isPending && ('selectedCount' in model.update.changedAttributes));
 
     let modalMessage = model.isCustom ?
       {
@@ -132,8 +130,9 @@ class PackageShow extends Component {
     }
 
     if (packageSelected) {
+      let messageId = model.isCustom ? 'deletePackage' : 'removeFromHoldings';
       actionMenuItems.push({
-        'label': 'Remove from holdings',
+        'label': intl.formatMessage({ id: `ui-eholdings.package.${messageId}` }),
         'state': { eholdings: true },
         'data-test-eholdings-package-remove-from-holdings-action': true,
         'onClick': this.handleSelectionToggle
@@ -211,8 +210,6 @@ class PackageShow extends Component {
               <Accordion label={intl.formatMessage({ id: 'ui-eholdings.label.holdingStatus' })}>
                 <SelectionStatus
                   model={model}
-                  isPending={packageSelectionPending}
-                  isSelectedInParentComponentState={packageSelected}
                   onAddToHoldings={this.props.addPackageToHoldings}
                 />
               </Accordion>

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -18,6 +18,10 @@ class Package {
   get isPartiallySelected() {
     return this.selectedCount > 0 && this.selectedCount !== this.titleCount;
   }
+
+  get isInFlight() {
+    return this.destroy.isPending || (this.update.isPending && ('selectedCount' in this.update.changedAttributes));
+  }
 }
 
 export default model({

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -120,7 +120,16 @@ class PackageEditRoute extends Component {
       updatePackage(model);
     }
   };
-
+  /* This method is common between package-show and package-edit routes
+   * This should be refactored once we can share model between the routes.
+  */
+  addPackageToHoldings = () => {
+    let { model, updatePackage } = this.props;
+    model.isSelected = true;
+    model.selectedCount = model.titleCount;
+    model.allowKbToAddTitles = true;
+    updatePackage(model);
+  };
   render() {
     let { model } = this.props;
 
@@ -129,6 +138,7 @@ class PackageEditRoute extends Component {
         <View
           model={model}
           onSubmit={this.packageEditSubmitted}
+          addPackageToHoldings={this.addPackageToHoldings}
         />
       </TitleManager>
     );

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -63,7 +63,9 @@ class PackageShowRoute extends Component {
       unloadResources(next.resources);
     }
   }
-
+  /* This method is common between package-show and package-edit routes
+   * This should be refactored once we can share model between the routes.
+  */
   addPackageToHoldings = () => {
     let { model, updatePackage } = this.props;
     model.isSelected = true;

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -2,6 +2,7 @@
     "meta.title": "eHoldings",
     "package.actionMenu.edit": "Edit",
     "package.addToHoldings": "Add to holdings",
+    "package.removeFromHoldings": "Remove from holdings",
     "package.contentType": "Content type",
     "package.coverageSettings": "Coverage settings",
     "package.coverageDates": "Coverage dates",


### PR DESCRIPTION
[UIEH-476 - Holding status: package edit page: Partially Selected Package Handling](https://issues.folio.org/browse/UIEH-476)

resolves #484 

## Purpose

The Managed Package Edit Page currently displays a holding status area with 2 states:
- Selected
- Not Selected (with an `Add to holdings` button)

The menu area also shows `Remove from holdings` or `Add to holdings` depending upon state.

This PR enhances the Managed Package Edit Page to support partially selected packages. (ie a package that does not have all of its titles selected). Specifically, it allows the user to completely select a partially selected package.  It adds a 3rd state:

- (# selected titles)  of (# total titles) titles selected (with an `Add all to holdings` button)

Added menu item `Add all to holdings`

Additional Items Addressed:
- Corrected text which appears on package show page menu for custom package. Specifically display `Delete package` instead of `Remove from holdings`
- Added use of selection status on custom package edit (to be consistent). For custom packages, state will simply show Selected. Since once a custom package is de-selected it is deleted.
- Moved packageSelectionPending state to redux model - merged in work from https://github.com/folio-org/ui-eholdings/pull/484 to remove state maintenance out of component to simplify.

Note -- test refactoring work was done in separate PR(s) https://github.com/folio-org/ui-eholdings/pull/488, https://github.com/folio-org/ui-eholdings/pull/490, https://github.com/folio-org/ui-eholdings/pull/494. There are still some issues -- so these tests are skipped temporariliy.
~~Additionally, we need to Refactor Package Selection tests. We currently see intermittent test failures when testing 'selecting a package title to add to holdings'.  The problem occurs when checking a temporary isSelecting state (due to timing)~~

## Approach 

Update Managed Package Edit Page as follows:
- Add a Status indicator which includes number of selected titles/total titles and a Button 'Add all to holdings' when a package is partially selected.
- Updated Package Edit Page(Pane Header Dropdown) to include 'Add all to holdings' depending on state

Plan to understand the work which was done for `UIEH-442 - Holding status: package show page: Partially Selected Package Handling`  as a model for functionality that is required. Pull request is https://github.com/folio-org/ui-eholdings/pull/475. This work implemented partially selected handling for the `package show` page. This PR adds the same functionality for the `package edit` page

Additional Goals:
- Move actions to route (as much as possible)
- Strive to move ManagedPackageEdit towards a functional component (like SelectionStatus)
- Move complex state(such as isPending) into redux/package.js model object (see isPartiallySelected as example)

#### TODOS and Open Questions
- [x] Per UIEH-406 Custom Package Show/Edit,  'Delete Package' should appear as text in header dropdown. Currently shows 'Remove from holdings' on the show page. Placeholder to fix in either this PR or as a follow on


## Learning


## Screenshots
![2018-07-30 17 49 53](https://user-images.githubusercontent.com/19415226/43425594-1d6e485a-9421-11e8-8662-c9a899596324.gif)
![2018-07-30 17 51 43](https://user-images.githubusercontent.com/19415226/43425666-53a1f3b8-9421-11e8-9164-9efa44440ac2.gif)
