### PR TITLE
Fix search paneset vignette behavior

### DIFF
--- a/src/components/preview-pane/preview-pane.css
+++ b/src/components/preview-pane/preview-pane.css
@@ -10,13 +10,19 @@
   position: absolute;
   right: 0;
   top: 0;
-  z-index: 11;
+  z-index: 12;
   background-color: white;
 }
 
 @media (--mediumUp) {
   .preview-pane {
     width: 600px;
+
+    /* preview pane is open, but not alone */
+    &:nth-child(3),
+    &:nth-child(5) {
+      border-left: 1px solid rgba(0, 0, 0, 0.2);
+    }
   }
 }
 
@@ -24,10 +30,5 @@
   .preview-pane {
     position: relative;
     width: auto;
-
-    /* preview pane is open next to results */
-    &:nth-child(5) {
-      border-left: 1px solid rgba(0, 0, 0, 0.2);
-    }
   }
 }

--- a/src/components/search-pane-vignette/search-pane-vignette.css
+++ b/src/components/search-pane-vignette/search-pane-vignette.css
@@ -2,17 +2,12 @@
 
 .search-pane-vignette {
   height: 100%;
-  z-index: 11;
   position: absolute;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
   background-color: rgba(0, 0, 0, 0.1);
-
-  &.is-hidden {
-    display: none;
-  }
 }
 
 @media (--largeUp) {

--- a/src/components/search-pane-vignette/search-pane-vignette.js
+++ b/src/components/search-pane-vignette/search-pane-vignette.js
@@ -7,19 +7,17 @@ const cx = classNames.bind(styles);
 
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-export default function SearchPaneVignette({ isHidden, onClick }) {
+export default function SearchPaneVignette({ className, onClick }) {
   return (
     <div
       data-test-search-vignette
       onClick={onClick}
-      className={cx('search-pane-vignette', {
-        'is-hidden': isHidden
-      })}
+      className={cx('search-pane-vignette', className)}
     />
   );
 }
 
 SearchPaneVignette.propTypes = {
-  isHidden: PropTypes.bool,
+  className: PropTypes.string,
   onClick: PropTypes.func
 };

--- a/src/components/search-pane/search-pane.css
+++ b/src/components/search-pane/search-pane.css
@@ -7,7 +7,7 @@
   position: absolute;
   top: 0;
   width: 100%;
-  z-index: 12;
+  z-index: 14;
 
   &:only-child {
     display: block;

--- a/src/components/search-paneset/search-paneset.css
+++ b/src/components/search-paneset/search-paneset.css
@@ -102,3 +102,11 @@
     color: #fff;
   }
 }
+
+.preview-pane-vignette {
+  z-index: 11;
+}
+
+.filters-pane-vignette {
+  z-index: 13;
+}

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -121,13 +121,16 @@ export default class SearchPaneset extends React.Component { // eslint-disable-l
 
     return (
       <div className={styles['search-paneset']}>
+        {detailsView && (
+          <SearchPaneVignette className={styles['preview-pane-vignette']} onClick={this.closePreview} />
+        )}
 
-        {!detailsView && (
-          <SearchPaneVignette isHidden={hideFilters} onClick={this.toggleFilters} />
+        {!hideFilters && (
+          <SearchPaneVignette className={styles['filters-pane-vignette']} onClick={this.toggleFilters} />
         )}
 
         {!hideFilters &&
-          <SearchPane >
+          <SearchPane>
             <div data-test-eholdings-search-pane>
               <PaneHeader
                 paneTitle={(<FormattedMessage id="ui-eholdings.search.searchAndFilter" />)}


### PR DESCRIPTION
## Purpose
Broken in https://github.com/folio-org/ui-eholdings/pull/525

## Approach
The layout needs two different `<SearchPaneVignette>`s: one behind the search filters pane and one behind the detail record preview pane. At some sizes they can simultaneously appear.

#### Open Questions
The `hideFilters` refactor lifted the state up for that a level... but there's one use case it didn't account for:
- When I'm on a mobile-sized screen and I click "Search", I want to be taken to the results. BUT on a larger screen, that exact same interaction shouldn't hide the filters pane. It seems like we need one more boolean in the state to deal with that.

## Screenshots
### Before
![2018-08-23 15 32 53](https://user-images.githubusercontent.com/230597/44550609-601ef600-a6ea-11e8-87fb-d9d2ccbbc90e.gif)

### After
![2018-08-23 15 32 24](https://user-images.githubusercontent.com/230597/44550615-6319e680-a6ea-11e8-8dfb-a5ac8bf10346.gif)
