### PR TITLE
Refactor Search Modal into its own component

### DIFF
--- a/src/components/provider-show/provider-show.js
+++ b/src/components/provider-show/provider-show.js
@@ -15,8 +15,8 @@ export default function ProviderShow({
   model,
   packages,
   fetchPackages,
-  searchPackages,
-  searchParams
+  searchModal,
+  listType
 }, {
   queryParams
 }) {
@@ -58,11 +58,8 @@ export default function ProviderShow({
             </KeyValue>
           </DetailsViewSection>
         )}
-        enableListSearch
-        listType="packages"
-        onSearch={searchPackages}
-        onFilter={searchPackages}
-        searchParams={searchParams}
+        searchModal={searchModal}
+        listType={listType}
         resultsLength={packages.length}
         renderList={scrollable => (
           <QueryList
@@ -91,8 +88,8 @@ ProviderShow.propTypes = {
   model: PropTypes.object.isRequired,
   packages: PropTypes.object.isRequired,
   fetchPackages: PropTypes.func.isRequired,
-  searchPackages: PropTypes.func.isRequired,
-  searchParams: PropTypes.object.isRequired
+  searchModal: PropTypes.node,
+  listType: PropTypes.string.isRequired
 };
 
 ProviderShow.contextTypes = {

--- a/src/components/search-modal.js
+++ b/src/components/search-modal.js
@@ -1,0 +1,173 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
+
+import {
+  Badge,
+  IconButton,
+  Modal,
+  ModalFooter,
+} from '@folio/stripes-components';
+
+import SearchForm from './search-form';
+import styles from './details-view/details-view.css';
+
+const normalize = (query = {}) => {
+  return {
+    filter: query.filter || {},
+    q: query.q || '',
+    searchfield: query.searchfield,
+    sort: query.sort
+  };
+};
+
+export default class SearchModal extends React.PureComponent {
+  static propTypes = {
+    query: PropTypes.object,
+    listType: PropTypes.string,
+    onSearch: PropTypes.func,
+    onFilter: PropTypes.func,
+  };
+
+  state = {
+    isModalVisible: false,
+    query: normalize(this.props.query)
+  };
+
+  updateFilter(query) {
+    if (this.props.onFilter) {
+      this.props.onFilter({
+        ...query,
+        q: query.q === '' ? undefined : query.q
+      });
+    }
+  }
+
+  toggle = () => {
+    this.setState(({ isModalVisible }) => ({
+      isModalVisible: !isModalVisible
+    }));
+  }
+
+  close = () => {
+    this.setState({
+      isModalVisible: false,
+    });
+  }
+
+  updateSearch = () => {
+    this.setState({
+      isModalVisible: false,
+    });
+
+    this.updateFilter(this.state.query);
+  }
+
+  resetSearch = () => {
+    this.setState({
+      isModalVisible: false,
+    });
+
+    this.updateFilter({});
+  }
+
+  handleListSearch = (params) => {
+    let { query } = this.props;
+
+    if (this.props.onSearch) {
+      this.props.onSearch(params);
+    }
+
+    this.setState({
+      isModalVisible: query.q === params.q
+    });
+  }
+
+  handleSearchQueryChange = q => {
+    this.setState({
+      query: {
+        ...this.state.query,
+        q
+      },
+    });
+  }
+
+  handleFilterChange = query => {
+    this.setState({
+      query: normalize(query),
+    });
+  }
+
+  render() {
+    let { listType } = this.props;
+
+    let {
+      isModalVisible,
+      query
+    } = this.state;
+
+    let queryFromProps = normalize(this.props.query);
+
+    let filterCount = [queryFromProps.q, queryFromProps.sort]
+      .concat(Object.values(queryFromProps.filter))
+      .filter(Boolean).length;
+
+    let hasChanges = !isEqual(queryFromProps, this.state.query);
+
+    return (
+      <Fragment>
+        <div className={styles['search-filter-area']}>
+          {filterCount > 0 && (
+            <div data-test-eholdings-details-view-filters>
+              <Badge className={styles['filter-count']}>{filterCount}</Badge>
+            </div>
+          )}
+          <div data-test-eholdings-details-view-search>
+            <IconButton icon="search" onClick={this.toggle} />
+          </div>
+        </div>
+
+        {isModalVisible && (
+          <Modal
+            open
+            size="small"
+            label={`Filter ${listType}`}
+            onClose={this.close}
+            id="eholdings-details-view-search-modal"
+            closeOnBackgroundClick
+            dismissible
+            footer={
+              <ModalFooter
+                primaryButton={{
+                  'label': 'Search',
+                  'onClick': this.updateSearch,
+                  'disabled': !hasChanges,
+                  'data-test-eholdings-modal-search-button': true
+                }}
+                secondaryButton={{
+                  'label': 'Reset all',
+                  'onClick': this.resetSearch,
+                  'disabled': isEqual(normalize({}), this.state.query),
+                  'data-test-eholdings-modal-reset-all-button': true
+                }}
+              />
+            }
+          >
+            <SearchForm
+              searchType={listType}
+              searchString={query.q}
+              filter={query.filter}
+              searchField={query.searchField}
+              sort={query.sort}
+              onSearch={this.handleListSearch}
+              displaySearchTypeSwitcher={false}
+              displaySearchButton={false}
+              onFilterChange={this.handleFilterChange}
+              onSearchQueryChange={this.handleSearchQueryChange}
+            />
+          </Modal>
+        )}
+      </Fragment>
+    );
+  }
+}

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -7,6 +7,7 @@ import { createResolver } from '../redux';
 import Provider from '../redux/provider';
 
 import View from '../components/provider-show';
+import SearchModal from '../components/search-modal';
 
 class ProviderShowRoute extends Component {
   static propTypes = {
@@ -28,7 +29,8 @@ class ProviderShowRoute extends Component {
   }
 
   state = {
-    pkgSearchParams: {}
+    pkgSearchParams: {},
+    queryId: 0
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -55,8 +57,11 @@ class ProviderShowRoute extends Component {
     });
   }
 
-  searchPackages = (params) => {
-    this.setState({ pkgSearchParams: params });
+  searchPackages = (pkgSearchParams) => {
+    this.setState({
+      pkgSearchParams,
+      queryId: ++this.state.queryId
+    });
   };
 
   fetchPackages = (page) => {
@@ -65,14 +70,24 @@ class ProviderShowRoute extends Component {
   };
 
   render() {
+    const listType = 'packages';
+
     return (
       <TitleManager record={this.props.model.name}>
         <View
           model={this.props.model}
           packages={this.getPkgResults()}
           fetchPackages={this.fetchPackages}
-          searchPackages={this.searchPackages}
-          searchParams={this.state.pkgSearchParams}
+          listType={listType}
+          searchModal={
+            <SearchModal
+              key={this.state.queryId}
+              listType={listType}
+              query={this.state.pkgSearchParams}
+              onSearch={this.searchPackages}
+              onFilter={this.searchPackages}
+            />
+          }
         />
       </TitleManager>
     );


### PR DESCRIPTION
This PR is part of a quest issue #482 that will address [Provider Detail Record (Show): Apply Accordion to List of Packages](https://issues.folio.org/browse/UIEH-438)

## Purpose
The purpose of this PR is to refactor Search Modal functionality into it's own component. This PR doesn't have any user perceivable change but it does set us up to reuse Search Modal in the future. All of the tests should pass as they did previously. 

## Approach
Instead of rendering Search Modal in Detail View, it is now being rendered in Provider Show route and passed to the view component. The View component then renders is it correct place. This eliminates the need to drip props through view component. 

There is something different here that is worth noting. I'm using `key` prop on Search Modal component to reset the query. Effectively, every filter operation create a new instance of the Search Modal component. This makes it possible to re-setup state from scratch when the query changes.

## Learning
You might want to learn about using key to reset state in article called [You Probably Don't need Derived State](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key). 

## Screenshots

There should not be perceivable changes.