### PR TITLE
 Streamline Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 jobs:
   checkout-and-install:
     docker:
-      - image: circleci/node:9
+      - image: circleci/node:10
     steps:
       - checkout
       - restore_cache:
@@ -21,13 +21,17 @@ jobs:
 
   eslint:
     docker:
-      - image: circleci/node:9
+      - image: circleci/node:10
     steps:
       - attach_workspace:
           at: ~/
       - run:
           name: Lint JS
-          command: yarn eslint --max-warnings=0 --format junit --output-file ./artifacts/eslint/eslint.xml
+          command:
+            yarn eslint
+            --max-warnings=0
+            --format junit
+            --output-file ./artifacts/eslint/eslint.xml
       - store_test_results:
           path: ./artifacts
       - store_artifacts:
@@ -35,7 +39,7 @@ jobs:
 
   stylelint:
     docker:
-      - image: circleci/node:9
+      - image: circleci/node:10
     steps:
       - attach_workspace:
           at: ~/
@@ -44,7 +48,9 @@ jobs:
           command: mkdir -p artifacts/stylelint
       - run:
           name: Lint CSS
-          command: yarn --silent stylelint --custom-formatter './node_modules/stylelint-junit-formatter' > ./artifacts/stylelint/stylelint.xml
+          command:
+            yarn --silent stylelint
+            --custom-formatter './node_modules/stylelint-junit-formatter' > ./artifacts/stylelint/stylelint.xml
       - store_test_results:
           path: ./artifacts
       - store_artifacts:
@@ -52,7 +58,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/node:9
+      - image: circleci/node:10
     steps:
       - attach_workspace:
           at: ~/
@@ -62,35 +68,26 @@ jobs:
 
   test-chrome:
     docker:
-      - image: circleci/node:9-browsers
+      - image: circleci/node:10-browsers
     steps:
       - attach_workspace:
           at: ~/
       - run:
           name: Run tests
-          command: yarn test --karma.singleRun --karma.browsers=Chrome --karma.reporters mocha junit --coverage
+          command:
+            yarn test
+            --karma.singleRun
+            --karma.browsers=Chrome
+            --karma.reporters mocha junit BrowserStack
+            --karma.junitReporter.outputDir artifacts/karma
       - store_test_results:
-          path: ./artifacts/junit
-      - store_artifacts:
           path: ./artifacts
-
-  test-safari:
-    docker:
-      - image: circleci/node:9
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Run tests
-          command: yarn test --karma.singleRun --karma.browsers=bs_safari_11 --karma.reporters mocha junit BrowserStack
-      - store_test_results:
-          path: ./artifacts/junit
       - store_artifacts:
           path: ./artifacts
 
   test-firefox:
     docker:
-      - image: circleci/node:9-browsers
+      - image: circleci/node:10-browsers
     steps:
       - attach_workspace:
           at: ~/
@@ -102,37 +99,52 @@ jobs:
             firefox --version
       - run:
           name: Run tests
-          command: yarn test --karma.singleRun --karma.browsers=Firefox --karma.reporters mocha junit
+          command:
+            yarn test
+            --karma.singleRun
+            --karma.browsers=Firefox
+            --karma.reporters mocha junit BrowserStack
+            --karma.junitReporter.outputDir artifacts/karma
       - store_test_results:
-          path: ./artifacts/junit
+          path: ./artifacts
+      - store_artifacts:
+          path: ./artifacts
+
+  test-safari:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run tests
+          command:
+            yarn test
+            --karma.singleRun
+            --karma.browsers=bs_safari_11
+            --karma.reporters mocha junit BrowserStack
+            --karma.junitReporter.outputDir artifacts/karma
+      - store_test_results:
+          path: ./artifacts
       - store_artifacts:
           path: ./artifacts
 
   test-edge:
     docker:
-      - image: circleci/node:9
+      - image: circleci/node:10
     steps:
       - attach_workspace:
           at: ~/
       - run:
           name: Run tests
-          command: yarn test --karma.singleRun --karma.browsers=bs_ieEdge_windows --karma.reporters mocha junit BrowserStack || true
+          command:
+            yarn test
+            --karma.singleRun
+            --karma.browsers=bs_ieEdge_windows
+            --karma.reporters mocha junit BrowserStack
+            --karma.junitReporter.outputDir artifacts/karma
       - store_test_results:
-          path: ./artifacts/junit
-      - store_artifacts:
           path: ./artifacts
-
-  test-ie:
-    docker:
-      - image: circleci/node:9
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Run tests
-          command: yarn test --karma.singleRun --karma.browsers=bs_ie11_windows --karma.reporters mocha junit BrowserStack || true
-      - store_test_results:
-          path: ./artifacts/junit
       - store_artifacts:
           path: ./artifacts
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -41,13 +41,6 @@ module.exports = (config) => {
         browser_version: '15.0',
         os: 'Windows',
         os_version: '10'
-      },
-      bs_ie11_windows: {
-        base: 'BrowserStack',
-        browser: 'ie',
-        browser_version: '11.0',
-        os: 'Windows',
-        os_version: '7'
       }
     }
   };
@@ -56,13 +49,6 @@ module.exports = (config) => {
   configuration.plugins = config.plugins;
   configuration.plugins.push('karma-firefox-launcher');
   configuration.plugins.push('karma-browserstack-launcher');
-
-  // Set output directory for junit reporter
-  if (config.junitReporter) {
-    configuration.junitReporter = {
-      outputDir: 'artifacts/junit/Karma'
-    };
-  }
 
   // Turn on coverage report thresholds
   if (configuration.coverageIstanbulReporter) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,6 @@ module.exports = (config) => {
     preprocessors,
 
     browserStack: {
-      username: 'folioproject1',
       project: 'ui-eholdings'
     },
 


### PR DESCRIPTION
The simplifications here to the Circle and Karma configs should make it much easier to run this stuff locally or on any other CI (like Jenkins).

Also:
- starts running Circle on node 10 (previously 9)
- makes Circle config easier to read
- IE 11 removed until a lot more attention paid to it.