### PR TITLE
 Replace all test Promises with server.block()

### DIFF
--- a/bigtest/tests/custom-package-edit-selection-test.js
+++ b/bigtest/tests/custom-package-edit-selection-test.js
@@ -73,15 +73,8 @@ describeApplication('CustomPackageEditSelection', () => {
       });
 
       describe('clicking confirm', () => {
-        let resolveRequest;
-
         beforeEach(function () {
-          this.server.delete('/packages/:id', () => {
-            return new Promise((resolve) => {
-              resolveRequest = resolve;
-            });
-          });
-
+          this.server.block();
           return PackageEditPage.modal.confirmDeselection();
         });
 
@@ -91,7 +84,6 @@ describeApplication('CustomPackageEditSelection', () => {
 
         it('confirmation button now reads "deleting"', () => {
           expect(PackageEditPage.modal.confirmButtonText).to.equal('Deleting...');
-          resolveRequest();
         });
 
         it('confirmation button is disabled', () => {
@@ -99,8 +91,8 @@ describeApplication('CustomPackageEditSelection', () => {
         });
 
         describe('when the request resolves', () => {
-          beforeEach(() => {
-            return resolveRequest();
+          beforeEach(function () {
+            this.server.unblock();
           });
 
           it('transitions to the package search page', function () {

--- a/bigtest/tests/custom-resource-edit-selection-test.js
+++ b/bigtest/tests/custom-resource-edit-selection-test.js
@@ -69,49 +69,26 @@ describeApplication('CustomResourceHoldingSelection', () => {
       });
 
       describe('confirming to continue deselection', () => {
-        /**
-         * We want to control when this endpoints resolves.
-         * Returning a unresolved promise from the endpoint within
-         * the beforeEach gives us the control to resolve the request
-         * later in tests.
-         */
-
-        let resolveRequest;
-
         beforeEach(function () {
-          this.server.delete('/resources/:id', ({ resources }, request) => {
-            let matchingResource = resources.find(request.params.id);
-
-            matchingResource.destroy();
-
-            // return {};
-
-            return new Promise((resolve) => {
-              resolveRequest = resolve;
-            });
-          });
-
+          this.server.block();
           return ResourceEditPage.modal.confirmDeselection();
         });
 
         it('should keep confirmation modal on screen until requests responds', () => {
           expect(ResourceEditPage.modal.isPresent).to.equal(true);
-          resolveRequest();
         });
 
         it('confirmation button now reads "Removing..."', () => {
           expect(ResourceEditPage.modal.confirmButtonText).to.equal('Removing...');
-          resolveRequest();
         });
 
         it('confirmation button is disabled', () => {
           expect(ResourceEditPage.modal.confirmButtonIsDisabled).to.equal(true);
-          resolveRequest();
         });
 
         describe('when the request resolves', () => {
-          beforeEach(() => {
-            resolveRequest();
+          beforeEach(function () {
+            this.server.unblock();
           });
 
           it('transition to package search page', () => {

--- a/bigtest/tests/managed-package-edit-selection-test.js
+++ b/bigtest/tests/managed-package-edit-selection-test.js
@@ -176,15 +176,8 @@ describeApplication('ManagedPackageEditSelection', () => {
       });
 
       describe('clicking confirm', () => {
-        let resolveRequest;
-
         beforeEach(function () {
-          this.server.put('/packages/:id', () => {
-            return new Promise((resolve) => {
-              resolveRequest = resolve;
-            });
-          });
-
+          this.server.block();
           return PackageEditPage.modal.confirmDeselection();
         });
 
@@ -194,7 +187,6 @@ describeApplication('ManagedPackageEditSelection', () => {
 
         it('confirmation button now reads "removing"', () => {
           expect(PackageEditPage.modal.confirmButtonText).to.equal('Removing...');
-          resolveRequest();
         });
 
         it('confirmation button is disabled', () => {
@@ -202,8 +194,8 @@ describeApplication('ManagedPackageEditSelection', () => {
         });
 
         describe('when request resolves', () => {
-          beforeEach(() => {
-            return resolveRequest();
+          beforeEach(function () {
+            this.server.unblock();
           });
 
           it('goes to the resource show page', () => {

--- a/bigtest/tests/resource-edit-deselection-test.js
+++ b/bigtest/tests/resource-edit-deselection-test.js
@@ -59,42 +59,26 @@ describeApplication('ResourceEditDeselection', () => {
       });
 
       describe('confirming to continue deselection', () => {
-        /**
-         * We want to control when this endpoints resolves.
-         * Returning a unresolved promise from the endpoint within
-         * the beforeEach gives us the control to resolve the request
-         * later in tests.
-         */
-        let resolveRequest;
-
         beforeEach(function () {
-          this.server.put('/resources/:id', () => {
-            return new Promise((resolve) => {
-              resolveRequest = resolve;
-            });
-          });
-
+          this.server.block();
           return ResourceEditPage.modal.confirmDeselection();
         });
 
         it('should keep confirmation modal on screen until requests responds', () => {
           expect(ResourceEditPage.modal.isPresent).to.equal(true);
-          resolveRequest();
         });
 
         it('confirmation button now reads "removing"', () => {
           expect(ResourceEditPage.modal.confirmButtonText).to.equal('Removing...');
-          resolveRequest();
         });
 
         it('confirmation button is disabled', () => {
           expect(ResourceEditPage.modal.confirmButtonIsDisabled).to.equal(true);
-          resolveRequest();
         });
 
         describe('when request resolves', () => {
-          beforeEach(() => {
-            resolveRequest();
+          beforeEach(function () {
+            this.server.unblock();
           });
 
           it('goes to the resource show page', () => {


### PR DESCRIPTION
## Purpose
Applies the pattern established in https://github.com/folio-org/ui-eholdings/pull/490 across all tests that need it.

## Approach
Instead of creating a Promise that doesn't yet resolve, use `server.block()` and `server.unblock()`.

## TODO
- [x] Merge https://github.com/folio-org/ui-eholdings/pull/490