### PR TITLE
UIEH-546: Update number records found when results have been limited to first 10K

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     "no-console": "warn",
     "prefer-const": "off",
     "react/forbid-prop-types": "off",
-    "react/destructuring-assignment": "off"
+    "react/destructuring-assignment": "off",
+    "react/sort-prop-types": ["error"]
   }
 };

--- a/src/components/coverage-date-list/coverage-date-list.js
+++ b/src/components/coverage-date-list/coverage-date-list.js
@@ -6,8 +6,8 @@ class CoverageDateList extends React.Component {
   static propTypes = {
     coverageArray: PropTypes.array,
     id: PropTypes.string,
-    isYearOnly: PropTypes.bool,
-    intl: intlShape.isRequired
+    intl: intlShape.isRequired,
+    isYearOnly: PropTypes.bool
   };
 
   compareCoverage(coverageObj1, coverageObj2) {

--- a/src/components/details-view/accordion-list-header.js
+++ b/src/components/details-view/accordion-list-header.js
@@ -7,7 +7,7 @@ import styles from './accordion-list-header.css';
 
 function AccordionListHeader(props) {
   let { intl } = props;
-  let showOver = props.resultsLength === 10000;
+  let showOver = props.metaLength > props.resultsLength;
 
   return (
     <div className={styles['accordion-list-header']}>
@@ -31,6 +31,7 @@ function AccordionListHeader(props) {
 
 AccordionListHeader.propTypes = {
   intl: intlShape.isRequired,
+  metaLength: PropTypes.number,
   open: PropTypes.bool,
   resultsLength: PropTypes.number
 };

--- a/src/components/details-view/accordion-list-header.js
+++ b/src/components/details-view/accordion-list-header.js
@@ -1,18 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedNumber, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage, FormattedNumber, injectIntl, intlShape } from 'react-intl';
 import { KeyValue } from '@folio/stripes-components';
 import AccordionHeader from '@folio/stripes-components/lib/Accordion/headers/DefaultAccordionHeader';
 import styles from './accordion-list-header.css';
 
 function AccordionListHeader(props) {
   let { intl } = props;
+  let showOver = props.resultsLength === 10000;
+
   return (
     <div className={styles['accordion-list-header']}>
       <AccordionHeader {...props} />
       {props.open && (
         <KeyValue label={intl.formatMessage({ id: 'ui-eholdings.label.accordionList' })}>
           <div data-test-eholdings-details-view-results-count>
+            {showOver && (
+              <span>
+                <FormattedMessage id="ui-eholdings.over" />
+                &nbsp;
+              </span>
+            )}
             <FormattedNumber value={props.resultsLength} />
           </div>
         </KeyValue>

--- a/src/components/details-view/accordion-list-header.js
+++ b/src/components/details-view/accordion-list-header.js
@@ -22,9 +22,9 @@ function AccordionListHeader(props) {
 }
 
 AccordionListHeader.propTypes = {
-  resultsLength: PropTypes.number,
+  intl: intlShape.isRequired,
   open: PropTypes.bool,
-  intl: intlShape.isRequired
+  resultsLength: PropTypes.number
 };
 
 export default injectIntl(AccordionListHeader);

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -58,6 +58,7 @@ class DetailsView extends Component {
     ]),
     renderList: PropTypes.func,
     resultsLength: PropTypes.number,
+    metaLength: PropTypes.number,
     searchModal: PropTypes.node,
     sections: PropTypes.object,
     type: PropTypes.string.isRequired
@@ -197,6 +198,7 @@ class DetailsView extends Component {
       actionMenuItems,
       lastMenu,
       resultsLength,
+      metaLength,
       searchModal,
       sections,
       handleExpandAll,
@@ -300,6 +302,7 @@ class DetailsView extends Component {
                     label={capitalize(listType)}
                     displayWhenOpen={searchModal}
                     resultsLength={resultsLength}
+                    metaLength={metaLength}
                     contentRef={(n) => { this.$list = n; measureRef(n); }}
                     open={isListAccordionOpen}
                     id={listSectionId}

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -32,35 +32,35 @@ const cx = classNames.bind(styles);
  */
 class DetailsView extends Component {
   static propTypes = {
-    type: PropTypes.string.isRequired,
+    actionMenuItems: PropTypes.array,
+    bodyContent: PropTypes.node.isRequired,
+    handleExpandAll: PropTypes.func,
+    intl: intlShape.isRequired,
+    lastMenu: PropTypes.node,
+    listSectionId: PropTypes.string,
+    listType: PropTypes.node,
     model: PropTypes.shape({
-      name: PropTypes.string.isRequired,
       isLoaded: PropTypes.bool.isRequired,
       isLoading: PropTypes.bool.isRequired,
+      name: PropTypes.string.isRequired,
       request: PropTypes.object.isRequired
     }).isRequired,
-    paneTitle: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.element,
-      PropTypes.node
-    ]),
+    onListToggle: PropTypes.func,
     paneSub: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.element,
       PropTypes.node
     ]),
-    bodyContent: PropTypes.node.isRequired,
+    paneTitle: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+      PropTypes.node
+    ]),
     renderList: PropTypes.func,
-    actionMenuItems: PropTypes.array,
-    lastMenu: PropTypes.node,
     resultsLength: PropTypes.number,
     searchModal: PropTypes.node,
     sections: PropTypes.object,
-    handleExpandAll: PropTypes.func,
-    listType: PropTypes.node,
-    listSectionId: PropTypes.string,
-    onListToggle: PropTypes.func,
-    intl: intlShape.isRequired
+    type: PropTypes.string.isRequired
   };
 
   static contextTypes = {

--- a/src/components/external-link/external-link.js
+++ b/src/components/external-link/external-link.js
@@ -20,6 +20,6 @@ export default function ExternalLink(props) {
 
 ExternalLink.propTypes = {
   href: PropTypes.string,
-  target: PropTypes.string,
-  rel: PropTypes.string
+  rel: PropTypes.string,
+  target: PropTypes.string
 };

--- a/src/components/impagination.js
+++ b/src/components/impagination.js
@@ -116,15 +116,15 @@ function updateDataset(props, state) {
 
 export default class Impagination extends Component {
   static propTypes = {
-    pageSize: PropTypes.number,
-    loadHorizon: PropTypes.number,
-    readOffset: PropTypes.number,
+    children: PropTypes.func.isRequired,
+    collection: PropTypes.object.isRequired,
     // this prop is most definitely used, but the way in which it gets
     // destructured from a default argument confuses eslint
     // eslint-disable-next-line react/no-unused-prop-types
     fetch: PropTypes.func.isRequired,
-    collection: PropTypes.object.isRequired,
-    children: PropTypes.func.isRequired
+    loadHorizon: PropTypes.number,
+    pageSize: PropTypes.number,
+    readOffset: PropTypes.number
   };
 
   static defaultProps = {

--- a/src/components/inline-form/inline-form.js
+++ b/src/components/inline-form/inline-form.js
@@ -6,11 +6,11 @@ import styles from './inline-form.css';
 
 export default class InlineForm extends Component {
   static propTypes = {
-    onSubmit: PropTypes.func.isRequired,
-    onCancel: PropTypes.func.isRequired,
-    pristine: PropTypes.bool.isRequired,
+    children: PropTypes.node.isRequired,
     isPending: PropTypes.bool.isRequired,
-    children: PropTypes.node.isRequired
+    onCancel: PropTypes.func.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    pristine: PropTypes.bool.isRequired
   }
 
   render() {

--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -96,17 +96,17 @@ function PackageListItem({
 }
 
 PackageListItem.propTypes = {
+  active: PropTypes.bool,
+  headingLevel: PropTypes.string,
   item: PropTypes.object,
   link: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object
   ]),
-  active: PropTypes.bool,
-  showTitleCount: PropTypes.bool,
-  showProviderName: PropTypes.bool,
-  packageName: PropTypes.string,
   onClick: PropTypes.func,
-  headingLevel: PropTypes.string
+  packageName: PropTypes.string,
+  showProviderName: PropTypes.bool,
+  showTitleCount: PropTypes.bool
 };
 
 // this HOC adds a prop, `shouldFocus` that will focus the component's

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -20,11 +20,11 @@ import styles from './package-create.css';
 
 class PackageCreate extends Component {
   static propTypes = {
-    request: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func.isRequired,
+    intl: intlShape.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool.isRequired,
-    intl: intlShape.isRequired
+    request: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -28,16 +28,16 @@ import styles from './custom-package-edit.css';
 
 class CustomPackageEdit extends Component {
   static propTypes = {
+    addPackageToHoldings: PropTypes.func.isRequired,
     change: PropTypes.func,
     handleSubmit: PropTypes.func,
     initialValues: PropTypes.object.isRequired,
+    intl: intlShape.isRequired,
     model: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    proxyTypes: PropTypes.object.isRequired,
-    intl: intlShape.isRequired,
-    addPackageToHoldings: PropTypes.func.isRequired,
-    provider: PropTypes.object.isRequired
+    provider: PropTypes.object.isRequired,
+    proxyTypes: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -26,16 +26,16 @@ import styles from './managed-package-edit.css';
 
 class ManagedPackageEdit extends Component {
   static propTypes = {
+    addPackageToHoldings: PropTypes.func.isRequired,
     change: PropTypes.func,
-    model: PropTypes.object.isRequired,
-    initialValues: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func,
+    initialValues: PropTypes.object.isRequired,
+    intl: intlShape.isRequired,
+    model: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    intl: intlShape.isRequired,
-    addPackageToHoldings: PropTypes.func.isRequired,
-    proxyTypes: PropTypes.object.isRequired,
-    provider: PropTypes.object.isRequired
+    provider: PropTypes.object.isRequired,
+    proxyTypes: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -420,6 +420,7 @@ class PackageShow extends Component {
           listSectionId="packageShowTitles"
           onListToggle={this.handleSectionToggle}
           resultsLength={model.resources.length}
+          metaLength={model.titleCount}
           renderList={scrollable => (
             <QueryList
               type="package-titles"

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -29,14 +29,14 @@ import styles from './package-show.css';
 
 class PackageShow extends Component {
   static propTypes = {
-    model: PropTypes.object.isRequired,
-    proxyTypes: PropTypes.object.isRequired,
-    provider: PropTypes.object.isRequired,
+    addPackageToHoldings: PropTypes.func.isRequired,
     fetchPackageTitles: PropTypes.func.isRequired,
     intl: intlShape.isRequired,
-    toggleSelected: PropTypes.func.isRequired,
-    addPackageToHoldings: PropTypes.func.isRequired,
-    searchModal: PropTypes.node
+    model: PropTypes.object.isRequired,
+    provider: PropTypes.object.isRequired,
+    proxyTypes: PropTypes.object.isRequired,
+    searchModal: PropTypes.node,
+    toggleSelected: PropTypes.func.isRequired
   };
 
   static contextTypes = {

--- a/src/components/provider-list-item/provider-list-item.js
+++ b/src/components/provider-list-item/provider-list-item.js
@@ -56,14 +56,14 @@ function ProviderListItem({ item, link, active, onClick, headingLevel }) {
 }
 
 ProviderListItem.propTypes = {
+  active: PropTypes.bool,
+  headingLevel: PropTypes.string,
   item: PropTypes.object,
   link: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object
   ]),
-  active: PropTypes.bool,
-  onClick: PropTypes.func,
-  headingLevel: PropTypes.string
+  onClick: PropTypes.func
 };
 
 // this HOC adds a prop, `shouldFocus` that will focus the component's

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -19,13 +19,13 @@ import styles from './provider-edit.css';
 
 class ProviderEdit extends Component {
   static propTypes = {
-    proxyTypes: PropTypes.object.isRequired,
-    rootProxy: PropTypes.object.isRequired,
-    model: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func,
+    intl: intlShape.isRequired,
+    model: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    intl: intlShape.isRequired
+    proxyTypes: PropTypes.object.isRequired,
+    rootProxy: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -17,14 +17,14 @@ import styles from './provider-show.css';
 
 class ProviderShow extends Component {
    static propTypes = {
-     proxyTypes: PropTypes.object.isRequired,
-     rootProxy: PropTypes.object.isRequired,
+     fetchPackages: PropTypes.func.isRequired,
+     intl: intlShape.isRequired,
+     listType: PropTypes.string.isRequired,
      model: PropTypes.object.isRequired,
      packages: PropTypes.object.isRequired,
-     fetchPackages: PropTypes.func.isRequired,
-     searchModal: PropTypes.node,
-     intl: intlShape.isRequired,
-     listType: PropTypes.string.isRequired
+     proxyTypes: PropTypes.object.isRequired,
+     rootProxy: PropTypes.object.isRequired,
+     searchModal: PropTypes.node
    };
 
   static contextTypes = {

--- a/src/components/proxy-select/proxy-select-field.js
+++ b/src/components/proxy-select/proxy-select-field.js
@@ -39,9 +39,9 @@ function ProxySelectField({ proxyTypes, inheritedProxyId, intl }) {
 }
 
 ProxySelectField.propTypes = {
-  proxyTypes: PropTypes.object.isRequired,
   inheritedProxyId: PropTypes.string.isRequired,
-  intl: intlShape.isRequired
+  intl: intlShape.isRequired,
+  proxyTypes: PropTypes.object.isRequired
 };
 
 export default injectIntl(ProxySelectField);

--- a/src/components/query-list/query-list.js
+++ b/src/components/query-list/query-list.js
@@ -14,22 +14,22 @@ export default class QueryList extends Component {
   }
 
   static propTypes = {
-    type: PropTypes.string.isRequired,
-    offset: PropTypes.number,
-    pageSize: PropTypes.number,
-    loadHorizon: PropTypes.number,
+    collection: PropTypes.object.isRequired,
+    fetch: PropTypes.func.isRequired,
+    fullWidth: PropTypes.bool,
     itemHeight: PropTypes.number,
-    scrollable: PropTypes.bool,
+    length: PropTypes.number,
+    loadHorizon: PropTypes.number,
     notFoundMessage: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.node
     ]).isRequired,
-    collection: PropTypes.object.isRequired,
-    fetch: PropTypes.func.isRequired,
-    renderItem: PropTypes.func.isRequired,
+    offset: PropTypes.number,
     onUpdateOffset: PropTypes.func,
-    length: PropTypes.number,
-    fullWidth: PropTypes.bool
+    pageSize: PropTypes.number,
+    renderItem: PropTypes.func.isRequired,
+    scrollable: PropTypes.bool,
+    type: PropTypes.string.isRequired
   };
 
   static defaultProps = {

--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -14,9 +14,9 @@ import styles from './custom-embargo-fields.css';
 class CustomEmbargoFields extends Component {
   static propTypes = {
     change: PropTypes.func.isRequired,
-    showInputs: PropTypes.bool,
     initialValue: PropTypes.object,
-    intl: intlShape.isRequired
+    intl: intlShape.isRequired,
+    showInputs: PropTypes.bool
   };
 
   state = {

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -27,14 +27,14 @@ import ProxySelectField from '../../proxy-select';
 
 class ResourceEditCustomTitle extends Component {
   static propTypes = {
-    model: PropTypes.object.isRequired,
-    initialValues: PropTypes.object.isRequired,
+    change: PropTypes.func,
+    customCoverageDateValues: PropTypes.array,
     handleSubmit: PropTypes.func,
+    initialValues: PropTypes.object.isRequired,
+    intl: intlShape.isRequired,
+    model: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    change: PropTypes.func,
-    intl: intlShape.isRequired,
-    customCoverageDateValues: PropTypes.array,
     proxyTypes: PropTypes.object.isRequired
   };
 

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -27,15 +27,15 @@ import ProxySelectField from '../../proxy-select';
 
 class ResourceEditManagedTitle extends Component {
   static propTypes = {
-    proxyTypes: PropTypes.object.isRequired,
-    model: PropTypes.object.isRequired,
-    initialValues: PropTypes.object.isRequired,
+    change: PropTypes.func,
+    customCoverageDateValues: PropTypes.array,
     handleSubmit: PropTypes.func,
+    initialValues: PropTypes.object.isRequired,
+    intl: intlShape.isRequired,
+    model: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    change: PropTypes.func,
-    intl: intlShape.isRequired,
-    customCoverageDateValues: PropTypes.array
+    proxyTypes: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -27,10 +27,10 @@ import ProxyDisplay from '../proxy-display';
 
 class ResourceShow extends Component {
   static propTypes = {
+    intl: intlShape.isRequired,
     model: PropTypes.object.isRequired,
-    toggleSelected: PropTypes.func.isRequired,
-    intl: intlShape.isRequired, // eslint-disable-line react/no-unused-prop-types
-    proxyTypes: PropTypes.object.isRequired
+    proxyTypes: PropTypes.object.isRequired,
+    toggleSelected: PropTypes.func.isRequired
   };
 
   static contextTypes = {

--- a/src/components/scroll-view/scroll-view.js
+++ b/src/components/scroll-view/scroll-view.js
@@ -14,17 +14,17 @@ export default class ScrollView extends Component {
   }
 
   static propTypes = {
+    children: PropTypes.func.isRequired,
+    fullWidth: PropTypes.bool,
+    itemHeight: PropTypes.number.isRequired,
     items: PropTypes.shape({
       length: PropTypes.number.isRequired,
       slice: PropTypes.func.isRequired
     }).isRequired,
     length: PropTypes.number,
     offset: PropTypes.number,
-    scrollable: PropTypes.bool,
-    itemHeight: PropTypes.number.isRequired,
     onUpdate: PropTypes.func,
-    children: PropTypes.func.isRequired,
-    fullWidth: PropTypes.bool
+    scrollable: PropTypes.bool
   };
 
   static defaultProps = {

--- a/src/components/search-form/search-filters.js
+++ b/src/components/search-form/search-filters.js
@@ -56,16 +56,16 @@ export default function SearchFilters({
 }
 
 SearchFilters.propTypes = {
-  searchType: PropTypes.string.isRequired,
   activeFilters: PropTypes.object,
   availableFilters: PropTypes.arrayOf(PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    label: PropTypes.string.isRequired,
     defaultValue: PropTypes.string,
+    label: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
     options: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired
     })).isRequired
   })).isRequired,
-  onUpdate: PropTypes.func.isRequired
+  onUpdate: PropTypes.func.isRequired,
+  searchType: PropTypes.string.isRequired
 };

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -17,28 +17,28 @@ const validSearchTypes = ['providers', 'packages', 'titles'];
 
 class SearchForm extends Component {
   static propTypes = {
-    searchType: PropTypes.oneOf(validSearchTypes).isRequired,
-    searchTypeUrls: PropTypes.shape({
-      providers: PropTypes.string.isRequired,
-      packages: PropTypes.string.isRequired,
-      titles: PropTypes.string.isRequired
-    }),
+    displaySearchButton: PropTypes.bool,
+    displaySearchTypeSwitcher: PropTypes.bool,
+    intl: intlShape.isRequired,
+    isLoading: PropTypes.bool,
+    onFilterChange: PropTypes.func.isRequired,
     onSearch: PropTypes.func.isRequired,
-    searchString: PropTypes.string,
+    onSearchChange: PropTypes.func.isRequired,
+    onSearchFieldChange: PropTypes.func,
     searchField: PropTypes.string,
     searchFilter: PropTypes.shape({
-      q: PropTypes.string,
       filter: PropTypes.object,
+      q: PropTypes.string,
       searchfield: PropTypes.string,
     }),
-    sort: PropTypes.string,
-    displaySearchTypeSwitcher: PropTypes.bool,
-    displaySearchButton: PropTypes.bool,
-    isLoading: PropTypes.bool,
-    onSearchChange: PropTypes.func.isRequired,
-    onFilterChange: PropTypes.func.isRequired,
-    onSearchFieldChange: PropTypes.func,
-    intl: intlShape.isRequired
+    searchString: PropTypes.string,
+    searchType: PropTypes.oneOf(validSearchTypes).isRequired,
+    searchTypeUrls: PropTypes.shape({
+      packages: PropTypes.string.isRequired,
+      providers: PropTypes.string.isRequired,
+      titles: PropTypes.string.isRequired
+    }),
+    sort: PropTypes.string
   };
 
   static defaultProps = {

--- a/src/components/search-modal/search-badge.js
+++ b/src/components/search-modal/search-badge.js
@@ -19,6 +19,6 @@ export default function SearchBadge({ filterCount = 0, onClick, ...rest }) {
 }
 
 SearchBadge.propTypes = {
-  onClick: PropTypes.func.isRequired,
   filterCount: PropTypes.number,
+  onClick: PropTypes.func.isRequired,
 };

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -30,8 +30,8 @@ class SearchModal extends React.PureComponent {
   static propTypes = {
     intl: intlShape.isRequired,
     listType: PropTypes.string,
-    onSearch: PropTypes.func,
     onFilter: PropTypes.func,
+    onSearch: PropTypes.func,
     query: PropTypes.object,
   };
 

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -18,18 +18,18 @@ import SearchBadge from '../search-modal/search-badge';
 
 export default class SearchPaneset extends React.Component { // eslint-disable-line react/no-deprecated
   static propTypes = {
-    searchForm: PropTypes.node,
-    hideFilters: PropTypes.bool,
-    resultsType: PropTypes.string,
-    resultsView: PropTypes.node,
     detailsView: PropTypes.node,
-    totalResults: PropTypes.number,
     filterCount: PropTypes.number,
+    hideFilters: PropTypes.bool,
     isLoading: PropTypes.bool,
     location: PropTypes.shape({
       pathname: PropTypes.string.isRequired,
       search: PropTypes.string.isRequired
     }).isRequired,
+    resultsType: PropTypes.string,
+    resultsView: PropTypes.node,
+    searchForm: PropTypes.node,
+    totalResults: PropTypes.number,
     updateFilters: PropTypes.func.isRequired
   };
 

--- a/src/components/settings-knowledge-base/settings-knowledge-base.js
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.js
@@ -14,13 +14,13 @@ import styles from './settings-knowledge-base.css';
 
 class SettingsKnowledgeBase extends Component {
   static propTypes = {
+    handleSubmit: PropTypes.func,
+    intl: intlShape.isRequired,
+    invalid: PropTypes.bool,
     model: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired,
-    handleSubmit: PropTypes.func,
     pristine: PropTypes.bool,
-    reset: PropTypes.func,
-    intl: intlShape.isRequired,
-    invalid: PropTypes.bool
+    reset: PropTypes.func
   };
 
   render() {

--- a/src/components/settings-root-proxy/settings-root-proxy.js
+++ b/src/components/settings-root-proxy/settings-root-proxy.js
@@ -15,14 +15,14 @@ import styles from './settings-root-proxy.css';
 
 class SettingsRootProxy extends Component {
   static propTypes = {
-    proxyTypes: PropTypes.object.isRequired,
-    rootProxy: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func,
+    intl: intlShape.isRequired,
+    invalid: PropTypes.bool,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
+    proxyTypes: PropTypes.object.isRequired,
     reset: PropTypes.func,
-    intl: intlShape.isRequired,
-    invalid: PropTypes.bool
+    rootProxy: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -82,16 +82,16 @@ function TitleListItem({
 }
 
 TitleListItem.propTypes = {
+  active: PropTypes.bool,
+  headingLevel: PropTypes.string,
   item: PropTypes.object,
   link: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object
   ]),
-  active: PropTypes.bool,
-  showSelected: PropTypes.bool,
-  showPublisherAndType: PropTypes.bool,
   onClick: PropTypes.func,
-  headingLevel: PropTypes.string
+  showPublisherAndType: PropTypes.bool,
+  showSelected: PropTypes.bool
 };
 
 // this HOC adds a prop, `shouldFocus` that will focus the component's

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -26,12 +26,12 @@ import styles from './title-create.css';
 
 class TitleCreate extends Component {
   static propTypes = {
-    request: PropTypes.object.isRequired,
     customPackages: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func.isRequired,
+    intl: intlShape.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool.isRequired,
-    intl: intlShape.isRequired
+    request: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -24,13 +24,13 @@ import styles from './title-edit.css';
 
 class TitleEdit extends Component {
   static propTypes = {
-    model: PropTypes.object.isRequired,
-    initialValues: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func,
+    initialValues: PropTypes.object.isRequired,
+    intl: intlShape.isRequired,
+    model: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    updateRequest: PropTypes.object.isRequired,
-    intl: intlShape.isRequired
+    updateRequest: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -24,11 +24,11 @@ import styles from './title-show.css';
 
 class TitleShow extends Component {
   static propTypes = {
-    request: PropTypes.object.isRequired,
-    model: PropTypes.object.isRequired,
-    customPackages: PropTypes.object.isRequired,
     addCustomPackage: PropTypes.func.isRequired,
-    intl: intlShape.isRequired
+    customPackages: PropTypes.object.isRequired,
+    intl: intlShape.isRequired,
+    model: PropTypes.object.isRequired,
+    request: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/src/components/toaster/toast.js
+++ b/src/components/toaster/toast.js
@@ -21,19 +21,19 @@ class Toast extends Component {
     animationPosition: PropTypes.string,
 
     // the type of toast: warn, error, or success
-    type: PropTypes.oneOf(['warn', 'error', 'success']),
-
-    // the error message is a child of the `Toast` component
     children: PropTypes.node.isRequired,
 
-    // to pick the specific toast out when calling `onClose`
+    // the error message is a child of the `Toast` component
     id: PropTypes.string.isRequired,
 
-    // called when the toast is closed
+    // to pick the specific toast out when calling `onClose`
     onClose: PropTypes.func.isRequired,
 
+    // called when the toast is closed
+    timeout: PropTypes.number,
+
     // change the amount of time the toast is displayed for
-    timeout: PropTypes.number
+    type: PropTypes.oneOf(['warn', 'error', 'success'])
   };
 
   static defaultProps = {

--- a/src/components/toaster/toaster.js
+++ b/src/components/toaster/toaster.js
@@ -22,17 +22,17 @@ class Toaster extends Component {
     // array of toast messages to display
     toasts: PropTypes.arrayOf(PropTypes.shape({
       // the type of toast: warn, error, or success
-      type: PropTypes.string,
-      // to pick the specific toast out when calling `onClose`
       id: PropTypes.string.isRequired,
-      // the toast message that will be displayed in the UI
+      // to pick the specific toast out when calling `onClose`
       message: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.func,
         PropTypes.node
       ]).isRequired,
+      // the toast message that will be displayed in the UI
+      timeout: PropTypes.number,
       // the time which the toast is shown
-      timeout: PropTypes.number
+      type: PropTypes.string
     })).isRequired
   };
 

--- a/src/components/toggle-switch/toggle-switch.js
+++ b/src/components/toggle-switch/toggle-switch.js
@@ -7,13 +7,13 @@ const cx = classNames.bind(styles);
 
 export default class ToggleSwitch extends Component {
   static propTypes = {
-    input: PropTypes.object,
-    onChange: PropTypes.func,
-    name: PropTypes.string,
-    id: PropTypes.string,
-    disabled: PropTypes.bool,
     checked: PropTypes.bool,
-    isPending: PropTypes.bool
+    disabled: PropTypes.bool,
+    id: PropTypes.string,
+    input: PropTypes.object,
+    isPending: PropTypes.bool,
+    name: PropTypes.string,
+    onChange: PropTypes.func
   }
 
   state = {

--- a/src/components/token/token-field.js
+++ b/src/components/token/token-field.js
@@ -11,8 +11,8 @@ import styles from './token-field.css';
 
 class TokenField extends Component {
   static propTypes = {
-    tokenValue: PropTypes.string,
     token: PropTypes.object,
+    tokenValue: PropTypes.string,
     type: PropTypes.string
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,11 +27,11 @@ class EHoldings extends Component {
     match: PropTypes.shape({
       path: PropTypes.string.isRequired
     }).isRequired,
-    showSettings: PropTypes.bool,
     root: PropTypes.shape({
-      addReducer: PropTypes.func.isRequired,
       addEpic: PropTypes.func.isRequired,
-    })
+      addReducer: PropTypes.func.isRequired,
+    }),
+    showSettings: PropTypes.bool
   };
 
   static contextTypes = {

--- a/src/router.js
+++ b/src/router.js
@@ -39,6 +39,6 @@ export function Route({ component: Component, children, ...props }) {
 }
 
 Route.propTypes = {
-  component: PropTypes.func,
-  children: PropTypes.node
+  children: PropTypes.node,
+  component: PropTypes.func
 };

--- a/src/routes/application/application.js
+++ b/src/routes/application/application.js
@@ -12,11 +12,11 @@ import styles from './application.css';
 
 class ApplicationRoute extends Component {
   static propTypes = {
-    showSettings: PropTypes.bool,
     children: PropTypes.node.isRequired,
+    getBackendStatus: PropTypes.func.isRequired,
     interfaces: PropTypes.object,
-    status: PropTypes.object.isRequired,
-    getBackendStatus: PropTypes.func.isRequired
+    showSettings: PropTypes.bool,
+    status: PropTypes.object.isRequired
   }
 
   constructor(props) {

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -11,8 +11,8 @@ import View from '../components/package/create';
 
 class PackageCreateRoute extends Component {
   static propTypes = {
-    createRequest: PropTypes.object.isRequired,
-    createPackage: PropTypes.func.isRequired
+    createPackage: PropTypes.func.isRequired,
+    createRequest: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -14,22 +14,22 @@ import View from '../components/package/edit';
 
 class PackageEditRoute extends Component {
   static propTypes = {
+    destroyPackage: PropTypes.func.isRequired,
+    getPackage: PropTypes.func.isRequired,
+    getProvider: PropTypes.func.isRequired,
+    getProxyTypes: PropTypes.func.isRequired,
+    intl: intlShape.isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         packageId: PropTypes.string.isRequired
       }).isRequired
     }).isRequired,
     model: PropTypes.object.isRequired,
-    intl: intlShape.isRequired,
-    getPackage: PropTypes.func.isRequired,
-    getProxyTypes: PropTypes.func.isRequired,
-    getProvider: PropTypes.func.isRequired,
-    proxyTypes: PropTypes.object.isRequired,
     provider: PropTypes.object.isRequired,
+    proxyTypes: PropTypes.object.isRequired,
     unloadResources: PropTypes.func.isRequired,
-    updateProvider: PropTypes.func.isRequired,
     updatePackage: PropTypes.func.isRequired,
-    destroyPackage: PropTypes.func.isRequired,
+    updateProvider: PropTypes.func.isRequired,
   };
 
   static contextTypes = {

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -15,21 +15,21 @@ import SearchModal from '../components/search-modal';
 
 class PackageShowRoute extends Component {
   static propTypes = {
+    destroyPackage: PropTypes.func.isRequired,
+    getPackage: PropTypes.func.isRequired,
+    getPackageTitles: PropTypes.func.isRequired,
+    getProvider: PropTypes.func.isRequired,
+    getProxyTypes: PropTypes.func.isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         packageId: PropTypes.string.isRequired
       }).isRequired
     }).isRequired,
     model: PropTypes.object.isRequired,
-    getPackage: PropTypes.func.isRequired,
-    getPackageTitles: PropTypes.func.isRequired,
-    getProxyTypes: PropTypes.func.isRequired,
-    getProvider: PropTypes.func.isRequired,
     provider: PropTypes.object.isRequired,
+    proxyTypes: PropTypes.object.isRequired,
     unloadResources: PropTypes.func.isRequired,
     updatePackage: PropTypes.func.isRequired,
-    destroyPackage: PropTypes.func.isRequired,
-    proxyTypes: PropTypes.object.isRequired,
   };
 
   static contextTypes = {

--- a/src/routes/provider-edit.js
+++ b/src/routes/provider-edit.js
@@ -11,18 +11,18 @@ import View from '../components/provider/edit';
 
 class ProviderEditRoute extends Component {
   static propTypes = {
+    getProvider: PropTypes.func.isRequired,
+    getProxyTypes: PropTypes.func.isRequired,
+    getRootProxy: PropTypes.func.isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         providerId: PropTypes.string.isRequired
       }).isRequired
     }).isRequired,
     model: PropTypes.object.isRequired,
-    getProxyTypes: PropTypes.func.isRequired,
-    getRootProxy: PropTypes.func.isRequired,
-    getProvider: PropTypes.func.isRequired,
-    updateProvider: PropTypes.func.isRequired,
     proxyTypes: PropTypes.object.isRequired,
-    rootProxy: PropTypes.object.isRequired
+    rootProxy: PropTypes.object.isRequired,
+    updateProvider: PropTypes.func.isRequired
   };
 
   static contextTypes = {

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -12,19 +12,19 @@ import SearchModal from '../components/search-modal';
 
 class ProviderShowRoute extends Component {
   static propTypes = {
+    getPackages: PropTypes.func.isRequired,
+    getProvider: PropTypes.func.isRequired,
+    getProxyTypes: PropTypes.func.isRequired,
+    getRootProxy: PropTypes.func.isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         providerId: PropTypes.string.isRequired
       }).isRequired
     }).isRequired,
     model: PropTypes.object.isRequired,
-    getProxyTypes: PropTypes.func.isRequired,
-    resolver: PropTypes.object.isRequired,
-    getProvider: PropTypes.func.isRequired,
-    getPackages: PropTypes.func.isRequired,
     proxyTypes: PropTypes.object.isRequired,
+    resolver: PropTypes.object.isRequired,
     rootProxy: PropTypes.object.isRequired,
-    getRootProxy: PropTypes.func.isRequired,
 
   };
 

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -12,17 +12,17 @@ import View from '../components/resource/edit';
 
 class ResourceEditRoute extends Component {
   static propTypes = {
+    destroyResource: PropTypes.func.isRequired,
+    getProxyTypes: PropTypes.func.isRequired,
+    getResource: PropTypes.func.isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         id: PropTypes.string.isRequired
       }).isRequired
     }).isRequired,
     model: PropTypes.object.isRequired,
-    getProxyTypes: PropTypes.func.isRequired,
-    getResource: PropTypes.func.isRequired,
-    updateResource: PropTypes.func.isRequired,
-    destroyResource: PropTypes.func.isRequired,
-    proxyTypes: PropTypes.object.isRequired
+    proxyTypes: PropTypes.object.isRequired,
+    updateResource: PropTypes.func.isRequired
   };
 
   static contextTypes = {

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -10,17 +10,17 @@ import { ProxyType } from '../redux/application';
 
 class ResourceShowRoute extends Component {
   static propTypes = {
+    destroyResource: PropTypes.func.isRequired,
+    getProxyTypes: PropTypes.func.isRequired,
+    getResource: PropTypes.func.isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         id: PropTypes.string.isRequired
       }).isRequired
     }).isRequired,
     model: PropTypes.object.isRequired,
-    getResource: PropTypes.func.isRequired,
-    updateResource: PropTypes.func.isRequired,
-    destroyResource: PropTypes.func.isRequired,
-    getProxyTypes: PropTypes.func.isRequired,
     proxyTypes: PropTypes.object.isRequired,
+    updateResource: PropTypes.func.isRequired,
   };
 
   static contextTypes = {

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -20,25 +20,25 @@ import { filterCountFromQuery } from '../components/search-modal/search-modal';
 
 class SearchRoute extends Component {
   static propTypes = {
+    children: PropTypes.node.isRequired,
+    history: PropTypes.shape({
+      location: PropTypes.object,
+      push: PropTypes.func.isRequired,
+      replace: PropTypes.func.isRequired
+    }).isRequired,
     location: PropTypes.shape({
       pathname: PropTypes.string.isRequired,
       search: PropTypes.string.isRequired
-    }).isRequired,
-    history: PropTypes.shape({
-      push: PropTypes.func.isRequired,
-      replace: PropTypes.func.isRequired,
-      location: PropTypes.object
     }).isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         id: PropTypes.string
       }).isRequired
     }).isRequired,
-    searchProviders: PropTypes.func.isRequired,
-    searchPackages: PropTypes.func.isRequired,
-    searchTitles: PropTypes.func.isRequired,
     resolver: PropTypes.object.isRequired,
-    children: PropTypes.node.isRequired
+    searchPackages: PropTypes.func.isRequired,
+    searchProviders: PropTypes.func.isRequired,
+    searchTitles: PropTypes.func.isRequired
   };
 
   static childContextTypes = {

--- a/src/routes/settings-root-proxy.js
+++ b/src/routes/settings-root-proxy.js
@@ -9,10 +9,10 @@ import View from '../components/settings-root-proxy';
 
 class SettingsRootProxyRoute extends Component {
   static propTypes = {
-    proxyTypes: PropTypes.object.isRequired,
-    rootProxy: PropTypes.object.isRequired,
     getProxyTypes: PropTypes.func.isRequired,
     getRootProxy: PropTypes.func.isRequired,
+    proxyTypes: PropTypes.object.isRequired,
+    rootProxy: PropTypes.object.isRequired,
     updateRootProxy: PropTypes.func.isRequired
   };
 

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -12,8 +12,8 @@ import View from '../components/title/create';
 class TitleCreateRoute extends Component {
   static propTypes = {
     createRequest: PropTypes.object.isRequired,
-    customPackages: PropTypes.object.isRequired,
     createTitle: PropTypes.func.isRequired,
+    customPackages: PropTypes.object.isRequired,
     getCustomPackages: PropTypes.func.isRequired
   };
 

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -11,15 +11,15 @@ import View from '../components/title/edit';
 
 class TitleEditRoute extends Component {
   static propTypes = {
+    getTitle: PropTypes.func.isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         titleId: PropTypes.string.isRequired
       }).isRequired
     }).isRequired,
     model: PropTypes.object.isRequired,
-    getTitle: PropTypes.func.isRequired,
-    updateResource: PropTypes.func.isRequired,
-    updateRequest: PropTypes.object
+    updateRequest: PropTypes.object,
+    updateResource: PropTypes.func.isRequired
   };
 
   static contextTypes = {

--- a/src/routes/title-show.js
+++ b/src/routes/title-show.js
@@ -11,17 +11,17 @@ import View from '../components/title/show';
 
 class TitleShowRoute extends Component {
   static propTypes = {
+    createRequest: PropTypes.object.isRequired,
+    createResource: PropTypes.func.isRequired,
+    customPackages: PropTypes.object.isRequired,
+    getCustomPackages: PropTypes.func.isRequired,
+    getTitle: PropTypes.func.isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         titleId: PropTypes.string.isRequired
       }).isRequired
     }).isRequired,
-    model: PropTypes.object.isRequired,
-    customPackages: PropTypes.object.isRequired,
-    getTitle: PropTypes.func.isRequired,
-    getCustomPackages: PropTypes.func.isRequired,
-    createResource: PropTypes.func.isRequired,
-    createRequest: PropTypes.object.isRequired
+    model: PropTypes.object.isRequired
   };
 
   static contextTypes = {

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -305,5 +305,6 @@
     "number": "Number",
     "hidden": "Hidden",
     "name.isRequired": "Name *",
-    "resultCount": "{count, number} {count, plural, one {search result} other {search results}}"
+    "resultCount": "{count, number} {count, plural, one {search result} other {search results}}",
+    "over": "Over"
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose

Per https://issues.folio.org/browse/UIEH-546, there is currently a discrepancy in the 
total number of titles displayed in package detail information and number of records found in the title result list accordion. This specifically happens for a package when the number of records (ie titles) found is greater than 10,000. This is currently a limitation in RM API as only the first 10,000 title results are returned. In these cases, UI should display `Over 10,000` as the number of records found to indicate this fact.

## Approach
Compare the number of titles (as returned from package details request meta data ) to the number of results (as returned from request to get title list for a package). If package meta data is greater than number of results returned from list, add `Over` to the accordion header display.

#### TODOS and Open Questions
- [ ] Create unit tests -- how to simulate large result list
- [ ] AccordionListHeader is used in multiple places (as part of DetailsView). Understand impact of adding a new parameter to determine of Over gets displayed.
- [ ] Should over apply to only titles list and if the count is 10,000?

## Learning

Sample package details request to mod-kb-ebsco 

`GET packages/19-5207`

Note - response includes titleCount  attribute:

"titleCount":1552561

Sample request to GET package associated resources

`GET packages/19-5207/resources?page=1`

Note - response includes totalResults  meta data:

"totalResults":10000

## Screenshots
Before:
<img width="1667" alt="screen shot 2018-09-23 at 8 59 56 pm" src="https://user-images.githubusercontent.com/19415226/45934983-ada1b380-bf73-11e8-921a-f2deb35c28a4.png">
After:
<img width="1680" alt="screen shot 2018-09-23 at 9 02 59 pm" src="https://user-images.githubusercontent.com/19415226/45934998-1b4ddf80-bf74-11e8-9c6e-27af5be35d3e.png">


