### PR TITLE
Lay out detail record data with KeyValueColumns

### DIFF
--- a/src/components/key-value-columns/index.js
+++ b/src/components/key-value-columns/index.js
@@ -1,0 +1,1 @@
+export { default } from './key-value-columns';

--- a/src/components/key-value-columns/key-value-columns.css
+++ b/src/components/key-value-columns/key-value-columns.css
@@ -1,0 +1,15 @@
+@import '@folio/stripes-components/lib/variables';
+
+.key-value-columns {
+  display: flex;
+  flex-flow: row wrap;
+
+  & > div {
+    flex: 1 0 20rem;
+    margin-right: var(--gutter);
+
+    [dir="rtl"] {
+      margin-left: var(--gutter);
+    }
+  }
+}

--- a/src/components/key-value-columns/key-value-columns.js
+++ b/src/components/key-value-columns/key-value-columns.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './key-value-columns.css';
+
+export default function KeyValueColumns({ children }) {
+  return (
+    <div
+      className={styles['key-value-columns']}
+    >
+      {children}
+    </div>
+  );
+}
+
+KeyValueColumns.propTypes = {
+  children: PropTypes.node
+};

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -21,6 +21,7 @@ import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 
 import SelectionStatus from '../selection-status';
+import KeyValueColumns from '../../key-value-columns';
 import styles from './package-show.css';
 
 class PackageShow extends Component {
@@ -244,39 +245,45 @@ class PackageShow extends Component {
                 id="packageShowInformation"
                 onToggle={this.handleSectionToggle}
               >
-                <KeyValue label={<FormattedMessage id="ui-eholdings.package.provider" />}>
-                  <div data-test-eholdings-package-details-provider>
-                    <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
+                <KeyValueColumns>
+                  <div>
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.package.provider" />}>
+                      <div data-test-eholdings-package-details-provider>
+                        <Link to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</Link>
+                      </div>
+                    </KeyValue>
+
+                    {model.contentType && (
+                      <KeyValue label={<FormattedMessage id="ui-eholdings.package.contentType" />}>
+                        <div data-test-eholdings-package-details-content-type>
+                          {model.contentType}
+                        </div>
+                      </KeyValue>
+                    )}
+
+                    {model.packageType && (
+                      <KeyValue label={<FormattedMessage id="ui-eholdings.package.packageType" />}>
+                        <div data-test-eholdings-package-details-type>
+                          {model.packageType}
+                        </div>
+                      </KeyValue>
+                    )}
                   </div>
-                </KeyValue>
 
-                {model.contentType && (
-                  <KeyValue label={<FormattedMessage id="ui-eholdings.package.contentType" />}>
-                    <div data-test-eholdings-package-details-content-type>
-                      {model.contentType}
-                    </div>
-                  </KeyValue>
-                )}
+                  <div>
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.package.titlesSelected" />}>
+                      <div data-test-eholdings-package-details-titles-selected>
+                        <FormattedNumber value={model.selectedCount} />
+                      </div>
+                    </KeyValue>
 
-                {model.packageType && (
-                  <KeyValue label={<FormattedMessage id="ui-eholdings.package.packageType" />}>
-                    <div data-test-eholdings-package-details-type>
-                      {model.packageType}
-                    </div>
-                  </KeyValue>
-                )}
-
-                <KeyValue label={<FormattedMessage id="ui-eholdings.package.titlesSelected" />}>
-                  <div data-test-eholdings-package-details-titles-selected>
-                    <FormattedNumber value={model.selectedCount} />
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.package.totalTitles" />}>
+                      <div data-test-eholdings-package-details-titles-total>
+                        <FormattedNumber value={model.titleCount} />
+                      </div>
+                    </KeyValue>
                   </div>
-                </KeyValue>
-
-                <KeyValue label={<FormattedMessage id="ui-eholdings.package.totalTitles" />}>
-                  <div data-test-eholdings-package-details-titles-total>
-                    <FormattedNumber value={model.titleCount} />
-                  </div>
-                </KeyValue>
+                </KeyValueColumns>
               </Accordion>
               <Accordion
                 label={intl.formatMessage({ id: 'ui-eholdings.package.packageSettings' })}

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -22,6 +22,7 @@ import ContributorsList from '..//contributors-list';
 import CoverageDateList from '../coverage-date-list';
 import { isBookPublicationType, isValidCoverageList, processErrors } from '../utilities';
 import Toaster from '../toaster';
+import KeyValueColumns from '../key-value-columns';
 
 class ResourceShow extends Component {
   static propTypes = {
@@ -216,87 +217,92 @@ class ResourceShow extends Component {
                 id="resourceShowInformation"
                 onToggle={this.handleSectionToggle}
               >
-                <KeyValue label={<FormattedMessage id="ui-eholdings.label.title" />}>
-                  <Link to={`/eholdings/titles/${model.titleId}`}>
-                    {model.title.name}
-                  </Link>
-                </KeyValue>
+                <KeyValueColumns>
+                  <div>
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.label.title" />}>
+                      <Link to={`/eholdings/titles/${model.titleId}`}>
+                        {model.title.name}
+                      </Link>
+                    </KeyValue>
 
-                {model.title.edition && (
-                  <KeyValue label={<FormattedMessage id="ui-eholdings.label.edition" />}>
-                    <div data-test-eholdings-resource-show-edition>
-                      {model.title.edition}
-                    </div>
-                  </KeyValue>
-                )}
+                    {model.title.edition && (
+                      <KeyValue label={<FormattedMessage id="ui-eholdings.label.edition" />}>
+                        <div data-test-eholdings-resource-show-edition>
+                          {model.title.edition}
+                        </div>
+                      </KeyValue>
+                    )}
 
-                <ContributorsList data={model.title.contributors} />
+                    <ContributorsList data={model.title.contributors} />
 
-                {model.title.publisherName && (
-                  <KeyValue label={<FormattedMessage id="ui-eholdings.label.publisher" />}>
-                    <div data-test-eholdings-resource-show-publisher-name>
-                      {model.title.publisherName}
-                    </div>
-                  </KeyValue>
-                )}
+                    {model.title.publisherName && (
+                      <KeyValue label={<FormattedMessage id="ui-eholdings.label.publisher" />}>
+                        <div data-test-eholdings-resource-show-publisher-name>
+                          {model.title.publisherName}
+                        </div>
+                      </KeyValue>
+                    )}
 
-                {model.title.publicationType && (
-                  <KeyValue label={<FormattedMessage id="ui-eholdings.label.publicationType" />}>
-                    <div data-test-eholdings-resource-show-publication-type>
-                      {model.title.publicationType}
-                    </div>
-                  </KeyValue>
-                )}
+                    {model.title.publicationType && (
+                      <KeyValue label={<FormattedMessage id="ui-eholdings.label.publicationType" />}>
+                        <div data-test-eholdings-resource-show-publication-type>
+                          {model.title.publicationType}
+                        </div>
+                      </KeyValue>
+                    )}
 
-                <IdentifiersList data={model.title.identifiers} />
+                    <IdentifiersList data={model.title.identifiers} />
 
-                {model.title.subjects.length > 0 && (
-                  <KeyValue label={<FormattedMessage id="ui-eholdings.label.subjects" />}>
-                    <div data-test-eholdings-resource-show-subjects-list>
-                      {model.title.subjects.map(subjectObj => subjectObj.subject).join('; ')}
-                    </div>
-                  </KeyValue>
-                )}
+                    {model.title.subjects.length > 0 && (
+                      <KeyValue label={<FormattedMessage id="ui-eholdings.label.subjects" />}>
+                        <div data-test-eholdings-resource-show-subjects-list>
+                          {model.title.subjects.map(subjectObj => subjectObj.subject).join('; ')}
+                        </div>
+                      </KeyValue>
+                    )}
 
-                <KeyValue label={<FormattedMessage id="ui-eholdings.label.peerReviewed" />}>
-                  <div data-test-eholdings-peer-reviewed-field>
-                    {model.title.isPeerReviewed ? 'Yes' : 'No'}
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.label.peerReviewed" />}>
+                      <div data-test-eholdings-peer-reviewed-field>
+                        {model.title.isPeerReviewed ? 'Yes' : 'No'}
+                      </div>
+                    </KeyValue>
+
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.label.titleType" />}>
+                      <div data-test-eholdings-package-details-type>
+                        {model.title.isTitleCustom ? 'Custom' : 'Managed'}
+                      </div>
+                    </KeyValue>
+
+                    {model.title.description && (
+                      <KeyValue label={<FormattedMessage id="ui-eholdings.label.description" />}>
+                        <div data-test-eholdings-description-field>
+                          {model.title.description}
+                        </div>
+                      </KeyValue>
+                    )}
                   </div>
-                </KeyValue>
+                  <div>
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.label.package" />}>
+                      <div data-test-eholdings-resource-show-package-name>
+                        <Link to={`/eholdings/packages/${model.packageId}`}>{model.package.name}</Link>
+                      </div>
+                    </KeyValue>
 
-                <KeyValue label={<FormattedMessage id="ui-eholdings.label.titleType" />}>
-                  <div data-test-eholdings-package-details-type>
-                    {model.title.isTitleCustom ? 'Custom' : 'Managed'}
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.label.provider" />}>
+                      <div data-test-eholdings-resource-show-provider-name>
+                        <Link to={`/eholdings/providers/${model.providerId}`}>{model.package.providerName}</Link>
+                      </div>
+                    </KeyValue>
+
+                    {model.package.contentType && (
+                      <KeyValue label="Package content type">
+                        <div data-test-eholdings-resource-show-content-type>
+                          {model.package.contentType}
+                        </div>
+                      </KeyValue>
+                    )}
                   </div>
-                </KeyValue>
-
-                {model.title.description && (
-                  <KeyValue label={<FormattedMessage id="ui-eholdings.label.description" />}>
-                    <div data-test-eholdings-description-field>
-                      {model.title.description}
-                    </div>
-                  </KeyValue>
-                )}
-
-                <KeyValue label={<FormattedMessage id="ui-eholdings.label.package" />}>
-                  <div data-test-eholdings-resource-show-package-name>
-                    <Link to={`/eholdings/packages/${model.packageId}`}>{model.package.name}</Link>
-                  </div>
-                </KeyValue>
-
-                <KeyValue label={<FormattedMessage id="ui-eholdings.label.provider" />}>
-                  <div data-test-eholdings-resource-show-provider-name>
-                    <Link to={`/eholdings/providers/${model.providerId}`}>{model.package.providerName}</Link>
-                  </div>
-                </KeyValue>
-
-                {model.package.contentType && (
-                  <KeyValue label="Package content type">
-                    <div data-test-eholdings-resource-show-content-type>
-                      {model.package.contentType}
-                    </div>
-                  </KeyValue>
-                )}
+                </KeyValueColumns>
               </Accordion>
 
               <Accordion

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -19,6 +19,7 @@ import IdentifiersList from '../../identifiers-list';
 import ContributorsList from '../../contributors-list';
 import AddToPackageForm from '../_forms/add-to-package';
 import Toaster from '../../toaster';
+import KeyValueColumns from '../../key-value-columns';
 import styles from './title-show.css';
 
 class TitleShow extends Component {
@@ -186,61 +187,68 @@ class TitleShow extends Component {
               id="titleShowTitleInformation"
               onToggle={this.handleSectionToggle}
             >
-              <ContributorsList data={model.contributors} />
+              <KeyValueColumns>
+                <div>
+                  <ContributorsList data={model.contributors} />
 
-              {model.edition && (
-                <KeyValue label={<FormattedMessage id="ui-eholdings.title.edition" />}>
-                  <div data-test-eholdings-title-show-edition>
-                    {model.edition}
-                  </div>
-                </KeyValue>
-              )}
+                  {model.edition && (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.edition" />}>
+                      <div data-test-eholdings-title-show-edition>
+                        {model.edition}
+                      </div>
+                    </KeyValue>
+                  )}
 
-              {model.publisherName && (
-                <KeyValue label={<FormattedMessage id="ui-eholdings.title.publisherName" />}>
-                  <div data-test-eholdings-title-show-publisher-name>
-                    {model.publisherName}
-                  </div>
-                </KeyValue>
-              )}
+                  {model.publisherName && (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.publisherName" />}>
+                      <div data-test-eholdings-title-show-publisher-name>
+                        {model.publisherName}
+                      </div>
+                    </KeyValue>
+                  )}
 
-              {model.publicationType && (
-                <KeyValue label={<FormattedMessage id="ui-eholdings.title.publicationType" />}>
-                  <div data-test-eholdings-title-show-publication-type>
-                    {model.publicationType}
-                  </div>
-                </KeyValue>
-              )}
+                  {model.publicationType && (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.publicationType" />}>
+                      <div data-test-eholdings-title-show-publication-type>
+                        {model.publicationType}
+                      </div>
+                    </KeyValue>
+                  )}
 
-              <IdentifiersList data={model.identifiers} />
+                  <IdentifiersList data={model.identifiers} />
 
-              {model.subjects.length > 0 && (
-                <KeyValue label={<FormattedMessage id="ui-eholdings.title.subjects" />}>
-                  <div data-test-eholdings-title-show-subjects-list>
-                    {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
-                  </div>
-                </KeyValue>
-              )}
-
-              <KeyValue label={<FormattedMessage id="ui-eholdings.title.peerReviewed" />}>
-                <div data-test-eholdings-peer-reviewed-field>
-                  {model.isPeerReviewed ? (<FormattedMessage id="ui-eholdings.yes" />) : (<FormattedMessage id="ui-eholdings.no" />)}
                 </div>
-              </KeyValue>
+                <div>
 
-              <KeyValue label={<FormattedMessage id="ui-eholdings.title.titleType" />}>
-                <div data-test-eholdings-title-details-type>
-                  {model.isTitleCustom ? (<FormattedMessage id="ui-eholdings.custom" />) : (<FormattedMessage id="ui-eholdings.managed" />)}
+                  {model.subjects.length > 0 && (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.subjects" />}>
+                      <div data-test-eholdings-title-show-subjects-list>
+                        {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
+                      </div>
+                    </KeyValue>
+                  )}
+
+                  <KeyValue label={<FormattedMessage id="ui-eholdings.title.peerReviewed" />}>
+                    <div data-test-eholdings-peer-reviewed-field>
+                      {model.isPeerReviewed ? (<FormattedMessage id="ui-eholdings.yes" />) : (<FormattedMessage id="ui-eholdings.no" />)}
+                    </div>
+                  </KeyValue>
+
+                  <KeyValue label={<FormattedMessage id="ui-eholdings.title.titleType" />}>
+                    <div data-test-eholdings-title-details-type>
+                      {model.isTitleCustom ? (<FormattedMessage id="ui-eholdings.custom" />) : (<FormattedMessage id="ui-eholdings.managed" />)}
+                    </div>
+                  </KeyValue>
+
+                  {model.description && (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.description" />}>
+                      <div data-test-eholdings-description-field>
+                        {model.description}
+                      </div>
+                    </KeyValue>
+                  )}
                 </div>
-              </KeyValue>
-
-              {model.description && (
-                <KeyValue label={<FormattedMessage id="ui-eholdings.title.description" />}>
-                  <div data-test-eholdings-description-field>
-                    {model.description}
-                  </div>
-                </KeyValue>
-              )}
+              </KeyValueColumns>
 
               <div className={styles['add-to-custom-package-button']}>
                 <Button


### PR DESCRIPTION
## Purpose
To visually resemble other FOLIO modules, lay out the "____ information" section of detail records in columns.

Resolves https://issues.folio.org/browse/UIEH-206 and https://issues.folio.org/browse/UIEH-507.

## Approach
- Created `<KeyValueColumns>` that can wrap the collections of `<KeyValue>` pairs. To create a column, use a `<div>`.
- The most difficult decision on each was where to place the break:
  - Provider: none, so that "_____ selected" is always above "Total ______" like a fraction
  - Package: before "Titles selected" and "Total titles" counts
  - Title: just tried to pick a halfway point; after identifiers, before subjects
  - Resource: break is between fields inherited from the title and fields inherited from the package
- When the detail record container is less than 630px wide, there's only a single column. That breakpoint was chosen just based on looking at what felt comfortable with some existing records.
- Gutter between columns set at 15px using the `stripes-components` `gutter` variable.

## Why not `react-flexbox-grid`?
`stripes-components` exports `react-flexbox-grid` as a recommendation for FOLIO modules to use.

### It relies on the window's context instead of its container.
`react-flexbox-grid` uses media queries, so it can only be responsive to the width of the entire window. This layout is being used both on its own and inside a pane.

In this example, the title pane is only 374px wide, at which we'd want just a single column to maintain legibility. `react-flexbox-grid` can't do anything with the pane width information.
#### With `react-flexbox-grid`
![43521050-825adf14-955a-11e8-8a55-78a546d45c29](https://user-images.githubusercontent.com/230597/43521848-0ebe44a8-955d-11e8-9865-261a99af1b83.png)

#### With `KeyValueColumns`
![43521052-85589684-955a-11e8-9692-eb01c9c95847](https://user-images.githubusercontent.com/230597/43521855-116550de-955d-11e8-9087-b2f6ccc05399.png)

### It wraps a limited, dated API around a much more powerful abstraction.
`react-flexbox-grid` uses the idea of a flexible-width 12-column layout, which far predates having the modern flexbox and CSS grid APIs available in browsers.

`react-flexbox-grid` uses flexbox CSS under the hood, but removes much of its power (similar to the problem with `stripes-components` `<Pane>`s). The API for `react-flexbox-grid` receives a number 1-12 to indicate a width as a percentage of 12. That means `react-flexbox-grid` really only provides a way to set `flex-basis` to a percentage.

But flexbox can do so much more! Specifically, `<KeyValueColumns>` uses:
- `flex-flow: row wrap`: tells the container to wrap the columns to be a single column if they don't fit horizontally
- `flex: 1 0 20rem`: sets `flex-grow` to 1, meaning the child can grow as wide as it needs to fill; sets `flex-shrink` to 0, meaning "don't shrink below the `flex-basis`"; sets `flex-basis` (the default size) to `20rem`

## Learning
[A Complete Guide to Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
[Don't Use My Grid System (or any others) by Miriam Suzanne](https://youtu.be/mDRfFEcj3-Q)

## Screenshots
### Package
![package](https://user-images.githubusercontent.com/230597/43521071-952ee3d8-955a-11e8-9d5f-ea36b2a434cc.png)

### Title
![title](https://user-images.githubusercontent.com/230597/43521075-99acab48-955a-11e8-89c8-36406f2afd7f.png)
![another title](https://user-images.githubusercontent.com/230597/43521081-9d1679a8-955a-11e8-8a0b-4023a4d4715e.png)

### Resource
![resource](https://user-images.githubusercontent.com/230597/43521087-a0e5f860-955a-11e8-8978-ee9bc9204789.png)

