### PR TITLE
Remove okapi.frontside.io as default dev back end

### DIFF
--- a/.stripesclirc.js
+++ b/.stripesclirc.js
@@ -1,13 +1,6 @@
 const webpack = require('webpack');
 
 const environment = process.env.NODE_ENV;
-let url;
-
-if (environment === 'sandbox') {
-  url = 'https://okapi-sandbox.frontside.io';
-} else {
-  url = 'https://okapi.frontside.io';
-}
 
 function mirage(config, enabled = false) {
   if (enabled) {
@@ -43,7 +36,6 @@ const servePlugin = {
 
 module.exports = {
   // Assign defaults to existing CLI options
-  okapi: url,
   tenant: "fs",
   install: true,
   hasAllPerms: true,

--- a/README.md
+++ b/README.md
@@ -25,14 +25,19 @@ The `ui-eholdings` module adds the ability to manage electronic holdings in FOLI
 ## Running
 
 * `yarn start`
-* Visit your app at [http://localhost:8080](http://localhost:8080).
+* Visit your app at [http://localhost:3000](http://localhost:3000).
 
 By default, this will use the backend OKAPI cluster at
-https://okapi.frontside.io However, if you want to run the application
-against the mirage server contained within the browser, you can turn
-it on with the `--mirage` option:
+http://localhost:9130
+
+If you want to run the application against the mirage server contained
+within the browser, you can turn it on with the `--mirage` option:
 
 * `yarn start --mirage`
+
+If you want to run the application against a different Okapi cluster:
+
+* `yarn start --okapi https://myokapi.cluster.folio.org`
 
 ## Running Tests
 


### PR DESCRIPTION
Removes Frontside's demo Okapi cluster as the default back end when running `yarn start`. Instead the default falls back to Stripes CLI's, `http://localhost:9130`.

The dev environment can still point to non-default Okapi clusters with `yarn start --okapi https://okapi.frontside.io`.