### PR TITLE
UIEH-556 Remove duplicate search call to server

### DIFF
--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -228,7 +228,6 @@ class SearchRoute extends Component {
     };
 
     this.updateURLParams(params);
-    this.search(params);
   };
 
   /**


### PR DESCRIPTION
## Purpose
Resolves https://issues.folio.org/browse/UIEH-556

## Approach
The search experience only needed to lean on the URL changing and didn't explicitly have to call `this.search()` to fire off the server event.