### PR TITLE
UIEH-542 - Remove second hidden reason on package show page

### DIFF
--- a/bigtest/interactors/package-show.js
+++ b/bigtest/interactors/package-show.js
@@ -70,8 +70,6 @@ import PackageSelectionStatus from './selection-status';
 
   isVisibleToPatrons = text('[data-test-eholdings-package-details-visibility-status]');
   isVisibilityStatusPresent = isPresent('[data-test-eholdings-package-details-visibility-status]');
-  isHiddenMessage = text('[data-test-eholdings-package-details-is-hidden]');
-  isHiddenMessagePresent = isPresent('[data-test-eholdings-package-details-is-hidden]');
   isHiding = hasClassBeginningWith('[data-test-eholdings-package-details-hidden] [data-test-toggle-switch]', 'is-pending--');
 
   allTitlesSelected = computed(function () {

--- a/bigtest/tests/package-visibility-test.js
+++ b/bigtest/tests/package-visibility-test.js
@@ -28,12 +28,12 @@ describeApplication('PackageVisibility', () => {
       });
     });
 
-    it('displays NO (Hidden from patrons)', () => {
+    it('displays No in (Show titles in package to patrons)', () => {
       expect(PackageShowPage.isVisibleToPatrons).to.contain('No');
     });
 
-    it('displays the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessage).to.equal('The content is for mature audiences only.');
+    it('displays hidden reason in (Show titles in package to patrons', () => {
+      expect(PackageShowPage.isVisibleToPatrons).to.contain('The content is for mature audiences only.');
     });
   });
 
@@ -51,12 +51,8 @@ describeApplication('PackageVisibility', () => {
       });
     });
 
-    it('does not show titles in package to patrons', () => {
+    it('displays No as (Show titles in package to patrons)', () => {
       expect(PackageShowPage.isVisibleToPatrons).to.equal('No');
-    });
-
-    it('does not display the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessagePresent).to.be.false;
     });
   });
 
@@ -74,12 +70,8 @@ describeApplication('PackageVisibility', () => {
       });
     });
 
-    it('shows titles in package to patrons', () => {
+    it('displays Yes as (Show titles in package to patrons)', () => {
       expect(PackageShowPage.isVisibleToPatrons).to.equal('Yes');
-    });
-
-    it.always('does not display the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessagePresent).to.be.false;
     });
   });
 
@@ -99,10 +91,6 @@ describeApplication('PackageVisibility', () => {
 
     it('does not display visibility', () => {
       expect(PackageShowPage.isVisibilityStatusPresent).to.be.false;
-    });
-
-    it.always('does not display the hidden/reason section', () => {
-      expect(PackageShowPage.isHiddenMessagePresent).to.be.false;
     });
   });
 });

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -304,12 +304,6 @@ class PackageShow extends Component {
                             :
                           (<FormattedMessage id="ui-eholdings.package.visibility.no" values={{ visibilityMessage }} />)}
                       </div>
-
-                      {model.visibilityData.isHidden && (
-                        <div data-test-eholdings-package-details-is-hidden>
-                          {model.visibilityData.reason}
-                        </div>
-                      )}
                     </KeyValue>
                     {!model.isCustom && (
                       <KeyValue label={<FormattedMessage id="ui-eholdings.package.packageAllowToAddTitles" />}>


### PR DESCRIPTION
https://issues.folio.org/browse/UIEH-542

## Purpose
Remove duplicate hidden message that appears on Package Show Page and adjust unit tests accordingly

## Screenshots
Before
<img width="1673" alt="screen shot 2018-08-30 at 12 16 25 pm" src="https://user-images.githubusercontent.com/19415226/44865034-310b0600-ac4f-11e8-96f0-667d4ec4ab7d.png">

After
<img width="1680" alt="screen shot 2018-08-30 at 12 22 06 pm" src="https://user-images.githubusercontent.com/19415226/44865101-5bf55a00-ac4f-11e8-9e9b-7a416f5380f0.png">

