### PR TITLE
Use rxjs 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "inflected": "^2.0.3",
     "react-intl": "^2.4.0",
     "react-measure": "^2.1.0",
-    "redux-actions": "^2.2.1"
+    "redux-actions": "^2.2.1",
+    "rxjs": "^5.5.12"
   },
   "peerDependencies": {
     "@folio/stripes-core": "^2.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8890,7 +8890,7 @@ rxjs@^5.4.3:
   dependencies:
     symbol-observable "1.0.1"
 
-rxjs@^6.1.0:
+rxjs@^6.1.0, rxjs@^6.3.2:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.2.tgz#6a688b16c4e6e980e62ea805ec30648e1c60907f"
   dependencies:


### PR DESCRIPTION
## Purpose
eHoldings was relying on an upstream `rxjs` instead of specifying its own dependency. At some point the upstream got bumped up to `6.x`, so the `5.x`-style imports in eHoldings broke.

Thanks @rjruizes for the report.

## Approach
Lock in eHoldings to use `rxjs` `5.x`.