### PR TITLE
UIEH-532  Title, 'add to custom package' does not show all packages

### DIFF
--- a/src/components/title/_forms/add-to-package.js
+++ b/src/components/title/_forms/add-to-package.js
@@ -6,9 +6,10 @@ import PackageSelectField, { validate as validatePackage } from '../_fields/pack
 import CustomURLField, { validate as validateURL } from '../../resource/_fields/custom-url';
 
 function AddTitleToPackageForm({ handleSubmit, onSubmit, packageOptions }) {
+  let filteredPackageOptions = packageOptions.filter(pkg => pkg.label !== '');
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <PackageSelectField options={packageOptions} />
+      <PackageSelectField options={filteredPackageOptions} />
       <CustomURLField />
     </form>
   );

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -131,6 +131,7 @@ class TitleShow extends Component {
 
   get customPackageOptions() {
     let titlePackageIds = this.props.model.resources.map(({ id }) => id);
+    this.props.customPackages.pageSize = 100;
 
     return this.props.customPackages.map(pkg => ({
       disabled: titlePackageIds.includes(pkg.id),


### PR DESCRIPTION
## Purpose
Display more than 25 packages when adding a title to a custom package.

Resolves a portion of [UIEH-532](https://issues.folio.org/browse/UIEH-532)

## Approach
We are currently setting 25 as the default page size on the front-end in the model, so the list can only display a max of 25 items. However, `customPackages` is a collection model that has this count attribute on it that is set to 100. So, the list does actually get all of the items beyond the displayed 25, but even when the page size is changed, we are only able to display 100 of them max. This is due to a cap in rmapi. As a temporary solution, I've set the page size to the max limit of 100. I've also added a filter within `AddToPackage` that cuts out the remaining results that do not display so that there is not a large chunk of blank-space in the select. 

## Screenshots
![2018-08-27 16 40 54](https://user-images.githubusercontent.com/25858667/44687881-097e2880-aa18-11e8-910c-087507fec6e7.gif)
