### PR TITLE
[UIEH-530] Provider Detail: Show message on edit form when no packages are selected

### DIFF
--- a/bigtest/interactors/provider-edit.js
+++ b/bigtest/interactors/provider-edit.js
@@ -42,10 +42,12 @@ import Toast from './toast';
   isSaveDisabled = property('[data-test-eholdings-provider-save-button]', 'disabled');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="provider"]');
 
-  ProxySelectValue = value('[data-test-eholdings-provider-proxy-select] select');
+  proxySelectValue = value('[data-test-eholdings-provider-proxy-select] select');
   chooseRootProxy = fillable('[data-test-eholdings-provider-proxy-select] select');
   dropDown = new ProviderEditDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   dropDownMenu = new ProviderEditDropDownMenu();
+  hasProxySelect = isPresent('[data-test-eholdings-provider-proxy-select] select');
+  noPackagesSelected = text('[data-test-eholdings-provider-package-not-selected]');
 
   toast = Toast;
 }

--- a/bigtest/tests/provider-edit-test.js
+++ b/bigtest/tests/provider-edit-test.js
@@ -12,7 +12,8 @@ describeApplication('ProviderEdit', () => {
   beforeEach(function () {
     provider = this.server.create('provider', 'withPackagesAndTitles', 'withProxy', {
       name: 'League of Ordinary Men',
-      packagesTotal: 5
+      packagesTotal: 5,
+      packagesSelected: 3
     });
 
     packages = this.server.schema.where('package', { providerId: provider.id }).models;
@@ -36,7 +37,7 @@ describeApplication('ProviderEdit', () => {
     });
 
     it('has a select field defaulted with current root proxy', () => {
-      expect(ProviderEditPage.ProxySelectValue).to.equal('microstates');
+      expect(ProviderEditPage.proxySelectValue).to.equal('microstates');
     });
 
     it('disables the save button', () => {
@@ -137,6 +138,26 @@ describeApplication('ProviderEdit', () => {
 
     it('dies with dignity', () => {
       expect(ProviderEditPage.hasErrors).to.be.true;
+    });
+  });
+
+  describe('visiting the provider edit page with no selected packages', () => {
+    beforeEach(function () {
+      let provider2 = this.server.create('provider', {
+        name: 'Sam is awesome',
+      });
+
+      return this.visit(`/eholdings/providers/${provider2.id}/edit`, () => {
+        expect(ProviderEditPage.isPresent).to.be.true;
+      });
+    });
+
+    it('does not display other fields', () => {
+      expect(ProviderEditPage.hasProxySelect).to.be.false;
+    });
+
+    it('displays add package to holdings message', () => {
+      expect(ProviderEditPage.noPackagesSelected).to.equal('Add any package from this provider to holdings to customize provider settings.');
     });
   });
 });

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -116,17 +116,22 @@ class ProviderEdit extends Component {
             )}
              bodyContent={(
                <Fragment>
-                 <DetailsViewSection
-                   label={intl.formatMessage({ id: 'ui-eholdings.provider.providerSettings' })}
-                 >
-                   {(!proxyTypes.request.isResolved || !rootProxy.request.isResolved) ? (
-                     <Icon icon="spinner-ellipsis" />
-          ) : (
-            <div data-test-eholdings-provider-proxy-select>
-              <ProxySelectField proxyTypes={proxyTypes} rootProxy={rootProxy} />
-            </div>
-          )}
-                 </DetailsViewSection>
+                 {model.packagesSelected > 0 ? (
+                   <DetailsViewSection
+                     label={intl.formatMessage({ id: 'ui-eholdings.provider.providerSettings' })}
+                   >
+                     {(!proxyTypes.request.isResolved || !rootProxy.request.isResolved) ? (
+                       <Icon icon="spinner-ellipsis" />
+                      ) : (
+                        <div data-test-eholdings-provider-proxy-select>
+                          <ProxySelectField proxyTypes={proxyTypes} rootProxy={rootProxy} />
+                        </div>
+                      )}
+                   </DetailsViewSection>
+                 ) : (
+                   <FormattedMessage id="ui-eholdings.provider.noPackagesSelected" />
+                 )}
+
                  <NavigationModal
                    modalLabel={intl.formatMessage({ id: 'ui-eholdings.navModal.modalLabel' })}
                    continueLabel={intl.formatMessage({ id: 'ui-eholdings.navModal.continueLabel' })}

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -116,22 +116,25 @@ class ProviderEdit extends Component {
             )}
              bodyContent={(
                <Fragment>
-                 {model.packagesSelected > 0 ? (
-                   <DetailsViewSection
-                     label={intl.formatMessage({ id: 'ui-eholdings.provider.providerSettings' })}
-                   >
-                     {(!proxyTypes.request.isResolved || !rootProxy.request.isResolved) ? (
-                       <Icon icon="spinner-ellipsis" />
+                 <DetailsViewSection
+                   label={intl.formatMessage({ id: 'ui-eholdings.provider.providerSettings' })}
+                 >
+                   {model.packagesSelected > 0 ? (
+                     <div>
+                       {(!proxyTypes.request.isResolved || !rootProxy.request.isResolved) ? (
+                         <Icon icon="spinner-ellipsis" />
                       ) : (
                         <div data-test-eholdings-provider-proxy-select>
                           <ProxySelectField proxyTypes={proxyTypes} rootProxy={rootProxy} />
                         </div>
                       )}
-                   </DetailsViewSection>
+                     </div>
                  ) : (
-                   <FormattedMessage id="ui-eholdings.provider.noPackagesSelected" />
+                   <div data-test-eholdings-provider-package-not-selected>
+                     <FormattedMessage id="ui-eholdings.provider.noPackagesSelected" />
+                   </div>
                  )}
-
+                 </DetailsViewSection>
                  <NavigationModal
                    modalLabel={intl.formatMessage({ id: 'ui-eholdings.navModal.modalLabel' })}
                    continueLabel={intl.formatMessage({ id: 'ui-eholdings.navModal.continueLabel' })}
@@ -139,7 +142,7 @@ class ProviderEdit extends Component {
                    when={!pristine && !model.update.isPending}
                  />
                </Fragment>
-          )}
+             )}
            />
          </form>
        </Fragment>

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -63,6 +63,7 @@
     "provider.resultsNotFound": "No providers found for '{query}'.",
     "provider.proxy": "Proxy",
     "provider.inherited": "Inherited",
+    "provider.noPackagesSelected": "Add any package from this provider to holdings to customize provider settings.",
 
     "provider.toast.isFreshlySaved": "Provider saved.",
 


### PR DESCRIPTION
## Purpose
Add a message in place of fields in edit view on providers with no packages selected. 

## Approach
Since this is a simple conditional, it should be easy to add onto later with future fields. 

#### TODOS 
- [x] Write tests
- [x] Provide Screenshots

## Screenshots

<img width="773" alt="screen shot 2018-08-22 at 3 29 45 pm" src="https://user-images.githubusercontent.com/25858667/44489236-8a0be600-a620-11e8-8fd3-60af72a6bb48.png">
