### PR TITLE
Don’t set max width for search results

### DIFF
--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -4,6 +4,10 @@
   margin: 0 auto;
   padding: 0;
 
+  &.full-width {
+    max-width: none;
+  }
+
   & li {
     border-bottom: 1px solid #eee;
     list-style-type: none;

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -1,11 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
 import styles from './list.css';
 
-export default function List({ className, ...props }) {
-  return <ul className={[styles.list, className].join(' ')} {...props} />;
+const cx = classNames.bind(styles);
+
+export default function List({ className, fullWidth, ...props }) {
+  return (
+    <ul
+      className={cx(styles.list, { 'full-width': fullWidth }, className)}
+      {...props}
+    />
+  );
 }
 
 List.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
+  fullWidth: PropTypes.bool
 };

--- a/src/components/package-search-list.js
+++ b/src/components/package-search-list.js
@@ -22,6 +22,7 @@ export default function PackageSearchList({
       onUpdateOffset={onUpdateOffset}
       itemHeight={84}
       notFoundMessage={`No packages found for "${params.q}".`}
+      fullWidth
       renderItem={item => (
         <PackageListItem
           showProviderName

--- a/src/components/provider-search-list.js
+++ b/src/components/provider-search-list.js
@@ -22,6 +22,7 @@ export default function ProviderSearchList({
       onUpdateOffset={onUpdateOffset}
       itemHeight={68}
       notFoundMessage={`No providers found for "${params.q}".`}
+      fullWidth
       renderItem={item => (
         <ProviderListItem
           item={item.content}

--- a/src/components/query-list/query-list.js
+++ b/src/components/query-list/query-list.js
@@ -25,11 +25,13 @@ export default class QueryList extends Component {
     fetch: PropTypes.func.isRequired,
     renderItem: PropTypes.func.isRequired,
     onUpdateOffset: PropTypes.func,
-    length: PropTypes.number
+    length: PropTypes.number,
+    fullWidth: PropTypes.bool
   };
 
   static defaultProps = {
-    notFoundMessage: 'Not found'
+    notFoundMessage: 'Not found',
+    fullWidth: false
   }
 
   state = {
@@ -55,7 +57,8 @@ export default class QueryList extends Component {
       fetch,
       itemHeight,
       renderItem,
-      length
+      length,
+      fullWidth
     } = this.props;
     let {
       offset
@@ -87,6 +90,7 @@ export default class QueryList extends Component {
               onUpdate={this.updateOffset}
               scrollable={scrollable}
               data-test-query-list={type}
+              fullWidth={fullWidth}
             >
               {item => (
                 item.isRejected ? (

--- a/src/components/scroll-view/scroll-view.js
+++ b/src/components/scroll-view/scroll-view.js
@@ -23,12 +23,14 @@ export default class ScrollView extends Component {
     scrollable: PropTypes.bool,
     itemHeight: PropTypes.number.isRequired,
     onUpdate: PropTypes.func,
-    children: PropTypes.func.isRequired
+    children: PropTypes.func.isRequired,
+    fullWidth: PropTypes.bool
   };
 
   static defaultProps = {
     offset: 0,
-    scrollable: true
+    scrollable: true,
+    fullWidth: false
   };
 
   constructor(props) {
@@ -144,7 +146,7 @@ export default class ScrollView extends Component {
   render() {
     // strip all other props to pass along the rest to the div
     // eslint-disable-next-line no-unused-vars
-    let { items, length, itemHeight, offset: _, onUpdate, scrollable, ...props } = this.props;
+    let { items, length, itemHeight, offset: _, onUpdate, scrollable, fullWidth, ...props } = this.props;
     let { offset, visibleItems } = this.state;
     let listHeight = (length || items.length) * itemHeight;
 
@@ -160,7 +162,10 @@ export default class ScrollView extends Component {
         onScroll={this.handleScroll}
         {...props}
       >
-        <List style={{ height: listHeight }}>
+        <List
+          fullWidth={fullWidth}
+          style={{ height: listHeight }}
+        >
           {this.renderChildren()}
         </List>
       </div>

--- a/src/components/title-search-list.js
+++ b/src/components/title-search-list.js
@@ -22,6 +22,7 @@ export default function TitleSearchList({
       onUpdateOffset={onUpdateOffset}
       itemHeight={84}
       notFoundMessage={`No titles found for "${params.q}".`}
+      fullWidth
       renderItem={item => (
         <TitleListItem
           showPublisherAndType


### PR DESCRIPTION
## Purpose
https://github.com/folio-org/ui-eholdings/pull/500 created a ton of whitespace and uncomfortable shifting of the search results when clicking a result.

## Approach
Don't set a `max-width` for the search results. Continue setting a max width on detail records.

This implementation feels a little clunky - we probably have too much coupling between the components used for search results and showing related item lists.

## Screenshots

### Before
![folio frontside io_eholdings_searchtype titles q science ipad pro](https://user-images.githubusercontent.com/230597/43483473-64147986-94d1-11e8-9c3c-7c4a16f46263.png)

### After
![localhost_3000_eholdings_searchtype packages q e ipad pro](https://user-images.githubusercontent.com/230597/43483484-6a382b3c-94d1-11e8-90e0-856230aaef6a.png)
