### PR TITLE
UIEH-537: Case insensitive checks for proxies

### DIFF
--- a/src/components/provider/_fields/proxy-select/proxy-select-field.js
+++ b/src/components/provider/_fields/proxy-select/proxy-select-field.js
@@ -8,13 +8,13 @@ import styles from './proxy-select-field.css';
 
 function ProxySelectField({ proxyTypes, rootProxy, intl }) {
   let proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
-  let rootProxyId = rootProxy.data.attributes.proxyTypeId;
+  let rootProxyId = rootProxy.data.attributes.proxyTypeId.toLowerCase();
   let options = [];
 
   if (proxyTypesRecords && rootProxyId) {
     for (let proxyTypesRecord in proxyTypesRecords) {
       if (Object.prototype.hasOwnProperty.call(proxyTypesRecords, proxyTypesRecord)) {
-        let selectValue = proxyTypesRecords[proxyTypesRecord].attributes.id;
+        let selectValue = proxyTypesRecords[proxyTypesRecord].attributes.id.toLowerCase();
         if (rootProxyId === selectValue) {
           options.push({ label: `${intl.formatMessage({ id: 'ui-eholdings.provider.inherited' })}-${proxyTypesRecords[proxyTypesRecord].attributes.name}`,
             value: proxyTypesRecords[proxyTypesRecord].attributes.id });

--- a/src/components/provider/proxy-display.js
+++ b/src/components/provider/proxy-display.js
@@ -4,12 +4,17 @@ import { FormattedMessage } from 'react-intl';
 
 export default function ProxyDisplay({ model, proxyTypes }) {
   let proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
-  let name = proxyTypesRecords[`${model.proxy.id}`].attributes.name;
+  let proxyId = model.proxy.id;
 
-  return (
-    <div data-test-eholdings-provider-details-proxy>
-      {model.proxy.inherited ? (<span><FormattedMessage id="ui-eholdings.provider.inherited" />&nbsp;-&nbsp;{name}</span>) : `${name}`}
-    </div>);
+  if (proxyTypesRecords && proxyId) {
+    let selectedValue = proxyTypesRecords[Object.keys(proxyTypesRecords).find(key => key.toLowerCase() === proxyId.toLowerCase())];
+    let name = selectedValue.attributes.name;
+
+    return (
+      <div data-test-eholdings-provider-details-proxy>
+        {model.proxy.inherited ? (<span><FormattedMessage id="ui-eholdings.provider.inherited" />&nbsp;-&nbsp;{name}</span>) : `${name}`}
+      </div>);
+  }
 }
 
 ProxyDisplay.propTypes = {


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-537, we identified an issue where there can be a case discrepancy between proxy set at the provider level and the list of proxies that we get from the root level. RM API, apparently, accepts proxy updates case insensitively without reporting an issue. So, it is quite possible we run into this issue on our end. 

## Approach
- Add case insensitive checks for proxy list and proxy updates. 

## Screenshots
![proxy_case_inse](https://user-images.githubusercontent.com/33662516/44789505-b799e780-ab6a-11e8-953e-278c3c20c17b.gif)
