### PR TITLE
UIEH-558 - Fix for issue with multiple re-rendering of the search pane

### DIFF
--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -86,7 +86,14 @@ class SearchRoute extends Component {
     let { location, match } = nextProps;
     let { searchType, ...params } = qs.parse(location.search);
     let hideDetails = /^\/eholdings\/?$/.test(location.pathname);
+    let shouldFocusItem = null;
 
+    if (hideDetails && match.params.id !== (prevState.match && prevState.match.params.id)) {
+      shouldFocusItem = prevState.match.params.id || null;
+    }
+    // update searchstring state only when it actually changes in the location instead of updating it each time on
+    // input to text field. This eliminates re-rendering of the text field on each keyboard in and solves problem
+    // stated in https://issues.folio.org/browse/UIEH-558
     if (!isEqual(location, prevState.location)) {
       return {
         ...prevState,
@@ -95,43 +102,21 @@ class SearchRoute extends Component {
         searchType,
         params,
         hideDetails,
+        shouldFocusItem,
         sort: params.sort,
         searchFilter: params.filter,
-        searchField: params.searchfield
+        searchField: params.searchfield,
+        searchString: params.q
       };
     }
     return null;
   }
 
-  componentDidUpdate(prevProps) {
-    let shouldFocusItem = null;
+  componentDidUpdate() {
     // cache the query so it can be restored via the search type
     if (this.state.searchType) {
       this.queries[this.state.searchType] = this.state.params;
       this.path[this.state.searchType] = this.state.location.pathname;
-    }
-
-    // when details are not visible, we need to focus the last active
-    // list item as determined by the `id` URL param
-    if (this.state.hideDetails && this.state.match.params.id !== prevProps.match.params.id) {
-      shouldFocusItem = prevProps.match.params.id || null;
-    }
-
-    // update searchstring state only when it actually changes in the location instead of updating it each time on
-    // input to text field. This eliminates re-rendering of the text field on each keyboard in and solves problem
-    // stated in https://issues.folio.org/browse/UIEH-558
-    // The eslint disable line that we added in the line below can be removed after we move to React 17.0
-    if (!isEqual(this.state.location, prevProps.location)) {
-      this.setState(({ params }) => ({ // eslint-disable-line react/no-did-update-set-state
-        searchString: params.q
-      }));
-    }
-
-    // Rest of the state is updated in getDerivedStateFromProps except the one below whose state is
-    // computed after component updates. So, update it here.
-    // The eslint disable line that we added in the line below can be removed after we move to React 17.0
-    if (!isEqual(shouldFocusItem, this.state.shouldFocusItem)) {
-      this.setState({ shouldFocusItem }); // eslint-disable-line react/no-did-update-set-state
     }
   }
 

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -105,7 +105,6 @@ class SearchRoute extends Component {
 
   componentDidUpdate(prevProps) {
     let shouldFocusItem = null;
-
     // cache the query so it can be restored via the search type
     if (this.state.searchType) {
       this.queries[this.state.searchType] = this.state.params;
@@ -123,7 +122,9 @@ class SearchRoute extends Component {
     // stated in https://issues.folio.org/browse/UIEH-558
     // The eslint disable line that we added in the line below can be removed after we move to React 17.0
     if (!isEqual(this.state.location, prevProps.location)) {
-      this.setState({ searchString: this.state.params.q }); // eslint-disable-line react/no-did-update-set-state
+      this.setState(({ params }) => ({ // eslint-disable-line react/no-did-update-set-state
+        searchString: params.q
+      }));
     }
 
     // Rest of the state is updated in getDerivedStateFromProps except the one below whose state is

--- a/yarn.lock
+++ b/yarn.lock
@@ -8884,13 +8884,13 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-rxjs@^5.4.3:
+rxjs@^5.4.3, rxjs@^5.5.12:
   version "5.5.12"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
   dependencies:
     symbol-observable "1.0.1"
 
-rxjs@^6.1.0, rxjs@^6.3.2:
+rxjs@^6.1.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.2.tgz#6a688b16c4e6e980e62ea805ec30648e1c60907f"
   dependencies:


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-558, input text in the search field is being reset due to re-rendering of the search pane. This PR attempts to fix the issue.

## Approach
- In search.js, conditionally modify when searchString should be updated instead of updating its state always like we were doing before.
- Since `componentWillReceiveProps` lifecycle hook is going to be deprecated from React 17, replace the use of `componentWillReceiveProps` with `getDerivedStateFromProps` and `componentDidUpdate` as suggested here: https://hackernoon.com/replacing-componentwillreceiveprops-with-getderivedstatefromprops-c3956f7ce607
- Ensure that all unit tests are passing with these changes.

## Learning
https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization
https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops
https://hackernoon.com/replacing-componentwillreceiveprops-with-getderivedstatefromprops-c3956f7ce607
