### PR TITLE
Lift pending state from the view into the model.

### DIFF
--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -93,8 +93,6 @@ class PackageShow extends Component {
     } = this.state;
 
     let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
-    let packageSelectionPending = model.destroy.isPending ||
-        (model.update.isPending && ('selectedCount' in model.update.changedAttributes));
 
     let modalMessage = model.isCustom ?
       {
@@ -246,14 +244,11 @@ class PackageShow extends Component {
                   </div>
                 </KeyValue>
               </DetailsViewSection>
+
               <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageInformation' })}>
-                <SelectionStatus
-                  model={model}
-                  isPending={packageSelectionPending}
-                  isSelectedInParentComponentState={packageSelected}
-                  onAddToHoldings={this.props.addPackageToHoldings}
-                />
+                <SelectionStatus pkg={model} onAddToHoldings={this.props.addPackageToHoldings} />
               </DetailsViewSection>
+
               <DetailsViewSection label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}>
                 {packageSelected ? (
                   <div>

--- a/src/components/package/show/selection-status.js
+++ b/src/components/package/show/selection-status.js
@@ -4,40 +4,36 @@ import PropTypes from 'prop-types';
 import { Icon, Button } from '@folio/stripes-components';
 import { FormattedMessage } from 'react-intl';
 
-export default function SelectionStatus({ model, isPending, onAddToHoldings }) {
+export default function SelectionStatus({ pkg, onAddToHoldings }) {
   return (
     <label data-test-eholdings-package-details-selected>
-      <SelectionStatusMessage isPending={isPending} model={model} />
+      <SelectionStatusMessage pkg={pkg} />
       <br />
-      <SelectionStatusButton
-        model={model}
-        isPending={isPending}
-        onAddToHoldings={onAddToHoldings}
-      />
+      <SelectionStatusButton pkg={pkg} onAddToHoldings={onAddToHoldings} />
     </label>);
 }
+
 SelectionStatus.propTypes = {
-  model: PropTypes.object.isRequired,
-  isPending: PropTypes.bool.isRequired,
+  pkg: PropTypes.object.isRequired,
   onAddToHoldings: PropTypes.func.isRequired
 };
 
-function SelectionStatusMessage({ model, isPending }) {
-  if (isPending) {
+function SelectionStatusMessage({ pkg }) {
+  if (pkg.isInFlight) {
     return <Icon icon="spinner-ellipsis" />;
   } else {
-    return <h4><FormattedMessage {...messageFor(model)} /></h4>; // eslint-disable-line no-use-before-define
+    return <h4><FormattedMessage {...messageFor(pkg)} /></h4>; // eslint-disable-line no-use-before-define
   }
 }
 
-function SelectionStatusButton({ model, isPending, onAddToHoldings }) {
-  if (model.isPartiallySelected || !model.isSelected || isPending) {
-    let messageId = model.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings';
+function SelectionStatusButton({ pkg, onAddToHoldings }) {
+  if (pkg.isPartiallySelected || !pkg.isSelected || pkg.isInFlight) {
+    let messageId = pkg.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings';
     return (
       <Button
         type="button"
         buttonStyle="primary"
-        disabled={isPending}
+        disabled={pkg.isInFlight}
         onClick={onAddToHoldings}
         data-test-eholdings-package-add-to-holdings-button
       >
@@ -49,15 +45,14 @@ function SelectionStatusButton({ model, isPending, onAddToHoldings }) {
   }
 }
 
-
-function messageFor(model) {
-  if (model.isPartiallySelected) {
+function messageFor(pkg) {
+  if (pkg.isPartiallySelected) {
     return {
       id: 'ui-eholdings.package.partiallySelected',
-      values: { selectedCount: model.selectedCount, titleCount: model.titleCount }
+      values: { selectedCount: pkg.selectedCount, titleCount: pkg.titleCount }
     };
   }
-  if (model.isSelected) {
+  if (pkg.isSelected) {
     return { id: 'ui-eholdings.selected' };
   } else {
     return { id: 'ui-eholdings.notSelected' };

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -18,6 +18,10 @@ class Package {
   get isPartiallySelected() {
     return this.selectedCount > 0 && this.selectedCount !== this.titleCount;
   }
+
+  get isInFlight() {
+    return this.destroy.isPending || (this.update.isPending && ('selectedCount' in this.update.changedAttributes));
+  }
 }
 
 export default model({


### PR DESCRIPTION
## Purpose

Our application concentrates state and the actions that change it within the route, and then the representations of that state go into the views. As a 99/1 rule, our views should be pure functions.

The PackageShow component maintains a lot of state internally, that belongs "higher up".

## Approach

This move a piece of that state (whether or not a package is in filght) up to the model layer, thereby simplifying the APIs of the components that get rendered down the stack.
