### PR TITLE
Update package select/deselect -- do not clear proxy object -- causes…

### DIFF
--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -89,7 +89,6 @@ class PackageEditRoute extends Component {
       model.visibilityData.isHidden = false;
       model.customCoverage = {};
       model.allowKbToAddTitles = false;
-      model.proxy = {};
       updatePackage(model);
     } else if (values.isSelected && !values.customCoverages) {
       model.isSelected = true;
@@ -146,7 +145,6 @@ class PackageEditRoute extends Component {
     model.isSelected = true;
     model.selectedCount = model.titleCount;
     model.allowKbToAddTitles = true;
-    model.proxy = {};
     updatePackage(model);
   };
 

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -89,7 +89,6 @@ class PackageShowRoute extends Component {
     model.isSelected = true;
     model.selectedCount = model.titleCount;
     model.allowKbToAddTitles = true;
-    model.proxy = {};
     updatePackage(model);
   };
 
@@ -112,7 +111,6 @@ class PackageShowRoute extends Component {
         model.visibilityData.isHidden = false;
         model.customCoverage = {};
         model.allowKbToAddTitles = false;
-        model.proxy = {};
       }
 
       updatePackage(model);


### PR DESCRIPTION
## Purpose

Kruthi reported an issue with selecting and deselecting packages after updates to a show/edit proxy was merged

Specifically -- she was seeing the following error:
`Proxy 'id' must be present when 'inherited' is false`

## Approach

Remove logic which clears proxy object on package select and de-select. This was causing proxy id to be cleared-- causing errors when making package update request to rm api
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Screenshots
Below error observed:
![screen shot 2018-09-10 at 10 41 34 am](https://user-images.githubusercontent.com/19415226/45304481-30dbf780-b4e6-11e8-97d1-943a8044863b.png)
