### PR TITLE
UIEH-508 Move Save button to header in settings forms

### DIFF
--- a/bigtest/interactors/settings-root-proxy.js
+++ b/bigtest/interactors/settings-root-proxy.js
@@ -1,21 +1,36 @@
 import {
-  interactor,
-  fillable,
+  action,
   clickable,
-  value,
-  isPresent
+  fillable,
+  interactor,
+  property,
+  value
 } from '@bigtest/interactor';
 import Toast from './toast';
 
+@interactor class SettingsRootProxyDropDown {
+  clickDropDownButton = clickable('button');
+}
+
+@interactor class SettingsRootProxyDropDownMenu {
+  clickCancel = clickable('.tether-element [data-test-eholdings-settings-root-proxy-cancel-action]');
+}
+
 @interactor class SettingsRootProxyPage {
   RootProxySelectValue = value('[data-test-eholdings-settings-root-proxy-select] select');
-  hasSaveButton = isPresent('[data-test-eholdings-root-proxy-save-button] button');
-  hasCancelButton = isPresent('[data-test-eholdings-root-proxy-cancel-button] button');
   chooseRootProxy = fillable('[data-test-eholdings-settings-root-proxy-select] select');
-  save = clickable('[data-test-eholdings-root-proxy-save-button] button');
-  cancel = clickable('[data-test-eholdings-root-proxy-cancel-button] button');
+  save = clickable('[data-test-eholdings-settings-root-proxy-save-button]');
+  saveButtonDisabled = property('[data-test-eholdings-settings-root-proxy-save-button]', 'disabled');
 
   toast = Toast;
+
+  dropDown = new SettingsRootProxyDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  dropDownMenu = new SettingsRootProxyDropDownMenu();
+  clickCancel= action(function () {
+    return this
+      .dropDown.clickDropDownButton()
+      .dropDownMenu.clickCancel();
+  });
 }
 
 export default new SettingsRootProxyPage('[data-test-eholdings-settings-root-proxy]');

--- a/bigtest/interactors/settings.js
+++ b/bigtest/interactors/settings.js
@@ -1,9 +1,9 @@
 import {
+  action,
   attribute,
   blurrable,
   clickable,
   fillable,
-  isPresent,
   interactor,
   property,
   value
@@ -12,6 +12,14 @@ import Toast from './toast';
 
 import { hasClassBeginningWith } from './helpers';
 
+@interactor class SettingsKBDropDown {
+  clickDropDownButton = clickable('button');
+}
+
+@interactor class SettingsKBDropDownMenu {
+  clickCancel = clickable('.tether-element [data-test-eholdings-settings-kb-cancel-action]');
+}
+
 @interactor class SettingsPage {
   customerId = value('[data-test-eholdings-settings-customerid] input');
   apiKey = value('[data-test-eholdings-settings-apikey] input');
@@ -19,15 +27,21 @@ import { hasClassBeginningWith } from './helpers';
   fillApiKey = fillable('[data-test-eholdings-settings-apikey] input');
   blurCustomerId = blurrable('[data-test-eholdings-settings-customerid] input');
   blurApiKey = blurrable('[data-test-eholdings-settings-apikey] input');
-  hasVisibleActions = isPresent('[data-test-eholdings-settings-kb-actions]');
   customerIdFieldIsInvalid = hasClassBeginningWith('[data-test-eholdings-settings-customerid] input', 'hasError--');
   apiKeyFieldIsInvalid = hasClassBeginningWith('[data-test-eholdings-settings-apikey] input', 'hasError--');
-  save = clickable('[data-test-eholdings-settings-kb-actions] [type="submit"]');
-  saveButtonDisabled = property('[data-test-eholdings-settings-kb-actions] [type="submit"]', 'disabled');
-  cancel = clickable('[data-test-eholdings-settings-kb-actions] [type="reset"]');
+  save = clickable('[data-test-eholdings-settings-kb-save-button]');
+  saveButtonDisabled = property('[data-test-eholdings-settings-kb-save-button]', 'disabled');
   apiKeyInputType = attribute('[data-test-eholdings-settings-apikey] input', 'type');
 
   toast = Toast;
+
+  dropDown = new SettingsKBDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  dropDownMenu = new SettingsKBDropDownMenu();
+  clickCancel= action(function () {
+    return this
+      .dropDown.clickDropDownButton()
+      .dropDownMenu.clickCancel();
+  });
 }
 
 export default new SettingsPage('[data-test-eholdings-settings]');

--- a/bigtest/tests/backend-configuration-test.js
+++ b/bigtest/tests/backend-configuration-test.js
@@ -57,8 +57,8 @@ describeApplication('With unconfigured backend', {
         return this.visit('/settings/eholdings/knowledge-base', () => expect(SettingsPage.$root).to.exist);
       });
 
-      it('shows the form action buttons', () => {
-        expect(SettingsPage.hasVisibleActions).to.be.true;
+      it('does not enable the save button', () => {
+        expect(SettingsPage.saveButtonDisabled).to.be.true;
       });
 
       describe('filling in incomplete data', () => {
@@ -116,8 +116,8 @@ describeApplication('With valid backend configuration', () => {
       expect(SettingsPage.apiKeyInputType).to.equal('password');
     });
 
-    it.always('does not have visible form action buttons', () => {
-      expect(SettingsPage.hasVisibleActions).to.be.false;
+    it.always('has a disabled save button', () => {
+      expect(SettingsPage.saveButtonDisabled).to.be.true;
     });
 
     describe('filling in invalid data', () => {
@@ -149,8 +149,8 @@ describeApplication('With valid backend configuration', () => {
           .fillApiKey('some-api-key');
       });
 
-      it('shows the form actions', () => {
-        expect(SettingsPage.hasVisibleActions).to.be.true;
+      it('enables the save button', () => {
+        expect(SettingsPage.saveButtonDisabled).to.be.false;
       });
 
       describe('saving the changes', () => {
@@ -166,8 +166,8 @@ describeApplication('With valid backend configuration', () => {
         it.skip('indicates that it is working');
 
         describe('when the changes succeed', () => {
-          it('hides the form actions', () => {
-            expect(SettingsPage.hasVisibleActions).to.be.false;
+          it('disables the save button', () => {
+            expect(SettingsPage.saveButtonDisabled).to.be.true;
           });
         });
       });
@@ -181,10 +181,6 @@ describeApplication('With valid backend configuration', () => {
           }, 500);
 
           return SettingsPage.save();
-        });
-
-        it.always('shows the form action buttons', () => {
-          expect(SettingsPage.hasVisibleActions).to.be.true;
         });
 
         it('enables the save button', () => {
@@ -209,7 +205,7 @@ describeApplication('With valid backend configuration', () => {
 
       describe('then hitting the cancel button', () => {
         beforeEach(() => {
-          return SettingsPage.cancel();
+          return SettingsPage.clickCancel();
         });
 
         it('reverts the changes', () => {

--- a/bigtest/tests/settings-root-proxy-test.js
+++ b/bigtest/tests/settings-root-proxy-test.js
@@ -20,12 +20,8 @@ describeApplication('With list of root proxies available to a customer', () => {
         return SettingsRootProxyPage.chooseRootProxy('microstates');
       });
 
-      it('should display cancel action button', () => {
-        expect(SettingsRootProxyPage.hasCancelButton).to.eq(true);
-      });
-
-      it('should display save action button', () => {
-        expect(SettingsRootProxyPage.hasSaveButton).to.eq(true);
+      it('should enable save action button', () => {
+        expect(SettingsRootProxyPage.saveButtonDisabled).to.eq(false);
       });
 
       describe('clicking save to update Root Proxy', () => {
@@ -37,12 +33,8 @@ describeApplication('With list of root proxies available to a customer', () => {
           expect(SettingsRootProxyPage.RootProxySelectValue).to.eq('microstates');
         });
 
-        it('should remove save button', () => {
-          expect(SettingsRootProxyPage.hasSaveButton).to.eq(false);
-        });
-
-        it('should remove cancel button', () => {
-          expect(SettingsRootProxyPage.hasCancelButton).to.eq(false);
+        it('should disable save button', () => {
+          expect(SettingsRootProxyPage.saveButtonDisabled).to.eq(true);
         });
 
         it('should show a success toast', () => {
@@ -52,19 +44,15 @@ describeApplication('With list of root proxies available to a customer', () => {
 
       describe('clicking cancel to cancel updating Root Proxy', () => {
         beforeEach(() => {
-          return SettingsRootProxyPage.cancel();
+          return SettingsRootProxyPage.clickCancel();
         });
 
         it('should display the initial root proxy', () => {
           expect(SettingsRootProxyPage.RootProxySelectValue).to.eq('bigTestJS');
         });
 
-        it('should remove save button', () => {
-          expect(SettingsRootProxyPage.hasSaveButton).to.eq(false);
-        });
-
-        it('should remove cancel button', () => {
-          expect(SettingsRootProxyPage.hasCancelButton).to.eq(false);
+        it('should disable save button', () => {
+          expect(SettingsRootProxyPage.saveButtonDisabled).to.eq(true);
         });
       });
     });

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -106,7 +106,7 @@ export default class SearchPaneset extends React.Component { // eslint-disable-l
         className={styles['search-new-button']}
         to={`/eholdings/${this.props.resultsType}/new`}
       >
-        <FormattedMessage id="ui-eholdings.addNew" />
+        <FormattedMessage id="ui-eholdings.search.addNew" />
       </Link>
     );
   };

--- a/src/components/settings-detail-pane/settings-detail-pane.css
+++ b/src/components/settings-detail-pane/settings-detail-pane.css
@@ -1,5 +1,9 @@
 @import '@folio/stripes-components/lib/variables';
 
+.settings-detail-pane-body {
+  max-width: 50em;
+}
+
 .settings-detail-pane-back-button {
   @media (--mediumUp) {
     display: none;

--- a/src/components/settings-detail-pane/settings-detail-pane.js
+++ b/src/components/settings-detail-pane/settings-detail-pane.js
@@ -16,11 +16,13 @@ export default class SettingsDetailPane extends Component {
   render() {
     let {
       children,
-      paneTitle
+      paneTitle,
+      ...paneProps
     } = this.props;
 
     return (
       <Pane
+        {...paneProps}
         defaultWidth="fill"
         paneTitle={paneTitle}
         firstMenu={(
@@ -32,7 +34,9 @@ export default class SettingsDetailPane extends Component {
           />
         )}
       >
-        {children}
+        <div className={styles['settings-detail-pane-body']}>
+          {children}
+        </div>
       </Pane>
     );
   }

--- a/src/components/settings-knowledge-base/settings-knowledge-base.css
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.css
@@ -1,16 +1,5 @@
 @import '@folio/stripes-components/lib/variables';
 
 .settings-kb-form {
-  max-width: 50em;
-}
-
-.settings-kb-form-actions {
-  align-items: flex-start;
-  border-top: 1px solid var(--minor-divider-color);
-  display: flex;
-  padding-top: 1em;
-
-  & button {
-    margin-right: 0.25em;
-  }
+  width: 100%;
 }

--- a/src/components/settings-knowledge-base/settings-knowledge-base.js
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.js
@@ -1,14 +1,14 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import {
-  Button,
   Icon,
   TextField
 } from '@folio/stripes-components';
 import SettingsDetailPane from '../settings-detail-pane';
 import { processErrors } from '../utilities';
 import Toaster from '../toaster';
+import PaneHeaderButton from '../pane-header-button';
 import styles from './settings-knowledge-base.css';
 
 class SettingsKnowledgeBase extends Component {
@@ -31,75 +31,78 @@ class SettingsKnowledgeBase extends Component {
       invalid
     } = this.props;
 
+    let actionMenuItems = [
+      {
+        'label': 'Cancel editing',
+        'state': { eholdings: true },
+        'onClick': reset,
+        'disabled': model.update.isPending || invalid || pristine,
+        'data-test-eholdings-settings-kb-cancel-action': true
+      }
+    ];
+
     return (
-      <SettingsDetailPane
-        paneTitle="Knowledge base"
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        data-test-eholdings-settings
+        className={styles['settings-kb-form']}
       >
-        <Toaster toasts={processErrors(model)} position="bottom" />
-
-        <h3>EBSCO RM API credentials</h3>
-
-        {model.isLoading ? (
-          <Icon icon="spinner-ellipsis" />
-        ) : (
-          <form
-            onSubmit={handleSubmit(onSubmit)}
-            data-test-eholdings-settings
-            className={styles['settings-kb-form']}
-          >
-            <div
-              data-test-eholdings-settings-customerid
-            >
-              <Field
-                id="eholdings-settings-kb-customerid"
-                label="Customer ID"
-                name="customerId"
-                component={TextField}
-                type="text"
-                autoComplete="off"
-              />
-            </div>
-
-            <div
-              data-test-eholdings-settings-apikey
-            >
-              <Field
-                id="eholdings-settings-kb-apikey"
-                label="API key"
-                name="apiKey"
-                component={TextField}
-                type="password"
-                autoComplete="off"
-              />
-            </div>
-
-            {(!pristine || (!model.customerId && !model.apiKey)) && (
-              <div
-                className={styles['settings-kb-form-actions']}
-                data-test-eholdings-settings-kb-actions
+        <SettingsDetailPane
+          paneTitle="Knowledge base"
+          actionMenuItems={actionMenuItems}
+          lastMenu={(
+            <Fragment>
+              {model.update.isPending && (
+                <Icon icon="spinner-ellipsis" />
+              )}
+              <PaneHeaderButton
+                disabled={model.update.isPending || invalid || pristine}
+                type="submit"
+                buttonStyle="primary"
+                data-test-eholdings-settings-kb-save-button
               >
-                <Button
-                  disabled={model.update.isPending}
-                  type="reset"
-                  onClick={reset}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  disabled={model.update.isPending || invalid}
-                  type="submit"
-                  buttonStyle="primary"
-                >
-                  {model.update.isPending ? 'Saving' : 'Save'}
-                </Button>
-                {model.update.isPending && (
-                  <Icon icon="spinner-ellipsis" />
-                )}
+                {model.update.isPending ? 'Saving' : 'Save'}
+              </PaneHeaderButton>
+            </Fragment>
+          )}
+        >
+          <Toaster toasts={processErrors(model)} position="bottom" />
+
+          <h3>EBSCO RM API credentials</h3>
+
+          {model.isLoading ? (
+            <Icon icon="spinner-ellipsis" />
+          ) : (
+            <Fragment>
+              <div
+                data-test-eholdings-settings-customerid
+              >
+                <Field
+                  id="eholdings-settings-kb-customerid"
+                  label="Customer ID"
+                  name="customerId"
+                  component={TextField}
+                  type="text"
+                  autoComplete="off"
+                />
               </div>
-            )}
-          </form>
-        )}
-      </SettingsDetailPane>
+
+              <div
+                data-test-eholdings-settings-apikey
+              >
+                <Field
+                  id="eholdings-settings-kb-apikey"
+                  label="API key"
+                  name="apiKey"
+                  component={TextField}
+                  type="password"
+                  autoComplete="off"
+                />
+              </div>
+            </Fragment>
+          )}
+        </SettingsDetailPane>
+      </form>
     );
   }
 }

--- a/src/components/settings-knowledge-base/settings-knowledge-base.js
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
+import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
 import {
   Icon,
   TextField
@@ -18,6 +19,7 @@ class SettingsKnowledgeBase extends Component {
     handleSubmit: PropTypes.func,
     pristine: PropTypes.bool,
     reset: PropTypes.func,
+    intl: intlShape.isRequired,
     invalid: PropTypes.bool
   };
 
@@ -28,12 +30,13 @@ class SettingsKnowledgeBase extends Component {
       onSubmit,
       pristine,
       reset,
+      intl,
       invalid
     } = this.props;
 
     let actionMenuItems = [
       {
-        'label': 'Cancel editing',
+        'label': intl.formatMessage({ id: 'ui-eholdings.actionMenu.cancelEditing' }),
         'state': { eholdings: true },
         'onClick': reset,
         'disabled': model.update.isPending || invalid || pristine,
@@ -61,7 +64,10 @@ class SettingsKnowledgeBase extends Component {
                 buttonStyle="primary"
                 data-test-eholdings-settings-kb-save-button
               >
-                {model.update.isPending ? 'Saving' : 'Save'}
+                {model.update.isPending ?
+                  (<FormattedMessage id="ui-eholdings.saving" />)
+                    :
+                  (<FormattedMessage id="ui-eholdings.save" />)}
               </PaneHeaderButton>
             </Fragment>
           )}
@@ -107,23 +113,23 @@ class SettingsKnowledgeBase extends Component {
   }
 }
 
-const validate = (values) => {
+const validate = (values, props) => {
   let errors = {};
 
   if (values.customerId.length <= 0) {
-    errors.customerId = 'Customer ID cannot be blank.';
+    errors.customerId = props.intl.formatMessage({ id: 'ui-eholdings.validate.errors.settings.customerId' });
   }
 
   if (values.apiKey.length <= 0) {
-    errors.apiKey = 'API key cannot be blank.';
+    errors.apiKey = props.intl.formatMessage({ id: 'ui-eholdings.validate.errors.settings.apiKey' });
   }
 
   return errors;
 };
 
-export default reduxForm({
+export default injectIntl(reduxForm({
   validate,
   enableReinitialize: true,
   form: 'SettingsKnowledgeBase',
   destroyOnUnmount: false,
-})(SettingsKnowledgeBase);
+})(SettingsKnowledgeBase));

--- a/src/components/settings-root-proxy/settings-root-proxy.css
+++ b/src/components/settings-root-proxy/settings-root-proxy.css
@@ -1,16 +1,5 @@
 @import '@folio/stripes-components/lib/variables';
 
 .settings-root-proxy-form {
-  max-width: 50em;
-}
-
-.settings-root-proxy-form-actions {
-  align-items: flex-start;
-  border-top: 1px solid var(--minor-divider-color);
-  display: flex;
-  padding-top: 1em;
-
-  & button {
-    margin-right: 0.25em;
-  }
+  width: 100%;
 }

--- a/src/components/settings-root-proxy/settings-root-proxy.js
+++ b/src/components/settings-root-proxy/settings-root-proxy.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import { Icon } from '@folio/stripes-components';
 import isEqual from 'lodash/isEqual';
+import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
+
 
 import SettingsDetailPane from '../settings-detail-pane';
 import { processErrors } from '../utilities';
@@ -19,6 +21,7 @@ class SettingsRootProxy extends Component {
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
     reset: PropTypes.func,
+    intl: intlShape.isRequired,
     invalid: PropTypes.bool
   };
 
@@ -53,6 +56,7 @@ class SettingsRootProxy extends Component {
       onSubmit,
       pristine,
       reset,
+      intl,
       invalid
     } = this.props;
 
@@ -73,7 +77,7 @@ class SettingsRootProxy extends Component {
 
     let actionMenuItems = [
       {
-        'label': 'Cancel editing',
+        'label': intl.formatMessage({ id: 'ui-eholdings.actionMenu.cancelEditing' }),
         'state': { eholdings: true },
         'onClick': reset,
         'disabled': rootProxy.update.isPending || invalid || pristine,
@@ -101,7 +105,10 @@ class SettingsRootProxy extends Component {
                 buttonStyle="primary"
                 data-test-eholdings-settings-root-proxy-save-button
               >
-                {rootProxy.update.isPending ? 'Saving' : 'Save'}
+                {rootProxy.update.isPending ?
+                  (<FormattedMessage id="ui-eholdings.saving" />)
+                    :
+                  (<FormattedMessage id="ui-eholdings.save" />)}
               </PaneHeaderButton>
             </Fragment>
           )}
@@ -117,11 +124,10 @@ class SettingsRootProxy extends Component {
             </div>
           )}
 
-          <p>EBSCO KB API customers: Please access EBSCOAdmin to setup and maintain proxies.</p>
+          <p><FormattedMessage id="ui-eholdings.settings.rootProxy.ebsco.customer.message" /></p>
 
           <p>
-            Warning: Changing the root proxy setting will override the proxy for all links and resources currently set
-            to inherit the root proxy selection.
+            <FormattedMessage id="ui-eholdings.settings.rootProxy.warning" />
           </p>
         </SettingsDetailPane>
       </form>
@@ -129,8 +135,8 @@ class SettingsRootProxy extends Component {
   }
 }
 
-export default reduxForm({
+export default injectIntl(reduxForm({
   enableReinitialize: true,
   form: 'SettingsRootProxy',
   destroyOnUnmount: false,
-})(SettingsRootProxy);
+})(SettingsRootProxy));

--- a/src/components/settings-root-proxy/settings-root-proxy.js
+++ b/src/components/settings-root-proxy/settings-root-proxy.js
@@ -1,17 +1,15 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
-import {
-  Icon,
-  Button
-} from '@folio/stripes-components';
+import { Icon } from '@folio/stripes-components';
 import isEqual from 'lodash/isEqual';
 
 import SettingsDetailPane from '../settings-detail-pane';
 import { processErrors } from '../utilities';
 import Toaster from '../toaster';
-import styles from './settings-root-proxy.css';
 import RootProxySelectField from './_fields/root-proxy-select';
+import PaneHeaderButton from '../pane-header-button';
+import styles from './settings-root-proxy.css';
 
 class SettingsRootProxy extends Component {
   static propTypes = {
@@ -20,7 +18,8 @@ class SettingsRootProxy extends Component {
     handleSubmit: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    reset: PropTypes.func
+    reset: PropTypes.func,
+    invalid: PropTypes.bool
   };
 
   static contextTypes = {
@@ -53,7 +52,8 @@ class SettingsRootProxy extends Component {
       handleSubmit,
       onSubmit,
       pristine,
-      reset
+      reset,
+      invalid
     } = this.props;
 
     let { router } = this.context;
@@ -71,63 +71,60 @@ class SettingsRootProxy extends Component {
       });
     }
 
+    let actionMenuItems = [
+      {
+        'label': 'Cancel editing',
+        'state': { eholdings: true },
+        'onClick': reset,
+        'disabled': rootProxy.update.isPending || invalid || pristine,
+        'data-test-eholdings-settings-root-proxy-cancel-action': true
+      }
+    ];
+
     return (
-      <SettingsDetailPane
-        paneTitle="Root proxy"
+      <form
+        data-test-eholdings-settings-root-proxy
+        onSubmit={handleSubmit(onSubmit)}
+        className={styles['settings-root-proxy-form']}
       >
-        <Toaster toasts={toasts} position="bottom" />
-        <h3>Root Proxy Setting</h3>
-
-        {proxyTypes.isLoading ? (
-          <Icon icon="spinner-ellipsis" />
-        ) : (
-          <form
-            data-test-eholdings-settings-root-proxy
-            onSubmit={handleSubmit(onSubmit)}
-            className={styles['settings-root-proxy-form']}
-          >
-            <div
-              data-test-eholdings-settings-root-proxy-select
-              className={styles['settings-root-proxy-form']}
-            >
-              <RootProxySelectField proxyTypes={proxyTypes} />
-            </div>
-
-            {!pristine && (
-            <div
-              className={styles['settings-root-proxy-form-actions']}
-              data-test-eholdings-settings-root-proxy-actions
-            >
-              <div data-test-eholdings-root-proxy-cancel-button>
-                <Button
-                  disabled={rootProxy.update.isPending}
-                  type="reset"
-                  onClick={reset}
-                >
-                  Cancel
-                </Button>
-              </div>
-              <div data-test-eholdings-root-proxy-save-button>
-                <Button
-                  disabled={rootProxy.update.isPending}
-                  type="submit"
-                  buttonStyle="primary"
-                >
-                  {rootProxy.update.isPending ? 'Saving' : 'Save'}
-                </Button>
-              </div>
+        <SettingsDetailPane
+          paneTitle="Root proxy"
+          actionMenuItems={actionMenuItems}
+          lastMenu={(
+            <Fragment>
               {rootProxy.update.isPending && (
                 <Icon icon="spinner-ellipsis" />
               )}
+              <PaneHeaderButton
+                disabled={rootProxy.update.isPending || invalid || pristine}
+                type="submit"
+                buttonStyle="primary"
+                data-test-eholdings-settings-root-proxy-save-button
+              >
+                {rootProxy.update.isPending ? 'Saving' : 'Save'}
+              </PaneHeaderButton>
+            </Fragment>
+          )}
+        >
+          <Toaster toasts={toasts} position="bottom" />
+          <h3>Root Proxy Setting</h3>
+
+          {proxyTypes.isLoading ? (
+            <Icon icon="spinner-ellipsis" />
+          ) : (
+            <div data-test-eholdings-settings-root-proxy-select>
+              <RootProxySelectField proxyTypes={proxyTypes} />
             </div>
           )}
-          </form>
-        )}
 
-        <p>EBSCO KB API customers: Please access EBSCOAdmin to setup and maintain proxies.</p>
+          <p>EBSCO KB API customers: Please access EBSCOAdmin to setup and maintain proxies.</p>
 
-        <p>Warning: Changing the root proxy setting will override the proxy for all links and resources currently set to inherit the root proxy selection.</p>
-      </SettingsDetailPane>
+          <p>
+            Warning: Changing the root proxy setting will override the proxy for all links and resources currently set
+            to inherit the root proxy selection.
+          </p>
+        </SettingsDetailPane>
+      </form>
     );
   }
 }

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -101,6 +101,9 @@
     "title.modalMessage.addTitleToCustomPackage": "Add title to custom package",
     "title.resultsNotFound": "No titles found for '{query}'.",
 
+    "settings.rootProxy.warning": "Warning: Changing the root proxy setting will override the proxy for all links and resources currently set to inherit the root proxy selection.",
+    "settings.rootProxy.ebsco.customer.message": "EBSCO KB API customers: Please access EBSCOAdmin to setup and maintain proxies.",
+
     "actionMenu.fullView": "Full view",
     "actionMenu.cancelEditing": "Cancel editing",
     "actionMenu.edit": "Edit",
@@ -167,6 +170,9 @@
     "validate.errors.customTitle.name.length": "Must be less than 400 characters.",
     "validate.errors.customPackage.name": "Custom packages must have a name.",
     "validate.errors.customPackage.name.length": "Must be less than 300 characters.",
+
+    "validate.errors.settings.customerId": "Customer ID cannot be blank",
+    "validate.errors.settings.apiKey": "API key cannot be blank",
 
     "server.errors.failedBackend": "Could not retrieve configuration information",
     "server.errors.errorDuringFetch": "There was a server error while retrieving your knowledge base configuration.",


### PR DESCRIPTION
## Purpose
Other FOLIO modules have a Save button in the pane header, instead of at the bottom of a form. Completes https://issues.folio.org/browse/UIEH-508

## Approach
Put the Save button in the pane header `lastMenu` and the Cancel action in the pane header action items dropdown.

## Open Questions
- The root proxy page has some odd loading behavior (see GIF below)
- The interactors for clicking items in pane header dropdowns can be DRYed up

## Screenshots
![2018-07-27 13 43 19](https://user-images.githubusercontent.com/230597/43340877-604864ba-91a3-11e8-8e09-86c89957d374.gif)

![2018-07-27 13 43 44](https://user-images.githubusercontent.com/230597/43340878-60581df6-91a3-11e8-8793-3614f473fe55.gif)