### PR TITLE
UIEH-506: Remove focus outlines from all headings in details view

### DIFF
--- a/src/components/details-view/details-view.css
+++ b/src/components/details-view/details-view.css
@@ -66,6 +66,15 @@
   }
 }
 
+h1,
+h2,
+h3,
+h4 {
+  &:focus {
+    outline: none;
+  }
+}
+
 .body {
   padding: 0 1rem;
 }


### PR DESCRIPTION
Resolves: [UIEH-506](https://issues.folio.org/browse/UIEH-506)

## Purpose
When navigating to a provider/package/title detail record, we are focusing the main page header to inform those using assistive technology of the context switch. On some browsers the focus outline looks jagged and wonky, [UIEH-506](https://issues.folio.org/browse/UIEH-506) was opened to address that look.


## Approach
After discussing solutions with @Robdel12, we came to the conclusion that removing focus outlines from headings makes the most sense. Seeing as headings are not part of the natural tab order of the web and we are mainly focusing the heading for the benefit of screen-readers (which will outline the focused element anyway) it feels more natural to remove outlines from h-tags in eholdings.


## Screenshots
*Before*
![screen shot 2018-07-26 at 11 21 35 am](https://user-images.githubusercontent.com/15052791/43274966-3548882c-90c6-11e8-9275-4179d3790dd0.png)


*After*
![screen shot 2018-07-26 at 11 24 34 am](https://user-images.githubusercontent.com/15052791/43275092-857b403c-90c6-11e8-8b82-443f9082291d.png)

