### PR TITLE
STCOM-292 Create new RepeatableField component

### DIFF
--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.css
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.css
@@ -1,27 +1,5 @@
-@import '@folio/stripes-components/lib/variables';
-
-.coverage-fields-date-range-rows {
-  list-style-type: none;
-  padding: 0;
-}
-
-.coverage-fields-date-range-row {
-  display: flex;
-  align-items: flex-start;
-}
-
 .coverage-fields-datepicker {
   align-self: flex-start;
   flex: 1 1 200px;
   margin-right: 1em;
-}
-
-.coverage-fields-date-range-clear-row {
-  flex: 0 0 3em;
-  margin-top: 2.25em;
-  text-align: center;
-
-  @media (--mediumUp) {
-    margin-top: 1.5em;
-  }
 }

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -1,15 +1,14 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { Field, FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 
 import {
-  Button,
-  Datepicker,
-  IconButton
+  Datepicker
 } from '@folio/stripes-components';
 
+import RepeatableField from '../../../repeatable-field';
 import styles from './package-coverage-fields.css';
 
 class PackageCoverageFields extends Component {
@@ -22,86 +21,55 @@ class PackageCoverageFields extends Component {
     initialValue: []
   };
 
-  renderCoverageFields = ({ fields }) => {
-    let { initialValue, intl } = this.props;
+  renderField = (dateRange) => {
+    const { intl } = this.props;
 
     return (
-      <div className={styles['coverage-fields']}>
-        {fields.length === 0
-          && initialValue.length > 0
-          && initialValue[0].beginCoverage
-          && (
-            <p data-test-eholdings-package-coverage-fields-saving-will-remove>
-              <FormattedMessage id="ui-eholdings.package.noCoverageDates" />
-            </p>
-          )}
-
-        {fields.length === 0 ? (
-          <div
-            className={styles['coverage-fields-add-row-button']}
-            data-test-eholdings-coverage-fields-add-row-button
-          >
-            <Button
-              type="button"
-              onClick={() => fields.push({})}
-            >
-              <FormattedMessage id="ui-eholdings.package.coverage.addDateRange" />
-            </Button>
-          </div>
-        ) : (
-          <ul className={styles['coverage-fields-date-range-rows']}>
-            {fields.map((dateRange, index) => (
-              <li
-                data-test-eholdings-coverage-fields-date-range-row
-                key={index}
-                className={styles['coverage-fields-date-range-row']}
-              >
-                <div
-                  data-test-eholdings-coverage-fields-date-range-begin
-                  className={styles['coverage-fields-datepicker']}
-                >
-                  <Field
-                    name={`${dateRange}.beginCoverage`}
-                    type="text"
-                    component={Datepicker}
-                    label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
-                    format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
-                  />
-                </div>
-                <div
-                  data-test-eholdings-coverage-fields-date-range-end
-                  className={styles['coverage-fields-datepicker']}
-                >
-                  <Field
-                    name={`${dateRange}.endCoverage`}
-                    type="text"
-                    component={Datepicker}
-                    label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
-                    format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
-                  />
-                </div>
-
-                <div
-                  data-test-eholdings-coverage-fields-remove-row-button
-                  className={styles['coverage-fields-date-range-clear-row']}
-                >
-                  <IconButton
-                    icon="hollowX"
-                    onClick={() => fields.remove(index)}
-                    size="small"
-                  />
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+      <Fragment>
+        <div
+          data-test-eholdings-coverage-fields-date-range-begin
+          className={styles['coverage-fields-datepicker']}
+        >
+          <Field
+            name={`${dateRange}.beginCoverage`}
+            type="text"
+            component={Datepicker}
+            label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
+            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+          />
+        </div>
+        <div
+          data-test-eholdings-coverage-fields-date-range-end
+          className={styles['coverage-fields-datepicker']}
+        >
+          <Field
+            name={`${dateRange}.endCoverage`}
+            type="text"
+            component={Datepicker}
+            label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
+            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+          />
+        </div>
+      </Fragment>
     );
-  };
+  }
 
   render() {
+    const { initialValue, intl } = this.props;
+
     return (
-      <FieldArray name="customCoverages" component={this.renderCoverageFields} />
+      <div data-test-eholdings-package-coverage-fields>
+        <FieldArray
+          addLabel={intl.formatMessage({ id: 'ui-eholdings.package.coverage.addDateRange' })}
+          component={RepeatableField}
+          emptyMessage={
+            initialValue.length > 0 && initialValue[0].beginCoverage ?
+              intl.formatMessage({ id: 'ui-eholdings.package.noCoverageDates' }) : ''
+          }
+          name="customCoverages"
+          renderField={this.renderField}
+        />
+      </div>
     );
   }
 }

--- a/src/components/repeatable-field/ReduxFormFieldArray.js
+++ b/src/components/repeatable-field/ReduxFormFieldArray.js
@@ -1,0 +1,36 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+
+const reduxFormFieldArray = (WrappedComponent, config) => {
+  function fieldArrayWithRef({ fields, meta, ...rest }, ref) {
+    if (meta !== undefined) {
+      return (
+        <WrappedComponent
+          ref={ref}
+          {...config({ fields, meta })}
+          {...rest}
+        />
+      );
+    } else {
+      return (
+        <WrappedComponent
+          fields={fields}
+          ref={ref}
+          {...rest}
+        />
+      );
+    }
+  }
+
+  const componentName = WrappedComponent.displayName || WrappedComponent.name;
+  fieldArrayWithRef.displayName = `reduxFormFieldArray(${componentName})`;
+
+  return forwardRef(fieldArrayWithRef);
+};
+
+reduxFormFieldArray.propTypes = {
+  config: PropTypes.func,
+  WrappedComponent: PropTypes.element.isRequired,
+};
+
+export default reduxFormFieldArray;

--- a/src/components/repeatable-field/RepeatableField.css
+++ b/src/components/repeatable-field/RepeatableField.css
@@ -1,0 +1,30 @@
+@import '@folio/stripes-components/lib/variables';
+
+.repeatableField {
+  margin: 1em 0;
+  padding: 0;
+}
+
+.repeatableFieldLegend {
+  margin-bottom: 0.5em;
+}
+
+.repeatableFieldList {
+  list-style-type: none;
+  padding: 0;
+}
+
+.repeatableFieldItem {
+  display: flex;
+  align-items: flex-start;
+}
+
+.repeatableFieldRemoveItem {
+  flex: 0 0 3em;
+  margin-top: 2.25em;
+  text-align: center;
+
+  @media (--mediumUp) {
+    margin-top: 1.5em;
+  }
+}

--- a/src/components/repeatable-field/RepeatableField.js
+++ b/src/components/repeatable-field/RepeatableField.js
@@ -1,0 +1,99 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  Button,
+  IconButton
+} from '@folio/stripes-components';
+import reduxFormFieldArray from './ReduxFormFieldArray';
+import css from './RepeatableField.css';
+
+class RepeatableField extends Component {
+  static propTypes = {
+    addLabel: PropTypes.string,
+    emptyMessage: PropTypes.string,
+    fields: PropTypes.oneOfType([
+      PropTypes.array,
+      PropTypes.object
+    ]).isRequired,
+    legend: PropTypes.string,
+    onAdd: PropTypes.func.isRequired,
+    onRemove: PropTypes.func.isRequired,
+    renderField: PropTypes.func.isRequired
+  };
+
+  render() {
+    const {
+      addLabel,
+      fields,
+      legend,
+      emptyMessage,
+      onAdd,
+      onRemove,
+      renderField
+    } = this.props;
+
+    return (
+      <fieldset
+        data-test-repeatable-field
+        className={css.repeatableField}
+      >
+        {legend && (
+          <legend
+            data-test-repeatable-field-legend
+            className={css.repeatableFieldLegend}
+          >
+            {legend}
+          </legend>
+        )}
+
+        {fields.length === 0 && emptyMessage && (
+          <p data-test-repeatable-field-empty-message>
+            {emptyMessage}
+          </p>
+        )}
+
+        {fields.length > 0 && (
+          <ul className={css.repeatableFieldList}>
+            {fields.map((field, index) => (
+              <li
+                className={css.repeatableFieldItem}
+                key={index}
+              >
+                {renderField(field, index, fields)}
+                <div
+                  className={css.repeatableFieldRemoveItem}
+                >
+                  <IconButton
+                    data-test-repeatable-field-remove-item-button
+                    icon="trashBin"
+                    onClick={() => onRemove(index)}
+                    size="small"
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        {addLabel && (
+          <Button
+            data-test-repeatable-field-add-item-button
+            onClick={onAdd}
+            type="button"
+          >
+            {addLabel}
+          </Button>
+        )}
+      </fieldset>
+    );
+  }
+}
+
+export default reduxFormFieldArray(
+  RepeatableField,
+  ({ fields }) => ({
+    fields,
+    onAdd: () => fields.push({}),
+    onRemove: (index) => fields.remove(index)
+  })
+);

--- a/src/components/repeatable-field/index.js
+++ b/src/components/repeatable-field/index.js
@@ -1,0 +1,1 @@
+export { default } from './RepeatableField';

--- a/src/components/resource/_fields/custom-coverage/custom-coverage-fields.css
+++ b/src/components/resource/_fields/custom-coverage/custom-coverage-fields.css
@@ -1,27 +1,5 @@
-@import '@folio/stripes-components/lib/variables';
-
-.coverage-fields-date-range-rows {
-  list-style-type: none;
-  padding: 0;
-}
-
-.coverage-fields-date-range-row {
-  display: flex;
-  align-items: flex-start;
-}
-
 .coverage-fields-datepicker {
   align-self: flex-start;
   flex: 1 1 200px;
   margin-right: 1em;
-}
-
-.coverage-fields-date-range-clear-row {
-  flex: 0 0 3em;
-  margin-top: 2.25em;
-  text-align: center;
-
-  @media (--mediumUp) {
-    margin-top: 1.5em;
-  }
 }

--- a/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
@@ -1,15 +1,14 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { Field, FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 
 import {
-  Button,
-  Datepicker,
-  IconButton
+  Datepicker
 } from '@folio/stripes-components';
 
+import RepeatableField from '../../../repeatable-field';
 import styles from './custom-coverage-fields.css';
 
 class ResourceCoverageFields extends Component {
@@ -22,87 +21,57 @@ class ResourceCoverageFields extends Component {
     initialValue: []
   };
 
-  renderCoverageFields = ({ fields }) => {
-    let { initialValue, intl } = this.props;
+  renderField = (dateRange) => {
+    const { intl } = this.props;
+
     return (
-      <div>
-        {fields.length === 0
-          && initialValue.length > 0
-          && initialValue[0].beginCoverage
-          && (
-          <p data-test-eholdings-coverage-fields-saving-will-remove>
-            <FormattedMessage id="ui-eholdings.package.noCoverageDates" />
-          </p>
-          )}
-
-        {fields.length > 0 && (
-          <ul className={styles['coverage-fields-date-range-rows']}>
-            {fields.map((dateRange, index) => (
-              <li
-                data-test-eholdings-coverage-fields-date-range-row
-                key={index}
-                className={styles['coverage-fields-date-range-row']}
-              >
-                <div
-                  data-test-eholdings-coverage-fields-date-range-begin
-                  className={styles['coverage-fields-datepicker']}
-                >
-                  <Field
-                    name={`${dateRange}.beginCoverage`}
-                    type="text"
-                    component={Datepicker}
-                    label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
-                    id="begin-coverage"
-                    format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
-                  />
-                </div>
-                <div
-                  data-test-eholdings-coverage-fields-date-range-end
-                  className={styles['coverage-fields-datepicker']}
-                >
-                  <Field
-                    name={`${dateRange}.endCoverage`}
-                    type="text"
-                    component={Datepicker}
-                    label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
-                    id="end-coverage"
-                    format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
-                  />
-                </div>
-
-                <div
-                  data-test-eholdings-coverage-fields-remove-row-button
-                  className={styles['coverage-fields-date-range-clear-row']}
-                >
-                  <IconButton
-                    icon="hollowX"
-                    onClick={() => fields.remove(index)}
-                    size="small"
-                  />
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-
+      <Fragment>
         <div
-          className={styles['coverage-fields-add-row-button']}
-          data-test-eholdings-coverage-fields-add-row-button
+          data-test-eholdings-coverage-fields-date-range-begin
+          className={styles['coverage-fields-datepicker']}
         >
-          <Button
-            type="button"
-            onClick={() => fields.push({})}
-          >
-            <FormattedMessage id="ui-eholdings.package.coverage.addDateRange" />
-          </Button>
+          <Field
+            name={`${dateRange}.beginCoverage`}
+            type="text"
+            component={Datepicker}
+            label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
+            id="begin-coverage"
+            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+          />
         </div>
-      </div>
+        <div
+          data-test-eholdings-coverage-fields-date-range-end
+          className={styles['coverage-fields-datepicker']}
+        >
+          <Field
+            name={`${dateRange}.endCoverage`}
+            type="text"
+            component={Datepicker}
+            label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
+            id="end-coverage"
+            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+          />
+        </div>
+      </Fragment>
     );
-  };
+  }
 
   render() {
+    const { initialValue, intl } = this.props;
+
     return (
-      <FieldArray name="customCoverages" component={this.renderCoverageFields} />
+      <div data-test-eholdings-resource-coverage-fields>
+        <FieldArray
+          addLabel={intl.formatMessage({ id: 'ui-eholdings.package.coverage.addDateRange' })}
+          component={RepeatableField}
+          emptyMessage={
+            initialValue.length > 0 && initialValue[0].beginCoverage ?
+              intl.formatMessage({ id: 'ui-eholdings.package.noCoverageDates' }) : ''
+          }
+          name="customCoverages"
+          renderField={this.renderField}
+        />
+      </div>
     );
   }
 }

--- a/src/components/resource/_fields/managed-coverage/managed-coverage-fields.css
+++ b/src/components/resource/_fields/managed-coverage/managed-coverage-fields.css
@@ -4,28 +4,8 @@
   margin: 0.5em 1.75em var(--controlMarginBottom);
 }
 
-.coverage-fields-date-range-rows {
-  list-style-type: none;
-  padding: 0;
-}
-
-.coverage-fields-date-range-row {
-  display: flex;
-  align-items: flex-start;
-}
-
 .coverage-fields-datepicker {
   align-self: flex-start;
   flex: 1 1 200px;
   margin: 0 0.5em;
-}
-
-.coverage-fields-date-range-clear-row {
-  flex: 0 0 3em;
-  margin-top: 2.25em;
-  text-align: center;
-
-  @media (--mediumUp) {
-    margin-top: 1.5em;
-  }
 }

--- a/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
+++ b/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
@@ -1,18 +1,17 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { Field, FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 
 import {
-  Button,
   Datepicker,
-  IconButton,
   RadioButton
 } from '@folio/stripes-components';
 
 import CoverageDateList from '../../../coverage-date-list';
 import { isBookPublicationType } from '../../../utilities';
+import RepeatableField from '../../../repeatable-field';
 import styles from './managed-coverage-fields.css';
 
 class ResourceCoverageFields extends Component {
@@ -25,6 +24,41 @@ class ResourceCoverageFields extends Component {
   static defaultProps = {
     initialValue: []
   };
+
+  renderField = (dateRange) => {
+    const { intl } = this.props;
+
+    return (
+      <Fragment>
+        <div
+          data-test-eholdings-coverage-fields-date-range-begin
+          className={styles['coverage-fields-datepicker']}
+        >
+          <Field
+            name={`${dateRange}.beginCoverage`}
+            type="text"
+            component={Datepicker}
+            label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
+            id="begin-coverage"
+            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+          />
+        </div>
+        <div
+          data-test-eholdings-coverage-fields-date-range-end
+          className={styles['coverage-fields-datepicker']}
+        >
+          <Field
+            name={`${dateRange}.endCoverage`}
+            type="text"
+            component={Datepicker}
+            label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
+            id="end-coverage"
+            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+          />
+        </div>
+      </Fragment>
+    );
+  }
 
   renderCoverageFields = (fieldArrayProps) => {
     let { fields } = fieldArrayProps;
@@ -68,78 +102,18 @@ class ResourceCoverageFields extends Component {
             }}
           />
           <div className={styles['coverage-fields-category']}>
-            <div>
-              {fields.length === 0
-                && initialValue.length > 0
-                && initialValue[0].beginCoverage
-                && (
-                <p data-test-eholdings-coverage-fields-saving-will-remove>
-                  <FormattedMessage id="ui-eholdings.package.noCoverageDates" />
-                </p>
-                )}
-
-              {fields.length > 0 && (
-                <ul className={styles['coverage-fields-date-range-rows']}>
-                  {fields.map((dateRange, index) => (
-                    <li
-                      data-test-eholdings-coverage-fields-date-range-row
-                      key={index}
-                      className={styles['coverage-fields-date-range-row']}
-                    >
-                      <div
-                        data-test-eholdings-coverage-fields-date-range-begin
-                        className={styles['coverage-fields-datepicker']}
-                      >
-                        <Field
-                          name={`${dateRange}.beginCoverage`}
-                          type="text"
-                          component={Datepicker}
-                          label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
-                          id="begin-coverage"
-                          format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
-                        />
-                      </div>
-                      <div
-                        data-test-eholdings-coverage-fields-date-range-end
-                        className={styles['coverage-fields-datepicker']}
-                      >
-                        <Field
-                          name={`${dateRange}.endCoverage`}
-                          type="text"
-                          component={Datepicker}
-                          label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
-                          id="end-coverage"
-                          format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
-                        />
-                      </div>
-
-                      <div
-                        data-test-eholdings-coverage-fields-remove-row-button
-                        className={styles['coverage-fields-date-range-clear-row']}
-                      >
-                        <IconButton
-                          icon="hollowX"
-                          onClick={() => fields.remove(index)}
-                          size="small"
-                        />
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              )}
-
-              <div
-                className={styles['coverage-fields-add-row-button']}
-                data-test-eholdings-coverage-fields-add-row-button
-              >
-                <Button
-                  type="button"
-                  onClick={() => fields.push({})}
-                >
-                  <FormattedMessage id="ui-eholdings.package.coverage.addDateRange" />
-                </Button>
-              </div>
-            </div>
+            <RepeatableField
+              addLabel={intl.formatMessage({ id: 'ui-eholdings.package.coverage.addDateRange' })}
+              emptyMessage={
+                initialValue.length > 0 && initialValue[0].beginCoverage ?
+                  intl.formatMessage({ id: 'ui-eholdings.package.noCoverageDates' }) : ''
+              }
+              fields={fields}
+              name="customCoverages"
+              onAdd={() => fields.push({})}
+              onRemove={(index) => fields.remove(index)}
+              renderField={this.renderField}
+            />
           </div>
         </div>
       </fieldset>
@@ -148,7 +122,9 @@ class ResourceCoverageFields extends Component {
 
   render() {
     return (
-      <FieldArray name="customCoverages" component={this.renderCoverageFields} />
+      <div data-test-eholdings-resource-coverage-fields>
+        <FieldArray name="customCoverages" component={this.renderCoverageFields} />
+      </div>
     );
   }
 }

--- a/src/components/title/_fields/contributor/contributor-field.css
+++ b/src/components/title/_fields/contributor/contributor-field.css
@@ -1,37 +1,6 @@
-@import '@folio/stripes-components/lib/variables';
-
-.contributor-fields {
-  margin: 1em 0;
-  padding: 0;
-
-  & legend {
-    margin-bottom: 0.5em;
-  }
-}
-
-.contributor-fields-rows {
-  list-style-type: none;
-  padding: 0;
-}
-
-.contributor-fields-row {
-  display: flex;
-  align-items: flex-start;
-}
-
 .contributor-fields-contributor,
 .contributor-fields-type {
   align-self: flex-start;
   flex: 1 1 200px;
   margin-right: 1em;
-}
-
-.contributor-fields-clear-row {
-  flex: 0 0 3em;
-  margin-top: 2.25em;
-  text-align: center;
-
-  @media (--mediumUp) {
-    margin-top: 1.5em;
-  }
 }

--- a/src/components/title/_fields/contributor/contributor-field.js
+++ b/src/components/title/_fields/contributor/contributor-field.js
@@ -1,13 +1,12 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Field, FieldArray } from 'redux-form';
 import {
-  TextField,
   Select,
-  Button,
-  IconButton
+  TextField
 } from '@folio/stripes-components';
-import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
+import RepeatableField from '../../../repeatable-field';
 import styles from './contributor-field.css';
 
 class ContributorField extends Component {
@@ -20,94 +19,61 @@ class ContributorField extends Component {
     initialValue: []
   };
 
-  renderContributorFields = ({ fields }) => {
-    let { initialValue, intl } = this.props;
-
-    function renderFields() {
-      return (
-        <ul className={styles['contributor-fields-rows']}>
-          {fields.map((contributor, index, allFields) => (
-            <li
-              className={styles['contributor-fields-row']}
-              key={index}
-            >
-              <div
-                data-test-eholdings-contributor-type
-                className={styles['contributor-fields-contributor']}
-              >
-                <Field
-                  name={`${contributor}.type`}
-                  component={Select}
-                  autoFocus={Object.keys(allFields.get(index)).length === 0}
-                  label={intl.formatMessage({ id: 'ui-eholdings.type' })}
-                  id={`${contributor}-type`}
-                  dataOptions={[
-                    { value: 'author', label: intl.formatMessage({ id: 'ui-eholdings.label.author' }) },
-                    { value: 'editor', label: intl.formatMessage({ id: 'ui-eholdings.label.editor' }) },
-                    { value: 'illustrator', label: intl.formatMessage({ id: 'ui-eholdings.label.illustrator' }) }
-                  ]}
-                />
-              </div>
-              <div
-                data-test-eholdings-contributor-contributor
-                className={styles['contributor-fields-contributor']}
-              >
-                <Field
-                  name={`${contributor}.contributor`}
-                  type="text"
-                  id={`${contributor}-input`}
-                  component={TextField}
-                  label={intl.formatMessage({ id: 'ui-eholdings.name' })}
-                />
-              </div>
-
-              <div
-                data-test-eholdings-contributor-fields-remove-row-button
-                className={styles['contributor-fields-clear-row']}
-              >
-                <IconButton
-                  icon="hollowX"
-                  aria-label={
-                    intl.formatMessage({ id: 'ui-eholdings.label.removeItem' }, { item: `${allFields.get(index).contributor}` })}
-                  onClick={() => fields.remove(index)}
-                  size="small"
-                />
-              </div>
-            </li>
-          ))}
-        </ul>
-      );
-    }
+  renderField = (contributor, index, fields) => {
+    const { intl } = this.props;
 
     return (
-      <fieldset className={styles['contributor-fields']}>
-        <legend><FormattedMessage id="ui-eholdings.label.contributors" /></legend>
-        {fields.length === 0
-          && initialValue.length > 0
-          && initialValue[0].id
-          && (
-            <p data-test-eholdings-contributors-fields-saving-will-remove>
-              {intl.formatMessage({ id: 'ui-eholdings.title.contributor.notSet' })}
-            </p>
-          )}
-        {fields.length !== 0 ? renderFields() : null}
+      <Fragment>
         <div
-          data-test-eholdings-contributor-fields-add-row-button
+          data-test-eholdings-contributor-type
+          className={styles['contributor-fields-contributor']}
         >
-          <Button
-            type="button"
-            onClick={() => fields.push({})}
-          >
-            {intl.formatMessage({ id: 'ui-eholdings.title.contributor.addContributor' })}
-          </Button>
+          <Field
+            name={`${contributor}.type`}
+            component={Select}
+            autoFocus={Object.keys(fields.get(index)).length === 0}
+            label={intl.formatMessage({ id: 'ui-eholdings.type' })}
+            id={`${contributor}-type`}
+            dataOptions={[
+              { value: 'author', label: intl.formatMessage({ id: 'ui-eholdings.label.author' }) },
+              { value: 'editor', label: intl.formatMessage({ id: 'ui-eholdings.label.editor' }) },
+              { value: 'illustrator', label: intl.formatMessage({ id: 'ui-eholdings.label.illustrator' }) }
+            ]}
+          />
         </div>
-      </fieldset>
+        <div
+          data-test-eholdings-contributor-contributor
+          className={styles['contributor-fields-contributor']}
+        >
+          <Field
+            name={`${contributor}.contributor`}
+            type="text"
+            id={`${contributor}-input`}
+            component={TextField}
+            label={intl.formatMessage({ id: 'ui-eholdings.name' })}
+          />
+        </div>
+      </Fragment>
     );
-  };
+  }
 
   render() {
+    const { initialValue, intl } = this.props;
+
     return (
-      <FieldArray name="contributors" component={this.renderContributorFields} />
+      <div data-test-eholdings-contributor-field>
+        <FieldArray
+          addLabel={intl.formatMessage({ id: 'ui-eholdings.title.contributor.addContributor' })}
+          component={RepeatableField}
+          emptyMessage={
+            initialValue.length > 0 && initialValue[0].contributor ?
+              intl.formatMessage({ id: 'ui-eholdings.title.contributor.notSet' }) : ''
+          }
+          legend={intl.formatMessage({ id: 'ui-eholdings.label.contributors' })}
+          name="contributors"
+          renderField={this.renderField}
+        />
+      </div>
     );
   }
 }

--- a/src/components/title/_fields/identifiers/identifiers-fields.css
+++ b/src/components/title/_fields/identifiers/identifiers-fields.css
@@ -1,36 +1,5 @@
-@import '@folio/stripes-components/lib/variables';
-
-.identifiers-fields {
-  margin: 1em 0;
-  padding: 0;
-
-  & legend {
-    margin-bottom: 0.5em;
-  }
-}
-
-.identifiers-fields-rows {
-  list-style-type: none;
-  padding: 0;
-}
-
-.identifiers-fields-row {
-  display: flex;
-  align-items: flex-start;
-}
-
 .identifiers-fields-field {
   align-self: flex-start;
   flex: 1 1 200px;
   margin-right: 1em;
-}
-
-.identifiers-fields-clear-row {
-  flex: 0 0 3em;
-  margin-top: 2.25em;
-  text-align: center;
-
-  @media (--mediumUp) {
-    margin-top: 1.5em;
-  }
 }

--- a/src/components/title/_fields/identifiers/identifiers-fields.js
+++ b/src/components/title/_fields/identifiers/identifiers-fields.js
@@ -1,15 +1,14 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { Field, FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
 
 import {
-  Button,
-  IconButton,
   Select,
   TextField
 } from '@folio/stripes-components';
 
-import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
+import RepeatableField from '../../../repeatable-field';
 import styles from './identifiers-fields.css';
 
 class IdentifiersFields extends Component {
@@ -22,95 +21,61 @@ class IdentifiersFields extends Component {
     initialValue: []
   };
 
-  renderIdentifierFields = ({ fields }) => {
-    let { initialValue, intl } = this.props;
+  renderField = (identifier, index, fields) => {
+    const { intl } = this.props;
 
     return (
-      <fieldset className={styles['identifiers-fields']}>
-        <legend><FormattedMessage id="ui-eholdings.label.identifiers" /></legend>
-
-        {fields.length === 0
-          && initialValue.length > 0
-          && initialValue[0].id
-          && (
-          <p data-test-eholdings-identifiers-fields-saving-will-remove>
-            {intl.formatMessage({ id: 'ui-eholdings.title.identifier.notSet' })}
-          </p>
-          )}
-
-        {fields.length > 0 && (
-          <ul className={styles['identifiers-fields-rows']}>
-            {fields.map((identifier, index, allFields) => (
-              <li
-                data-test-eholdings-identifiers-fields-row
-                key={index}
-                className={styles['identifiers-fields-row']}
-              >
-                <div
-                  data-test-eholdings-identifiers-fields-type
-                  className={styles['identifiers-fields-field']}
-                >
-                  <Field
-                    name={`${identifier}.flattenedType`}
-                    type="text"
-                    component={Select}
-                    autoFocus={Object.keys(allFields.get(index)).length === 0}
-                    label={intl.formatMessage({ id: 'ui-eholdings.type' })}
-                    dataOptions={[
-                      { value: '0', label: intl.formatMessage({ id: 'ui-eholdings.label.identifier.issnOnline' }) },
-                      { value: '1', label: intl.formatMessage({ id: 'ui-eholdings.label.identifier.issnPrint' }) },
-                      { value: '2', label: intl.formatMessage({ id: 'ui-eholdings.label.identifier.isbnOnline' }) },
-                      { value: '3', label: intl.formatMessage({ id: 'ui-eholdings.label.identifier.isbnPrint' }) }
-                    ]}
-                  />
-                </div>
-                <div
-                  data-test-eholdings-identifiers-fields-id
-                  className={styles['identifiers-fields-field']}
-                >
-                  <Field
-                    name={`${identifier}.id`}
-                    type="text"
-                    component={TextField}
-                    label={intl.formatMessage({ id: 'ui-eholdings.id' })}
-                  />
-                </div>
-
-                <div
-                  data-test-eholdings-identifiers-fields-remove-row-button
-                  className={styles['identifiers-fields-clear-row']}
-                >
-                  <IconButton
-                    icon="hollowX"
-                    ariaLabel={
-                      intl.formatMessage({ id: 'ui-eholdings.label.removeItem' }, { item: `${allFields.get(index).id}` })}
-                    onClick={() => fields.remove(index)}
-                    size="small"
-                  />
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-
+      <Fragment>
         <div
-          className={styles['identifiers-fields-add-row-button']}
-          data-test-eholdings-identifiers-fields-add-row-button
+          data-test-eholdings-identifiers-fields-type
+          className={styles['identifiers-fields-field']}
         >
-          <Button
-            type="button"
-            onClick={() => fields.push({})}
-          >
-            {intl.formatMessage({ id: 'ui-eholdings.title.identifier.addIdentifier' })}
-          </Button>
+          <Field
+            name={`${identifier}.flattenedType`}
+            type="text"
+            component={Select}
+            autoFocus={Object.keys(fields.get(index)).length === 0}
+            label={intl.formatMessage({ id: 'ui-eholdings.type' })}
+            dataOptions={[
+              { value: '0', label: intl.formatMessage({ id: 'ui-eholdings.label.identifier.issnOnline' }) },
+              { value: '1', label: intl.formatMessage({ id: 'ui-eholdings.label.identifier.issnPrint' }) },
+              { value: '2', label: intl.formatMessage({ id: 'ui-eholdings.label.identifier.isbnOnline' }) },
+              { value: '3', label: intl.formatMessage({ id: 'ui-eholdings.label.identifier.isbnPrint' }) }
+            ]}
+          />
         </div>
-      </fieldset>
+        <div
+          data-test-eholdings-identifiers-fields-id
+          className={styles['identifiers-fields-field']}
+        >
+          <Field
+            name={`${identifier}.id`}
+            type="text"
+            component={TextField}
+            label={intl.formatMessage({ id: 'ui-eholdings.id' })}
+          />
+        </div>
+      </Fragment>
     );
-  };
+  }
 
   render() {
+    const { initialValue, intl } = this.props;
+
     return (
-      <FieldArray name="identifiers" component={this.renderIdentifierFields} />
+      <div data-test-eholdings-identifiers-fields>
+        <FieldArray
+          addLabel={intl.formatMessage({ id: 'ui-eholdings.title.identifier.addIdentifier' })}
+          component={RepeatableField}
+          emptyMessage={
+            initialValue.length > 0 && initialValue[0].id ?
+              intl.formatMessage({ id: 'ui-eholdings.title.identifier.notSet' }) : ''
+          }
+          legend={intl.formatMessage({ id: 'ui-eholdings.label.identifiers' })}
+          name="identifiers"
+          renderField={this.renderField}
+        />
+      </div>
     );
   }
 }

--- a/test/bigtest/interactors/package-create.js
+++ b/test/bigtest/interactors/package-create.js
@@ -25,12 +25,12 @@ import Datepicker from './datepicker';
   hasContentType = isPresent('[data-test-eholdings-package-content-type-field]');
   chooseContentType = fillable('[data-test-eholdings-package-content-type-field] select');
   contentTypeValue = value('[data-test-eholdings-package-content-type-field] select');
-  hasAddCoverageButton = isPresent('[data-test-eholdings-coverage-fields-add-row-button]');
-  addCoverage = clickable('[data-test-eholdings-coverage-fields-add-row-button] button');
+  hasAddCoverageButton = isPresent('[data-test-eholdings-package-coverage-fields] [data-test-repeatable-field-add-item-button]');
+  addCoverage = clickable('[data-test-eholdings-package-coverage-fields] [data-test-repeatable-field-add-item-button]');
   save = clickable('[data-test-eholdings-package-create-save-button]');
   isSaveDisabled = property('[data-test-eholdings-package-create-save-button]', 'disabled');
 
-  dateRangeRowList = collection('[data-test-eholdings-coverage-fields-date-range-row]', {
+  dateRangeRowList = collection('[data-test-eholdings-package-coverage-fields] li', {
     beginDate: scoped('[data-test-eholdings-coverage-fields-date-range-begin]', Datepicker),
     endDate: scoped('[data-test-eholdings-coverage-fields-date-range-end]', Datepicker),
     fillDates(beginDate, endDate) {

--- a/test/bigtest/interactors/package-edit.js
+++ b/test/bigtest/interactors/package-edit.js
@@ -82,7 +82,7 @@ import PackageSelectionStatus from './selection-status';
   allowKbToAddTitlesRadio = property('[data-test-eholdings-allow-kb-to-add-titles-radio-yes]', 'checked');
   clickAllowKbToAddTitlesRadio = clickable('[data-test-eholdings-allow-kb-to-add-titles-radio-yes]');
   clickDisallowKbToAddTitlesRadio = clickable('[data-test-eholdings-allow-kb-to-add-titles-radio-no]');
-  hasCoverageDatesPresent = isPresent('[data-test-eholdings-coverage-fields-date-range-row]');
+  hasCoverageDatesPresent = isPresent('[data-test-eholdings-package-coverage-fields] li');
   hasNameFieldPresent = isPresent('[data-test-eholdings-package-name-field]');
   hasReadOnlyNameFieldPresent = isPresent('[data-test-eholdings-package-readonly-name-field]');
   hasContentTypeFieldPresent = isPresent('[data-test-eholdings-package-content-type-field]');
@@ -118,10 +118,10 @@ import PackageSelectionStatus from './selection-status';
   contentType = fillable('[data-test-eholdings-package-content-type-field] select');
   nameHasError = hasClassBeginningWith('[data-test-eholdings-package-name-field] input', 'hasError--');
 
-  dateRangeRowList = collection('[data-test-eholdings-coverage-fields-date-range-row]', {
+  dateRangeRowList = collection('[data-test-eholdings-package-coverage-fields] li', {
     beginDate: scoped('[data-test-eholdings-coverage-fields-date-range-begin]', Datepicker),
     endDate: scoped('[data-test-eholdings-coverage-fields-date-range-end]', Datepicker),
-    clickRemoveRowButton: clickable('[data-test-eholdings-coverage-fields-remove-row-button] button'),
+    clickRemoveRowButton: clickable('[data-test-repeatable-field-add-item-button]'),
     fillDates(beginDate, endDate) {
       return this.beginDate.fillAndBlur(beginDate)
         .endDate.fillAndBlur(endDate);

--- a/test/bigtest/interactors/resource-edit.js
+++ b/test/bigtest/interactors/resource-edit.js
@@ -83,19 +83,19 @@ import Datepicker from './datepicker';
   name = fillable('[data-test-eholdings-resource-name-field] input');
   nameHasError = hasClassBeginningWith('[data-test-eholdings-resource-name-field] input', 'hasError--');
 
-  clickAddRowButton = clickable('[data-test-eholdings-coverage-fields-add-row-button] button');
+  clickAddRowButton = clickable('[data-test-eholdings-resource-coverage-fields] [data-test-repeatable-field-add-item-button]');
 
-  dateRangeRowList = collection('[data-test-eholdings-coverage-fields-date-range-row]', {
+  dateRangeRowList = collection('[data-test-eholdings-resource-coverage-fields] li', {
     beginDate: scoped('[data-test-eholdings-coverage-fields-date-range-begin]', Datepicker),
     endDate: scoped('[data-test-eholdings-coverage-fields-date-range-end]', Datepicker),
-    clickRemoveRowButton: clickable('[data-test-eholdings-coverage-fields-remove-row-button] button'),
+    clickRemoveRowButton: clickable('[data-test-repeatable-field-remove-item-button]'),
     fillDates(beginDate, endDate) {
       return this.beginDate.fillAndBlur(beginDate)
         .endDate.fillAndBlur(endDate);
     }
   });
 
-  hasSavingWillRemoveMessage = isPresent('[data-test-eholdings-coverage-fields-saving-will-remove]');
+  hasSavingWillRemoveMessage = isPresent('[data-test-eholdings-resource-coverage-fields] [data-test-repeatable-field-empty-message]');
   hasCoverageStatementArea = isPresent('[data-test-eholdings-coverage-statement-textarea] textarea');
   coverageStatement = value('[data-test-eholdings-coverage-statement-textarea] textarea');
   customUrlFieldValue = value('[data-test-eholdings-custom-url-textfield] input');
@@ -122,7 +122,7 @@ import Datepicker from './datepicker';
   blurEmbargoUnit = blurrable('[data-test-eholdings-custom-embargo-select] select');
   validationErrorOnEmbargoTextField = text('[data-test-eholdings-custom-embargo-textfield] [class^="feedbackError--"]');
   validationErrorOnEmbargoSelect = text('[data-test-eholdings-custom-embargo-select] [class^="feedbackError--"]');
-  hasAddCustomCoverageButton = isPresent('[data-test-eholdings-coverage-fields-add-row-button] button');
+  hasAddCustomCoverageButton = isPresent('[data-test-eholdings-resource-coverage-fields] [data-test-repeatable-field-add-item-button]');
   hasAddCustomEmbargoButton = isPresent('[data-test-eholdings-custom-embargo-add-row-button] button');
   clickAddCustomEmbargoButton = clickable('[data-test-eholdings-custom-embargo-add-row-button] button');
   hasSavingWillRemoveEmbargoMessage = isPresent('[data-test-eholdings-embargo-fields-saving-will-remove]');

--- a/test/bigtest/interactors/title-create.js
+++ b/test/bigtest/interactors/title-create.js
@@ -23,10 +23,10 @@ import {
   hasName = isPresent('[data-test-eholdings-title-name-field]');
   fillName = fillable('[data-test-eholdings-title-name-field] input');
 
-  hasContributorBtn = isPresent('[data-test-eholdings-contributor-fields-add-row-button]');
+  hasContributorBtn = isPresent('[data-test-eholdings-contributor-field] [data-test-repeatable-field-add-item-button]');
   addContributor(type, name) {
     return this
-      .click('[data-test-eholdings-contributor-fields-add-row-button] button')
+      .click('[data-test-eholdings-contributor-field] [data-test-repeatable-field-add-item-button]')
       .fill('[data-test-eholdings-contributor-type] select', type)
       .fill('[data-test-eholdings-contributor-contributor] input', name);
   }
@@ -39,7 +39,7 @@ import {
   choosePublicationType = fillable('[data-test-eholdings-publication-type-field] select');
   publicationType = value('[data-test-eholdings-publication-type-field] select');
 
-  hasIdentifiersBtn = isPresent('[data-test-eholdings-identifiers-fields-add-row-button]');
+  hasIdentifiersBtn = isPresent('[data-test-eholdings-identifiers-fields] [data-test-repeatable-field-add-item-button]');
   addIdentifier(type, id) {
     let values = {
       'ISSN (Online)': '0',
@@ -49,7 +49,7 @@ import {
     };
 
     return this
-      .click('[data-test-eholdings-identifiers-fields-add-row-button] button')
+      .click('[data-test-eholdings-identifiers-fields] [data-test-repeatable-field-add-item-button]')
       .fill('[data-test-eholdings-identifiers-fields-type] select', values[type])
       .fill('[data-test-eholdings-identifiers-fields-id] input', id);
   }

--- a/test/bigtest/interactors/title-edit.js
+++ b/test/bigtest/interactors/title-edit.js
@@ -65,26 +65,26 @@ import Toast from './toast';
   contributorHasError = hasClassBeginningWith('[data-test-eholdings-contributor-contributor] input', 'hasError--');
   contributorError = text('[data-test-eholdings-contributor-contributor] [class^="feedbackError--"]');
 
-  hasContributorBtn = isPresent('[data-test-eholdings-contributor-fields-add-row-button]');
-  clickAddContributor = clickable('[data-test-eholdings-contributor-fields-add-row-button] button');
+  hasContributorBtn = isPresent('[data-test-eholdings-contributor-field] [data-test-repeatable-field-add-item-button]');
+  clickAddContributor = clickable('[data-test-eholdings-contributor-field] [data-test-repeatable-field-add-item-button]');
   secondContributorType = fillable('[data-test-eholdings-contributor-type] select[id="contributors[1]-type"]');
   secondContributorName = fillable('[data-test-eholdings-contributor-contributor] input[id="contributors[1]-input"]');
 
-  removeContributorCollection = collection('[data-test-eholdings-contributor-fields-remove-row-button]', {
-    remove: clickable('button')
+  removeContributorCollection = collection('[data-test-eholdings-contributor-field] [data-test-repeatable-field-remove-item-button]', {
+    remove: clickable()
   });
 
-  contributorsWillBeRemoved = text('[data-test-eholdings-contributors-fields-saving-will-remove]');
+  contributorsWillBeRemoved = text('[data-test-eholdings-contributor-field] [data-test-repeatable-field-empty-message]');
 
-  hasIdentifiersBtn = isPresent('[data-test-eholdings-identifiers-fields-add-row-button]');
-  clickAddIdentifiersRowButton = clickable('[data-test-eholdings-identifiers-fields-add-row-button] button');
+  hasIdentifiersBtn = isPresent('[data-test-eholdings-identifiers-fields] [data-test-repeatable-field-add-item-button]');
+  clickAddIdentifiersRowButton = clickable('[data-test-eholdings-identifiers-fields] [data-test-repeatable-field-add-item-button]');
   secondIdentifierType = fillable('[data-test-eholdings-identifiers-fields-type] select[name="identifiers[1].flattenedType"]');
   secondIdentifierId = fillable('[data-test-eholdings-identifiers-fields-id] input[name="identifiers[1].id"]');
-  identifiersRowList = collection('[data-test-eholdings-identifiers-fields-row]', {
+  identifiersRowList = collection('[data-test-eholdings-identifiers-fields] li', {
     type: fillable('[data-test-eholdings-identifiers-fields-type] select'),
     id: fillable('[data-test-eholdings-identifiers-fields-id] input'),
     idHasError: hasClassBeginningWith('[data-test-eholdings-identifiers-fields-id] input', 'hasError--'),
-    clickRemoveRowButton: clickable('[data-test-eholdings-identifiers-fields-remove-row-button] button')
+    clickRemoveRowButton: clickable('[data-test-repeatable-field-remove-item-button]')
   });
 
   dropDown = new TitleEditDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');


### PR DESCRIPTION
## Purpose
Abstract repeatable field design into a component that works with or without Redux Form.

## Approach
- Uses camelCase CSS to match `stripes-components` practices
- Only design change for eHoldings: remove row button is now a trash can instead of a circle X
- Will replace with upstream `stripes-components` version when that gets released

Example usage:
```
<FieldArray
  addLabel={intl.formatMessage({ id: 'ui-eholdings.package.coverage.addDateRange' })}
  component={RepeatableField}
  emptyMessage={
    initialValue.length > 0 && initialValue[0].beginCoverage ?
    intl.formatMessage({ id: 'ui-eholdings.package.noCoverageDates' }) : ''
  }
  name="customCoverages"
  renderField={this.renderField}
 />
```

## Screenshot
![2018-09-05 07 36 32](https://user-images.githubusercontent.com/230597/45093587-7495c200-b0de-11e8-849d-6c8af7f18af7.gif)

