### PR TITLE
Bump version up for further releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eholdings",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "FOLIO UI module for eHoldings",
   "main": "src/index.js",
   "repository": "https://github.com/folio-org/ui-eholdings",


### PR DESCRIPTION
## Purpose
Since, we released v1.0.0, we want to ensure that going forward, builds get a new version. Bump up version for that reason. 