### PR TITLE
UIEH-514: Use react-measure to automatically resize accordion container

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "impagination": "^1.0.0-alpha.3",
     "inflected": "^2.0.3",
     "react-intl": "^2.4.0",
+    "react-measure": "2.1.0",
     "redux-actions": "^2.2.1"
   },
   "peerDependencies": {

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import capitalize from 'lodash/capitalize';
 import { ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
+import Measure from 'react-measure';
 
 import {
   Accordion,
@@ -288,19 +289,23 @@ export default class DetailsView extends Component {
               className={styles.sticky}
               data-test-eholdings-details-view-list={type}
             >
-              <Accordion
-                separator={!isSticky}
-                header={AccordionListHeader}
-                label={capitalize(listType)}
-                displayWhenOpen={searchModal}
-                resultsLength={resultsLength}
-                contentRef={(n) => { this.$list = n; }}
-                open={isListAccordionOpen}
-                id={listSectionId}
-                onToggle={onListToggle}
-              >
-                {renderList(isSticky)}
-              </Accordion>
+              <Measure onResize={this.handleLayout}>
+                {({ measureRef }) => (
+                  <Accordion
+                    separator={!isSticky}
+                    header={AccordionListHeader}
+                    label={capitalize(listType)}
+                    displayWhenOpen={searchModal}
+                    resultsLength={resultsLength}
+                    contentRef={(n) => { this.$list = n; measureRef(n); }}
+                    open={isListAccordionOpen}
+                    id={listSectionId}
+                    onToggle={onListToggle}
+                  >
+                    {renderList(isSticky)}
+                  </Accordion>
+                )}
+              </Measure>
             </div>
           )}
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4266,6 +4266,10 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
+get-node-dimensions@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz#fb7b4bb57060fb4247dd51c9d690dfbec56b0823"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -8227,6 +8231,14 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
+react-measure@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-measure/-/react-measure-2.1.0.tgz#e9a4645066d6fed54cf0ce44aa7a28da6dd7a9f7"
+  dependencies:
+    get-node-dimensions "^1.2.0"
+    prop-types "^15.5.10"
+    resize-observer-polyfill "^1.4.2"
+
 react-overlays@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"
@@ -8841,6 +8853,10 @@ resize-img@^1.1.0:
     jimp "^0.2.21"
     jpeg-js "^0.1.1"
     parse-png "^1.1.1"
+
+resize-observer-polyfill@^1.4.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
 
 resolve-from@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
[UIEH-514](https://issues.folio.org/browse/UIEH-514)

## Purpose

The purpose of this PR is to make sure that list expands to consume all available space after accordion container is collapsed. 

## Approach

Use [react-measure](https://github.com/souporserious/react-measure) component to watch when the accordion changes size and call `handleLayout` to update the size of the list.

#### TODOS and Open Questions

- [x] Do I need to write a test for this?

## Learning

My original strategy was to add hooks to Accordion component that would allow me to call the callback after collapse/expand. It turned out that it's extremely difficult to figure out how to test that a callback was called after RAF. Ultimately, this approach is better because it relies on composition of a specialized component over adding props to common components.

## Screenshots

### Before

![2018-08-07 16 14 52](https://user-images.githubusercontent.com/74687/43800012-1e0a62de-9a5d-11e8-8f97-f91287856d61.gif)

### After

![2018-08-07 16 01 50](https://user-images.githubusercontent.com/74687/43799951-e4c8f72e-9a5c-11e8-8295-4a8b12dbf2aa.gif)
