### PR TITLE
Fix Apply button styles

### DIFF
--- a/src/components/search-paneset/search-paneset.css
+++ b/src/components/search-paneset/search-paneset.css
@@ -7,6 +7,7 @@
 
 .search-pane-toggle {
   height: 45px;
+  margin-bottom: 0;
   padding: 0 1em;
 }
 

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -135,7 +135,7 @@ export default class SearchPaneset extends React.Component { // eslint-disable-l
               <PaneHeader
                 paneTitle={(<FormattedMessage id="ui-eholdings.search.searchAndFilter" />)}
                 lastMenu={showApply ? (
-                  <Button buttonStyle="transparent" onClick={this.toggleFilters} className={styles['search-pane-toggle']}>
+                  <Button buttonStyle="transparent" onClick={this.toggleFilters} buttonClass={styles['search-pane-toggle']}>
                     <FormattedMessage id="ui-eholdings.search.apply" />
                   </Button>
                 ) : null}


### PR DESCRIPTION
## Purpose
The search filters pane "Apply" button lost its style information, so was showing up too often:

![image](https://user-images.githubusercontent.com/230597/44864847-43cd0d00-ac46-11e8-84b4-c43a54925a63.png)

## Approach
https://github.com/folio-org/stripes-components/pull/558 broke passing a `className` into a `<Button>`. Switched to using `buttonClass` prop instead.

## Screenshots
### After
Shown on fairly narrow screen, Apply button disappears at larger sizes.

![localhost_3000_eholdings_searchtype providers q e](https://user-images.githubusercontent.com/230597/44864860-4b8cb180-ac46-11e8-8162-98de2183f2b8.png)
