### PR TITLE
UIEH-516 Use intl.format within template string

### DIFF
--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -320,7 +320,11 @@ class ResourceShow extends Component {
                 </KeyValue>
 
                 {model.url && (
-                  <KeyValue label={`${model.title.isTitleCustom ? (<FormattedMessage id="ui-eholdings.custom" />) : (<FormattedMessage id="ui-eholdings.managed" />)} URL`}>
+                  <KeyValue label={`${model.title.isTitleCustom ?
+                    intl.formatMessage({ id: 'ui-eholdings.custom' })
+                      :
+                    intl.formatMessage({ id: 'ui-eholdings.managed' })} URL`}
+                  >
                     <div data-test-eholdings-resource-show-url>
                       <ExternalLink
                         href={model.url}


### PR DESCRIPTION
## Purpose
Javascript Template strings expected a string to be use in order to create the resulting string ouput. Since we were passing a component it was rendering to screen [Object, Object] and not the actual
string representation.

## Approach
- use intl.formatMessage to return a string over using the component

## Screenshots
#### Before
<img width="1318" alt="screen shot 2018-08-06 at 12 24 57 pm" src="https://user-images.githubusercontent.com/1953098/43730520-94558d86-9979-11e8-84a6-cb0782f2c2c5.png">

#### After
<img width="1472" alt="screen shot 2018-08-06 at 12 25 49 pm" src="https://user-images.githubusercontent.com/1953098/43730555-b3299a7c-9979-11e8-9a41-70ad7a9e90ed.png">
