### PR TITLE
Follow react/no-access-state-in-setstate

### DIFF
--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -28,9 +28,9 @@ export default class CustomEmbargoFields extends Component {
   }
 
   toggleInputs = () => {
-    this.setState({
-      'showInputs': !this.state.showInputs
-    });
+    this.setState(({ showInputs }) => ({
+      showInputs: !showInputs
+    }));
   }
 
   render() {

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -86,22 +86,22 @@ class SearchModal extends React.PureComponent {
   }
 
   handleSearchQueryChange = q => {
-    this.setState({
+    this.setState(({ query }) => ({
       query: {
-        ...this.state.query,
+        ...query,
         q
       },
-    });
+    }));
   }
 
   handleFilterChange = (sort, filter) => {
-    this.setState({
+    this.setState(({ query }) => ({
       query: normalize({
         sort,
         filter,
-        q: this.state.query.q
+        q: query.q
       }),
-    });
+    }));
   }
 
   render() {

--- a/src/components/toaster/toaster.js
+++ b/src/components/toaster/toaster.js
@@ -55,9 +55,9 @@ class Toaster extends Component {
   }
 
   destroyToast = (toastId) => {
-    let removedToast = this.state.toasts.filter(toast => toast.id !== toastId);
-
-    this.setState({ toasts: removedToast });
+    this.setState(({ toasts }) => ({
+      toasts: toasts.filter(toast => toast.id !== toastId)
+    }));
   }
 
   renderToasts() {

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -58,10 +58,10 @@ class ProviderShowRoute extends Component {
   }
 
   searchPackages = (pkgSearchParams) => {
-    this.setState({
+    this.setState(({ queryId }) => ({
       pkgSearchParams,
-      queryId: ++this.state.queryId
-    });
+      queryId: (queryId + 1)
+    }));
   };
 
   fetchPackages = (page) => {


### PR DESCRIPTION
## Purpose
Newer `eslint` rule that's not applied to this repo yet but appears in `eslint-config-stripes@3`: [`react/no-access-state-in-setstate`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md)

## Approach
Use callbacks with `setState` to prevent cases where an old state might be used.