### PR TITLE
Fix ampersand in Search Filter pane header

### DIFF
--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -187,7 +187,7 @@
     "search.apply": "Apply",
     "search.addNew": "+ New",
     "search.loading": "Loading...",
-    "search.searchAndFilter": "Search &amp; Filter",
+    "search.searchAndFilter": "Search \\u0026 Filter",
     "search.enterQuery": "Enter a query to show search results.",
 
     "date.present": "Present",


### PR DESCRIPTION
Intl'ed string needed Unicode number instead of HTML entity for ampersand.

### Before
<img width="314" alt="screen shot 2018-08-07 at 10 10 42 am" src="https://user-images.githubusercontent.com/230597/43784690-45a74ae2-9a2a-11e8-9b7c-e1753fe39eac.png">

### After
<img width="308" alt="screen shot 2018-08-07 at 10 10 32 am" src="https://user-images.githubusercontent.com/230597/43784699-4aa405f8-9a2a-11e8-9385-c4bf39240c99.png">
