### PR TITLE
UIEH-518: Fix accessing context in the scope of a constructor

### DIFF
--- a/src/components/navigation-modal/navigation-modal.js
+++ b/src/components/navigation-modal/navigation-modal.js
@@ -24,11 +24,11 @@ export default class NavigationModal extends Component {
     }).isRequired
   };
 
-  constructor(props) {
+  constructor(props, context) {
     super(props);
 
     if (props.when) {
-      this.enable();
+      this.enable(context);
     }
   }
 
@@ -49,12 +49,12 @@ export default class NavigationModal extends Component {
     this.disable();
   }
 
-  enable() {
+  enable(context = this.context) {
     if (this.unblock) {
       this.unblock();
     }
 
-    this.unblock = this.context.router.history.block((nextLocation) => {
+    this.unblock = context.router.history.block((nextLocation) => {
       this.setState({
         showModal: true,
         nextLocation


### PR DESCRIPTION
## Purpose
To resolve bug [UIEH-518](https://issues.folio.org/browse/UIEH-518).  

## Approach
In the `NavigationModal` component there were cases in which we would try to access `this.context` from within the class constructor. This is a simple fix for these cases.