### PR TITLE
UIEH-526 Adjust resource coverage date selection UI

### DIFF
--- a/bigtest/interactors/resource-edit.js
+++ b/bigtest/interactors/resource-edit.js
@@ -125,6 +125,7 @@ import Datepicker from './datepicker';
   clickRemoveCustomEmbargoButton = clickable('[data-test-eholdings-custom-embargo-remove-row-button] button');
   isEmbargoNotShownLabelPresent = isPresent('[data-test-eholdings-resource-embargo-not-shown-label]');
   validationErrorOnCustomUrl = text('[data-test-eholdings-custom-url-textfield] [class^="feedbackError--"]');
+  managedCoverageDisplay = text('[data-test-eholdings-resource-edit-managed-coverage-list]');
 
   selectPublicationType = fillable('[data-test-eholdings-publication-type-field] select');
   publicationTypeValue = value('[data-test-eholdings-publication-type-field] select');

--- a/bigtest/tests/resource-edit-custom-title-test.js
+++ b/bigtest/tests/resource-edit-custom-title-test.js
@@ -40,6 +40,12 @@ describeApplication('ResourceEditCustomTitle', () => {
       title,
       url: 'https://frontside.io'
     });
+
+    resource.managedCoverages = this.server.createList('managed-coverage', 1, {
+      beginCoverage: '1969-07-16',
+      endCoverage: '1972-12-19'
+    }).map(m => m.toJSON());
+    resource.save();
   });
 
   describe('visting the custom resource edit page but the resource is unselected', () => {
@@ -88,6 +94,10 @@ describeApplication('ResourceEditCustomTitle', () => {
       return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
         expect(ResourceEditPage.$root).to.exist;
       });
+    });
+
+    it('displays the managed coverage dates in the form', () => {
+      expect(ResourceEditPage.managedCoverageDisplay).to.equal('1969 - 1972');
     });
 
     it('shows a form with coverage statement', () => {

--- a/bigtest/tests/resource-edit-managed-title-test.js
+++ b/bigtest/tests/resource-edit-managed-title-test.js
@@ -41,6 +41,12 @@ describeApplication('ResourceEditManagedTitleInManagedPackage', () => {
         isHidden: true
       }
     });
+
+    resource.managedCoverages = this.server.createList('managed-coverage', 1, {
+      beginCoverage: '1969-07-16',
+      endCoverage: '1972-12-19'
+    }).map(m => m.toJSON());
+    resource.save();
   });
 
   describe('visiting the resource edit page without coverage dates, statement, or embargo', () => {
@@ -48,6 +54,10 @@ describeApplication('ResourceEditManagedTitleInManagedPackage', () => {
       return this.visit(`/eholdings/resources/${resource.titleId}/edit`, () => {
         expect(ResourceEditPage.$root).to.exist;
       });
+    });
+
+    it('displays the managed coverage dates in the form', () => {
+      expect(ResourceEditPage.managedCoverageDisplay).to.equal('1969 - 1972');
     });
 
     it('shows a form with coverage statement', () => {

--- a/src/components/resource/_fields/custom-coverage/resource-coverage-fields.css
+++ b/src/components/resource/_fields/custom-coverage/resource-coverage-fields.css
@@ -1,5 +1,9 @@
 @import '@folio/stripes-components/lib/variables';
 
+.coverage-fields-category {
+  margin: 0.5em 1.75em var(--controlMarginBottom);
+}
+
 .coverage-fields-date-range-rows {
   list-style-type: none;
   padding: 0;
@@ -13,7 +17,7 @@
 .coverage-fields-datepicker {
   align-self: flex-start;
   flex: 1 1 200px;
-  margin-right: 1em;
+  margin: 0 0.5em;
 }
 
 .coverage-fields-date-range-clear-row {

--- a/src/components/resource/_fields/custom-coverage/resource-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/resource-coverage-fields.js
@@ -7,96 +7,142 @@ import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import {
   Button,
   Datepicker,
-  IconButton
+  IconButton,
+  RadioButton
 } from '@folio/stripes-components';
 
+import CoverageDateList from '../../../coverage-date-list';
+import { isBookPublicationType } from '../../../utilities';
 import styles from './resource-coverage-fields.css';
 
 class ResourceCoverageFields extends Component {
   static propTypes = {
     initialValue: PropTypes.array,
-    intl: intlShape.isRequired
+    intl: intlShape.isRequired,
+    model: PropTypes.object.isRequired
   };
 
   static defaultProps = {
     initialValue: []
   };
 
-  renderCoverageFields = ({ fields }) => {
-    let { initialValue, intl } = this.props;
+  renderCoverageFields = (fieldArrayProps) => {
+    let { fields } = fieldArrayProps;
+    let { initialValue, intl, model } = this.props;
     return (
-      <div>
-        {fields.length === 0
-          && initialValue.length > 0
-          && initialValue[0].beginCoverage
-          && (
-          <p data-test-eholdings-coverage-fields-saving-will-remove>
-            <FormattedMessage id="ui-eholdings.package.noCoverageDates" />
-          </p>
-        )}
-
-        {fields.length > 0 && (
-          <ul className={styles['coverage-fields-date-range-rows']}>
-            {fields.map((dateRange, index) => (
-              <li
-                data-test-eholdings-coverage-fields-date-range-row
-                key={index}
-                className={styles['coverage-fields-date-range-row']}
-              >
-                <div
-                  data-test-eholdings-coverage-fields-date-range-begin
-                  className={styles['coverage-fields-datepicker']}
-                >
-                  <Field
-                    name={`${dateRange}.beginCoverage`}
-                    type="text"
-                    component={Datepicker}
-                    label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
-                    id="begin-coverage"
-                    format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
-                  />
-                </div>
-                <div
-                  data-test-eholdings-coverage-fields-date-range-end
-                  className={styles['coverage-fields-datepicker']}
-                >
-                  <Field
-                    name={`${dateRange}.endCoverage`}
-                    type="text"
-                    component={Datepicker}
-                    label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
-                    id="end-coverage"
-                    format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
-                  />
-                </div>
-
-                <div
-                  data-test-eholdings-coverage-fields-remove-row-button
-                  className={styles['coverage-fields-date-range-clear-row']}
-                >
-                  <IconButton
-                    icon="hollowX"
-                    onClick={() => fields.remove(index)}
-                    size="small"
-                  />
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-
-        <div
-          className={styles['coverage-fields-add-row-button']}
-          data-test-eholdings-coverage-fields-add-row-button
-        >
-          <Button
-            type="button"
-            onClick={() => fields.push({})}
-          >
-            <FormattedMessage id="ui-eholdings.package.coverage.addDateRange" />
-          </Button>
+      <fieldset>
+        <div>
+          <RadioButton
+            label={intl.formatMessage({ id: 'ui-eholdings.label.managed.coverageDates' })}
+            disabled={model.managedCoverages.length === 0}
+            input={{
+              checked: (fields.length === 0 && model.managedCoverages.length > 0),
+              onChange: (e) => {
+                if (e.target.value === 'on') {
+                  fields.removeAll();
+                }
+              }
+            }}
+          />
+          <div className={styles['coverage-fields-category']} data-test-eholdings-resource-edit-managed-coverage-list>
+            {model.managedCoverages.length > 0 ? (
+              <CoverageDateList
+                coverageArray={model.managedCoverages}
+                isYearOnly={isBookPublicationType(model.publicationType)}
+              />
+            ) : (
+              <p><FormattedMessage id="ui-eholdings.resource.managedCoverageDates.notSet" /></p>
+            )}
+          </div>
         </div>
-      </div>
+        <div>
+          <RadioButton
+            label={intl.formatMessage({ id: 'ui-eholdings.label.custom.coverageDates' })}
+            input={{
+              checked: fields.length > 0,
+              onChange: (e) => {
+                if (e.target.value === 'on' && fields.length === 0) {
+                  fields.push({});
+                }
+              }
+            }}
+          />
+          <div className={styles['coverage-fields-category']}>
+            <div>
+              {fields.length === 0
+                && initialValue.length > 0
+                && initialValue[0].beginCoverage
+                && (
+                <p data-test-eholdings-coverage-fields-saving-will-remove>
+                  <FormattedMessage id="ui-eholdings.package.noCoverageDates" />
+                </p>
+              )}
+
+              {fields.length > 0 && (
+                <ul className={styles['coverage-fields-date-range-rows']}>
+                  {fields.map((dateRange, index) => (
+                    <li
+                      data-test-eholdings-coverage-fields-date-range-row
+                      key={index}
+                      className={styles['coverage-fields-date-range-row']}
+                    >
+                      <div
+                        data-test-eholdings-coverage-fields-date-range-begin
+                        className={styles['coverage-fields-datepicker']}
+                      >
+                        <Field
+                          name={`${dateRange}.beginCoverage`}
+                          type="text"
+                          component={Datepicker}
+                          label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
+                          id="begin-coverage"
+                          format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+                        />
+                      </div>
+                      <div
+                        data-test-eholdings-coverage-fields-date-range-end
+                        className={styles['coverage-fields-datepicker']}
+                      >
+                        <Field
+                          name={`${dateRange}.endCoverage`}
+                          type="text"
+                          component={Datepicker}
+                          label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
+                          id="end-coverage"
+                          format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+                        />
+                      </div>
+
+                      <div
+                        data-test-eholdings-coverage-fields-remove-row-button
+                        className={styles['coverage-fields-date-range-clear-row']}
+                      >
+                        <IconButton
+                          icon="hollowX"
+                          onClick={() => fields.remove(index)}
+                          size="small"
+                        />
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              <div
+                className={styles['coverage-fields-add-row-button']}
+                data-test-eholdings-coverage-fields-add-row-button
+              >
+                <Button
+                  type="button"
+                  onClick={() => fields.push({})}
+                >
+                  <FormattedMessage id="ui-eholdings.package.coverage.addDateRange" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
     );
   };
 

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -238,9 +238,11 @@ class ResourceEditCustomTitle extends Component {
                 >
                   {resourceSelected ? (
                     <Fragment>
-                      <h4><FormattedMessage id="ui-eholdings.label.coverageDates" /></h4>
+                      <h4><FormattedMessage id="ui-eholdings.label.dates" /></h4>
+                      <p><FormattedMessage id="ui-eholdings.resource.coverageDates.fullTextLinking" /></p>
                       <CustomCoverageFields
                         initialValue={initialValues.customCoverages}
+                        model={model}
                       />
 
                       <h4><FormattedMessage id="ui-eholdings.label.coverageStatement" /></h4>

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -239,7 +239,6 @@ class ResourceEditCustomTitle extends Component {
                   {resourceSelected ? (
                     <Fragment>
                       <h4><FormattedMessage id="ui-eholdings.label.dates" /></h4>
-                      <p><FormattedMessage id="ui-eholdings.resource.coverageDates.fullTextLinking" /></p>
                       <CustomCoverageFields
                         initialValue={initialValues.customCoverages}
                         model={model}

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -255,7 +255,6 @@ class ResourceEditManagedTitle extends Component { // eslint-disable-line react/
                   {managedResourceSelected ? (
                     <Fragment>
                       <h4><FormattedMessage id="ui-eholdings.label.dates" /></h4>
-                      <p><FormattedMessage id="ui-eholdings.resource.coverageDates.fullTextLinking" /></p>
                       <CustomCoverageFields
                         initialValue={initialValues.customCoverages}
                         model={model}

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -250,13 +250,15 @@ class ResourceEditManagedTitle extends Component { // eslint-disable-line react/
                   </DetailsViewSection>
                 )}
                 <DetailsViewSection
-                  label={<FormattedMessage id="ui-eholdings.label.coverageDates" />}
+                  label={<FormattedMessage id="ui-eholdings.label.coverageSettings" />}
                 >
                   {managedResourceSelected ? (
                     <Fragment>
-                      <h4><FormattedMessage id="ui-eholdings.label.coverageDates" /></h4>
+                      <h4><FormattedMessage id="ui-eholdings.label.dates" /></h4>
+                      <p><FormattedMessage id="ui-eholdings.resource.coverageDates.fullTextLinking" /></p>
                       <CustomCoverageFields
                         initialValue={initialValues.customCoverages}
+                        model={model}
                       />
 
                       <h4><FormattedMessage id="ui-eholdings.label.coverageStatement" /></h4>

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -87,6 +87,8 @@
     "resource.embargoPeriod.clear": "Clear embargo period",
     "resource.embargoPeriod.addCustom": "+ Add custom embargo period",
     "resource.embargoPeriod.saveWillRemove": "Nothing set. Saving will remove custom embargo period.",
+    "resource.managedCoverageDates.notSet": "No managed coverage dates have been set.",
+    "resource.coverageDates.fullTextLinking": "Used for full text linking.",
     "resource.coverageDates.notSet": "No coverage dates have been set.",
     "resource.coverageStatement.notSet": "No coverage statement has been set.",
     "resource.resourceSettings.notSelected": "Add the resource to holdings to customize resource settings.",
@@ -185,6 +187,7 @@
     "label.years": "Years",
     "label.no.reason": "No {disabledReason}",
     "label.editLink": "Edit {name}",
+    "label.dates": "Dates",
 
     "filter.all": "All",
     "filter.sortOptions.relevance": "Relevance",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -88,7 +88,6 @@
     "resource.embargoPeriod.addCustom": "+ Add custom embargo period",
     "resource.embargoPeriod.saveWillRemove": "Nothing set. Saving will remove custom embargo period.",
     "resource.managedCoverageDates.notSet": "No managed coverage dates have been set.",
-    "resource.coverageDates.fullTextLinking": "Used for full text linking.",
     "resource.coverageDates.notSet": "No coverage dates have been set.",
     "resource.coverageStatement.notSet": "No coverage statement has been set.",
     "resource.resourceSettings.notSelected": "Add the resource to holdings to customize resource settings.",


### PR DESCRIPTION
## Purpose
Changes coverage date selection UI for resources (https://issues.folio.org/browse/UIEH-526).

Does not yet change coverage statement selection; will address in separate PR.

## Approach
Lean more heavily on the `ResourceCoverageFields` component and the power of `redux-form` `FieldArray`.

## Screenshots
![2018-08-22 11 23 57](https://user-images.githubusercontent.com/230597/44476728-42746280-a5fe-11e8-9bf0-f998afa28567.gif)
