### PR TITLE
UIEH-517 Reduce search form min width

### DIFF
--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -2,7 +2,7 @@
 
 .search-form-container {
   margin: 0 auto;
-  min-width: 320px;
+  min-width: 200px;
   max-width: 640px;
   padding: 1em;
 


### PR DESCRIPTION
## Purpose
Resolves https://issues.folio.org/browse/UIEH-517

## Approach
The search form had a min width of 320px, but the pane with or without a scrollbar was sized at 320px. That meant the `1em` padding was behind the scrollbar instead of to the left of it.

`min-width` reduced to `200px`.

## Screenshots
### Before
![screen shot 2018-08-07 at 3 15 57 pm](https://user-images.githubusercontent.com/230597/43800249-759a21d6-9a55-11e8-8850-d1441ba43ecc.png)

### After
![screen shot 2018-08-07 at 3 15 41 pm](https://user-images.githubusercontent.com/230597/43800256-786b0d6c-9a55-11e8-8e7f-62f7a3592865.png)
