### PR TITLE
Clean up warnings

### DIFF
--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -44,8 +44,8 @@ export default class DetailsView extends Component {
     lastMenu: PropTypes.node,
     resultsLength: PropTypes.number,
     searchModal: PropTypes.node,
-    sections: PropTypes.object.isRequired,
-    handleExpandAll: PropTypes.func.isRequired
+    sections: PropTypes.object,
+    handleExpandAll: PropTypes.func
   };
 
   static contextTypes = {

--- a/src/components/package/_fields/name/package-name-field.js
+++ b/src/components/package/_fields/name/package-name-field.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Field } from 'redux-form';
-import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 
 import { TextField } from '@folio/stripes-components';
 
@@ -23,15 +23,15 @@ PackageNameField.propTypes = {
 
 export default injectIntl(PackageNameField);
 
-export function validate(values) {
+export function validate(values, props) {
   let errors = {};
 
   if (values.name === '') {
-    errors.name = <FormattedMessage id="ui-eholdings.validate.errors.customPackage.name" />;
+    errors.name = props.intl.formatMessage({ id: 'ui-eholdings.validate.errors.customPackage.name' });
   }
 
   if (values.name.length >= 300) {
-    errors.name = <FormattedMessage id="ui-eholdings.validate.errors.customPackage.name.length" />;
+    errors.name = props.intl.formatMessage({ id: 'ui-eholdings.validate.errors.customPackage.name.length' });
   }
 
   return errors;

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -121,7 +121,7 @@ class PackageCreate extends Component {
 }
 
 const validate = (values, props) => {
-  return Object.assign({}, validatePackageName(values), validateCoverageDates(values, props));
+  return Object.assign({}, validatePackageName(values, props), validateCoverageDates(values, props));
 };
 
 export default injectIntl(reduxForm({

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -336,7 +336,7 @@ class CustomPackageEdit extends Component {
 }
 
 const validate = (values, props) => {
-  return Object.assign({}, validatePackageName(values), validateCoverageDates(values, props));
+  return Object.assign({}, validatePackageName(values, props), validateCoverageDates(values, props));
 };
 
 export default injectIntl(reduxForm({

--- a/src/components/title/_fields/name/title-name-field.js
+++ b/src/components/title/_fields/name/title-name-field.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Field } from 'redux-form';
-import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 
 import { TextField } from '@folio/stripes-components';
 
@@ -23,15 +23,15 @@ TitleNameField.propTypes = {
 
 export default injectIntl(TitleNameField);
 
-export function validate(values) {
+export function validate(values, props) {
   let errors = {};
 
   if (values.name === '') {
-    errors.name = <FormattedMessage id="ui-eholdings.validate.errors.customTitle.name" />;
+    errors.name = props.intl.formatMessage({ id: 'ui-eholdings.validate.errors.customTitle.name' });
   }
 
   if (values.name.length >= 400) {
-    errors.name = <FormattedMessage id="ui-eholdings.validate.errors.customTitle.name.length" />;
+    errors.name = props.intl.formatMessage({ id: 'ui-eholdings.validate.errors.customTitle.name.length' });
   }
 
   return errors;

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -141,9 +141,9 @@ class TitleCreate extends Component {
   }
 }
 
-const validate = (values) => {
+const validate = (values, props) => {
   return Object.assign({},
-    validateName(values),
+    validateName(values, props),
     validateContributor(values),
     validateEdition(values),
     validatePublisherName(values),

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -169,9 +169,9 @@ class TitleEdit extends Component {
   }
 }
 
-const validate = (values) => {
+const validate = (values, props) => {
   return Object.assign({},
-    validateName(values),
+    validateName(values, props),
     validateContributor(values),
     validateEdition(values),
     validatePublisher(values),

--- a/src/components/toaster/toaster.js
+++ b/src/components/toaster/toaster.js
@@ -26,7 +26,11 @@ class Toaster extends Component {
       // to pick the specific toast out when calling `onClose`
       id: PropTypes.string.isRequired,
       // the toast message that will be displayed in the UI
-      message: PropTypes.string.isRequired,
+      message: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+        PropTypes.node
+      ]).isRequired,
       // the time which the toast is shown
       timeout: PropTypes.number
     })).isRequired


### PR DESCRIPTION
## Purpose
Addresses a few different classes of warnings that were popping up on test runs (https://circleci.com/gh/folio-org/ui-eholdings/6310):

```
ERROR: 'Warning: Failed prop type: The prop `handleExpandAll` is marked as required in `DetailsView`, but its value is `undefined`.
```
`sections` and `handleExpandAll` were set as required props on `<DetailsView>`, but it doesn't appear that they're actually required.

```
ERROR: 'Warning: Failed prop type: Invalid prop `error` of type `object` supplied to `TextField`, expected `string`.
```
`redux-form` expects the message in `errors` to be a string, which means we can't use `<FormattedMessage>` or `<FormattedDate>` in error messages.

```
ERROR: 'Warning: Failed prop type: Invalid prop `error` of type `boolean` supplied to `TextField`, expected `string`.
```
In a few cases, we were passing a boolean to the `errors` `message` instead of a string.


## Not Solved
```
ERROR: 'Warning: Failed prop type: Invalid prop `component` supplied to `Field`.
```
Needs new release of `redux-form`.


```
WARN: 'Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date()...
```
Needs some `Datepicker` work.