### PR TITLE
UIEH-526 Create coverage display section on resource forms

### DIFF
--- a/src/components/coverage-date-list/coverage-date-list.js
+++ b/src/components/coverage-date-list/coverage-date-list.js
@@ -58,6 +58,7 @@ class CoverageDateList extends React.Component {
     return (
       <div id={id} data-test-eholdings-display-coverage-list>
         { coverageArray
+          .concat() // clones original array so we aren't mutating upstream
           .sort((coverageObj1, coverageObj2) => this.compareCoverage(coverageObj1, coverageObj2))
           .map(coverageArrayObj => (isYearOnly ?
             this.formatCoverageYear(coverageArrayObj) :

--- a/src/components/resource/_fields/coverage-statement/coverage-statement-fields.css
+++ b/src/components/resource/_fields/coverage-statement/coverage-statement-fields.css
@@ -1,0 +1,5 @@
+@import '@folio/stripes-components/lib/variables';
+
+.coverage-statement-fields-category {
+  margin: 0.5em 1.75em var(--controlMarginBottom);
+}

--- a/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
+++ b/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
@@ -64,7 +64,9 @@ export function validate(values, { intl }) {
   }
 
   if (values.hasCoverageStatement === 'yes' && values.coverageStatement.length === 0) {
-    errors.coverageStatement = 'If selected, coverage statement cannot be blank.';
+    errors.coverageStatement = intl.formatMessage({
+      id: 'validate.errors.coverageStatement.blank'
+    });
   }
 
   return errors;

--- a/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
+++ b/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
@@ -1,24 +1,53 @@
 import React, { Component } from 'react';
 import { Field } from 'redux-form';
+import PropTypes from 'prop-types';
 
-import { TextArea } from '@folio/stripes-components';
+import { RadioButton, TextArea } from '@folio/stripes-components';
 import { injectIntl, intlShape } from 'react-intl';
+import styles from './coverage-statement-fields.css';
 
 class CoverageStatementFields extends Component {
   static propTypes = {
+    change: PropTypes.func.isRequired,
+    coverageDates: PropTypes.node,
     intl: intlShape.isRequired
   };
 
   render() {
-    let { intl } = this.props;
+    let { change, coverageDates, intl } = this.props;
+
     return (
-      <div data-test-eholdings-coverage-statement-textarea>
+      <fieldset>
         <Field
-          name="coverageStatement"
-          component={TextArea}
-          label={intl.formatMessage({ id:'ui-eholdings.resource.coverageStatement.textArea' })}
+          name="hasCoverageStatement"
+          component={RadioButton}
+          type="radio"
+          label={intl.formatMessage({ id:'ui-eholdings.label.dates' })}
+          value="no"
+          onChange={() => {
+            change('coverageStatement', '');
+          }}
         />
-      </div>
+        <div className={styles['coverage-statement-fields-category']}>
+          {coverageDates}
+        </div>
+        <Field
+          name="hasCoverageStatement"
+          component={RadioButton}
+          type="radio"
+          label={intl.formatMessage({ id:'ui-eholdings.label.coverageStatement' })}
+          value="yes"
+        />
+        <div data-test-eholdings-coverage-statement-textarea className={styles['coverage-statement-fields-category']}>
+          <Field
+            name="coverageStatement"
+            component={TextArea}
+            onChange={(e, newValue) => {
+              change('hasCoverageStatement', (newValue.length > 0) ? 'yes' : 'no');
+            }}
+          />
+        </div>
+      </fieldset>
     );
   }
 }
@@ -32,6 +61,10 @@ export function validate(values, { intl }) {
     errors.coverageStatement = intl.formatMessage({
       id: 'ui-eholdings.validate.errors.coverageStatement.length'
     });
+  }
+
+  if (values.hasCoverageStatement === 'yes' && values.coverageStatement.length === 0) {
+    errors.coverageStatement = 'If selected, coverage statement cannot be blank.';
   }
 
   return errors;

--- a/src/components/resource/edit.js
+++ b/src/components/resource/edit.js
@@ -15,6 +15,7 @@ export default function ResourceEdit({ model, ...props }) {
       isVisible: !model.visibilityData.isHidden,
       customCoverages: model.customCoverages,
       coverageStatement: model.coverageStatement,
+      hasCoverageStatement: model.coverageStatement.length > 0 ? 'yes' : 'no',
       customEmbargoValue: model.customEmbargoPeriod.embargoValue,
       customEmbargoUnit: model.customEmbargoPeriod.embargoUnit,
       customUrl: model.url
@@ -26,6 +27,7 @@ export default function ResourceEdit({ model, ...props }) {
       isVisible: !model.visibilityData.isHidden,
       customCoverages: model.customCoverages,
       coverageStatement: model.coverageStatement,
+      hasCoverageStatement: model.coverageStatement.length > 0 ? 'yes' : 'no',
       customEmbargoValue: model.customEmbargoPeriod.embargoValue,
       customEmbargoUnit: model.customEmbargoPeriod.embargoUnit
     };

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -144,6 +144,7 @@
     "label.coverageDates": "Coverage dates",
     "label.coverageSettings": "Coverage settings",
     "label.coverageStatement": "Coverage statement",
+    "label.coverageDisplay": "Coverage display",
     "label.custom.coverageStatement": "Custom coverage statement",
     "label.titleInformation": "Title information",
     "label.packageInformation": "Package information",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -228,6 +228,7 @@
     "validate.errors.customPackage.name": "Custom packages must have a name.",
     "validate.errors.customPackage.name.length": "Must be less than 300 characters.",
     "validate.errors.coverageStatement.length": "Statement must be 350 characters or less.",
+    "validate.errors.coverageStatement.blank": "Statement field cannot be blank if selected.",
 
     "validate.errors.edition.value": "Invalid value.",
     "validate.errors.edition.length": "Value exceeds the 250 character limit.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -414,9 +414,9 @@
     mousetrap "^1.6.1"
     prop-types "^15.5.10"
 
-"@folio/ui-testing@github:folio-org/ui-testing#framework-only":
+"@folio/ui-testing@folio-org/ui-testing#framework-only":
   version "4.0.0"
-  resolved "https://codeload.github.com/folio-org/ui-testing/tar.gz/0e5ac5f7c1f4e444e64ac83766e79d3825329acf"
+  resolved "https://codeload.github.com/folio-org/ui-testing/tar.gz/f0c4cba7147c5dc868e8b37b27f1967e0fc654ec"
   dependencies:
     debug "^3.1.0"
     minimist "^1.2.0"


### PR DESCRIPTION
## Purpose
Part of https://issues.folio.org/browse/UIEH-526

## Approach
Bulks up the `CoverageStatementFields` component with radio buttons to indicate whether the end patron will see dates or a custom coverage statement.

#### TODOS and Open Questions
Resources belonging to a custom title don't need to show the managed coverage dates option - that should be the final PR needed to wrap up UIEH-526.

## Learning
Gotcha I ran into: when dealing with radio buttons and Redux Form `Field`s, `type="radio"` on the `<Field>` manages the input's `checked` for you.

## Screenshots
![2018-08-23 16 19 03](https://user-images.githubusercontent.com/230597/44552569-54363280-a6f0-11e8-8649-d375ffb7e384.gif)
