### PR TITLE
Minor search form modal fix

### DIFF
--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -130,7 +130,7 @@ class PackageShow extends Component {
 
     let actionMenuItems = [
       {
-        label:<FormattedMessage id="ui-eholdings.actionMenu.edit" />,
+        label: <FormattedMessage id="ui-eholdings.actionMenu.edit" />,
         to: {
           pathname: `/eholdings/packages/${model.id}/edit`,
           search: router.route.location.search,

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -135,46 +135,44 @@ class SearchModal extends React.PureComponent {
           />
         </div>
 
-        {isModalVisible && (
-          <Modal
-            open
-            size="small"
-            label={intl.formatMessage({ id: 'ui-eholdings.filter.filterType' }, { listType })}
-            onClose={this.close}
-            id="eholdings-details-view-search-modal"
-            closeOnBackgroundClick
-            dismissible
-            footer={
-              <ModalFooter
-                primaryButton={{
-                  'label': intl.formatMessage({ id: 'ui-eholdings.label.search' }),
-                  'onClick': this.updateSearch,
-                  'disabled': !hasChanges,
-                  'data-test-eholdings-modal-search-button': true
-                }}
-                secondaryButton={{
-                  'label': intl.formatMessage({ id: 'ui-eholdings.filter.resetAll' }),
-                  'onClick': this.resetSearch,
-                  'disabled': isEqual(normalize({}), this.state.query),
-                  'data-test-eholdings-modal-reset-all-button': true
-                }}
-              />
-            }
-          >
-            <SearchForm
-              searchType={listType}
-              searchString={query.q}
-              searchFilter={query.filter}
-              searchField={query.searchField}
-              sort={query.sort}
-              onSearch={this.handleListSearch}
-              displaySearchTypeSwitcher={false}
-              displaySearchButton={false}
-              onFilterChange={this.handleFilterChange}
-              onSearchChange={this.handleSearchQueryChange}
+        <Modal
+          open={isModalVisible}
+          size="small"
+          label={intl.formatMessage({ id: 'ui-eholdings.filter.filterType' }, { listType })}
+          onClose={this.close}
+          id="eholdings-details-view-search-modal"
+          closeOnBackgroundClick
+          dismissible
+          footer={
+            <ModalFooter
+              primaryButton={{
+                'label': intl.formatMessage({ id: 'ui-eholdings.label.search' }),
+                'onClick': this.updateSearch,
+                'disabled': !hasChanges,
+                'data-test-eholdings-modal-search-button': true
+              }}
+              secondaryButton={{
+                'label': intl.formatMessage({ id: 'ui-eholdings.filter.resetAll' }),
+                'onClick': this.resetSearch,
+                'disabled': isEqual(normalize({}), this.state.query),
+                'data-test-eholdings-modal-reset-all-button': true
+              }}
             />
-          </Modal>
-        )}
+          }
+        >
+          <SearchForm
+            searchType={listType}
+            searchString={query.q}
+            searchFilter={query.filter}
+            searchField={query.searchField}
+            sort={query.sort}
+            onSearch={this.handleListSearch}
+            displaySearchTypeSwitcher={false}
+            displaySearchButton={false}
+            onFilterChange={this.handleFilterChange}
+            onSearchChange={this.handleSearchQueryChange}
+          />
+        </Modal>
       </Fragment>
     );
   }


### PR DESCRIPTION
This is a very small fix to make sure the newly added Modal transition can run correctly. 

Because of the condition wrapping around the `<Modal>` it would only transition when entering. Now it works both when the modal enters and leaves the DOM.

Also fixed a tiny linting error.