### PR TITLE
[UIEH-214] Implement filtering for package resources

### DIFF
--- a/bigtest/interactors/package-show.js
+++ b/bigtest/interactors/package-show.js
@@ -16,6 +16,7 @@ import {
 import { getComputedStyle, hasClassBeginningWith } from './helpers';
 import Datepicker from './datepicker';
 import Toast from './toast';
+import SearchModal from './search-modal';
 import PackageSelectionStatus from './selection-status';
 
 @interactor class PackageShowModal {
@@ -39,6 +40,10 @@ import PackageSelectionStatus from './selection-status';
   hasAllowKbToAddTitlesToggle = isPresent('[package-details-toggle-allow-add-new-titles-switch]');
   selectionStatus = new PackageSelectionStatus();
   modal = new PackageShowModal('#eholdings-package-confirmation-modal');
+  searchModal = new SearchModal('#eholdings-details-view-search-modal');
+  searchResultsCount = text('[data-test-eholdings-details-view-results-count]');
+  numFilters = text('[data-test-eholdings-details-view-filters]');
+  clickListSearch = clickable('[data-test-eholdings-details-view-search]');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   contentType = text('[data-test-eholdings-package-details-content-type]');
   name = text('[data-test-eholdings-details-view-name="package"]');

--- a/bigtest/interactors/package-show.js
+++ b/bigtest/interactors/package-show.js
@@ -17,6 +17,7 @@ import { getComputedStyle, hasClassBeginningWith } from './helpers';
 import Datepicker from './datepicker';
 import Toast from './toast';
 import SearchModal from './search-modal';
+import SearchBadge from './search-badge';
 import PackageSelectionStatus from './selection-status';
 
 @interactor class PackageShowModal {
@@ -42,8 +43,7 @@ import PackageSelectionStatus from './selection-status';
   modal = new PackageShowModal('#eholdings-package-confirmation-modal');
   searchModal = new SearchModal('#eholdings-details-view-search-modal');
   searchResultsCount = text('[data-test-eholdings-details-view-results-count]');
-  numFilters = text('[data-test-eholdings-details-view-filters]');
-  clickListSearch = clickable('[data-test-eholdings-details-view-search]');
+  clickListSearch = clickable('[data-test-eholdings-search-filters="icon"]');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   contentType = text('[data-test-eholdings-package-details-content-type]');
   name = text('[data-test-eholdings-details-view-name="package"]');
@@ -61,6 +61,7 @@ import PackageSelectionStatus from './selection-status';
   clickEditButton = clickable('[data-test-eholdings-package-edit-link]');
   dropDown= new PackageShowDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   dropDownMenu = new PackageShowDropDownMenu();
+  searchModalBadge = new SearchBadge('[data-test-eholdings-search-modal-badge]');
 
   detailPaneMouseWheel = triggerable('[data-test-eholdings-detail-pane-contents]', 'wheel', {
     bubbles: true,

--- a/bigtest/interactors/provider-show.js
+++ b/bigtest/interactors/provider-show.js
@@ -26,7 +26,6 @@ import SearchBadge from './search-badge';
   hasErrors = isPresent('[data-test-eholdings-details-view-error="provider"]');
   errorMessage = text('[data-test-eholdings-details-view-error="provider"]');
   clickListSearch = clickable('[data-test-eholdings-search-filters="icon"]');
-  numFilters = text('[data-test-eholdings-search-filters="badge"]');
   filterBadge = isPresent('[data-test-eholdings-details-view-filters-badge]');
   proxy = text('[data-test-eholdings-provider-details-proxy]');
 

--- a/bigtest/interactors/search-modal.js
+++ b/bigtest/interactors/search-modal.js
@@ -12,22 +12,17 @@ import {
 export default @interactor class SearchModal {
   searchType = attribute('data-test-search-form', '[data-test-search-form]')
   searchFieldValue = value('[data-test-search-field] input[name="search"]');
+  isSearchButtonDisabled = property('[data-test-eholdings-modal-search-button]', 'disabled');
+  isResetButtonDisabled = property('[data-test-eholdings-modal-reset-all-button]', 'disabled');
+  clickResetAll = clickable('[data-test-eholdings-modal-reset-all-button]');
+  searchTitles = fillable('[data-test-title-search-field] input[name="search"]');
+  selectSearchField = selectable('[data-test-title-search-field] select');
+  searchDisabled = property('[data-test-search-submit]', 'disabled')
+  clickSearch = clickable('[data-test-eholdings-modal-search-button]');
 
   clickFilter = action(function (name, val) {
     return this.click(`[data-test-eholdings-search-filters] input[name="${name}"][value="${val}"]`);
   });
-
-  clickSearch = clickable('[data-test-eholdings-modal-search-button]');
-
-  getFilter(name) {
-    return this.$(`[data-test-eholdings-search-filters] input[name="${name}"]:checked`).value;
-  }
-
-  isSearchButtonDisabled = property('[data-test-eholdings-modal-search-button]', 'disabled');
-  isResetButtonDisabled = property('[data-test-eholdings-modal-reset-all-button]', 'disabled');
-  clickResetAll = clickable('[data-test-eholdings-modal-reset-all-button]');
-
-  searchDisabled = property('[data-test-search-submit]', 'disabled')
 
   search = action(function (query) {
     return this
@@ -35,12 +30,12 @@ export default @interactor class SearchModal {
       .click('[data-test-eholdings-modal-search-button]');
   });
 
-  searchTitles = fillable('[data-test-title-search-field] input[name="search"]');
-
-  selectSearchField = selectable('[data-test-title-search-field] select');
-
   clearSearch = action(function () {
     return this
       .fill('[data-test-search-field] input[name="search"]', '');
   });
+
+  getFilter(name) {
+    return this.$(`[data-test-eholdings-search-filters] input[name="${name}"]:checked`).value;
+  }
 }

--- a/bigtest/interactors/search-modal.js
+++ b/bigtest/interactors/search-modal.js
@@ -6,6 +6,7 @@ import {
   property,
   value,
   fillable,
+  selectable,
 } from '@bigtest/interactor';
 
 export default @interactor class SearchModal {
@@ -35,6 +36,8 @@ export default @interactor class SearchModal {
   });
 
   searchTitles = fillable('[data-test-title-search-field] input[name="search"]');
+
+  selectSearchField = selectable('[data-test-title-search-field] select');
 
   clearSearch = action(function () {
     return this

--- a/bigtest/interactors/search-modal.js
+++ b/bigtest/interactors/search-modal.js
@@ -5,6 +5,7 @@ import {
   clickable,
   property,
   value,
+  fillable,
 } from '@bigtest/interactor';
 
 export default @interactor class SearchModal {
@@ -32,6 +33,8 @@ export default @interactor class SearchModal {
       .fill('[data-test-search-field] input[name="search"]', query)
       .click('[data-test-eholdings-modal-search-button]');
   });
+
+  searchTitles = fillable('[data-test-title-search-field] input[name="search"]');
 
   clearSearch = action(function () {
     return this

--- a/bigtest/tests/package-show-titles-search-test.js
+++ b/bigtest/tests/package-show-titles-search-test.js
@@ -1,0 +1,102 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { describeApplication } from '../helpers/describe-application';
+import PackageShowPage from '../interactors/package-show';
+
+describeApplication('Package Show Title Search', () => {
+  let provider,
+    resources,
+    providerPackage;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', {
+      name: 'Cool Provider'
+    });
+
+    providerPackage = this.server.create(
+      'package',
+      'withTitles',
+      'withCustomCoverage',
+      {
+        provider,
+        name: 'Cool Package',
+        contentType: 'E-Book',
+        isSelected: false,
+        titleCount: 3,
+        packageType: 'Complete'
+      }
+    );
+
+    resources = this.server.schema.where('resource', {
+      packageId: providerPackage.id
+    }).models;
+
+    resources[0].title.update({
+      name: 'My Title 1',
+      isSelected: true
+    });
+
+    resources[1].title.update({
+      name: 'My Title 2',
+      isSelected: true
+    });
+
+    resources[2].title.update({
+      name: 'SUPER Duper 3',
+      isSelected: false
+    });
+  });
+
+  describe('navigating to package show page to filter titles', () => {
+    beforeEach(function () {
+      return this.visit(
+        {
+          pathname: `/eholdings/packages/${providerPackage.id}`,
+          // our internal link component automatically sets the location state
+          state: { eholdings: true }
+        },
+        () => {
+          expect(PackageShowPage.$root).to.exist;
+        }
+      );
+    });
+
+    it('displays the proper title count', () => {
+      expect(PackageShowPage.titleList().length).to.equal(3);
+    });
+
+    it('has no filters by default', () => {
+      expect(PackageShowPage.numFilters).to.equal('');
+    });
+
+    describe('searching for a title', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch()
+          .searchModal.searchTitles('My Title')
+          .searchModal.clickSearch();
+      });
+
+      it('properly filters the results', () => {
+        expect(PackageShowPage.titleList(0).name).to.equal('My Title 1');
+        expect(PackageShowPage.titleList(1).name).to.equal('My Title 2');
+      });
+
+      it('has the right amount of titles displayed', () => {
+        expect(PackageShowPage.titleList().length).to.equal(2);
+      });
+    });
+
+    describe('searching for a title with filters', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch()
+          .searchModal.clickFilter('selected', 'true')
+          .searchModal.clickSearch();
+      });
+
+      it('properly filters the results', () => {
+        expect(PackageShowPage.titleList().length).to.equal(2);
+      });
+    });
+  });
+});

--- a/bigtest/tests/package-show-titles-search-test.js
+++ b/bigtest/tests/package-show-titles-search-test.js
@@ -34,16 +34,30 @@ describeApplication('Package Show Title Search', () => {
 
     resources[0].title.update({
       name: 'My Title 1',
-      isSelected: true
+      publicationType: 'report',
+      subjects: [this.server.create('subject', { subject: 'FooBar' }).toJSON()],
+    });
+
+    resources[0].update({
+      isSelected: true,
     });
 
     resources[1].title.update({
       name: 'My Title 2',
-      isSelected: true
+      publicationType: 'book',
+      publisherName: "The Frontside"
+    });
+
+    resources[1].update({
+      isSelected: false
     });
 
     resources[2].title.update({
       name: 'SUPER Duper 3',
+      publicationType: 'book'
+    });
+
+    resources[2].update({
       isSelected: false
     });
   });
@@ -87,7 +101,7 @@ describeApplication('Package Show Title Search', () => {
       });
     });
 
-    describe('searching for a title with filters', () => {
+    describe('searching for a title with the selected filter', () => {
       beforeEach(() => {
         return PackageShowPage.clickListSearch()
           .searchModal.clickFilter('selected', 'true')
@@ -95,7 +109,68 @@ describeApplication('Package Show Title Search', () => {
       });
 
       it('properly filters the results', () => {
-        expect(PackageShowPage.titleList().length).to.equal(2);
+        expect(PackageShowPage.titleList().length).to.equal(1);
+      });
+    });
+
+    describe('searching for a title with the publication type filter', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch()
+          .searchModal.clickFilter('type', 'report')
+          .searchModal.clickSearch();
+      });
+
+      it('properly filters to one result', () => {
+        expect(PackageShowPage.titleList().length).to.equal(1);
+      });
+
+      it('has the right title name', () => {
+        expect(PackageShowPage.titleList(0).name).to.equal('My Title 1');
+      });
+    });
+
+    describe('searching for a title by title publisher filter', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch()
+          .searchModal.selectSearchField('Publisher')
+          .searchModal.searchTitles('The Frontside')
+          .searchModal.clickSearch();
+      });
+
+      it('properly filters to one result', () => {
+        expect(PackageShowPage.titleList().length).to.equal(1);
+      });
+
+      it('has the right title name', () => {
+        expect(PackageShowPage.titleList(0).name).to.equal('My Title 2');
+      });
+
+      describe('changing the filter to subject', () => {
+        beforeEach(() => {
+          return PackageShowPage.clickListSearch()
+            .searchModal.selectSearchField('Subject')
+            .searchModal.searchTitles('FooBar')
+            .searchModal.clickSearch();
+        });
+
+        it('properly filters to one result', () => {
+          expect(PackageShowPage.titleList().length).to.equal(1);
+        });
+
+        it('has the right title name', () => {
+          expect(PackageShowPage.titleList(0).name).to.equal('My Title 1');
+        });
+      });
+
+      describe('resetting the search', () => {
+        beforeEach(() => {
+          return PackageShowPage.clickListSearch()
+            .searchModal.clickResetAll();
+        });
+
+        it('properly filters to one result', () => {
+          expect(PackageShowPage.titleList().length).to.equal(3);
+        });
       });
     });
   });

--- a/bigtest/tests/package-show-titles-search-test.js
+++ b/bigtest/tests/package-show-titles-search-test.js
@@ -45,7 +45,7 @@ describeApplication('Package Show Title Search', () => {
     resources[1].title.update({
       name: 'My Title 2',
       publicationType: 'book',
-      publisherName: "The Frontside"
+      publisherName: 'The Frontside'
     });
 
     resources[1].update({

--- a/bigtest/tests/package-show-titles-search-test.js
+++ b/bigtest/tests/package-show-titles-search-test.js
@@ -81,7 +81,7 @@ describeApplication('Package Show Title Search', () => {
     });
 
     it('has no filters by default', () => {
-      expect(PackageShowPage.numFilters).to.equal('');
+      expect(PackageShowPage.searchModalBadge.filterText).to.equal('');
     });
 
     describe('searching for a title', () => {

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -31,7 +31,8 @@ class PackageShow extends Component {
     fetchPackageTitles: PropTypes.func.isRequired,
     intl: intlShape.isRequired,
     toggleSelected: PropTypes.func.isRequired,
-    addPackageToHoldings: PropTypes.func.isRequired
+    addPackageToHoldings: PropTypes.func.isRequired,
+    searchModal: PropTypes.node
   };
 
   static contextTypes = {
@@ -102,7 +103,7 @@ class PackageShow extends Component {
   }
 
   render() {
-    let { model, fetchPackageTitles, intl } = this.props;
+    let { model, fetchPackageTitles, intl, searchModal } = this.props;
     let { router, queryParams } = this.context;
     let {
       showSelectionModal,
@@ -216,6 +217,7 @@ class PackageShow extends Component {
           actionMenuItems={actionMenuItems}
           sections={sections}
           handleExpandAll={this.handleExpandAll}
+          searchModal={searchModal}
           lastMenu={(
             <IconButton
               data-test-eholdings-package-edit-link

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -175,7 +175,7 @@ class SearchModal extends React.PureComponent {
               searchFilter={query.filter}
               searchField={query.searchfield}
               sort={query.sort}
-              onSearch={this.handleListSearch}
+              onSearch={this.updateSearch}
               displaySearchTypeSwitcher={false}
               displaySearchButton={false}
               onFilterChange={this.handleFilterChange}

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -85,7 +85,7 @@ class SearchModal extends React.PureComponent {
     });
   }
 
-  handleSerchFieldChange = (searchfield) => {
+  handleSearchFieldChange = (searchfield) => {
     this.setState({
       query: normalize({
         ...this.state.query,
@@ -180,7 +180,7 @@ class SearchModal extends React.PureComponent {
               displaySearchButton={false}
               onFilterChange={this.handleFilterChange}
               onSearchChange={this.handleSearchQueryChange}
-              onSearchFieldChange={this.handleSerchFieldChange}
+              onSearchFieldChange={this.handleSearchFieldChange}
             />
           </Modal>
         )}

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -85,6 +85,15 @@ class SearchModal extends React.PureComponent {
     });
   }
 
+  handleSerchFieldChange = (searchfield) => {
+    this.setState({
+      query: normalize({
+        ...this.state.query,
+        searchfield
+      }),
+    });
+  }
+
   handleSearchQueryChange = q => {
     this.setState({
       query: {
@@ -134,45 +143,47 @@ class SearchModal extends React.PureComponent {
             data-test-eholdings-details-view-search
           />
         </div>
-
-        <Modal
-          open={isModalVisible}
-          size="small"
-          label={intl.formatMessage({ id: 'ui-eholdings.filter.filterType' }, { listType })}
-          onClose={this.close}
-          id="eholdings-details-view-search-modal"
-          closeOnBackgroundClick
-          dismissible
-          footer={
-            <ModalFooter
-              primaryButton={{
-                'label': intl.formatMessage({ id: 'ui-eholdings.label.search' }),
-                'onClick': this.updateSearch,
-                'disabled': !hasChanges,
-                'data-test-eholdings-modal-search-button': true
-              }}
-              secondaryButton={{
-                'label': intl.formatMessage({ id: 'ui-eholdings.filter.resetAll' }),
-                'onClick': this.resetSearch,
-                'disabled': isEqual(normalize({}), this.state.query),
-                'data-test-eholdings-modal-reset-all-button': true
-              }}
+        {isModalVisible && (
+          <Modal
+            open
+            size="small"
+            label={intl.formatMessage({ id: 'ui-eholdings.filter.filterType' }, { listType })}
+            onClose={this.close}
+            id="eholdings-details-view-search-modal"
+            closeOnBackgroundClick
+            dismissible
+            footer={
+              <ModalFooter
+                primaryButton={{
+                  'label': intl.formatMessage({ id: 'ui-eholdings.label.search' }),
+                  'onClick': this.updateSearch,
+                  'disabled': !hasChanges,
+                  'data-test-eholdings-modal-search-button': true
+                }}
+                secondaryButton={{
+                  'label': intl.formatMessage({ id: 'ui-eholdings.filter.resetAll' }),
+                  'onClick': this.resetSearch,
+                  'disabled': isEqual(normalize({}), this.state.query),
+                  'data-test-eholdings-modal-reset-all-button': true
+                }}
+              />
+            }
+          >
+            <SearchForm
+              searchType={listType}
+              searchString={query.q}
+              searchFilter={query.filter}
+              searchField={query.searchfield}
+              sort={query.sort}
+              onSearch={this.handleListSearch}
+              displaySearchTypeSwitcher={false}
+              displaySearchButton={false}
+              onFilterChange={this.handleFilterChange}
+              onSearchChange={this.handleSearchQueryChange}
+              onSearchFieldChange={this.handleSerchFieldChange}
             />
-          }
-        >
-          <SearchForm
-            searchType={listType}
-            searchString={query.q}
-            searchFilter={query.filter}
-            searchField={query.searchField}
-            sort={query.sort}
-            onSearch={this.handleListSearch}
-            displaySearchTypeSwitcher={false}
-            displaySearchButton={false}
-            onFilterChange={this.handleFilterChange}
-            onSearchChange={this.handleSearchQueryChange}
-          />
-        </Modal>
+          </Modal>
+        )}
       </Fragment>
     );
   }

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -60,3 +60,17 @@ export const processErrors = ({ request, update, destroy }) => {
 
   return [...putErrors, ...getErrors, ...destroyErrors];
 };
+
+/**
+ * Transforms UI params into search params
+ *
+ * @param {Object} parms - query param object
+ */
+export function transformQueryParams(searchType, params) {
+  if (searchType === 'titles') {
+    let { q, searchfield = 'name', filter = {}, ...searchParams } = params;
+    if (searchfield === 'title') { searchfield = 'name'; }
+    let searchfilter = { ...filter, [searchfield]: q };
+    return { ...searchParams, filter: searchfilter };
+  } else { return params; }
+}

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -56,7 +56,7 @@ class PackageShowRoute extends Component {
     pkgSearchParams: {}
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     let { model: next, match, getPackage, unloadResources } = this.props;
     let { model: old, match: oldMatch } = prevProps;
     let { packageId } = match.params;

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -10,6 +10,17 @@ import Resource from '../redux/resource';
 import View from '../components/package/show';
 import SearchModal from '../components/search-modal';
 
+// TODO this is out of place.
+function transformTitleQueryParams(params) {
+  let { q, searchfield = 'name', filter = {}, ...searchParams } = params;
+
+  if (searchfield === 'title') { searchfield = 'name'; }
+
+  let searchfilter = { ...filter, [searchfield]: q };
+
+  return { ...searchParams, filter: searchfilter };
+}
+
 class PackageShowRoute extends Component {
   static propTypes = {
     match: PropTypes.shape({
@@ -72,7 +83,9 @@ class PackageShowRoute extends Component {
     }
 
     if (pkgSearchParams !== prevState.pkgSearchParams || page !== prevState.page) {
-      getPackageTitles(packageId, { ...pkgSearchParams, page });
+      let params = transformTitleQueryParams({ ...pkgSearchParams });
+
+      getPackageTitles(packageId, { ...params, page });
     }
   }
   /* This method is common between package-show and package-edit routes

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -6,20 +6,10 @@ import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 import { createResolver } from '../redux';
 import Package from '../redux/package';
 import Resource from '../redux/resource';
+import { transformQueryParams } from '../components/utilities';
 
 import View from '../components/package/show';
 import SearchModal from '../components/search-modal';
-
-// TODO this is out of place.
-function transformTitleQueryParams(params) {
-  let { q, searchfield = 'name', filter = {}, ...searchParams } = params;
-
-  if (searchfield === 'title') { searchfield = 'name'; }
-
-  let searchfilter = { ...filter, [searchfield]: q };
-
-  return { ...searchParams, filter: searchfilter };
-}
 
 class PackageShowRoute extends Component {
   static propTypes = {
@@ -122,7 +112,7 @@ class PackageShowRoute extends Component {
     let { getPackageTitles, match } = this.props;
     let { pkgSearchParams, page } = this.state;
     let { packageId } = match.params;
-    let params = transformTitleQueryParams({ ...pkgSearchParams });
+    let params = transformQueryParams('titles', { ...pkgSearchParams });
 
     getPackageTitles(packageId, { ...params, page });
   }

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import capitalize from 'lodash/capitalize';
 import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 
-import { qs } from '../components/utilities';
+import { qs, transformQueryParams } from '../components/utilities';
 import { createResolver } from '../redux';
 import Provider from '../redux/provider';
 import Package from '../redux/package';
@@ -123,21 +123,6 @@ class SearchRoute extends Component { // eslint-disable-line react/no-deprecated
   }
 
   /**
-   * Transforms UI params into search params
-   * @param {Object} parms - query param object
-   */
-
-  transformQueryParams(params) {
-    let { searchType } = this.state;
-    if (searchType === 'titles') {
-      let { q, searchfield = 'name', filter = {}, ...searchParams } = params;
-      if (searchfield === 'title') { searchfield = 'name'; }
-      let searchfilter = { ...filter, [searchfield]: q };
-      return { ...searchParams, filter: searchfilter };
-    } else { return params; }
-  }
-
-  /**
    * Uses the resolver to get a results collection for the current
    * search type and search params (including the page)
    * @returns {Collection} a collection instance
@@ -146,7 +131,7 @@ class SearchRoute extends Component { // eslint-disable-line react/no-deprecated
     let { resolver } = this.props;
     let { searchType, params } = this.state;
     let { offset = 0, ...queryParams } = params;
-    let searchParams = this.transformQueryParams(queryParams);
+    let searchParams = transformQueryParams(searchType, queryParams);
     let page = Math.floor(offset / 25) + 1;
 
     return resolver.query(searchType, {
@@ -217,8 +202,8 @@ class SearchRoute extends Component { // eslint-disable-line react/no-deprecated
    * @param {Object} params - search params for the action
    */
   search(params) {
-    let searchParams = this.transformQueryParams(params);
     let { searchType } = this.state;
+    let searchParams = transformQueryParams(searchType, params);
     if (searchType === 'providers') this.props.searchProviders(searchParams);
     if (searchType === 'packages') this.props.searchPackages(searchParams);
     if (searchType === 'titles') this.props.searchTitles(searchParams);


### PR DESCRIPTION
## Purpose

Allow the ability for you to filter packages nested resources (which are titles). 


## Approach

I started with implementing the search modal inside of the `package-show` detail view. A lot of the work was getting the mirage config setup to where we can filter & search nested package resources. Once that work was done I was able to whip up some tests to make sure filtering titles worked properly. 

One thing I noticed while working through this is we could leverage the composability of interactors. We still have a lot of _page objects_. It would be nice to start to refactor our interactors to map to their component. This would allow us to compose interactors the same way we can compose the components. 

For example, the details view component could have it's own interactor. Then we could refactor our `show` pages to consume the `details-view` interactor. In this PR I had to copy over some interactors that were defined on a specific `show` page but they all are rendered by the `details-view` component. 

## Screenshots

![2018-08-10 17 38 06](https://user-images.githubusercontent.com/2072894/43984867-f901b500-9cc8-11e8-902a-dfc89c4f34e4.gif)