### PR TITLE
UIEH-320 - Provider Detail: List of Packages: Search Within Modal : Unable to Reset Search

### DIFF
--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -60,7 +60,7 @@ export default class DetailsView extends Component {
   state = {
     isSticky: false,
     showSearchModal: false,
-    showSearchModalSearchButton: false,
+    showSearchModalSearchButton: true,
     searchParams: null
   };
 
@@ -191,7 +191,17 @@ export default class DetailsView extends Component {
   updateSearch = () => {
     this.setState({
       showSearchModal: false,
-      showSearchModalSearchButton: false
+    });
+
+    if (this.props.onFilter) {
+      this.props.onFilter(this.state.searchParams);
+    }
+  }
+
+  resetSearch = () => {
+    this.setState({
+      searchParams: null,
+      showSearchModal: false,
     });
 
     if (this.props.onFilter) {
@@ -384,6 +394,11 @@ export default class DetailsView extends Component {
                   'label': 'Search',
                   'onClick': this.updateSearch,
                   'data-test-eholdings-modal-search-button': true
+                }}
+                secondaryButton={{
+                  'label': 'Reset all',
+                  'onClick': this.resetSearch,
+                  'data-test-eholdings-modal-reset-all-button': true
                 }}
               />
             )}

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -60,7 +60,7 @@ export default class DetailsView extends Component {
   state = {
     isSticky: false,
     showSearchModal: false,
-    showSearchModalSearchButton: true,
+    enableModalSearchButton: false,
     searchParams: null
   };
 
@@ -191,6 +191,7 @@ export default class DetailsView extends Component {
   updateSearch = () => {
     this.setState({
       showSearchModal: false,
+      enableModalSearchButton: false
     });
 
     if (this.props.onFilter) {
@@ -200,27 +201,29 @@ export default class DetailsView extends Component {
 
   resetSearch = () => {
     this.setState({
-      searchParams: null,
+      searchParams: {},
       showSearchModal: false,
+      enableModalSearchButton: false
+    },
+    () => {
+      if (this.props.onFilter) {
+        this.props.onFilter(this.state.searchParams);
+      }
     });
-
-    if (this.props.onFilter) {
-      this.props.onFilter(this.state.searchParams);
-    }
   }
 
   closeSearchModal = () => {
     this.setState({
       searchParams: null,
       showSearchModal: false,
-      showSearchModalSearchButton: false
+      enableModalSearchButton: false
     });
   }
 
   handleFilterChange = searchParams => {
     this.setState({
       searchParams,
-      showSearchModalSearchButton: true
+      enableModalSearchButton: true
     });
   }
 
@@ -230,7 +233,7 @@ export default class DetailsView extends Component {
         ...(this.state.searchParams || this.props.searchParams),
         q
       },
-      showSearchModalSearchButton: true
+      enableModalSearchButton: true
     });
   }
 
@@ -262,7 +265,7 @@ export default class DetailsView extends Component {
     let {
       isSticky,
       showSearchModal,
-      showSearchModalSearchButton
+      enableModalSearchButton
     } = this.state;
 
     let containerClassName = cx('container', {
@@ -271,7 +274,7 @@ export default class DetailsView extends Component {
 
     let historyState = router.history.location.state;
 
-    let filterCount = [searchParams.q]
+    let filterCount = [searchParams.q, searchParams.sort]
       .concat(Object.values(searchParams.filter || {}))
       .filter(Boolean).length;
 
@@ -388,16 +391,18 @@ export default class DetailsView extends Component {
             id="eholdings-details-view-search-modal"
             closeOnBackgroundClick
             dismissible
-            footer={showSearchModalSearchButton && (
+            footer={(
               <ModalFooter
                 primaryButton={{
                   'label': 'Search',
                   'onClick': this.updateSearch,
+                  'disabled': !enableModalSearchButton,
                   'data-test-eholdings-modal-search-button': true
                 }}
                 secondaryButton={{
                   'label': 'Reset all',
                   'onClick': this.resetSearch,
+                  'disabled': !(filterCount > 0),
                   'data-test-eholdings-modal-reset-all-button': true
                 }}
               />

--- a/tests/pages/search-modal.js
+++ b/tests/pages/search-modal.js
@@ -3,7 +3,6 @@ import {
   action,
   attribute,
   clickable,
-  isPresent,
   property,
   value,
 } from '@bigtest/interactor';
@@ -17,11 +16,14 @@ export default @interactor class SearchModal {
   });
 
   clickSearch = clickable('[data-test-eholdings-modal-search-button]');
-  hasModalSearchButton = isPresent('[data-test-eholdings-modal-search-button]');
 
   getFilter(name) {
     return this.$(`[data-test-eholdings-search-filters] input[name="${name}"]:checked`).value;
   }
+
+  isSearchButtonDisabled = property('[data-test-eholdings-modal-search-button]', 'disabled');
+  isResetButtonDisabled = property('[data-test-eholdings-modal-reset-all-button]', 'disabled');
+  clickResetAll = clickable('[data-test-eholdings-modal-reset-all-button]');
 
   searchDisabled = property('[data-test-search-submit]', 'disabled')
 

--- a/tests/provider-show-package-search-test.js
+++ b/tests/provider-show-package-search-test.js
@@ -64,11 +64,11 @@ describeApplication('ProviderShow package search', () => {
 
 
     it('disables search button', () => {
-      expect(ProviderShowPage.searchModal.hasModalSearchButton).to.be.false;
+      expect(ProviderShowPage.searchModal.isSearchButtonDisabled).to.be.true;
     });
 
     it('disables the reset all button', () => {
-
+      expect(ProviderShowPage.searchModal.isResetButtonDisabled).to.be.true;
     });
 
     describe('with filter change', () => {
@@ -76,12 +76,12 @@ describeApplication('ProviderShow package search', () => {
         return ProviderShowPage.searchModal.clickFilter('sort', 'name');
       });
 
-      it('enables search button', () => {
-        expect(ProviderShowPage.searchModal.hasModalSearchButton).to.be.true;
+      it('enables the search button', () => {
+        expect(ProviderShowPage.searchModal.isSearchButtonDisabled).to.be.false;
       });
 
       it('enables the reset all button', () => {
-
+        expect(ProviderShowPage.searchModal.isResetButtonDisabled).to.be.false;
       });
 
       describe('applying filters', () => {
@@ -118,11 +118,11 @@ describeApplication('ProviderShow package search', () => {
       });
 
       it('enables the search button', () => {
-        expect(ProviderShowPage.searchModal.hasModalSearchButton).to.be.true;
+        expect(ProviderShowPage.searchModal.isSearchButtonDisabled).to.be.false;
       });
 
-      it('enables the reset all button', () => {
-
+      it('disables the reset all button', () => {
+        expect(ProviderShowPage.searchModal.isResetButtonDisabled).to.be.true;
       });
 
       describe('applying the cleared search changes', () => {
@@ -177,13 +177,17 @@ describeApplication('ProviderShow package search', () => {
       describe('resetting all filters', () => {
         // open modal
         // click reset all button
+        beforeEach(() => {
+          return ProviderShowPage.clickListSearch()
+            .searchModal.clickResetAll();
+        });
 
         it('closes the modal', () => {
-
+          expect(ProviderShowPage.searchModal.isPresent).to.be.false;
         });
 
         it('shows unfiltered list', () => {
-
+          expect(ProviderShowPage.packageList()).to.have.lengthOf(5);
         });
       });
     });

--- a/tests/provider-show-package-search-test.js
+++ b/tests/provider-show-package-search-test.js
@@ -63,8 +63,12 @@ describeApplication('ProviderShow package search', () => {
     });
 
 
-    it('does not display search button', () => {
+    it('disables search button', () => {
       expect(ProviderShowPage.searchModal.hasModalSearchButton).to.be.false;
+    });
+
+    it('disables the reset all button', () => {
+
     });
 
     describe('with filter change', () => {
@@ -72,8 +76,12 @@ describeApplication('ProviderShow package search', () => {
         return ProviderShowPage.searchModal.clickFilter('sort', 'name');
       });
 
-      it('shows search button', () => {
+      it('enables search button', () => {
         expect(ProviderShowPage.searchModal.hasModalSearchButton).to.be.true;
+      });
+
+      it('enables the reset all button', () => {
+
       });
 
       describe('applying filters', () => {
@@ -109,8 +117,12 @@ describeApplication('ProviderShow package search', () => {
         expect(ProviderShowPage.searchModal.searchFieldValue).to.equal('');
       });
 
-      it('shows the search button', () => {
+      it('enables the search button', () => {
         expect(ProviderShowPage.searchModal.hasModalSearchButton).to.be.true;
+      });
+
+      it('enables the reset all button', () => {
+
       });
 
       describe('applying the cleared search changes', () => {
@@ -160,6 +172,19 @@ describeApplication('ProviderShow package search', () => {
         expect(ProviderShowPage.packageList()).to.have.lengthOf(2);
         expect(ProviderShowPage.packageList(0).name).to.equal('Ordinary Package');
         expect(ProviderShowPage.packageList(1).name).to.equal('Other Ordinary Package');
+      });
+
+      describe('resetting all filters', () => {
+        // open modal
+        // click reset all button
+
+        it('closes the modal', () => {
+
+        });
+
+        it('shows unfiltered list', () => {
+
+        });
       });
     });
 


### PR DESCRIPTION
## Purpose
Per [UIEH-320](https://issues.folio.org/browse/UIEH-320) we currently do not have a way to reset all filters back to default within the search modal. This change adds that function to the modal.

## Approach
With this change I am removing the feature that hides the modal footer and buttons that I put in with [UIEH-371](https://issues.folio.org/browse/UIEH-317) in favor of always displaying the buttons, but just enabling/disabling them when applicable. The `Reset all` button also uses the `stripes-components` modal button styles for consistency. 

## Screenshots
![2018-07-25 12 44 26](https://user-images.githubusercontent.com/25858667/43218073-fdecbd0c-9008-11e8-843a-cf304edec9ee.gif)

