### PR TITLE
UIEH-511: Fix "Results found NaN" on the title-show page

### DIFF
--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -261,6 +261,7 @@ class TitleShow extends Component {
             </Accordion>
           )}
           listType="packages"
+          resultsLength={model.resources.length}
           renderList={scrollable => (
             <ScrollView
               itemHeight={70}


### PR DESCRIPTION
Resolves [UIEH-511](https://issues.folio.org/browse/UIEH-511)

## Purpose
This PR is about replicating the work @taras and @cherewaty did on the provider detail page to collapse/expand the package list using the `<Accordion>` from stripes-components.

## Approach
As it turns out, this ticket was pretty much resolved by #482.
All that I needed to do was fix a spot in the UI where the number of results was displayed as `NaN`