### PR TITLE
Set max widths for page layouts

### DIFF
--- a/src/components/details-view-section/details-view-section.css
+++ b/src/components/details-view-section/details-view-section.css
@@ -2,6 +2,8 @@
 
 .details-view-section {
   border-top: 1px solid var(--minor-divider-color);
+  margin: 0 auto;
+  max-width: 50rem;
   padding-bottom: 1em;
 
   &.hide-separator {
@@ -13,4 +15,6 @@
   color: var(--subLabelColor #999);
   font-size: 18px;
   font-weight: 600;
+  margin: 1em auto;
+  max-width: 50rem;
 }

--- a/src/components/details-view/details-view.css
+++ b/src/components/details-view/details-view.css
@@ -14,11 +14,13 @@
     border-top: 1px solid var(--minor-divider-color);
     justify-content: space-between;
     flex-shrink: 0;
+    margin: 0 auto;
+    max-width: 48rem;
+    width: 100%;
 
     & p {
       color: var(--secondary);
       margin: 0;
-      padding-left: 1rem;
       padding-bottom: 1rem;
     }
 
@@ -49,7 +51,8 @@
 
 .header {
   padding: 0 1rem;
-  margin: 2rem 0;
+  margin: 2rem auto;
+  max-width: 50rem;
 
   & h2 {
     font-size: 2.5em;
@@ -61,8 +64,7 @@
     color: var(--secondary);
     font-size: 1.5em;
     font-weight: 600;
-    margin-bottom: 0;
-    margin-top: 0.25em;
+    margin: 0.25em auto 0;
   }
 }
 
@@ -76,6 +78,8 @@ h4 {
 }
 
 .body {
+  margin: 0 auto;
+  max-width: 50rem;
   padding: 0 1rem;
 }
 
@@ -89,7 +93,7 @@ h4 {
     color: var(--subLabelColor #999);
     font-size: 18px;
     font-weight: 600;
-    padding: 1rem;
+    padding: 1rem 0;
     margin: 0;
 
     &:not(:only-child) {

--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -1,6 +1,7 @@
 .list {
   line-height: 1.15;
-  margin: 0;
+  max-width: 48rem;
+  margin: 0 auto;
   padding: 0;
 
   & li {

--- a/src/components/package/_fields/content-type/package-content-type-field.css
+++ b/src/components/package/_fields/content-type/package-content-type-field.css
@@ -1,3 +1,0 @@
-.package-content-type-field {
-  max-width: 50em;
-}

--- a/src/components/package/_fields/content-type/package-content-type-field.js
+++ b/src/components/package/_fields/content-type/package-content-type-field.js
@@ -2,15 +2,11 @@ import React, { Component } from 'react';
 import { Field } from 'redux-form';
 
 import { Select } from '@folio/stripes-components';
-import styles from './package-content-type-field.css';
 
 export default class PackageContentTypeField extends Component {
   render() {
     return (
-      <div
-        data-test-eholdings-package-content-type-field
-        className={styles['package-content-type-field']}
-      >
+      <div data-test-eholdings-package-content-type-field>
         <Field
           name="contentType"
           component={Select}

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.css
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.css
@@ -1,9 +1,5 @@
 @import '@folio/stripes-components/lib/variables';
 
-.coverage-fields {
-  max-width: 50em;
-}
-
 .coverage-fields-date-range-rows {
   list-style-type: none;
   padding: 0;

--- a/src/components/package/_fields/name/package-name-field.css
+++ b/src/components/package/_fields/name/package-name-field.css
@@ -1,3 +1,0 @@
-.package-name-field {
-  max-width: 50em;
-}

--- a/src/components/package/_fields/name/package-name-field.js
+++ b/src/components/package/_fields/name/package-name-field.js
@@ -3,14 +3,10 @@ import { Field } from 'redux-form';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 
 import { TextField } from '@folio/stripes-components';
-import styles from './package-name-field.css';
 
 function PackageNameField({ intl }) {
   return (
-    <div
-      data-test-eholdings-package-name-field
-      className={styles['package-name-field']}
-    >
+    <div data-test-eholdings-package-name-field>
       <Field
         name="name"
         type="text"

--- a/src/components/package/edit-custom/custom-package-edit.css
+++ b/src/components/package/edit-custom/custom-package-edit.css
@@ -9,7 +9,6 @@
 }
 
 .visibility-radios {
-  max-width: 50em;
   margin-top: 2em;
 
   & fieldset {

--- a/src/components/package/edit-managed/managed-package-edit.css
+++ b/src/components/package/edit-managed/managed-package-edit.css
@@ -10,7 +10,6 @@
 
 .visibility-radios,
 .title-management-radios {
-  max-width: 50em;
   margin-top: 2em;
 
   & fieldset {

--- a/src/components/resource/_fields/coverage-statement/coverage-statement-fields.css
+++ b/src/components/resource/_fields/coverage-statement/coverage-statement-fields.css
@@ -1,3 +1,0 @@
-.coverage-statement-textarea {
-  max-width: 50em;
-}

--- a/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
+++ b/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
@@ -2,15 +2,11 @@ import React, { Component } from 'react';
 import { Field } from 'redux-form';
 
 import { TextArea } from '@folio/stripes-components';
-import styles from './coverage-statement-fields.css';
 
 export default class CoverageStatementFields extends Component {
   render() {
     return (
-      <div
-        data-test-eholdings-coverage-statement-textarea
-        className={styles['coverage-statement-textarea']}
-      >
+      <div data-test-eholdings-coverage-statement-textarea>
         <Field
           name="coverageStatement"
           component={TextArea}

--- a/src/components/resource/_fields/custom-coverage/resource-coverage-fields.css
+++ b/src/components/resource/_fields/custom-coverage/resource-coverage-fields.css
@@ -1,9 +1,5 @@
 @import '@folio/stripes-components/lib/variables';
 
-.coverage-fields {
-  max-width: 50em;
-}
-
 .coverage-fields-date-range-rows {
   list-style-type: none;
   padding: 0;

--- a/src/components/resource/_fields/custom-coverage/resource-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/resource-coverage-fields.js
@@ -25,7 +25,7 @@ class ResourceCoverageFields extends Component {
   renderCoverageFields = ({ fields }) => {
     let { initialValue, intl } = this.props;
     return (
-      <div className={styles['coverage-fields']}>
+      <div>
         {fields.length === 0
           && initialValue.length > 0
           && initialValue[0].beginCoverage

--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.css
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.css
@@ -3,7 +3,6 @@
 .custom-embargo-fields {
   align-items: flex-start;
   display: flex;
-  max-width: 50em;
 }
 
 .custom-embargo-text-field {

--- a/src/components/resource/_fields/custom-url/custom-url-fields.css
+++ b/src/components/resource/_fields/custom-url/custom-url-fields.css
@@ -1,3 +1,0 @@
-.url-text-area {
-  max-width: 50em;
-}

--- a/src/components/resource/_fields/custom-url/custom-url-fields.js
+++ b/src/components/resource/_fields/custom-url/custom-url-fields.js
@@ -2,16 +2,12 @@ import React, { Component } from 'react';
 import { Field } from 'redux-form';
 
 import { TextField } from '@folio/stripes-components';
-import styles from './custom-url-fields.css';
 
 class CustomUrlFields extends Component {
   render() {
     return (
       <div>
-        <div
-          className={styles['url-text-area']}
-          data-test-eholdings-custom-url-textfield
-        >
+        <div data-test-eholdings-custom-url-textfield>
           <Field
             name="customUrl"
             component={TextField}

--- a/src/components/scroll-view/scroll-view.css
+++ b/src/components/scroll-view/scroll-view.css
@@ -16,5 +16,4 @@
 .list-item {
   position: absolute;
   width: 100%;
-  left: 0;
 }

--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -2,6 +2,7 @@
 
 .search-form-container {
   margin: 0 auto;
+  min-width: 320px;
   max-width: 640px;
   padding: 1em;
 

--- a/src/components/title/_fields/contributor/contributor-field.css
+++ b/src/components/title/_fields/contributor/contributor-field.css
@@ -2,7 +2,6 @@
 
 .contributor-fields {
   margin: 1em 0;
-  max-width: 50em;
   padding: 0;
 
   & legend {

--- a/src/components/title/_fields/description/description-field.css
+++ b/src/components/title/_fields/description/description-field.css
@@ -1,3 +1,0 @@
-.description-textarea {
-  max-width: 50em;
-}

--- a/src/components/title/_fields/description/description-field.js
+++ b/src/components/title/_fields/description/description-field.js
@@ -3,14 +3,10 @@ import { Field } from 'redux-form';
 
 import { TextArea } from '@folio/stripes-components';
 import { injectIntl, intlShape } from 'react-intl';
-import styles from './description-field.css';
 
 function DescriptionField({ intl }) {
   return (
-    <div
-      data-test-eholdings-description-textarea
-      className={styles['description-textarea']}
-    >
+    <div data-test-eholdings-description-textarea>
       <Field
         name="description"
         component={TextArea}

--- a/src/components/title/_fields/edition/edition-field.css
+++ b/src/components/title/_fields/edition/edition-field.css
@@ -1,3 +1,0 @@
-.edition-field {
-  max-width: 50em;
-}

--- a/src/components/title/_fields/edition/edition-field.js
+++ b/src/components/title/_fields/edition/edition-field.js
@@ -3,14 +3,10 @@ import { Field } from 'redux-form';
 
 import { TextField } from '@folio/stripes-components';
 import { injectIntl, intlShape } from 'react-intl';
-import styles from './edition-field.css';
 
 function EditionField({ intl }) {
   return (
-    <div
-      data-test-eholdings-edition-field
-      className={styles['edition-field']}
-    >
+    <div data-test-eholdings-edition-field>
       <Field
         name="edition"
         component={TextField}

--- a/src/components/title/_fields/identifiers/identifiers-fields.css
+++ b/src/components/title/_fields/identifiers/identifiers-fields.css
@@ -2,7 +2,6 @@
 
 .identifiers-fields {
   margin: 1em 0;
-  max-width: 50em;
   padding: 0;
 
   & legend {

--- a/src/components/title/_fields/name/title-name-field.css
+++ b/src/components/title/_fields/name/title-name-field.css
@@ -1,3 +1,0 @@
-.title-name-field {
-  max-width: 50em;
-}

--- a/src/components/title/_fields/name/title-name-field.js
+++ b/src/components/title/_fields/name/title-name-field.js
@@ -3,14 +3,10 @@ import { Field } from 'redux-form';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 
 import { TextField } from '@folio/stripes-components';
-import styles from './title-name-field.css';
 
 function TitleNameField({ intl }) {
   return (
-    <div
-      data-test-eholdings-title-name-field
-      className={styles['title-name-field']}
-    >
+    <div data-test-eholdings-title-name-field>
       <Field
         name="name"
         type="text"

--- a/src/components/title/_fields/package-select/package-select-field.css
+++ b/src/components/title/_fields/package-select/package-select-field.css
@@ -1,3 +1,0 @@
-.package-select-field {
-  max-width: 50em;
-}

--- a/src/components/title/_fields/package-select/package-select-field.js
+++ b/src/components/title/_fields/package-select/package-select-field.js
@@ -4,7 +4,6 @@ import { Field } from 'redux-form';
 import { injectIntl, intlShape } from 'react-intl';
 
 import { Select } from '@folio/stripes-components';
-import styles from './package-select-field.css';
 
 function PackageSelectField({ intl, options }) {
   let optionsWithPlaceholder = [{
@@ -14,10 +13,7 @@ function PackageSelectField({ intl, options }) {
   }, ...options];
 
   return (
-    <div
-      data-test-eholdings-package-select-field
-      className={styles['package-select-field']}
-    >
+    <div data-test-eholdings-package-select-field>
       <Field
         name="packageId"
         component={Select}

--- a/src/components/title/_fields/publication-type/publication-type.css
+++ b/src/components/title/_fields/publication-type/publication-type.css
@@ -1,3 +1,0 @@
-.publication-type-field {
-  max-width: 50em;
-}

--- a/src/components/title/_fields/publication-type/publication-type.js
+++ b/src/components/title/_fields/publication-type/publication-type.js
@@ -3,14 +3,10 @@ import { Field } from 'redux-form';
 
 import { Select } from '@folio/stripes-components';
 import { injectIntl, intlShape } from 'react-intl';
-import styles from './publication-type.css';
 
 function PublicationTypeField({ intl }) {
   return (
-    <div
-      data-test-eholdings-publication-type-field
-      className={styles['publication-type-field']}
-    >
+    <div data-test-eholdings-publication-type-field>
       <Field
         name="publicationType"
         component={Select}

--- a/src/components/title/_fields/publisher-name/publisher-name.css
+++ b/src/components/title/_fields/publisher-name/publisher-name.css
@@ -1,3 +1,0 @@
-.publisher-name-field {
-  max-width: 50em;
-}

--- a/src/components/title/_fields/publisher-name/publisher-name.js
+++ b/src/components/title/_fields/publisher-name/publisher-name.js
@@ -3,14 +3,10 @@ import { Field } from 'redux-form';
 
 import { TextField } from '@folio/stripes-components';
 import { injectIntl, intlShape } from 'react-intl';
-import styles from './publisher-name.css';
 
 function PublisherNameField({ intl }) {
   return (
-    <div
-      data-test-eholdings-publisher-name-field
-      className={styles['publisher-name-field']}
-    >
+    <div data-test-eholdings-publisher-name-field>
       <Field
         name="publisherName"
         component={TextField}


### PR DESCRIPTION
## Purpose
Part of https://issues.folio.org/browse/UIEH-206

Page layouts are far too wide on large monitors, hurting readability and leading to not-great layout choices.

## Approach
Put max-widths on pages. Remove them from child components.

## Screenshots
![2018-07-27 15 40 50](https://user-images.githubusercontent.com/230597/43346442-c0100a16-91b6-11e8-9d91-d89e347572e8.gif)

