### PR TITLE
UIEH-176 Display and Edit Provider Level Tokens

### DIFF
--- a/bigtest/interactors/provider-edit.js
+++ b/bigtest/interactors/provider-edit.js
@@ -12,7 +12,7 @@ import {
   action,
   isPresent
 } from '@bigtest/interactor';
-
+import { hasClassBeginningWith } from './helpers';
 import Toast from './toast';
 
 @interactor class ProviderEditNavigationModal {
@@ -65,6 +65,9 @@ import Toast from './toast';
   dropDownMenu = new ProviderEditDropDownMenu();
   hasProxySelect = isPresent('[data-test-eholdings-provider-proxy-select] select');
   noPackagesSelected = text('[data-test-eholdings-provider-package-not-selected]');
+
+  tokenHasError = hasClassBeginningWith('[data-test-eholdings-token-value-textarea] textarea', 'hasError--');
+  tokenError = text('[data-test-eholdings-token-value-textarea] [class^="feedbackError--"]');
 
   toast = Toast;
 }

--- a/bigtest/interactors/provider-edit.js
+++ b/bigtest/interactors/provider-edit.js
@@ -45,8 +45,11 @@ import Toast from './toast';
 
   proxySelectValue = value('[data-test-eholdings-provider-proxy-select] select');
   chooseRootProxy = fillable('[data-test-eholdings-provider-proxy-select] select');
+  hasTokenHelpText = isPresent('[data-test-eholdings-token-fields-help-text]');
   tokenHelpText = text('[data-test-eholdings-token-fields-help-text]');
+  hasTokenPrompt = isPresent('[data-test-eholdings-token-fields-prompt]');
   tokenPrompt = text('[data-test-eholdings-token-fields-prompt]');
+  hasTokenValue = isPresent('[data-test-eholdings-token-value-textarea]');
   tokenValue = text('[data-test-eholdings-token-value-textarea]');
   hasAddTokenBtn = isPresent('[data-test-eholdings-token-add-button]');
   clickAddTokenButton = clickable('[data-test-eholdings-token-add-button] button');

--- a/bigtest/interactors/provider-edit.js
+++ b/bigtest/interactors/provider-edit.js
@@ -5,6 +5,7 @@ import {
   property,
   value,
   fillable,
+  blurrable,
   text,
   is,
   attribute,
@@ -44,6 +45,19 @@ import Toast from './toast';
 
   proxySelectValue = value('[data-test-eholdings-provider-proxy-select] select');
   chooseRootProxy = fillable('[data-test-eholdings-provider-proxy-select] select');
+  tokenHelpText = text('[data-test-eholdings-token-fields-help-text]');
+  tokenPrompt = text('[data-test-eholdings-token-fields-prompt]');
+  tokenValue = text('[data-test-eholdings-token-value-textarea]');
+  hasAddTokenBtn = isPresent('[data-test-eholdings-token-add-button]');
+  clickAddTokenButton = clickable('[data-test-eholdings-token-add-button] button');
+  fillTokenValue = fillable('[data-test-eholdings-token-value-textarea] textarea');
+  blurTokenValue = blurrable('[data-test-eholdings-token-value-textarea] textarea');
+
+  inputTokenValue = action(function (tokenValue) {
+    return this
+      .fillTokenValue(tokenValue)
+      .blurTokenValue();
+  });
   dropDown = new ProviderEditDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   dropDownMenu = new ProviderEditDropDownMenu();
   hasProxySelect = isPresent('[data-test-eholdings-provider-proxy-select] select');

--- a/bigtest/interactors/provider-show.js
+++ b/bigtest/interactors/provider-show.js
@@ -28,7 +28,12 @@ import SearchBadge from './search-badge';
   clickListSearch = clickable('[data-test-eholdings-search-filters="icon"]');
   filterBadge = isPresent('[data-test-eholdings-details-view-filters-badge]');
   proxy = text('[data-test-eholdings-provider-details-proxy]');
+  token = text('[data-test-eholdings-provider-details-token]');
+  tokenMessage = text('[data-test-eholdings-provider-details-token-message]');
 
+  isTokenPresent = computed(function () {
+    try { return !!this.token; } catch (e) { return false; }
+  });
   toast = Toast;
   searchModal = new SearchModal('#eholdings-details-view-search-modal');
   searchModalBadge = new SearchBadge('[data-test-eholdings-search-modal-badge]');

--- a/bigtest/interactors/provider-show.js
+++ b/bigtest/interactors/provider-show.js
@@ -30,10 +30,7 @@ import SearchBadge from './search-badge';
   proxy = text('[data-test-eholdings-provider-details-proxy]');
   token = text('[data-test-eholdings-provider-details-token]');
   tokenMessage = text('[data-test-eholdings-provider-details-token-message]');
-
-  isTokenPresent = computed(function () {
-    try { return !!this.token; } catch (e) { return false; }
-  });
+  isTokenPresent = isPresent('[data-test-eholdings-provider-details-token]');
   toast = Toast;
   searchModal = new SearchModal('#eholdings-details-view-search-modal');
   searchModalBadge = new SearchBadge('[data-test-eholdings-search-modal-badge]');

--- a/bigtest/network/config.js
+++ b/bigtest/network/config.js
@@ -164,10 +164,11 @@ export default function configure() {
     let matchingProvider = providers.find(request.params.id);
     let body = JSON.parse(request.requestBody);
     let {
-      proxy
+      proxy,
+      providerToken
     } = body.data.attributes;
-
     matchingProvider.update('proxy', proxy);
+    matchingProvider.update('providerToken', providerToken);
     return matchingProvider;
   });
 

--- a/bigtest/network/factories/provider.js
+++ b/bigtest/network/factories/provider.js
@@ -1,5 +1,7 @@
 import { Factory, faker, trait } from '@bigtest/mirage';
 
+let helpText = '<ul><li>Enter your Gale<sup></sup> site ID in the space provided below. The site ID may contain a combination of alpha/numeric characters, varying in length. <blockquote><p> Example: The site ID immediately follows /itweb/ in a URL. The site ID in the following URL is …………….</ul>';
+
 export default Factory.extend({
   name: () => faker.company.companyName(),
   packagesTotal: 0,
@@ -54,6 +56,32 @@ export default Factory.extend({
     }
   }),
 
+  withToken: trait({
+    afterCreate(provider, server) {
+      let token = server.create('token', {
+        factName: '[[mysiteid]]',
+        prompt: '/test1/',
+        helpText,
+        value: ''
+      });
+      provider.update('providerToken', token.toJSON());
+      provider.save();
+    }
+  }),
+
+  withTokenAndValue: trait({
+    afterCreate(provider, server) {
+      let token = server.create('token', {
+        factName: '[[mysiteid]]',
+        prompt: '/test1/',
+        helpText,
+        value: 'abcdefghijk'
+      });
+      provider.update('providerToken', token.toJSON());
+      provider.save();
+    }
+  }),
+
   afterCreate(provider, server) {
     if (!provider.proxy) {
       let proxy = server.create('proxy', {
@@ -61,6 +89,17 @@ export default Factory.extend({
         id: 'bigTestJS'
       });
       provider.update('proxy', proxy.toJSON());
+      provider.save();
+    }
+
+    if (!provider.token) {
+      let token = server.create('token', {
+        factName: '[[mysiteid]]',
+        prompt: '/test1/',
+        helpText,
+        value:'abcdefghijk'
+      });
+      provider.update('providerToken', token.toJSON());
       provider.save();
     }
   }

--- a/bigtest/network/factories/provider.js
+++ b/bigtest/network/factories/provider.js
@@ -1,6 +1,6 @@
 import { Factory, faker, trait } from '@bigtest/mirage';
 
-let helpText = '<ul><li>Enter your Gale<sup></sup> site ID in the space provided below. The site ID may contain a combination of alpha/numeric characters, varying in length. <blockquote><p> Example: The site ID immediately follows /itweb/ in a URL. The site ID in the following URL is …………….</ul>';
+let helpText = '<ul><li>Enter your Gale token</li></ul>';
 
 export default Factory.extend({
   name: () => faker.company.companyName(),

--- a/bigtest/network/factories/token.js
+++ b/bigtest/network/factories/token.js
@@ -1,0 +1,26 @@
+import { Factory, faker } from '@bigtest/mirage';
+
+let helpText = '<ul><li>Enter your Gale<sup></sup> site ID in the space provided below. The site ID may contain a combination of alpha/numeric characters, varying in length. <blockquote><p> Example: The site ID immediately follows /itweb/ in a URL. The site ID in the following URL is …………….</ul>';
+
+export default Factory.extend({
+  factName: () => faker.random.arrayElement([
+    '[[mysiteid]]',
+    '[[yoursited]]]',
+    '[[testsiteid]]'
+  ]),
+  prompt: () => faker.random.arrayElement([
+    '/test1/',
+    '/test2/',
+    '/test3/'
+  ]),
+  helpText: () => faker.random.arrayElement([
+    '\u003cul\u003e\r\n    \u003cli\u003eEnter your Test\u003csup\u003e®\u003c/sup\u003e site ID in the space provided below. The site ID may contain a combination of alpha/numeric characters, varying in length. \u003cblockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"\u003e\r\n    \u003cp\u003e Example: The site ID immediately follows /itweb/ in a URL. The site ID in the following URL is \u003ci\u003eaa11bb22\u003c/i\u003e. \u003c/p\u003e\r\n    \u003c/blockquote\u003e\u003c/li\u003e\r\n\u003c/ul\u003e\r\n\u003cblockquote style=\\"margin-right: 0px;\\"',
+    helpText,
+    'http://test.com/authentication'
+  ]),
+  value: () => faker.random.arrayElement([
+    null,
+    '123456',
+    'abcdef'
+  ]),
+});

--- a/bigtest/network/factories/token.js
+++ b/bigtest/network/factories/token.js
@@ -3,7 +3,7 @@ import { Factory, faker } from '@bigtest/mirage';
 export default Factory.extend({
   factName: () => faker.random.arrayElement([
     '[[mysiteid]]',
-    '[[yoursited]]]',
+    '[[yoursiteid]]]',
     '[[testsiteid]]'
   ]),
   prompt: () => faker.random.arrayElement([

--- a/bigtest/network/factories/token.js
+++ b/bigtest/network/factories/token.js
@@ -1,7 +1,5 @@
 import { Factory, faker } from '@bigtest/mirage';
 
-let helpText = '<ul><li>Enter your Gale<sup></sup> site ID in the space provided below. The site ID may contain a combination of alpha/numeric characters, varying in length. <blockquote><p> Example: The site ID immediately follows /itweb/ in a URL. The site ID in the following URL is …………….</ul>';
-
 export default Factory.extend({
   factName: () => faker.random.arrayElement([
     '[[mysiteid]]',
@@ -14,9 +12,9 @@ export default Factory.extend({
     '/test3/'
   ]),
   helpText: () => faker.random.arrayElement([
-    '\u003cul\u003e\r\n    \u003cli\u003eEnter your Test\u003csup\u003e®\u003c/sup\u003e site ID in the space provided below. The site ID may contain a combination of alpha/numeric characters, varying in length. \u003cblockquote style=\\"margin-right: 0px;\\" dir=\\"ltr\\"\u003e\r\n    \u003cp\u003e Example: The site ID immediately follows /itweb/ in a URL. The site ID in the following URL is \u003ci\u003eaa11bb22\u003c/i\u003e. \u003c/p\u003e\r\n    \u003c/blockquote\u003e\u003c/li\u003e\r\n\u003c/ul\u003e\r\n\u003cblockquote style=\\"margin-right: 0px;\\"',
-    helpText,
-    'http://test.com/authentication'
+    '<ul><li>Enter your Gale Token</li></ul>',
+    '<a>http://test.com/authentication</a>',
+    '<ul><li>Get Help Here</li></ul>'
   ]),
   value: () => faker.random.arrayElement([
     null,

--- a/bigtest/network/models/token.js
+++ b/bigtest/network/models/token.js
@@ -1,0 +1,3 @@
+import { Model } from '@bigtest/mirage';
+
+export default Model.extend();

--- a/bigtest/tests/provider-edit-token-test.js
+++ b/bigtest/tests/provider-edit-token-test.js
@@ -32,7 +32,7 @@ describeApplication('ProviderEditToken', () => {
       expect(ProviderEditPage.tokenHelpText).to.equal('Enter your Gale token');
     });
 
-    it('has token help prompt', () => {
+    it('has token prompt', () => {
       expect(ProviderEditPage.tokenPrompt).to.equal(provider.providerToken.prompt);
     });
 
@@ -118,7 +118,7 @@ describeApplication('ProviderEditToken', () => {
         expect(ProviderEditPage.tokenHelpText).to.equal('Enter your token');
       });
 
-      it('has token help prompt', () => {
+      it('has token prompt', () => {
         expect(ProviderEditPage.tokenPrompt).to.equal('/test1/');
       });
 

--- a/bigtest/tests/provider-edit-token-test.js
+++ b/bigtest/tests/provider-edit-token-test.js
@@ -7,7 +7,8 @@ import ProviderEditPage from '../interactors/provider-edit';
 
 describeApplication('ProviderEditToken', () => {
   let provider,
-    packages;
+    packages,
+    longToken;
 
   beforeEach(function () {
     provider = this.server.create('provider', 'withPackagesAndTitles', 'withTokenAndValue', {
@@ -27,8 +28,8 @@ describeApplication('ProviderEditToken', () => {
       });
     });
 
-    it.skip('has token help text', () => {
-      expect(ProviderEditPage.tokenHelpText).to.equal(provider.providerToken.helpText);
+    it('has token help text', () => {
+      expect(ProviderEditPage.tokenHelpText).to.equal('Enter your Gale token');
     });
 
     it('has token help prompt', () => {
@@ -151,6 +152,38 @@ describeApplication('ProviderEditToken', () => {
 
     it('does not have add token button', () => {
       expect(ProviderEditPage.hasAddTokenBtn).to.equal(false);
+    });
+  });
+
+  describe('visiting the provider edit page and setting token to a long value ', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/providers/${provider.id}/edit`, () => {
+        expect(ProviderEditPage.$root).to.exist;
+      });
+    });
+
+    it('has token value', () => {
+      expect(ProviderEditPage.tokenValue).to.equal(provider.providerToken.value);
+    });
+
+    it('disables the save button', () => {
+      expect(ProviderEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('choosing a lengthy value for token', () => {
+      beforeEach(() => {
+        longToken = 'a'.repeat(501);
+        return ProviderEditPage
+          .inputTokenValue(longToken);
+      });
+
+      it('highlights the textarea with an error state', () => {
+        expect(ProviderEditPage.tokenHasError).to.be.true;
+      });
+
+      it('displays the correct validation message', () => {
+        expect(ProviderEditPage.tokenError).to.equal('Tokens must be 500 characters or less.');
+      });
     });
   });
 });

--- a/bigtest/tests/provider-edit-token-test.js
+++ b/bigtest/tests/provider-edit-token-test.js
@@ -1,0 +1,139 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+
+import { describeApplication } from '../helpers/describe-application';
+import ProviderShowPage from '../interactors/provider-show';
+import ProviderEditPage from '../interactors/provider-edit';
+
+describeApplication('ProviderEditToken', () => {
+  let provider,
+    packages;
+
+  beforeEach(function () {
+    provider = this.server.create('provider', 'withPackagesAndTitles', 'withTokenAndValue', {
+      name: 'League of Ordinary Men',
+      packagesTotal: 5
+    });
+
+    packages = this.server.schema.where('package', { providerId: provider.id }).models;
+    packages[0].visibilityData.isHidden = true;
+  });
+
+  describe('visiting the provider edit page with a token and value ', () => {
+    beforeEach(function () {
+      return this.visit(`/eholdings/providers/${provider.id}/edit`, () => {
+        expect(ProviderEditPage.$root).to.exist;
+      });
+    });
+
+    it.skip('has token help text', () => {
+      expect(ProviderEditPage.tokenHelpText).to.equal(provider.providerToken.helpText);
+    });
+
+    it('has token help prompt', () => {
+      expect(ProviderEditPage.tokenPrompt).to.equal(provider.providerToken.prompt);
+    });
+
+    it('has token value', () => {
+      expect(ProviderEditPage.tokenValue).to.equal(provider.providerToken.value);
+    });
+
+    it('disables the save button', () => {
+      expect(ProviderEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return ProviderEditPage.clickCancel();
+      });
+
+      it('goes to the provider show page', () => {
+        expect(ProviderShowPage.$root).to.exist;
+      });
+    });
+
+    describe('choosing another value for token', () => {
+      beforeEach(() => {
+        return ProviderEditPage.inputTokenValue('test-token');
+      });
+
+      it('should enable save action button', () => {
+        expect(ProviderEditPage.isSaveDisabled).to.eq(false);
+      });
+
+      describe('clicking save to update token value', () => {
+        beforeEach(() => {
+          return ProviderEditPage.clickSave();
+        });
+
+        it('disables the save button', () => {
+          expect(ProviderEditPage.isSaveDisabled).to.be.true;
+        });
+
+        it('goes to the provider show page', () => {
+          expect(ProviderShowPage.$root).to.exist;
+        });
+
+        it('shows newly saved token', () => {
+          expect(ProviderShowPage.token).to.include(`${provider.providerToken.prompt}`);
+          expect(ProviderShowPage.token).to.include('test-token');
+        });
+
+
+        it('shows a success toast message', () => {
+          expect(ProviderShowPage.toast.successText).to.equal('Provider saved.');
+        });
+      });
+    });
+  });
+
+  describe('visiting the provider edit page with a token without a value ', () => {
+    beforeEach(function () {
+      let token = this.server.create('token', {
+        factName: '[[mysiteid]]',
+        prompt: '/test1/',
+        helpText: '<ul><li>Enter your token</li></ul>',
+        value: ''
+      });
+      provider.update('providerToken', token.toJSON());
+      provider.save();
+
+      return this.visit(`/eholdings/providers/${provider.id}/edit`, () => {
+        expect(ProviderEditPage.$root).to.exist;
+      });
+    });
+
+    it('has add token button', () => {
+      expect(ProviderEditPage.hasAddTokenBtn).to.be.true;
+    });
+
+    describe('clicking add token button', () => {
+      beforeEach(() => {
+        return ProviderEditPage.clickAddTokenButton();
+      });
+
+      it('has token help text', () => {
+        expect(ProviderEditPage.tokenHelpText).to.equal('Enter your token');
+      });
+
+      it('has token help prompt', () => {
+        expect(ProviderEditPage.tokenPrompt).to.equal('/test1/');
+      });
+
+      it('has empty token value', () => {
+        expect(ProviderEditPage.tokenValue).to.equal('');
+      });
+    });
+  });
+
+  describe('visiting the provider edit page without a token', () => {
+    beforeEach(function () {
+      provider.update('providerToken', null);
+      provider.save();
+
+      return this.visit(`/eholdings/providers/${provider.id}/edit`, () => {
+        expect(ProviderEditPage.$root).to.exist;
+      });
+    });
+  });
+});

--- a/bigtest/tests/provider-edit-token-test.js
+++ b/bigtest/tests/provider-edit-token-test.js
@@ -142,7 +142,7 @@ describeApplication('ProviderEditToken', () => {
       expect(ProviderEditPage.hasTokenHelpText).to.equal(false);
     });
 
-    it('does not show token help prompt', () => {
+    it('does not show token prompt', () => {
       expect(ProviderEditPage.hasTokenPrompt).to.equal(false);
     });
 

--- a/bigtest/tests/provider-edit-token-test.js
+++ b/bigtest/tests/provider-edit-token-test.js
@@ -12,7 +12,8 @@ describeApplication('ProviderEditToken', () => {
   beforeEach(function () {
     provider = this.server.create('provider', 'withPackagesAndTitles', 'withTokenAndValue', {
       name: 'League of Ordinary Men',
-      packagesTotal: 5
+      packagesTotal: 5,
+      packagesSelected: 3
     });
 
     packages = this.server.schema.where('package', { providerId: provider.id }).models;

--- a/bigtest/tests/provider-edit-token-test.js
+++ b/bigtest/tests/provider-edit-token-test.js
@@ -136,5 +136,21 @@ describeApplication('ProviderEditToken', () => {
         expect(ProviderEditPage.$root).to.exist;
       });
     });
+
+    it('does not show token help text', () => {
+      expect(ProviderEditPage.hasTokenHelpText).to.equal(false);
+    });
+
+    it('does not show token help prompt', () => {
+      expect(ProviderEditPage.hasTokenPrompt).to.equal(false);
+    });
+
+    it('does not show token value', () => {
+      expect(ProviderEditPage.hasTokenValue).to.equal(false);
+    });
+
+    it('does not have add token button', () => {
+      expect(ProviderEditPage.hasAddTokenBtn).to.equal(false);
+    });
   });
 });

--- a/bigtest/tests/provider-show-test.js
+++ b/bigtest/tests/provider-show-test.js
@@ -9,7 +9,7 @@ describeApplication('ProviderShow', () => {
     packages;
 
   beforeEach(function () {
-    provider = this.server.create('provider', 'withPackagesAndTitles', 'withProxy', {
+    provider = this.server.create('provider', 'withPackagesAndTitles', 'withProxy', 'withTokenAndValue', {
       name: 'League of Ordinary Men',
       packagesTotal: 5
     });
@@ -48,6 +48,11 @@ describeApplication('ProviderShow', () => {
 
     it('displays the proxy', () => {
       expect(ProviderShowPage.proxy).to.equal(`${provider.proxy.id}`);
+    });
+
+    it('displays the token prompt and value', () => {
+      expect(ProviderShowPage.token).to.include(`${provider.providerToken.prompt}`);
+      expect(ProviderShowPage.token).to.include(`${provider.providerToken.value}`);
     });
 
     it('displays a list of packages', () => {
@@ -170,6 +175,46 @@ describeApplication('ProviderShow', () => {
 
     it('displays the proxy as None', () => {
       expect(ProviderShowPage.proxy).to.equal('None');
+    });
+  });
+
+  describe('visiting the provider details page with a token without value', () => {
+    beforeEach(function () {
+      let token = this.server.create('token', {
+        factName: '[[mysiteid]]',
+        prompt: '/test1/',
+        helpText: '',
+        value: ''
+      });
+      provider.update('providerToken', token.toJSON());
+      provider.save();
+
+      return this.visit(`/eholdings/providers/${provider.id}`, () => {
+        expect(ProviderShowPage.$root).to.exist;
+      });
+    });
+
+    it('does not display the token', () => {
+      expect(ProviderShowPage.isTokenPresent).to.equal(false);
+    });
+
+    it('displays a message that no provider token has been set', () => {
+      expect(ProviderShowPage.tokenMessage).to.equal('No provider token has been set.');
+    });
+  });
+
+  describe('visiting the provider details page without a token', () => {
+    beforeEach(function () {
+      provider.update('providerToken', null);
+      provider.save();
+
+      return this.visit(`/eholdings/providers/${provider.id}`, () => {
+        expect(ProviderShowPage.$root).to.exist;
+      });
+    });
+
+    it('does not display the token', () => {
+      expect(ProviderShowPage.isTokenPresent).to.equal(false);
     });
   });
 

--- a/src/components/provider/_fields/token/index.js
+++ b/src/components/provider/_fields/token/index.js
@@ -1,0 +1,1 @@
+export { default } from './token-field';

--- a/src/components/provider/_fields/token/index.js
+++ b/src/components/provider/_fields/token/index.js
@@ -1,1 +1,1 @@
-export { default } from './token-field';
+export { default, validate } from './token-field';

--- a/src/components/provider/_fields/token/token-field.css
+++ b/src/components/provider/_fields/token/token-field.css
@@ -1,0 +1,1 @@
+@import '@folio/stripes-components/lib/variables';

--- a/src/components/provider/_fields/token/token-field.js
+++ b/src/components/provider/_fields/token/token-field.js
@@ -66,3 +66,14 @@ class TokenField extends Component {
 }
 
 export default injectIntl(TokenField);
+
+export function validate(values, props) {
+  const errors = {};
+  let { intl } = props;
+
+  if (values.tokenValue && values.tokenValue.length > 500) {
+    errors.tokenValue = intl.formatMessage({ id: 'ui-eholdings.validate.errors.token.length' });
+  }
+
+  return errors;
+}

--- a/src/components/provider/_fields/token/token-field.js
+++ b/src/components/provider/_fields/token/token-field.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Field } from 'redux-form';
+import { injectIntl, FormattedMessage } from 'react-intl';
+
+import {
+  Button,
+  TextArea
+} from '@folio/stripes-components';
+import styles from './token-field.css';
+
+class TokenField extends Component {
+  static propTypes = {
+    showInputs: PropTypes.bool,
+    model: PropTypes.object
+  };
+
+  state = {
+    showInputs: this.props.showInputs
+  };
+
+  toggleInputs = () => {
+    this.setState(({ showInputs }) => ({
+      showInputs: !showInputs
+    }));
+  }
+
+
+  render() {
+    /* eslint-disable react/no-danger */
+    let { model } = this.props;
+    let { showInputs } = this.state;
+    let helpTextMarkup = { __html: model.providerToken.helpText };
+
+    return (showInputs) ? (
+      <div className={styles['token-fields']}>
+        <div
+          data-test-eholdings-token-fields-help-text
+          className={styles['token-help-text']}
+          dangerouslySetInnerHTML={helpTextMarkup}
+        />
+        <div data-test-eholdings-token-fields-prompt className={styles['token-prompt-text']}>
+          {model.providerToken.prompt}
+        </div>
+        <div data-test-eholdings-token-value-textarea className={styles['token-value-textarea']}>
+          <Field
+            name="tokenValue"
+            component={TextArea}
+          />
+        </div>
+      </div>
+    ) : (
+      <div
+        className={styles['token-add-row-button']}
+        data-test-eholdings-token-add-button
+      >
+        <Button
+          type="button"
+          onClick={this.toggleInputs}
+        >
+          <FormattedMessage id="ui-eholdings.provider.token.addToken" />
+        </Button>
+      </div>
+    );
+  }
+}
+
+export default injectIntl(TokenField);

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -13,6 +13,7 @@ import DetailsViewSection from '../../details-view-section';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 import ProxySelectField from '../_fields/proxy-select';
+import TokenField from '../_fields/token';
 import PaneHeaderButton from '../../pane-header-button';
 import styles from './provider-edit.css';
 
@@ -62,6 +63,8 @@ class ProviderEdit extends Component {
      } = this.props;
 
      let { router, queryParams } = this.context;
+     let supportsTokens = model.providerToken && model.providerToken.prompt;
+     let hasTokenValue = model.providerToken && model.providerToken.value;
 
      let actionMenuItems = [
        {
@@ -127,6 +130,12 @@ class ProviderEdit extends Component {
                         <div data-test-eholdings-provider-proxy-select>
                           <ProxySelectField proxyTypes={proxyTypes} rootProxy={rootProxy} />
                         </div>
+                      )}
+                       {supportsTokens && (
+                       <Fragment>
+                         <h4><FormattedMessage id="ui-eholdings.provider.token" /></h4>
+                         <TokenField model={model} showInputs={hasTokenValue} />
+                       </Fragment>
                       )}
                      </div>
                  ) : (

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -134,7 +134,7 @@ class ProviderEdit extends Component {
                       )}
                        {supportsTokens && (
                        <Fragment>
-                         <h4><FormattedMessage id="ui-eholdings.provider.token" /></h4>
+                         <label><FormattedMessage id="ui-eholdings.provider.token" /></label>
                          <TokenField model={model} showInputs={hasTokenValue} />
                        </Fragment>
                       )}

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -40,9 +40,10 @@ class ProviderEdit extends Component {
    componentDidUpdate(prevProps) {
      let wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
      let needsUpdate = !isEqual(prevProps.model, this.props.model);
+     let isRejected = this.props.model.update.isRejected;
      let { router } = this.context;
 
-     if (wasPending && needsUpdate) {
+     if (wasPending && needsUpdate && !isRejected) {
        router.history.push({
          pathname: `/eholdings/providers/${prevProps.model.id}`,
          search: router.route.location.search,

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -13,7 +13,7 @@ import DetailsViewSection from '../../details-view-section';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 import ProxySelectField from '../_fields/proxy-select';
-import TokenField from '../_fields/token';
+import TokenField, { validate as validateToken } from '../_fields/token';
 import PaneHeaderButton from '../../pane-header-button';
 import styles from './provider-edit.css';
 
@@ -159,7 +159,12 @@ class ProviderEdit extends Component {
    }
 }
 
+const validate = (values, props) => {
+  return validateToken(values, props);
+};
+
 export default injectIntl(reduxForm({
+  validate,
   enableReinitialize: true,
   form: 'ProviderEdit',
   destroyOnUnmount: false,

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -12,6 +12,7 @@ import QueryList from '../../query-list';
 import PackageListItem from '../../package-list-item';
 import Toaster from '../../toaster';
 import ProxyDisplay from '../proxy-display';
+import TokenDisplay from '../token-display';
 import styles from './provider-show.css';
 
 class ProviderShow extends Component {
@@ -78,6 +79,9 @@ class ProviderShow extends Component {
     let { router, queryParams } = this.context;
     let { sections } = this.state;
     let hasProxy = model.proxy && model.proxy.id;
+    let hasToken = model.providerToken && model.providerToken.prompt;
+    let hasProviderSettings = hasProxy || hasToken;
+
     let actionMenuItems = [
       {
         label: <FormattedMessage id="ui-eholdings.actionMenu.edit" />,
@@ -144,14 +148,15 @@ class ProviderShow extends Component {
                   </div>
                 </KeyValue>
               </Accordion>
-              {hasProxy && (
+              {hasProviderSettings && (
                 <Accordion
                   label={<FormattedMessage id="ui-eholdings.provider.providerSettings" />}
                   open={sections.providerShowProviderSettings}
                   id="providerShowProviderSettings"
                   onToggle={this.handleSectionToggle}
                 >
-                  {(proxyTypes.isLoading || model.isLoading) ? (
+                  {hasProxy && (
+                  (proxyTypes.isLoading || model.isLoading) ? (
                     <Icon icon="spinner-ellipsis" />
                   ) : (
                     <KeyValue label={<FormattedMessage id="ui-eholdings.provider.proxy" />}>
@@ -160,7 +165,17 @@ class ProviderShow extends Component {
                         proxyTypes={proxyTypes}
                       />
                     </KeyValue>
-                  )}
+                  ))}
+                  {hasToken && (
+                  (proxyTypes.isLoading || model.isLoading) ? (
+                    <Icon icon="spinner-ellipsis" />
+                  ) : (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.provider.token" />}>
+                      <TokenDisplay
+                        model={model}
+                      />
+                    </KeyValue>
+                  ))}
                 </Accordion>
               )}
             </div>

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -167,7 +167,7 @@ class ProviderShow extends Component {
                     </KeyValue>
                   ))}
                   {hasToken && (
-                  (proxyTypes.isLoading || model.isLoading) ? (
+                  (model.isLoading) ? (
                     <Icon icon="spinner-ellipsis" />
                   ) : (
                     <KeyValue label={<FormattedMessage id="ui-eholdings.provider.token" />}>

--- a/src/components/provider/token-display.js
+++ b/src/components/provider/token-display.js
@@ -6,7 +6,7 @@ export default function TokenDisplay({ model }) {
   if (model.providerToken.value) {
     return (
       <div data-test-eholdings-provider-details-token>
-        <span>{model.providerToken.prompt}&nbsp;:&nbsp;{model.providerToken.value}</span>
+        <span>{model.providerToken.prompt}:&nbsp;{model.providerToken.value}</span>
       </div>);
   } else {
     return (

--- a/src/components/provider/token-display.js
+++ b/src/components/provider/token-display.js
@@ -10,7 +10,9 @@ export default function TokenDisplay({ model }) {
       </div>);
   } else {
     return (
-      <span><FormattedMessage id="ui-eholdings.provider.noTokenSet" /></span>
+      <div data-test-eholdings-provider-details-token-message>
+        <span><FormattedMessage id="ui-eholdings.provider.noTokenSet" /></span>
+      </div>
     );
   }
 }

--- a/src/components/provider/token-display.js
+++ b/src/components/provider/token-display.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+export default function TokenDisplay({ model }) {
+  if (model.providerToken.value) {
+    return (
+      <div data-test-eholdings-provider-details-token>
+        <span>{model.providerToken.prompt}&nbsp;:&nbsp;{model.providerToken.value}</span>
+      </div>);
+  } else {
+    return (
+      <span><FormattedMessage id="ui-eholdings.provider.noTokenSet" /></span>
+    );
+  }
+}
+
+TokenDisplay.propTypes = {
+  model: PropTypes.object.isRequired
+};

--- a/src/redux/provider.js
+++ b/src/redux/provider.js
@@ -6,6 +6,7 @@ class Provider {
   packagesTotal = 0;
   packages = hasMany();
   proxy = {};
+  providerToken = {};
 }
 
 export default model({

--- a/src/routes/provider-edit.js
+++ b/src/routes/provider-edit.js
@@ -55,6 +55,7 @@ class ProviderEditRoute extends Component {
   providerEditSubmitted = (values) => {
     let { model, updateProvider } = this.props;
     model.proxy.id = values.proxyId;
+    model.providerToken.value = values.tokenValue;
     updateProvider(model);
   };
 
@@ -67,7 +68,8 @@ class ProviderEditRoute extends Component {
           model={model}
           onSubmit={this.providerEditSubmitted}
           initialValues={{
-            proxyId: model.proxy.id
+            proxyId: model.proxy.id,
+            tokenValue: model.providerToken.value
           }}
           proxyTypes={proxyTypes}
           rootProxy={rootProxy}

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -65,6 +65,8 @@
     "provider.inherited": "Inherited",
     "provider.noPackagesSelected": "Add any package from this provider to holdings to customize provider settings.",
 
+    "provider.token": "Provider token",
+    "provider.noTokenSet": "No provider token has been set.",
     "provider.toast.isFreshlySaved": "Provider saved.",
 
     "resource.modal.header": "Remove title from holdings?",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -68,6 +68,7 @@
     "provider.token": "Provider token",
     "provider.noTokenSet": "No provider token has been set.",
     "provider.toast.isFreshlySaved": "Provider saved.",
+    "provider.token.addToken": "+ Add a provider level token",
 
     "resource.modal.header": "Remove title from holdings?",
     "resource.show.modal.header": "Remove resource from holdings?",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -256,6 +256,8 @@
     "validate.errors.customUrl.length": "Custom URLs must be 600 characters or less.",
     "validate.errors.customUrl.include": "The URL should include http:// or https://",
 
+    "validate.errors.token.length": "Tokens must be 500 characters or less.",
+
     "server.errors.failedBackend": "Could not retrieve configuration information",
     "server.errors.errorDuringFetch": "There was a server error while retrieving your knowledge base configuration.",
     "server.errors.kbNotConfigured": "Knowledge base not configured",


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-176, users should have the ability to display and edit provider level tokens.

Backend support for provider level tokens has been added with the following
PR https://github.com/folio-org/mod-kb-ebsco/pull/89

## Approach
There are 3 possible states for a provider with respect to tokens:
(1) Provider does not support tokens - nil value is returned for providerToken
(2) Provider supports tokens but does not have a token value set - providerToken object does not have a value
(3) Provider supports tokens and has a token value set - providerToken object has a value

Provider Token object that is returned from mod-kb-ebsco Providers GET request includes the following fields (factName, prompt, helpText and value)

```
"providerToken": {
                "factName": "[[galesiteid]]",
                "prompt": "/itweb/",
                "helpText": "<ul>\r\n    <li>Enter your Gale<sup>®</sup> ... </li>\r\n</ul>\r\n",
                "value": null
```

Update Provider Show page as follows:
- If provider does not support tokens do not show anything
- If provider supports tokens and has a token value, display 'token prompt: value'
- If provider supports tokens but does not have a token value, display message 'No provider token has been set.'

Token information is added as the end of the Provider Settings section.

Provider Edit
- If provider does not support tokens do not show anything
- If provider supports tokens and has a token value - display helpText, prompt and value (value is in a text box and can be edited). Value can be up to a maximum of 500 characters
- if provider supports tokens but does not have a token value, display a button `Add a provider level token`, clicking the button displays help text, prompt and a text box for entry of a token value

#### TODOS and Open Questions
- [ X] Add Unit Test for Provider Edit of Tokens
- [ ] Common functionality (such as tokenfield.js and token-display.js) should eventually get moved to a more common area, so that they can be used at other levels. Not planning to address this in this PR 

## Learning
https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml

## Screenshots
![2018-08-28 16 54 11](https://user-images.githubusercontent.com/19415226/44750396-419e6d80-aae3-11e8-88d3-08da988b9e89.gif)

