### PR TITLE
Add a section about motivations for writing our own data layer

### DIFF
--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -215,5 +215,15 @@ The resolver for the eHoldings data layer lives in
 
 ## Motivation
 
-When we started building eHoldings project we knew that we wanted our data layer to have certain features that were not available in Stripes Connect. At the time, Stripes Connect was tightly coupled CQL and the static manifest files that it provided was not flexible enough for the error states that we wanted to surface in our components. In addition, Stripes Connect didn't provide normalization or side loading that we needed to provide a good user experience. We didn't have the resources to re-architect Stripes Connect to make it flexible for our use, so we decided to create our own data layer. There are currently conversations about adopting Apollo GraphQL instead of Stripes Connect. Apollo GraphQL has a similar feature set as the eHoldings Data Layer with the exception that data requirements are specified via queries rather than resources.
+When we started building eHoldings project we knew that we wanted our data layer to 
+have certain features that were not available in Stripes Connect. At the time, Stripes 
+Connect was tightly coupled to CQL and the static manifest files that it provided were 
+not flexible enough for the error states that we wanted to surface in our components. 
 
+In addition, Stripes Connect didn't provide normalization or side loading that we needed 
+to provide a good user experience. We didn't have the resources to re-architect Stripes 
+Connect to make it flexible for our use, so we decided to create our own data layer. 
+
+There are currently conversations about adopting Apollo GraphQL instead of Stripes Connect. 
+Apollo GraphQL has a similar feature set as the eHoldings Data Layer with the exception that 
+data requirements are specified via queries rather than resources.

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -1,5 +1,14 @@
 # Data Layer
 
+## Table of Contents
+
+* [Redux](#redux)
+* [Models](#models)
+* [Requesting and Resolving Data](#requesting--resolving-data)
+* [Debugging Requests](#debugging-requests)
+* [The Resolver](#the-resolver)
+* [Motivation](#motivation)
+
 ## Redux
 
 In eHoldings, only `routes` are connected to data. This is done via
@@ -203,3 +212,8 @@ request.
 The resolver for the eHoldings data layer lives in
 `src/redux/resolver.js` and the model and collection objects live in
 `src/redux/model.js`.
+
+## Motivation
+
+When we started building eHoldings project we knew that we wanted our data layer to have certain features that were not available in Stripes Connect. At the time, Stripes Connect was tightly coupled CQL and the static manifest files that it provided was not flexible enough for the error states that we wanted to surface in our components. In addition, Stripes Connect didn't provide normalization or side loading that we needed to provide a good user experience. We didn't have the resources to re-architect Stripes Connect to make it flexible for our use, so we decided to create our own data layer. There are currently conversations about adopting Apollo GraphQL instead of Stripes Connect. Apollo GraphQL has a similar feature set as the eHoldings Data Layer with the exception that data requirements are specified via queries rather than resources.
+

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -215,7 +215,7 @@ The resolver for the eHoldings data layer lives in
 
 ## Motivation
 
-When we started building eHoldings project we knew that we wanted our data layer to 
+When we started building eHoldings we knew that we wanted our data layer to 
 have certain features that were not available in Stripes Connect. At the time, Stripes 
 Connect was tightly coupled to CQL and the static manifest files that it provided were 
 not flexible enough for the error states that we wanted to surface in our components. 


### PR DESCRIPTION
Issue: https://issues.folio.org/browse/UIEH-519

## Purpose

We want future maintainers to understand motivations for why we did something. In this case, we want them to understand why we did not use Stripes Connect and created our own data layer.

[Rendered](https://github.com/folio-org/ui-eholdings/blob/ca49fcc76d6953582c702cbb8bf0abb30d9c8c27/docs/data-layer.md#motivation)

## Approach

- Added a paragraph to explain our motivations
- Added a table of contents to the document