### PR TITLE
Lift routing actions into routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "qs": "^6.5.1",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
+    "react-router-prop-types": "^1.0.4",
     "react-transition-group": "^2.2.1",
     "react-trigger-change": "^1.0.2",
     "stylelint": "^9.5.0",

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
-import { intlShape, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
+import { withRouter } from 'react-router';
+import { intlShape, injectIntl } from 'react-intl';
 import classNames from 'classnames/bind';
 import capitalize from 'lodash/capitalize';
 import { ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
@@ -35,10 +37,12 @@ class DetailsView extends Component {
     actionMenuItems: PropTypes.array,
     bodyContent: PropTypes.node.isRequired,
     handleExpandAll: PropTypes.func,
+    history: ReactRouterPropTypes.history.isRequired,
     intl: intlShape.isRequired,
     lastMenu: PropTypes.node,
     listSectionId: PropTypes.string,
     listType: PropTypes.node,
+    location: ReactRouterPropTypes.location.isRequired,
     model: PropTypes.shape({
       isLoaded: PropTypes.bool.isRequired,
       isLoading: PropTypes.bool.isRequired,
@@ -61,11 +65,6 @@ class DetailsView extends Component {
     searchModal: PropTypes.node,
     sections: PropTypes.object,
     type: PropTypes.string.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.object,
-    queryParams: PropTypes.object
   };
 
   static defaultProps = {
@@ -202,10 +201,10 @@ class DetailsView extends Component {
       handleExpandAll,
       listSectionId,
       onListToggle,
-      intl
+      intl,
+      history,
+      location
     } = this.props;
-
-    let { router, queryParams } = this.context;
 
     let { isSticky } = this.state;
 
@@ -213,25 +212,25 @@ class DetailsView extends Component {
       locked: isSticky
     });
 
-    let historyState = router.history.location.state;
+    let historyState = history.location.state;
 
     let isListAccordionOpen = sections && sections[listSectionId];
 
     return (
       <div data-test-eholdings-details-view={type}>
         <PaneHeader
-          firstMenu={queryParams.searchType ? (
+          firstMenu={location.search ? (
             <IconButton
               icon="closeX"
               ariaLabel={intl.formatMessage({ id: 'ui-eholdings.label.icon.closeX' }, { paneTitle })}
-              href={`/eholdings${router.route.location.search}`}
+              href={`/eholdings${location.search}`}
               data-test-eholdings-details-view-close-button
             />
           ) : historyState && historyState.eholdings && (
             <IconButton
               icon="left-arrow"
               ariaLabel={intl.formatMessage({ id: 'ui-eholdings.label.icon.goBack' })}
-              onClick={() => router.history.goBack()}
+              onClick={() => history.goBack()}
               data-test-eholdings-details-view-back-button
             />
           )}
@@ -317,4 +316,4 @@ class DetailsView extends Component {
   }
 }
 
-export default (injectIntl(DetailsView));
+export default (injectIntl(withRouter(DetailsView)));

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -7,6 +7,7 @@ import classNames from 'classnames/bind';
 import capitalize from 'lodash/capitalize';
 import { ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
 import Measure from 'react-measure';
+import queryString from 'qs';
 
 import {
   Accordion,
@@ -215,11 +216,12 @@ class DetailsView extends Component {
     let historyState = history.location.state;
 
     let isListAccordionOpen = sections && sections[listSectionId];
+    const { searchType } = queryString.parse(location.search, { ignoreQueryPrefix: true });
 
     return (
       <div data-test-eholdings-details-view={type}>
         <PaneHeader
-          firstMenu={location.search ? (
+          firstMenu={searchType ? (
             <IconButton
               icon="closeX"
               ariaLabel={intl.formatMessage({ id: 'ui-eholdings.label.icon.closeX' }, { paneTitle })}

--- a/src/components/navigation-modal/navigation-modal.js
+++ b/src/components/navigation-modal/navigation-modal.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
+import { withRouter } from 'react-router';
 import { Modal, ModalFooter } from '@folio/stripes-components';
 import { FormattedMessage } from 'react-intl';
 
-export default class NavigationModal extends Component {
+class NavigationModal extends Component {
   static propTypes = {
     children: PropTypes.oneOfType([
       PropTypes.func,
@@ -11,24 +13,16 @@ export default class NavigationModal extends Component {
     ]),
     continueLabel: PropTypes.string.isRequired,
     dismissLabel: PropTypes.string.isRequired,
+    history: ReactRouterPropTypes.history.isRequired,
     modalLabel: PropTypes.string.isRequired,
     when: PropTypes.bool.isRequired
   };
 
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        block: PropTypes.func.isRequired,
-        push: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
-  };
-
-  constructor(props, context) {
+  constructor(props) {
     super(props);
 
     if (props.when) {
-      this.enable(context);
+      this.enable();
     }
   }
 
@@ -49,12 +43,14 @@ export default class NavigationModal extends Component {
     this.disable();
   }
 
-  enable(context = this.context) {
+  enable() {
+    const { history } = this.props;
+
     if (this.unblock) {
       this.unblock();
     }
 
-    this.unblock = context.router.history.block((nextLocation) => {
+    this.unblock = history.block((nextLocation) => {
       this.setState({
         showModal: true,
         nextLocation
@@ -78,10 +74,13 @@ export default class NavigationModal extends Component {
   };
 
   continue = () => {
+    const { history } = this.props;
+    const { nextLocation } = this.state;
+
     this.disable();
 
-    if (this.state.nextLocation) {
-      this.context.router.history.push(this.state.nextLocation);
+    if (nextLocation) {
+      history.push(nextLocation);
     }
   };
 
@@ -124,3 +123,5 @@ export default class NavigationModal extends Component {
     }
   }
 }
+
+export default withRouter(NavigationModal);

--- a/src/components/package-search-list.js
+++ b/src/components/package-search-list.js
@@ -5,15 +5,15 @@ import { FormattedMessage } from 'react-intl';
 import QueryList from './query-list';
 import PackageListItem from './package-list-item';
 
-export default function PackageSearchList({
+function PackageSearchList({
   activeId,
   collection,
   fetch,
-  location,
   onUpdateOffset,
   params,
-  shouldFocusItem
-}, { router }) {
+  shouldFocusItem,
+  onClickItem
+}) {
   return (
     <QueryList
       type="packages"
@@ -38,11 +38,7 @@ export default function PackageSearchList({
           }}
           active={item.content && activeId && item.content.id === activeId}
           shouldFocus={item.content && shouldFocusItem && item.content.id === shouldFocusItem}
-          onClick={() => {
-            router.history.push(
-              `/eholdings/packages/${item.content.id}${location.search}`
-            );
-          }}
+          onClick={() => onClickItem(`/eholdings/packages/${item.content.id}`)}
         />
       )}
     />
@@ -53,12 +49,10 @@ PackageSearchList.propTypes = {
   activeId: PropTypes.string,
   collection: PropTypes.object.isRequired,
   fetch: PropTypes.func.isRequired,
-  location: PropTypes.object.isRequired,
+  onClickItem: PropTypes.func.isRequired,
   onUpdateOffset: PropTypes.func.isRequired,
   params: PropTypes.object.isRequired,
   shouldFocusItem: PropTypes.string
 };
 
-PackageSearchList.contextTypes = {
-  router: PropTypes.object
-};
+export default PackageSearchList;

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -40,7 +40,7 @@ class PackageCreate extends Component {
 
     let actionMenuItems = [];
 
-    if (!request.isPending) {
+    if (!request.isPending && onCancel) {
       actionMenuItems.push({
         'label': intl.formatMessage({ id: 'ui-eholdings.actionMenu.cancelEditing' }),
         'state': { eholdings: true },

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -22,22 +22,11 @@ class PackageCreate extends Component {
   static propTypes = {
     handleSubmit: PropTypes.func.isRequired,
     intl: intlShape.isRequired,
+    onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool.isRequired,
     request: PropTypes.object.isRequired
   };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        goBack: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
-  };
-
-  handleCancel = () => {
-    this.context.router.history.goBack();
-  }
 
   render() {
     let {
@@ -45,14 +34,9 @@ class PackageCreate extends Component {
       request,
       handleSubmit,
       onSubmit,
+      onCancel,
       pristine
     } = this.props;
-
-    let {
-      router
-    } = this.context;
-
-    let historyState = router.history.location.state;
 
     let actionMenuItems = [];
 
@@ -60,7 +44,7 @@ class PackageCreate extends Component {
       actionMenuItems.push({
         'label': intl.formatMessage({ id: 'ui-eholdings.actionMenu.cancelEditing' }),
         'state': { eholdings: true },
-        'onClick': this.handleCancel,
+        'onClick': onCancel,
         'data-test-eholdings-package-create-cancel-action': true
       });
     }
@@ -80,11 +64,11 @@ class PackageCreate extends Component {
           <PaneHeader
             paneTitle={<FormattedMessage id="ui-eholdings.package.create.custom" />}
             actionMenuItems={actionMenuItems}
-            firstMenu={historyState && historyState.eholdings && (
+            firstMenu={onCancel && (
               <IconButton
                 icon="left-arrow"
                 ariaLabel={intl.formatMessage({ id: 'ui-eholdings.label.icon.goBack' })}
-                onClick={this.handleCancel}
+                onClick={onCancel}
                 data-test-eholdings-details-view-back-button
               />
             )}

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -53,19 +53,22 @@ class CustomPackageEdit extends Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
+    let stateUpdates = {};
+
     if (nextProps.model.destroy.errors.length) {
-      return { showSelectionModal: false };
+      stateUpdates.showSelectionModal = false;
     }
 
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
-      return {
+      Object.assign(stateUpdates, {
         initialValues: {
           isSelected: nextProps.initialValues.isSelected
         },
         packageSelected: nextProps.initialValues.isSelected
-      };
+      });
     }
-    return null;
+
+    return Object.keys(stateUpdates) ? stateUpdates : null;
   }
 
   handleDeleteAction = () => {

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
-import isEqual from 'lodash/isEqual';
 import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
 
 import {
@@ -30,23 +29,19 @@ class CustomPackageEdit extends Component {
   static propTypes = {
     addPackageToHoldings: PropTypes.func.isRequired,
     change: PropTypes.func,
+    fullViewLink: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]),
     handleSubmit: PropTypes.func,
     initialValues: PropTypes.object.isRequired,
     intl: intlShape.isRequired,
     model: PropTypes.object.isRequired,
+    onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
     provider: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        push: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired,
-    queryParams: PropTypes.object
   };
 
   state = {
@@ -54,9 +49,8 @@ class CustomPackageEdit extends Component {
     allowFormToSubmit: false,
     packageSelected: this.props.initialValues.isSelected,
     formValues: {},
-    // these are used above in getDerivedStateFromProps
-    packageVisible: this.props.initialValues.isVisible, // eslint-disable-line react/no-unused-state
-    initialValues: this.props.initialValues // eslint-disable-line react/no-unused-state
+    packageVisible: this.props.initialValues.isVisible,
+    initialValues: this.props.initialValues
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -75,30 +69,6 @@ class CustomPackageEdit extends Component {
       };
     }
     return prevState;
-  }
-
-  componentDidUpdate(prevProps) {
-    let wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
-    let needsUpdate = !isEqual(prevProps.model, this.props.model);
-    let { router } = this.context;
-
-    if (wasPending && needsUpdate) {
-      router.history.push({
-        pathname: `/eholdings/packages/${this.props.model.id}`,
-        search: router.route.location.search,
-        state: { eholdings: true, isFreshlySaved: true }
-      });
-    }
-  }
-
-  handleCancel = () => {
-    let { router } = this.context;
-
-    router.history.push({
-      pathname: `/eholdings/packages/${this.props.model.id}`,
-      search: this.context.router.route.location.search,
-      state: { eholdings: true }
-    });
   }
 
   handleDeleteAction = () => {
@@ -148,7 +118,9 @@ class CustomPackageEdit extends Component {
       pristine,
       proxyTypes,
       provider,
-      intl
+      intl,
+      onCancel,
+      fullViewLink
     } = this.props;
 
     let {
@@ -156,32 +128,20 @@ class CustomPackageEdit extends Component {
       packageSelected
     } = this.state;
 
-    let {
-      queryParams,
-      router
-    } = this.context;
-
     let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
 
     let actionMenuItems = [
       {
         'label': intl.formatMessage({ id: 'ui-eholdings.actionMenu.cancelEditing' }),
-        'to': {
-          pathname: `/eholdings/packages/${model.id}`,
-          search: router.route.location.search,
-          state: { eholdings: true }
-        },
+        'onClick': onCancel,
         'data-test-eholdings-package-cancel-action': true
       }
     ];
 
-    if (queryParams.searchType) {
+    if (fullViewLink) {
       actionMenuItems.push({
         label: intl.formatMessage({ id: 'ui-eholdings.actionMenu.fullView' }),
-        to: {
-          pathname: `/eholdings/packages/${model.id}/edit`,
-          state: { eholdings: true }
-        },
+        to: fullViewLink,
         className: styles['full-view-link']
       });
     }

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -49,7 +49,6 @@ class CustomPackageEdit extends Component {
     allowFormToSubmit: false,
     packageSelected: this.props.initialValues.isSelected,
     formValues: {},
-    packageVisible: this.props.initialValues.isVisible,
     initialValues: this.props.initialValues
   }
 
@@ -60,15 +59,13 @@ class CustomPackageEdit extends Component {
 
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
       return {
-        ...prevState,
         initialValues: {
-          ...prevState.initialValues,
           isSelected: nextProps.initialValues.isSelected
         },
         packageSelected: nextProps.initialValues.isSelected
       };
     }
-    return prevState;
+    return null;
   }
 
   handleDeleteAction = () => {

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -47,7 +47,6 @@ class ManagedPackageEdit extends Component {
     allowFormToSubmit: false,
     packageSelected: this.props.initialValues.isSelected,
     formValues: {},
-    packageVisible: this.props.initialValues.isVisible,
     initialValues: this.props.initialValues
   }
 
@@ -58,15 +57,13 @@ class ManagedPackageEdit extends Component {
 
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
       return {
-        ...prevState,
         initialValues: {
-          ...prevState.initialValues,
           isSelected: nextProps.initialValues.isSelected
         },
         packageSelected: nextProps.initialValues.isSelected
       };
     }
-    return prevState;
+    return null;
   }
 
   handleSelectionAction = () => {

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -51,19 +51,22 @@ class ManagedPackageEdit extends Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
+    let stateUpdates = {};
+
     if (nextProps.model.update.errors.length) {
-      return { showSelectionModal: false };
+      stateUpdates.showSelectionModal = false;
     }
 
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
-      return {
+      Object.assign(stateUpdates, {
         initialValues: {
           isSelected: nextProps.initialValues.isSelected
         },
         packageSelected: nextProps.initialValues.isSelected
-      };
+      });
     }
-    return null;
+
+    return Object.keys(stateUpdates) ? stateUpdates : null;
   }
 
   handleSelectionAction = () => {

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -30,18 +30,24 @@ import styles from './package-show.css';
 class PackageShow extends Component {
   static propTypes = {
     addPackageToHoldings: PropTypes.func.isRequired,
+    editLink: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]).isRequired,
     fetchPackageTitles: PropTypes.func.isRequired,
+    fullViewLink: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]),
     intl: intlShape.isRequired,
+    isDestroyed: PropTypes.bool,
+    isFreshlySaved: PropTypes.bool,
+    isNewRecord: PropTypes.bool,
     model: PropTypes.object.isRequired,
     provider: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
     searchModal: PropTypes.node,
     toggleSelected: PropTypes.func.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.object,
-    queryParams: PropTypes.object
   };
 
   state = {
@@ -113,9 +119,14 @@ class PackageShow extends Component {
       intl,
       proxyTypes,
       provider,
-      searchModal
+      searchModal,
+      editLink,
+      fullViewLink,
+      isFreshlySaved,
+      isNewRecord,
+      isDestroyed
     } = this.props;
-    let { router, queryParams } = this.context;
+
     let {
       showSelectionModal,
       packageSelected,
@@ -145,21 +156,14 @@ class PackageShow extends Component {
     let actionMenuItems = [
       {
         label: <FormattedMessage id="ui-eholdings.actionMenu.edit" />,
-        to: {
-          pathname: `/eholdings/packages/${model.id}/edit`,
-          search: router.route.location.search,
-          state: { eholdings: true }
-        }
+        to: editLink
       }
     ];
 
-    if (queryParams.searchType) {
+    if (fullViewLink) {
       actionMenuItems.push({
         label: <FormattedMessage id="ui-eholdings.actionMenu.fullView" />,
-        to: {
-          pathname: `/eholdings/packages/${model.id}`,
-          state: { eholdings: true }
-        },
+        to: fullViewLink,
         className: styles['full-view-link']
       });
     }
@@ -186,9 +190,7 @@ class PackageShow extends Component {
     let toasts = processErrors(model);
 
     // if coming from creating a new custom package, show a success toast
-    if (router.history.action === 'REPLACE' &&
-        router.history.location.state &&
-        router.history.location.state.isNewRecord) {
+    if (isNewRecord) {
       toasts.push({
         id: `success-package-creation-${model.id}`,
         message: intl.formatMessage({ id: 'ui-eholdings.package.toast.isNewRecord' }),
@@ -198,9 +200,7 @@ class PackageShow extends Component {
 
     // if coming from destroying a custom or managed title
     // from within custom-package, show a success toast
-    if (router.history.action === 'REPLACE' &&
-        router.history.location.state &&
-        router.history.location.state.isDestroyed) {
+    if (isDestroyed) {
       toasts.push({
         id: `success-resource-destruction-${model.id}`,
         message: intl.formatMessage({ id: 'ui-eholdings.package.toast.isDestroyed' }),
@@ -209,9 +209,7 @@ class PackageShow extends Component {
     }
 
     // if coming from saving edits to the package, show a success toast
-    if (router.history.action === 'PUSH' &&
-        router.history.location.state &&
-        router.history.location.state.isFreshlySaved) {
+    if (isFreshlySaved) {
       toasts.push({
         id: `success-package-saved-${model.id}`,
         message: intl.formatMessage({ id: 'ui-eholdings.package.toast.isFreshlySaved' }),
@@ -236,11 +234,7 @@ class PackageShow extends Component {
               data-test-eholdings-package-edit-link
               icon="edit"
               ariaLabel={intl.formatMessage({ id: 'ui-eholdings.label.editLink' }, { name: model.name })}
-              to={{
-                pathname: `/eholdings/packages/${model.id}/edit`,
-                search: router.route.location.search,
-                state: { eholdings: true }
-              }}
+              to={editLink}
             />
           )}
           bodyContent={(

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -64,16 +64,15 @@ class PackageShow extends Component {
     }
   };
 
-  static getDerivedStateFromProps(nextProps, prevState) {
+  static getDerivedStateFromProps(nextProps) {
     const { model: { allowKbToAddTitles, isSaving, isSelected } } = nextProps;
     if (!isSaving) {
       return {
-        ...prevState,
         packageSelected: isSelected,
         packageAllowedToAddTitles: allowKbToAddTitles
       };
     }
-    return prevState;
+    return null;
   }
 
   handleSelectionToggle = () => {

--- a/src/components/provider-search-list.js
+++ b/src/components/provider-search-list.js
@@ -9,11 +9,11 @@ export default function ProviderSearchList({
   activeId,
   collection,
   fetch,
-  location,
   onUpdateOffset,
   params,
   shouldFocusItem,
-}, { router }) {
+  onClickItem
+}) {
   return (
     <QueryList
       type="providers"
@@ -38,11 +38,7 @@ export default function ProviderSearchList({
           }}
           active={item.content && activeId && item.content.id === activeId}
           shouldFocus={item.content && shouldFocusItem && item.content.id === shouldFocusItem}
-          onClick={() => {
-            router.history.push(
-              `/eholdings/providers/${item.content.id}${location.search}`
-            );
-          }}
+          onClick={() => onClickItem(`/eholdings/providers/${item.content.id}`)}
         />
       )}
     />
@@ -53,12 +49,8 @@ ProviderSearchList.propTypes = {
   activeId: PropTypes.string,
   collection: PropTypes.object.isRequired,
   fetch: PropTypes.func.isRequired,
-  location: PropTypes.object.isRequired,
+  onClickItem: PropTypes.func.isRequired,
   onUpdateOffset: PropTypes.func.isRequired,
   params: PropTypes.object.isRequired,
-  shouldFocusItem: PropTypes.string,
-};
-
-ProviderSearchList.contextTypes = {
-  router: PropTypes.object
+  shouldFocusItem: PropTypes.string
 };

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
-import isEqual from 'lodash/isEqual';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import {
   Icon
@@ -19,38 +18,19 @@ import styles from './provider-edit.css';
 
 class ProviderEdit extends Component {
   static propTypes = {
+    fullViewLink: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]),
     handleSubmit: PropTypes.func,
     intl: intlShape.isRequired,
     model: PropTypes.object.isRequired,
+    onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
     proxyTypes: PropTypes.object.isRequired,
     rootProxy: PropTypes.object.isRequired
   };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        push: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired,
-    queryParams: PropTypes.object
-  };
-
-  componentDidUpdate(prevProps) {
-    let wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
-    let needsUpdate = !isEqual(prevProps.model, this.props.model);
-    let isRejected = this.props.model.update.isRejected;
-    let { router } = this.context;
-
-    if (wasPending && needsUpdate && !isRejected) {
-      router.history.push({
-        pathname: `/eholdings/providers/${prevProps.model.id}`,
-        search: router.route.location.search,
-        state: { eholdings: true, isFreshlySaved: true }
-      });
-    }
-  }
 
   render() {
     let {
@@ -59,33 +39,27 @@ class ProviderEdit extends Component {
       rootProxy,
       handleSubmit,
       onSubmit,
+      onCancel,
       pristine,
-      intl
+      intl,
+      fullViewLink
     } = this.props;
 
-    let { router, queryParams } = this.context;
     let supportsTokens = model.providerToken && model.providerToken.prompt;
     let hasTokenValue = model.providerToken && model.providerToken.value;
 
     let actionMenuItems = [
       {
         'label': <FormattedMessage id="ui-eholdings.actionMenu.cancelEditing" />,
-        'to': {
-          pathname: `/eholdings/providers/${model.id}`,
-          search: router.route.location.search,
-          state: { eholdings: true }
-        },
+        'onClick': onCancel,
         'data-test-eholdings-provider-cancel-action': true
       }
     ];
 
-    if (queryParams.searchType) {
+    if (fullViewLink) {
       actionMenuItems.push({
         label: <FormattedMessage id="ui-eholdings.actionMenu.fullView" />,
-        to: {
-          pathname: `/eholdings/providers/${model.id}`,
-          state: { eholdings: true }
-        },
+        to: fullViewLink,
         className: styles['full-view-link']
       });
     }

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -17,8 +17,17 @@ import styles from './provider-show.css';
 
 class ProviderShow extends Component {
    static propTypes = {
+     editLink: PropTypes.oneOfType([
+       PropTypes.string,
+       PropTypes.object
+     ]).isRequired,
      fetchPackages: PropTypes.func.isRequired,
+     fullViewLink: PropTypes.oneOfType([
+       PropTypes.string,
+       PropTypes.object
+     ]),
      intl: intlShape.isRequired,
+     isFreshlySaved: PropTypes.bool,
      listType: PropTypes.string.isRequired,
      model: PropTypes.object.isRequired,
      packages: PropTypes.object.isRequired,
@@ -26,11 +35,6 @@ class ProviderShow extends Component {
      rootProxy: PropTypes.object.isRequired,
      searchModal: PropTypes.node
    };
-
-  static contextTypes = {
-    router: PropTypes.object,
-    queryParams: PropTypes.object
-  };
 
   state = {
     sections: {
@@ -51,14 +55,11 @@ class ProviderShow extends Component {
   }
 
   get toasts() {
-    let { model, intl } = this.props;
-    let { router } = this.context;
+    let { model, intl, isFreshlySaved } = this.props;
     let toasts = processErrors(model);
 
     // if coming from saving edits to the package, show a success toast
-    if (router.history.action === 'PUSH' &&
-        router.history.location.state &&
-        router.history.location.state.isFreshlySaved) {
+    if (isFreshlySaved) {
       toasts.push({
         id: `success-provider-saved-${model.id}`,
         message: intl.formatMessage({ id: 'ui-eholdings.provider.toast.isFreshlySaved' }),
@@ -77,9 +78,10 @@ class ProviderShow extends Component {
       packages,
       searchModal,
       proxyTypes,
-      rootProxy
+      rootProxy,
+      editLink,
+      fullViewLink
     } = this.props;
-    let { router, queryParams } = this.context;
     let { sections } = this.state;
     let hasProxy = model.proxy && model.proxy.id;
     let hasToken = model.providerToken && model.providerToken.prompt;
@@ -88,21 +90,14 @@ class ProviderShow extends Component {
     let actionMenuItems = [
       {
         label: <FormattedMessage id="ui-eholdings.actionMenu.edit" />,
-        to: {
-          pathname: `/eholdings/providers/${model.id}/edit`,
-          search: router.route.location.search,
-          state: { eholdings: true }
-        }
+        to: editLink
       }
     ];
 
-    if (queryParams.searchType) {
+    if (fullViewLink) {
       actionMenuItems.push({
         label: <FormattedMessage id="ui-eholdings.actionMenu.fullView" />,
-        to: {
-          pathname: `/eholdings/providers/${model.id}`,
-          state: { eholdings: true }
-        },
+        to: fullViewLink,
         className: styles['full-view-link']
       });
     }
@@ -124,11 +119,7 @@ class ProviderShow extends Component {
               data-test-eholdings-provider-edit-link
               icon="edit"
               ariaLabel={`Edit ${model.name}`}
-              to={{
-                pathname: `/eholdings/providers/${model.id}/edit`,
-                search: router.route.location.search,
-                state: { eholdings: true }
-              }}
+              to={editLink}
             />
           )}
           bodyContent={(

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -47,21 +47,22 @@ class ResourceEditCustomTitle extends Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
+    let stateUpdates = {};
+
     if (nextProps.model.destroy.errors.length) {
-      return {
-        showSelectionModal: false
-      };
+      stateUpdates.showSelectionModal = false;
     }
 
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
-      return {
+      Object.assign(stateUpdates, {
         initialValues: {
           isSelected: nextProps.initialValues.isSelected
         },
         resourceSelected: nextProps.initialValues.isSelected
-      };
+      });
     }
-    return null;
+
+    return Object.keys(stateUpdates) ? stateUpdates : null;
   }
 
   handleRemoveResourceFromHoldings = () => {

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -55,15 +55,13 @@ class ResourceEditCustomTitle extends Component {
 
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
       return {
-        ...prevState,
         initialValues: {
-          ...prevState.initialValues,
           isSelected: nextProps.initialValues.isSelected
         },
         resourceSelected: nextProps.initialValues.isSelected
       };
     }
-    return prevState;
+    return null;
   }
 
   handleRemoveResourceFromHoldings = () => {

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -2,7 +2,6 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { formValueSelector, reduxForm } from 'redux-form';
-import isEqual from 'lodash/isEqual';
 import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
 
 import {
@@ -33,17 +32,10 @@ class ResourceEditCustomTitle extends Component {
     initialValues: PropTypes.object.isRequired,
     intl: intlShape.isRequired,
     model: PropTypes.object.isRequired,
+    onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
     proxyTypes: PropTypes.object.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        push: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
   };
 
   state = {
@@ -51,8 +43,6 @@ class ResourceEditCustomTitle extends Component {
     showSelectionModal: false,
     allowFormToSubmit: false,
     formValues: {},
-    // this is used above in getDerivedStateFromProps
-    // eslint-disable-next-line react/no-unused-state
     initialValues: this.props.initialValues
   }
 
@@ -74,26 +64,6 @@ class ResourceEditCustomTitle extends Component {
       };
     }
     return prevState;
-  }
-
-  componentDidUpdate(prevProps) {
-    let wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
-    let needsUpdate = !isEqual(prevProps.model, this.props.model);
-    let { router } = this.context;
-
-    if (wasPending && needsUpdate) {
-      router.history.push(
-        `/eholdings/resources/${this.props.model.id}`,
-        { eholdings: true, isFreshlySaved: true }
-      );
-    }
-  }
-
-  handleCancel = () => {
-    this.context.router.history.push(
-      `/eholdings/resources/${this.props.model.id}`,
-      { eholdings: true }
-    );
   }
 
   handleRemoveResourceFromHoldings = () => {
@@ -165,7 +135,8 @@ class ResourceEditCustomTitle extends Component {
       handleSubmit,
       pristine,
       intl,
-      change
+      change,
+      onCancel
     } = this.props;
 
     let {
@@ -180,10 +151,7 @@ class ResourceEditCustomTitle extends Component {
     let actionMenuItems = [
       {
         'label': <FormattedMessage id="ui-eholdings.actionMenu.cancelEditing" />,
-        'to': {
-          pathname: `/eholdings/resources/${model.id}`,
-          state: { eholdings: true },
-        },
+        'onClick': onCancel,
         'data-test-eholdings-resource-cancel-action': true
       }
     ];

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -47,19 +47,22 @@ class ResourceEditManagedTitle extends Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
+    let stateUpdates = {};
+
     if (nextProps.model.update.errors.length) {
-      return { showSelectionModal: false };
+      stateUpdates.showSelectionModal = false;
     }
 
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
-      return {
+      Object.assign(stateUpdates, {
         initialValues: {
           isSelected: nextProps.initialValues.isSelected
         },
         managedResourceSelected: nextProps.initialValues.isSelected
-      };
+      });
     }
-    return null;
+
+    return Object.keys(stateUpdates) ? stateUpdates : null;
   }
 
   handleSelectionToggle = (e) => {

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -53,15 +53,13 @@ class ResourceEditManagedTitle extends Component {
 
     if (nextProps.initialValues.isSelected !== prevState.initialValues.isSelected) {
       return {
-        ...prevState,
         initialValues: {
-          ...prevState.initialValues,
           isSelected: nextProps.initialValues.isSelected
         },
         managedResourceSelected: nextProps.initialValues.isSelected
       };
     }
-    return prevState;
+    return null;
   }
 
   handleSelectionToggle = (e) => {

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -51,7 +51,7 @@ class ResourceShow extends Component {
 
   static getDerivedStateFromProps({ model }, prevState) {
     return !model.isSaving ?
-      { ...prevState, resourceSelected: model.isSelected } :
+      { resourceSelected: model.isSelected } :
       prevState;
   }
 

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -27,14 +27,15 @@ import ProxyDisplay from '../proxy-display';
 
 class ResourceShow extends Component {
   static propTypes = {
+    editLink: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]).isRequired,
     intl: intlShape.isRequired,
+    isFreshlySaved: PropTypes.bool,
     model: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
     toggleSelected: PropTypes.func.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.object
   };
 
   state = {
@@ -88,8 +89,7 @@ class ResourceShow extends Component {
   }
 
   render() {
-    let { model, intl, proxyTypes } = this.props;
-    let { router } = this.context;
+    let { model, intl, proxyTypes, editLink, isFreshlySaved } = this.props;
     let {
       showSelectionModal,
       resourceSelected,
@@ -118,10 +118,7 @@ class ResourceShow extends Component {
     let actionMenuItems = [
       {
         label: <FormattedMessage id="ui-eholdings.actionMenu.edit" />,
-        to: {
-          pathname: `/eholdings/resources/${model.id}/edit`,
-          state: { eholdings: true }
-        }
+        to: editLink
       }
     ];
 
@@ -129,9 +126,7 @@ class ResourceShow extends Component {
 
     // if coming from updating any value on managed title in a managed package
     // show a success toast
-    if (router.history.action === 'PUSH' &&
-        router.history.location.state &&
-        router.history.location.state.isFreshlySaved) {
+    if (isFreshlySaved) {
       toasts.push({
         id: `success-package-creation-${model.id}`,
         message: <FormattedMessage id="ui-eholdings.resource.toast.isFreshlySaved" />,
@@ -172,10 +167,7 @@ class ResourceShow extends Component {
               data-test-eholdings-resource-edit-link
               icon="edit"
               ariaLabel={`Edit ${model.title.name}`}
-              to={{
-                pathname: `/eholdings/resources/${model.id}/edit`,
-                state: { eholdings: true }
-              }}
+              to={editLink}
             />
           )}
           bodyContent={(

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -16,27 +16,19 @@ import Link from '../link';
 import styles from './search-paneset.css';
 import SearchBadge from '../search-modal/search-badge';
 
-export default class SearchPaneset extends React.Component { // eslint-disable-line react/no-deprecated
+class SearchPaneset extends React.Component {
   static propTypes = {
     detailsView: PropTypes.node,
     filterCount: PropTypes.number,
     hideFilters: PropTypes.bool,
     isLoading: PropTypes.bool,
-    location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,
-      search: PropTypes.string.isRequired
-    }).isRequired,
+    onClosePreview: PropTypes.func.isRequired,
     resultsType: PropTypes.string,
     resultsView: PropTypes.node,
     searchForm: PropTypes.node,
+    searchLocation: PropTypes.string.isRequired,
     totalResults: PropTypes.number,
     updateFilters: PropTypes.func.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.object
-    })
   };
 
   static defaultProps = {
@@ -54,7 +46,7 @@ export default class SearchPaneset extends React.Component { // eslint-disable-l
   }
 
   componentDidUpdate(prevProps) {
-    let isNewSearch = prevProps.location.search !== this.props.location.search;
+    let isNewSearch = prevProps.searchLocation !== this.props.searchLocation;
     let isSameSearchType = prevProps.resultsType === this.props.resultsType;
 
     // focus the pane title when a new search happens within the same search type
@@ -64,13 +56,6 @@ export default class SearchPaneset extends React.Component { // eslint-disable-l
   }
 
   toggleFilters = () => this.props.updateFilters(hideFilters => !hideFilters)
-
-  closePreview = () => {
-    this.context.router.history.push({
-      pathname: '/eholdings',
-      search: this.props.location.search
-    });
-  };
 
   renderNewButton = () => {
     return (
@@ -92,7 +77,8 @@ export default class SearchPaneset extends React.Component { // eslint-disable-l
       totalResults,
       isLoading,
       hideFilters,
-      filterCount
+      filterCount,
+      onClosePreview
     } = this.props;
 
     hideFilters = hideFilters && !!resultsView;
@@ -122,7 +108,7 @@ export default class SearchPaneset extends React.Component { // eslint-disable-l
     return (
       <div className={styles['search-paneset']}>
         {detailsView && (
-          <SearchPaneVignette className={styles['preview-pane-vignette']} onClick={this.closePreview} />
+          <SearchPaneVignette className={styles['preview-pane-vignette']} onClick={onClosePreview} />
         )}
 
         {!hideFilters && (
@@ -202,3 +188,5 @@ export default class SearchPaneset extends React.Component { // eslint-disable-l
     );
   }
 }
+
+export default SearchPaneset;

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -60,6 +60,7 @@ class SearchPaneset extends React.Component {
   renderNewButton = () => {
     return (
       <Link
+        data-test-eholdings-search-new-button
         className={styles['search-new-button']}
         to={`/eholdings/${this.props.resultsType}/new`}
       >

--- a/src/components/settings-root-proxy/settings-root-proxy.js
+++ b/src/components/settings-root-proxy/settings-root-proxy.js
@@ -2,9 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import { Icon } from '@folio/stripes-components';
-import isEqual from 'lodash/isEqual';
 import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
-
 
 import SettingsDetailPane from '../settings-detail-pane';
 import { processErrors } from '../utilities';
@@ -18,35 +16,13 @@ class SettingsRootProxy extends Component {
     handleSubmit: PropTypes.func,
     intl: intlShape.isRequired,
     invalid: PropTypes.bool,
+    isFreshlySaved: PropTypes.bool,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
     proxyTypes: PropTypes.object.isRequired,
     reset: PropTypes.func,
     rootProxy: PropTypes.object.isRequired
   };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        push: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
-  };
-
-  componentDidUpdate(prevProps) {
-    let wasPending = prevProps.rootProxy.update.isPending && !this.props.rootProxy.update.isPending;
-    let needsUpdate = !isEqual(prevProps.rootProxy, this.props.rootProxy);
-    let isRejected = this.props.rootProxy.update.isRejected;
-
-    let { router } = this.context;
-
-    if (wasPending && needsUpdate && !isRejected) {
-      router.history.push({
-        pathname: '/settings/eholdings/root-proxy',
-        state: { eholdings: true, isFreshlySaved: true }
-      });
-    }
-  }
 
   render() {
     let {
@@ -57,17 +33,12 @@ class SettingsRootProxy extends Component {
       pristine,
       reset,
       intl,
-      invalid
+      invalid,
+      isFreshlySaved
     } = this.props;
-
-    let { router } = this.context;
-
     let toasts = processErrors(rootProxy);
 
-    if (router.history.action === 'PUSH' &&
-        router.history.location.state &&
-        router.history.location.state.isFreshlySaved &&
-        rootProxy.update.isResolved) {
+    if (isFreshlySaved) {
       toasts.push({
         id: `root-proxy-${rootProxy.update.timestamp}`,
         message: <FormattedMessage id="ui-eholdings.settings.rootProxy.updated" />,

--- a/src/components/title-search-list.js
+++ b/src/components/title-search-list.js
@@ -9,11 +9,11 @@ export default function TitleSearchList({
   activeId,
   collection,
   fetch,
-  location,
   onUpdateOffset,
   params,
-  shouldFocusItem
-}, { router }) {
+  shouldFocusItem,
+  onClickItem
+}) {
   return (
     <QueryList
       type="titles"
@@ -38,11 +38,7 @@ export default function TitleSearchList({
           }}
           active={item.content && activeId && item.content.id === activeId}
           shouldFocus={item.content && shouldFocusItem && item.content.id === shouldFocusItem}
-          onClick={() => {
-            router.history.push(
-              `/eholdings/titles/${item.content.id}${location.search}`
-            );
-          }}
+          onClick={() => onClickItem(`/eholdings/titles/${item.content.id}`)}
         />
       )}
     />
@@ -53,12 +49,8 @@ TitleSearchList.propTypes = {
   activeId: PropTypes.string,
   collection: PropTypes.object.isRequired,
   fetch: PropTypes.func.isRequired,
-  location: PropTypes.object.isRequired,
+  onClickItem: PropTypes.func.isRequired,
   onUpdateOffset: PropTypes.func.isRequired,
   params: PropTypes.object.isRequired,
   shouldFocusItem: PropTypes.string
-};
-
-TitleSearchList.contextTypes = {
-  router: PropTypes.object
 };

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -29,22 +29,11 @@ class TitleCreate extends Component {
     customPackages: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     intl: intlShape.isRequired,
+    onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool.isRequired,
     request: PropTypes.object.isRequired
   };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        goBack: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
-  };
-
-  handleCancel = () => {
-    this.context.router.history.goBack();
-  }
 
   render() {
     let {
@@ -53,14 +42,9 @@ class TitleCreate extends Component {
       handleSubmit,
       onSubmit,
       pristine,
-      intl
+      intl,
+      onCancel
     } = this.props;
-
-    let {
-      router
-    } = this.context;
-
-    let historyState = router.history.location.state;
 
     let packageOptions = customPackages.map(pkg => ({
       label: pkg.name,
@@ -73,7 +57,7 @@ class TitleCreate extends Component {
       actionMenuItems.push({
         'label': intl.formatMessage({ id: 'ui-eholdings.actionMenu.cancelEditing' }),
         'state': { eholdings: true },
-        'onClick': this.handleCancel,
+        'onClick': onCancel,
         'data-test-eholdings-title-create-cancel-action': true
       });
     }
@@ -93,11 +77,11 @@ class TitleCreate extends Component {
           <PaneHeader
             paneTitle={intl.formatMessage({ id: 'ui-eholdings.title.create.paneTitle' })}
             actionMenuItems={actionMenuItems}
-            firstMenu={historyState && historyState.eholdings && (
+            firstMenu={onCancel && (
               <IconButton
                 icon="left-arrow"
                 ariaLabel={intl.formatMessage({ id: 'ui-eholdings.label.icon.goBack' })}
-                onClick={this.handleCancel}
+                onClick={onCancel}
                 data-test-eholdings-details-view-back-button
               />
             )}

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -53,7 +53,7 @@ class TitleCreate extends Component {
 
     let actionMenuItems = [];
 
-    if (!request.isPending) {
+    if (!request.isPending && onCancel) {
       actionMenuItems.push({
         'label': intl.formatMessage({ id: 'ui-eholdings.actionMenu.cancelEditing' }),
         'state': { eholdings: true },

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
-import isEqual from 'lodash/isEqual';
 
 import {
   Icon
@@ -24,47 +23,19 @@ import styles from './title-edit.css';
 
 class TitleEdit extends Component {
   static propTypes = {
+    fullViewLink: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]),
     handleSubmit: PropTypes.func,
     initialValues: PropTypes.object.isRequired,
     intl: intlShape.isRequired,
     model: PropTypes.object.isRequired,
+    onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    updateRequest: PropTypes.object.isRequired
+    updateRequest: PropTypes.object.isRequired,
   };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        push: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired,
-    queryParams: PropTypes.object
-  };
-
-  componentDidUpdate(prevProps) {
-    let wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
-    let needsUpdate = !isEqual(prevProps.initialValues, this.props.initialValues);
-    let { router } = this.context;
-
-    if (wasPending && needsUpdate) {
-      router.history.push({
-        pathname: `/eholdings/titles/${prevProps.model.id}`,
-        search: router.route.location.search,
-        state: { eholdings: true }
-      });
-    }
-  }
-
-  handleCancel = () => {
-    let { router } = this.context;
-
-    router.history.push({
-      pathname: `/eholdings/titles/${this.props.model.id}`,
-      search: router.route.location.search,
-      state: { eholdings: true }
-    });
-  }
 
   render() {
     let {
@@ -74,33 +45,23 @@ class TitleEdit extends Component {
       pristine,
       updateRequest,
       initialValues,
-      intl
+      intl,
+      onCancel,
+      fullViewLink
     } = this.props;
-
-    let {
-      queryParams,
-      router
-    } = this.context;
 
     let actionMenuItems = [
       {
         'label': <FormattedMessage id="ui-eholdings.actionMenu.cancelEditing" />,
-        'to': {
-          pathname: `/eholdings/titles/${model.id}`,
-          search: router.route.location.search,
-          state: { eholdings: true }
-        },
+        'onClick': onCancel,
         'data-test-eholdings-title-cancel-action': true
       }
     ];
 
-    if (queryParams.searchType) {
+    if (fullViewLink) {
       actionMenuItems.push({
         label: <FormattedMessage id="ui-eholdings.actionMenu.fullView" />,
-        to: {
-          pathname: `/eholdings/titles/${model.id}`,
-          state: { eholdings: true }
-        },
+        to: fullViewLink,
         className: styles['full-view-link']
       });
     }

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -26,14 +26,19 @@ class TitleShow extends Component {
   static propTypes = {
     addCustomPackage: PropTypes.func.isRequired,
     customPackages: PropTypes.object.isRequired,
+    editLink: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]),
+    fullViewLink: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]),
     intl: intlShape.isRequired,
+    isFreshlySaved: PropTypes.bool,
+    isNewRecord: PropTypes.bool,
     model: PropTypes.object.isRequired,
     request: PropTypes.object.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.object,
-    queryParams: PropTypes.object
   };
 
   state = {
@@ -44,28 +49,20 @@ class TitleShow extends Component {
   };
 
   get actionMenuItems() {
-    let { model } = this.props;
-    let { queryParams, router } = this.context;
+    let { editLink, fullViewLink, model } = this.props;
     let items = [];
 
     if (model.isTitleCustom) {
       items.push({
         label: <FormattedMessage id="ui-eholdings.actionMenu.edit" />,
-        to: {
-          pathname: `/eholdings/titles/${model.id}/edit`,
-          search: router.route.location.search,
-          state: { eholdings: true }
-        }
+        to: editLink
       });
     }
 
-    if (queryParams.searchType) {
+    if (fullViewLink) {
       items.push({
         label: <FormattedMessage id="ui-eholdings.actionMenu.fullView" />,
-        to: {
-          pathname: `/eholdings/titles/${model.id}`,
-          state: { eholdings: true }
-        },
+        to: fullViewLink,
         className: styles['full-view-link']
       });
     }
@@ -74,10 +71,9 @@ class TitleShow extends Component {
   }
 
   get lastMenu() {
-    let { model, intl } = this.props;
-    let { router } = this.context;
+    let { model, intl, editLink } = this.props;
 
-    if (model.isTitleCustom) {
+    if (editLink) {
       return (
         <IconButton
           data-test-eholdings-title-edit-link
@@ -87,11 +83,7 @@ class TitleShow extends Component {
               { id: 'ui-eholdings.title.editCustomTitle' },
               { name: model.name }
             )}
-          to={{
-            pathname: `/eholdings/titles/${model.id}/edit`,
-            search: router.route.location.search,
-            state: { eholdings: true }
-          }}
+          to={editLink}
         />
       );
     } else {
@@ -100,14 +92,11 @@ class TitleShow extends Component {
   }
 
   get toasts() {
-    let { model } = this.props;
-    let { router } = this.context;
+    let { model, isFreshlySaved, isNewRecord } = this.props;
     let toasts = processErrors(model);
 
     // if coming from creating a new custom package, show a success toast
-    if (router.history.action === 'REPLACE' &&
-        router.history.location.state &&
-        router.history.location.state.isNewRecord) {
+    if (isNewRecord) {
       toasts.push({
         id: `success-title-${model.id}`,
         message: <FormattedMessage id="ui-eholdings.title.toast.isNewRecord" />,
@@ -116,9 +105,7 @@ class TitleShow extends Component {
     }
 
     // if coming from saving edits to the package, show a success toast
-    if (router.history.action === 'PUSH' &&
-        router.history.location.state &&
-        router.history.location.state.isFreshlySaved) {
+    if (isFreshlySaved) {
       toasts.push({
         id: `success-title-saved-${model.id}`,
         message: <FormattedMessage id="ui-eholdings.title.toast.isFreshlySaved" />,

--- a/src/components/toaster/toaster.js
+++ b/src/components/toaster/toaster.js
@@ -48,10 +48,10 @@ class Toaster extends Component {
     };
   }
 
-  static getDerivedStateFromProps(nextProps, prevState) {
+  static getDerivedStateFromProps(nextProps) {
     return nextProps.toasts ?
-      { ...prevState, toasts: nextProps.toasts } :
-      prevState;
+      { toasts: nextProps.toasts } :
+      null;
   }
 
   destroyToast = (toastId) => {

--- a/src/index.js
+++ b/src/index.js
@@ -34,10 +34,6 @@ class EHoldings extends Component {
     showSettings: PropTypes.bool
   };
 
-  static contextTypes = {
-    router: PropTypes.object
-  };
-
   constructor(props) {
     super(props);
     props.root.addReducer('eholdings', reducer);

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -58,14 +58,7 @@ class PackageCreateRoute extends Component {
         <View
           request={this.props.createRequest}
           onSubmit={this.packageCreateSubmitted}
-          onCancel={() => (location.state && location.state.eholdings
-            ? history.goBack()
-            : history.push({
-              pathname: '/eholdings',
-              search: 'searchType=packages',
-              state: { eholdings: true }
-            }))
-          }
+          onCancel={() => (location.state && location.state.eholdings && history.goBack())}
           initialValues={{
             name: '',
             contentType: 'Unknown',

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -52,13 +52,17 @@ class PackageCreateRoute extends Component {
 
   render() {
     const { history, location } = this.props;
+    let onCancel = null;
+    if (location.state && location.state.eholdings) {
+      onCancel = () => history.goBack();
+    }
 
     return (
       <TitleManager record="New custom package">
         <View
           request={this.props.createRequest}
           onSubmit={this.packageCreateSubmitted}
-          onCancel={() => (location.state && location.state.eholdings && history.goBack())}
+          onCancel={onCancel}
           initialValues={{
             name: '',
             contentType: 'Unknown',

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
 import { TitleManager } from '@folio/stripes-core';
@@ -12,20 +13,14 @@ import View from '../components/package/create';
 class PackageCreateRoute extends Component {
   static propTypes = {
     createPackage: PropTypes.func.isRequired,
-    createRequest: PropTypes.object.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        replace: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
+    createRequest: PropTypes.object.isRequired,
+    history: ReactRouterPropTypes.history.isRequired,
+    location: ReactRouterPropTypes.location.isRequired
   };
 
   componentDidUpdate(prevProps) {
     if (!prevProps.createRequest.isResolved && this.props.createRequest.isResolved) {
-      this.context.router.history.replace(
+      this.props.history.replace(
         `/eholdings/packages/${this.props.createRequest.records[0]}`,
         { eholdings: true, isNewRecord: true }
       );
@@ -56,11 +51,21 @@ class PackageCreateRoute extends Component {
   };
 
   render() {
+    const { history, location } = this.props;
+
     return (
       <TitleManager record="New custom package">
         <View
           request={this.props.createRequest}
           onSubmit={this.packageCreateSubmitted}
+          onCancel={() => (location.state && location.state.eholdings
+            ? history.goBack()
+            : history.push({
+              pathname: '/eholdings',
+              search: 'searchType=packages',
+              state: { eholdings: true }
+            }))
+          }
           initialValues={{
             name: '',
             contentType: 'Unknown',

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -4,6 +4,7 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import moment from 'moment';
+import queryString from 'qs';
 import { TitleManager } from '@folio/stripes-core';
 import { injectIntl, intlShape } from 'react-intl';
 import { createResolver } from '../redux';
@@ -178,6 +179,7 @@ class PackageEditRoute extends Component {
 
   render() {
     let { model, intl, proxyTypes, provider, history, location } = this.props;
+    const { searchType } = queryString.parse(location.search, { ignoreQueryPrefix: true });
 
     return (
       <TitleManager record={intl.formatMessage({ id: 'ui-eholdings.label.editLink' }, { name: model.name })}>
@@ -192,7 +194,7 @@ class PackageEditRoute extends Component {
             state: { eholdings: true }
           })}
           addPackageToHoldings={this.addPackageToHoldings}
-          fullViewLink={location.search && {
+          fullViewLink={searchType && {
             to: {
               pathname: `/eholdings/packages/${model.id}/edit`,
               state: { eholdings: true }

--- a/src/routes/provider-edit.js
+++ b/src/routes/provider-edit.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
+import isEqual from 'lodash/isEqual';
 import { TitleManager } from '@folio/stripes-core';
 
 import { createResolver } from '../redux';
@@ -14,23 +16,13 @@ class ProviderEditRoute extends Component {
     getProvider: PropTypes.func.isRequired,
     getProxyTypes: PropTypes.func.isRequired,
     getRootProxy: PropTypes.func.isRequired,
-    match: PropTypes.shape({
-      params: PropTypes.shape({
-        providerId: PropTypes.string.isRequired
-      }).isRequired
-    }).isRequired,
+    history: ReactRouterPropTypes.history.isRequired,
+    location: ReactRouterPropTypes.location.isRequired,
+    match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
     rootProxy: PropTypes.object.isRequired,
     updateProvider: PropTypes.func.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        replace: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
   };
 
   constructor(props) {
@@ -44,11 +36,23 @@ class ProviderEditRoute extends Component {
 
 
   componentDidUpdate(prevProps) {
-    let { match, getProvider } = this.props;
+    let { match, getProvider, history, location, model } = this.props;
     let { providerId } = match.params;
 
     if (providerId !== prevProps.match.params.providerId) {
       getProvider(providerId);
+    }
+
+    let wasPending = prevProps.model.update.isPending && !model.update.isPending;
+    let needsUpdate = !isEqual(prevProps.model, model);
+    let isRejected = model.update.isRejected;
+
+    if (wasPending && needsUpdate && !isRejected) {
+      history.push({
+        pathname: `/eholdings/providers/${model.id}`,
+        search: location.search,
+        state: { eholdings: true, isFreshlySaved: true }
+      });
     }
   }
 
@@ -60,19 +64,30 @@ class ProviderEditRoute extends Component {
   };
 
   render() {
-    let { model, proxyTypes, rootProxy } = this.props;
+    let { model, proxyTypes, rootProxy, history, location } = this.props;
 
     return (
       <TitleManager record={`Edit ${this.props.model.name}`}>
         <View
           model={model}
           onSubmit={this.providerEditSubmitted}
+          onCancel={() => history.push({
+            pathname: `/eholdings/providers/${model.id}`,
+            search: location.search,
+            state: { eholdings: true }
+          })}
           initialValues={{
             proxyId: model.proxy.id,
             providerTokenValue: model.providerToken.value
           }}
           proxyTypes={proxyTypes}
           rootProxy={rootProxy}
+          fullViewLink={location.search && {
+            to: {
+              pathname: `/eholdings/providers/${model.id}/edit`,
+              state: { eholdings: true }
+            }
+          }}
         />
       </TitleManager>
     );

--- a/src/routes/provider-edit.js
+++ b/src/routes/provider-edit.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
+import queryString from 'qs';
 import { TitleManager } from '@folio/stripes-core';
 
 import { createResolver } from '../redux';
@@ -65,6 +66,7 @@ class ProviderEditRoute extends Component {
 
   render() {
     let { model, proxyTypes, rootProxy, history, location } = this.props;
+    const { searchType } = queryString.parse(location.search, { ignoreQueryPrefix: true });
 
     return (
       <TitleManager record={`Edit ${this.props.model.name}`}>
@@ -82,7 +84,7 @@ class ProviderEditRoute extends Component {
           }}
           proxyTypes={proxyTypes}
           rootProxy={rootProxy}
-          fullViewLink={location.search && {
+          fullViewLink={searchType && {
             to: {
               pathname: `/eholdings/providers/${model.id}/edit`,
               state: { eholdings: true }

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import { TitleManager } from '@folio/stripes-core';
 
@@ -16,16 +17,13 @@ class ProviderShowRoute extends Component {
     getProvider: PropTypes.func.isRequired,
     getProxyTypes: PropTypes.func.isRequired,
     getRootProxy: PropTypes.func.isRequired,
-    match: PropTypes.shape({
-      params: PropTypes.shape({
-        providerId: PropTypes.string.isRequired
-      }).isRequired
-    }).isRequired,
+    history: ReactRouterPropTypes.history.isRequired,
+    location: ReactRouterPropTypes.location.isRequired,
+    match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
     resolver: PropTypes.object.isRequired,
-    rootProxy: PropTypes.object.isRequired,
-
+    rootProxy: PropTypes.object.isRequired
   };
 
   constructor(props) {
@@ -79,24 +77,46 @@ class ProviderShowRoute extends Component {
 
   render() {
     const listType = 'packages';
+    const { history, location, model, proxyTypes, rootProxy } = this.props;
+    const { pkgSearchParams, queryId } = this.state;
 
     return (
-      <TitleManager record={this.props.model.name}>
+      <TitleManager record={model.name}>
         <View
-          model={this.props.model}
+          model={model}
           packages={this.getPkgResults()}
           fetchPackages={this.fetchPackages}
-          proxyTypes={this.props.proxyTypes}
-          rootProxy={this.props.rootProxy}
+          proxyTypes={proxyTypes}
+          rootProxy={rootProxy}
           listType={listType}
           searchModal={
             <SearchModal
-              key={this.state.queryId}
+              key={queryId}
               listType={listType}
-              query={this.state.pkgSearchParams}
+              query={pkgSearchParams}
               onSearch={this.searchPackages}
               onFilter={this.searchPackages}
             />
+          }
+          editLink={{
+            pathname: `/eholdings/providers/${model.id}/edit`,
+            search: location.search,
+            state: { eholdings: true }
+          }}
+          isFreshlySaved={
+            history.action === 'PUSH' &&
+            history.location.state &&
+            history.location.state.isFreshlySaved
+          }
+          isDestroyed={
+            history.action === 'REPLACE' &&
+            history.location.state &&
+            history.location.state.isDestroyed
+          }
+          isNewRecord={
+            history.action === 'REPLACE' &&
+            history.location.state &&
+            history.location.state.isNewRecord
           }
         />
       </TitleManager>

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
+import isEqual from 'lodash/isEqual';
 import moment from 'moment';
 import { TitleManager } from '@folio/stripes-core';
 
@@ -15,22 +17,12 @@ class ResourceEditRoute extends Component {
     destroyResource: PropTypes.func.isRequired,
     getProxyTypes: PropTypes.func.isRequired,
     getResource: PropTypes.func.isRequired,
-    match: PropTypes.shape({
-      params: PropTypes.shape({
-        id: PropTypes.string.isRequired
-      }).isRequired
-    }).isRequired,
+    history: ReactRouterPropTypes.history.isRequired,
+    location: ReactRouterPropTypes.location.isRequired,
+    match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
     updateResource: PropTypes.func.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        replace: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
   };
 
   constructor(props) {
@@ -43,16 +35,30 @@ class ResourceEditRoute extends Component {
 
   componentDidUpdate(prevProps) {
     let { packageName, packageId } = prevProps.model;
-    let { match, getResource } = this.props;
+    let { match, getResource, history, location, model } = this.props;
     let { id } = match.params;
 
     if (!prevProps.model.destroy.isResolved && this.props.model.destroy.isResolved) {
-      this.context.router.history.replace(`/eholdings/packages/${packageId}?searchType=packages&q=${packageName}`,
+      history.replace(`/eholdings/packages/${packageId}?searchType=packages&q=${packageName}`,
         { eholdings: true, isDestroyed: true });
     }
 
     if (id !== prevProps.match.params.id) {
       getResource(id);
+    }
+
+    let wasPending = prevProps.model.update.isPending && !model.update.isPending;
+    let needsUpdate = !isEqual(prevProps.model, model);
+    let isRejected = model.update.isRejected;
+    let wasUnSelected = prevProps.model.isSelected && !model.isSelected;
+    let isCurrentlySelected = prevProps.model.isSelected && model.isSelected;
+
+    if (wasPending && needsUpdate && !isRejected && ((wasUnSelected || isCurrentlySelected))) {
+      history.push({
+        pathname: `/eholdings/resources/${model.id}`,
+        search: location.search,
+        state: { eholdings: true, isFreshlySaved: true }
+      });
     }
   }
 
@@ -112,13 +118,18 @@ class ResourceEditRoute extends Component {
   }
 
   render() {
-    let { model, proxyTypes } = this.props;
+    let { model, proxyTypes, history, location } = this.props;
 
     return (
-      <TitleManager record={`Edit ${this.props.model.name}`}>
+      <TitleManager record={`Edit ${model.name}`}>
         <View
           model={model}
           onSubmit={this.resourceEditSubmitted}
+          onCancel={() => history.push({
+            pathname: `/eholdings/resources/${model.id}`,
+            search: location.search,
+            state: { eholdings: true }
+          })}
           proxyTypes={proxyTypes}
         />
       </TitleManager>

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import { TitleManager } from '@folio/stripes-core';
 
@@ -13,22 +14,12 @@ class ResourceShowRoute extends Component {
     destroyResource: PropTypes.func.isRequired,
     getProxyTypes: PropTypes.func.isRequired,
     getResource: PropTypes.func.isRequired,
-    match: PropTypes.shape({
-      params: PropTypes.shape({
-        id: PropTypes.string.isRequired
-      }).isRequired
-    }).isRequired,
+    history: ReactRouterPropTypes.history.isRequired,
+    location: ReactRouterPropTypes.location.isRequired,
+    match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
-    updateResource: PropTypes.func.isRequired,
-  };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        replace: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
+    updateResource: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -41,20 +32,19 @@ class ResourceShowRoute extends Component {
 
   componentDidUpdate(prevProps) {
     let wasUpdated = !this.props.model.update.isPending && prevProps.model.update.isPending && (!this.props.model.update.errors.length > 0);
-    let { router } = this.context;
-    let { match, getResource } = this.props;
+    let { match, getResource, history, location } = this.props;
     let { id } = match.params;
 
     let { packageName, packageId } = prevProps.model;
     if (!prevProps.model.destroy.isResolved && this.props.model.destroy.isResolved) {
-      this.context.router.history.replace(`/eholdings/packages/${packageId}?searchType=packages&q=${packageName}`,
+      history.replace(`/eholdings/packages/${packageId}?searchType=packages&q=${packageName}`,
         { eholdings: true, isDestroyed: true });
     }
 
     if (wasUpdated) {
-      router.history.push({
+      history.push({
         pathname: `/eholdings/resources/${this.props.model.id}`,
-        search: router.route.location.search,
+        search: location.search,
         state: { eholdings: true, isFreshlySaved: true }
       });
     }
@@ -89,12 +79,23 @@ class ResourceShowRoute extends Component {
   }
 
   render() {
+    const { model, proxyTypes, history } = this.props;
+
     return (
-      <TitleManager record={this.props.model.name}>
+      <TitleManager record={model.name}>
         <View
-          model={this.props.model}
-          proxyTypes={this.props.proxyTypes}
+          model={model}
+          proxyTypes={proxyTypes}
           toggleSelected={this.toggleSelected}
+          editLink={{
+            pathname: `/eholdings/resources/${model.id}/edit`,
+            state: { eholdings: true }
+          }}
+          isFreshlySaved={
+            history.action === 'PUSH' &&
+            history.location.state &&
+            history.location.state.isFreshlySaved
+          }
         />
       </TitleManager>
     );

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -72,7 +72,6 @@ class SearchRoute extends Component {
     // stated in https://issues.folio.org/browse/UIEH-558
     if (!isEqual(location, prevState.location)) {
       return {
-        ...prevState,
         location,
         match,
         searchType,

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import capitalize from 'lodash/capitalize';
 import isEqual from 'lodash/isEqual';
@@ -21,28 +22,13 @@ import { filterCountFromQuery } from '../components/search-modal/search-modal';
 class SearchRoute extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
-    history: PropTypes.shape({
-      location: PropTypes.object,
-      push: PropTypes.func.isRequired,
-      replace: PropTypes.func.isRequired
-    }).isRequired,
-    location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,
-      search: PropTypes.string.isRequired
-    }).isRequired,
-    match: PropTypes.shape({
-      params: PropTypes.shape({
-        id: PropTypes.string
-      }).isRequired
-    }).isRequired,
+    history: ReactRouterPropTypes.history.isRequired,
+    location: ReactRouterPropTypes.location.isRequired,
+    match: ReactRouterPropTypes.match.isRequired,
     resolver: PropTypes.object.isRequired,
     searchPackages: PropTypes.func.isRequired,
     searchProviders: PropTypes.func.isRequired,
     searchTitles: PropTypes.func.isRequired
-  };
-
-  static childContextTypes = {
-    queryParams: PropTypes.object
   };
 
   constructor(props) {
@@ -69,16 +55,6 @@ class SearchRoute extends Component {
       searchFilter: params.filter,
       searchField: params.searchfield,
       hideFilters: !!params.q
-    };
-  }
-
-  getChildContext() {
-    return {
-      // provide child components with query params that we've already parsed
-      queryParams: {
-        searchType: this.state.searchType,
-        ...this.state.params
-      }
     };
   }
 
@@ -264,7 +240,7 @@ class SearchRoute extends Component {
    */
   renderResults() {
     let { searchType, params, shouldFocusItem } = this.state;
-    let { match: { params: { id } } } = this.props;
+    let { history, location, match: { params: { id } } } = this.props;
 
     let props = {
       params,
@@ -273,7 +249,14 @@ class SearchRoute extends Component {
       location: this.props.location,
       collection: this.getResults(),
       onUpdateOffset: this.handleOffset,
-      fetch: this.fetchPage
+      fetch: this.fetchPage,
+      onClickItem: (detailUrl) => {
+        history.push({
+          pathname: detailUrl,
+          search: location.search,
+          state: { eholdings: true }
+        });
+      }
     };
 
     if (params.q) {
@@ -294,7 +277,7 @@ class SearchRoute extends Component {
    * render the search paneset, otherwise simply render our children
    */
   render() {
-    let { location, children } = this.props;
+    let { children, history, location } = this.props;
     let {
       searchType,
       params,
@@ -319,7 +302,6 @@ class SearchRoute extends Component {
         <TitleManager record={capitalize(searchType)}>
           <div data-test-eholdings>
             <SearchPaneset
-              location={location}
               filterCount={filterCount}
               hideFilters={hideFilters}
               resultsType={searchType}
@@ -328,6 +310,12 @@ class SearchRoute extends Component {
               totalResults={results.length}
               isLoading={!results.hasLoaded}
               updateFilters={this.updateFilters}
+              searchLocation={location.search}
+              onClosePreview={() => history.push({
+                pathname: '/eholdings',
+                search: location.search,
+                state: { eholdings: true }
+              })}
               searchForm={(
                 <SearchForm
                   sort={sort}

--- a/src/routes/settings-root-proxy.js
+++ b/src/routes/settings-root-proxy.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
+import isEqual from 'lodash/isEqual';
 import { TitleManager } from '@folio/stripes-core';
 
 import { createResolver } from '../redux';
@@ -11,6 +13,7 @@ class SettingsRootProxyRoute extends Component {
   static propTypes = {
     getProxyTypes: PropTypes.func.isRequired,
     getRootProxy: PropTypes.func.isRequired,
+    history: ReactRouterPropTypes.history.isRequired,
     proxyTypes: PropTypes.object.isRequired,
     rootProxy: PropTypes.object.isRequired,
     updateRootProxy: PropTypes.func.isRequired
@@ -22,6 +25,20 @@ class SettingsRootProxyRoute extends Component {
     props.getRootProxy();
   }
 
+  componentDidUpdate(prevProps) {
+    const { history, rootProxy } = this.props;
+    let wasPending = prevProps.rootProxy.update.isPending && !rootProxy.update.isPending;
+    let needsUpdate = !isEqual(prevProps.rootProxy, rootProxy);
+    let isRejected = rootProxy.update.isRejected;
+
+    if (wasPending && needsUpdate && !isRejected) {
+      history.push({
+        pathname: '/settings/eholdings/root-proxy',
+        state: { eholdings: true, isFreshlySaved: true }
+      });
+    }
+  }
+
   rootProxySubmitted = (values) => {
     let { rootProxy, updateRootProxy } = this.props;
 
@@ -31,7 +48,7 @@ class SettingsRootProxyRoute extends Component {
   }
 
   render() {
-    let { proxyTypes, rootProxy } = this.props;
+    let { proxyTypes, rootProxy, history } = this.props;
 
     return (
       <TitleManager page="eHoldings settings" record="Root proxy">
@@ -42,6 +59,11 @@ class SettingsRootProxyRoute extends Component {
           proxyTypes={proxyTypes}
           rootProxy={rootProxy}
           onSubmit={this.rootProxySubmitted}
+          isFreshlySaved={
+            history.action === 'PUSH' &&
+            history.location.state &&
+            history.location.state.isFreshlySaved
+          }
         />
       </TitleManager>
     );

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -1,22 +1,20 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { TitleManager } from '@folio/stripes-core';
 
 import { Settings as View } from '@folio/stripes-smart-components';
 import ApplicationRoute from './application';
 
-export default class SettingsRoute extends Component {
+class SettingsRoute extends Component {
   static propTypes = {
-    children: PropTypes.node.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.object
+    children: PropTypes.node.isRequired,
+    location: ReactRouterPropTypes.location.isRequired,
+    match: ReactRouterPropTypes.match.isRequired
   };
 
   render() {
-    let { children } = this.props;
-    let { router } = this.context;
+    let { children, location, match } = this.props;
 
     let pages = React.Children.map(children, child => ({
       route: child.props.path,
@@ -29,9 +27,9 @@ export default class SettingsRoute extends Component {
         <TitleManager page="eHoldings settings">
           <View
             paneTitle="eHoldings"
-            activeLink={router.route.location.pathname}
-            match={router.route.match}
-            location={router.route.location}
+            activeLink={location.pathname}
+            match={match}
+            location={location}
             pages={pages}
           />
         </TitleManager>
@@ -39,3 +37,5 @@ export default class SettingsRoute extends Component {
     );
   }
 }
+
+export default SettingsRoute;

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import { TitleManager } from '@folio/stripes-core';
 
@@ -14,15 +15,9 @@ class TitleCreateRoute extends Component {
     createRequest: PropTypes.object.isRequired,
     createTitle: PropTypes.func.isRequired,
     customPackages: PropTypes.object.isRequired,
-    getCustomPackages: PropTypes.func.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        replace: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
+    getCustomPackages: PropTypes.func.isRequired,
+    history: ReactRouterPropTypes.history.isRequired,
+    location: ReactRouterPropTypes.location.isRequired
   };
 
   componentDidMount() {
@@ -31,7 +26,7 @@ class TitleCreateRoute extends Component {
 
   componentDidUpdate(prevProps) {
     if (!prevProps.createRequest.isResolved && this.props.createRequest.isResolved) {
-      this.context.router.history.replace(
+      this.props.history.replace(
         `/eholdings/titles/${this.props.createRequest.records[0]}`,
         { eholdings: true, isNewRecord: true }
       );
@@ -66,7 +61,9 @@ class TitleCreateRoute extends Component {
   render() {
     let {
       createRequest,
-      customPackages
+      customPackages,
+      history,
+      location
     } = this.props;
 
     return (
@@ -75,6 +72,14 @@ class TitleCreateRoute extends Component {
           request={createRequest}
           customPackages={customPackages}
           onSubmit={this.createTitle}
+          onCancel={() => (location.state && location.state.eholdings
+            ? history.goBack()
+            : history.push({
+              pathname: '/eholdings',
+              search: 'searchType=titles',
+              state: { eholdings: true }
+            }))
+          }
           initialValues={{
             name: '',
             edition: '',

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -66,13 +66,18 @@ class TitleCreateRoute extends Component {
       location
     } = this.props;
 
+    let onCancel = null;
+    if (location.state && location.state.eholdings) {
+      onCancel = () => history.goBack();
+    }
+
     return (
       <TitleManager record="New custom title">
         <View
           request={createRequest}
           customPackages={customPackages}
           onSubmit={this.createTitle}
-          onCancel={() => (location.state && location.state.eholdings && history.goBack())}
+          onCancel={onCancel}
           initialValues={{
             name: '',
             edition: '',

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -72,14 +72,7 @@ class TitleCreateRoute extends Component {
           request={createRequest}
           customPackages={customPackages}
           onSubmit={this.createTitle}
-          onCancel={() => (location.state && location.state.eholdings
-            ? history.goBack()
-            : history.push({
-              pathname: '/eholdings',
-              search: 'searchType=titles',
-              state: { eholdings: true }
-            }))
-          }
+          onCancel={() => (location.state && location.state.eholdings && history.goBack())}
           initialValues={{
             name: '',
             edition: '',

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
+import queryString from 'qs';
 import { TitleManager } from '@folio/stripes-core';
 
 import { createResolver } from '../redux';
@@ -102,6 +103,7 @@ class TitleEditRoute extends Component {
       history,
       location
     } = this.props;
+    const { searchType } = queryString.parse(location.search, { ignoreQueryPrefix: true });
 
     return (
       <TitleManager record={`Edit ${this.props.model.name}`}>
@@ -124,7 +126,7 @@ class TitleEditRoute extends Component {
             contributors: model.contributors,
             identifiers: this.mergeIdentifiers(model.identifiers)
           }}
-          fullViewLink={location.search && {
+          fullViewLink={searchType && {
             to: {
               pathname: `/eholdings/titles/${model.id}/edit`,
               state: { eholdings: true }

--- a/src/routes/title-show.js
+++ b/src/routes/title-show.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import { TitleManager } from '@folio/stripes-core';
 
@@ -16,20 +17,10 @@ class TitleShowRoute extends Component {
     customPackages: PropTypes.object.isRequired,
     getCustomPackages: PropTypes.func.isRequired,
     getTitle: PropTypes.func.isRequired,
-    match: PropTypes.shape({
-      params: PropTypes.shape({
-        titleId: PropTypes.string.isRequired
-      }).isRequired
-    }).isRequired,
+    history: ReactRouterPropTypes.history.isRequired,
+    location: ReactRouterPropTypes.location.isRequired,
+    match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired
-  };
-
-  static contextTypes = {
-    router: PropTypes.shape({
-      history: PropTypes.shape({
-        push: PropTypes.func.isRequired
-      }).isRequired
-    }).isRequired
   };
 
   componentDidMount() {
@@ -49,7 +40,7 @@ class TitleShowRoute extends Component {
     }
 
     if (!createRequest.isResolved && this.props.createRequest.isResolved) {
-      this.context.router.history.push(
+      this.props.history.push(
         `/eholdings/resources/${this.props.createRequest.records[0]}`,
         { eholdings: true, isNewRecord: true }
       );
@@ -68,7 +59,7 @@ class TitleShowRoute extends Component {
   };
 
   render() {
-    let { model, customPackages, createRequest } = this.props;
+    let { model, customPackages, createRequest, history, location } = this.props;
 
     return (
       <TitleManager record={this.props.model.name}>
@@ -77,6 +68,21 @@ class TitleShowRoute extends Component {
           model={model}
           customPackages={customPackages}
           addCustomPackage={this.createResource}
+          editLink={{
+            pathname: `/eholdings/titles/${model.id}/edit`,
+            search: location.search,
+            state: { eholdings: true }
+          }}
+          isFreshlySaved={
+            history.action === 'PUSH' &&
+            history.location.state &&
+            history.location.state.isFreshlySaved
+          }
+          isNewRecord={
+            history.action === 'REPLACE' &&
+            history.location.state &&
+            history.location.state.isNewRecord
+          }
         />
       </TitleManager>
     );

--- a/test/bigtest/interactors/package-create.js
+++ b/test/bigtest/interactors/package-create.js
@@ -29,6 +29,7 @@ import Datepicker from './datepicker';
   addCoverage = clickable('[data-test-eholdings-package-coverage-fields] [data-test-repeatable-field-add-item-button]');
   save = clickable('[data-test-eholdings-package-create-save-button]');
   isSaveDisabled = property('[data-test-eholdings-package-create-save-button]', 'disabled');
+  hasBackButton = isPresent('[data-test-eholdings-details-view-back-button]');
 
   dateRangeRowList = collection('[data-test-eholdings-package-coverage-fields] li', {
     beginDate: scoped('[data-test-eholdings-coverage-fields-date-range-begin]', Datepicker),

--- a/test/bigtest/interactors/package-search.js
+++ b/test/bigtest/interactors/package-search.js
@@ -39,6 +39,7 @@ import SearchBadge from './search-badge';
   hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
   searchBadge = new SearchBadge('[data-test-eholdings-results-pane-search-badge]');
   isSearchPanePresent = isPresent('[data-test-eholdings-search-pane]');
+  clickNewButton = clickable('[data-test-eholdings-search-new-button]');
 
   toast = Toast;
 

--- a/test/bigtest/interactors/title-create.js
+++ b/test/bigtest/interactors/title-create.js
@@ -64,6 +64,7 @@ import {
   isPeerReviewed = property('[data-test-eholdings-peer-reviewed-field] input', 'checked');
   save = clickable('[data-test-eholdings-title-create-save-button]');
   isSaveDisabled = property('[data-test-eholdings-title-create-save-button]', 'disabled');
+  hasBackButton = isPresent('[data-test-eholdings-details-view-back-button]');
 
   dropDown = new TitleCreateDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   dropDownMenu = new TitleCreateDropDownMenu();

--- a/test/bigtest/interactors/title-search.js
+++ b/test/bigtest/interactors/title-search.js
@@ -37,6 +37,7 @@ import { hasClassBeginningWith } from './helpers';
   isSearchVignetteHidden = hasClassBeginningWith('[data-test-search-vignette]', 'is-hidden--');
   clickCloseButton = clickable('[data-test-eholdings-details-view-close-button]');
   hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
+  clickNewButton = clickable('[data-test-eholdings-search-new-button]');
 
   hasLoaded = computed(function () {
     return this.titleList().length > 0;

--- a/test/bigtest/tests/package-create-test.js
+++ b/test/bigtest/tests/package-create-test.js
@@ -83,7 +83,7 @@ describeApplication('PackageCreate', () => {
     });
   });
 
-  describe('clicking cancel', () => {
+  describe.skip('clicking cancel', () => {
     beforeEach(() => {
       return PackageCreatePage.cancel();
     });
@@ -93,7 +93,7 @@ describeApplication('PackageCreate', () => {
     });
   });
 
-  describe('clicking cancel after filling in data', () => {
+  describe.skip('clicking cancel after filling in data', () => {
     beforeEach(() => {
       return PackageCreatePage
         .fillName('My Package')

--- a/test/bigtest/tests/package-create-test.js
+++ b/test/bigtest/tests/package-create-test.js
@@ -4,130 +4,151 @@ import { expect } from 'chai';
 import { describeApplication } from '../helpers/describe-application';
 import PackageCreatePage from '../interactors/package-create';
 import PackageShowPage from '../interactors/package-show';
+import PackageSearchPage from '../interactors/package-search';
 import NavigationModal from '../interactors/navigation-modal';
 
 describeApplication('PackageCreate', () => {
-  beforeEach(function () {
-    return this.visit('/eholdings/packages/new', () => {
-      expect(PackageCreatePage.$root).to.exist;
+  describe('submitting the form', () => {
+    beforeEach(function () {
+      return this.visit('/eholdings/packages/new', () => {
+        expect(PackageCreatePage.$root).to.exist;
+      });
     });
-  });
 
-  it('has a package name field', () => {
-    expect(PackageCreatePage.hasName).to.be.true;
-  });
+    it('has a package name field', () => {
+      expect(PackageCreatePage.hasName).to.be.true;
+    });
 
-  it('has a content-type field', () => {
-    expect(PackageCreatePage.hasContentType).to.be.true;
-  });
+    it('has a content-type field', () => {
+      expect(PackageCreatePage.hasContentType).to.be.true;
+    });
 
-  it('content-type field is "Unknown" by default', () => {
-    expect(PackageCreatePage.contentTypeValue).to.eq('Unknown');
-  });
+    it('content-type field is "Unknown" by default', () => {
+      expect(PackageCreatePage.contentTypeValue).to.eq('Unknown');
+    });
 
-  it('has an add coverage button', () => {
-    expect(PackageCreatePage.hasAddCoverageButton).to.be.true;
-  });
-
-  it('disables the save button', () => {
-    expect(PackageCreatePage.isSaveDisabled).to.be.true;
-  });
-
-  describe('creating a new package', () => {
-    beforeEach(() => {
-      return PackageCreatePage
-        .fillName('My Package')
-        .save();
+    it('has an add coverage button', () => {
+      expect(PackageCreatePage.hasAddCoverageButton).to.be.true;
     });
 
     it('disables the save button', () => {
       expect(PackageCreatePage.isSaveDisabled).to.be.true;
     });
 
-    it('redirects to the new package show page', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
-      expect(PackageShowPage.name).to.equal('My Package');
+    it('does not have a back button', () => {
+      expect(PackageCreatePage.hasBackButton).to.be.false;
     });
 
-    it('shows a success toast message', () => {
-      expect(PackageShowPage.toast.successText).to.equal('Custom package created.');
+    describe('creating a new package', () => {
+      beforeEach(() => {
+        return PackageCreatePage
+          .fillName('My Package')
+          .save();
+      });
+
+      it('disables the save button', () => {
+        expect(PackageCreatePage.isSaveDisabled).to.be.true;
+      });
+
+      it('redirects to the new package show page', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
+        expect(PackageShowPage.name).to.equal('My Package');
+      });
+
+      it('shows a success toast message', () => {
+        expect(PackageShowPage.toast.successText).to.equal('Custom package created.');
+      });
+    });
+
+    describe('creating a new package with a specified content type', () => {
+      beforeEach(() => {
+        return PackageCreatePage
+          .fillName('My Package')
+          .chooseContentType('Print')
+          .save();
+      });
+
+      it('redirects to the new package with the specified content type', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
+        expect(PackageShowPage.contentType).to.equal('Print');
+      });
+    });
+
+    describe('creating a new package with custom coverages', () => {
+      beforeEach(() => {
+        return PackageCreatePage
+          .fillName('My Package')
+          .addCoverage()
+          .dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018')
+          .save();
+      });
+
+      it('redirects to the new package with custom coverages', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
+        expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
+      });
+    });
+
+    describe('getting an error when creating a new package', () => {
+      beforeEach(function () {
+        this.server.post('/packages', {
+          errors: [{
+            title: 'There was an error'
+          }]
+        }, 500);
+
+        return PackageCreatePage
+          .fillName('My Package')
+          .save();
+      });
+
+      it.always('does not create the new package', function () {
+        expect(this.app.history.location.pathname).to.equal('/eholdings/packages/new');
+      });
+
+      it('shows an error toast message', () => {
+        expect(PackageShowPage.toast.errorText).to.equal('There was an error');
+      });
+
+      it('enables the save button', () => {
+        expect(PackageCreatePage.isSaveDisabled).to.be.false;
+      });
     });
   });
 
-  describe('creating a new package with a specified content type', () => {
-    beforeEach(() => {
-      return PackageCreatePage
-        .fillName('My Package')
-        .chooseContentType('Print')
-        .save();
-    });
-
-    it('redirects to the new package with the specified content type', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
-      expect(PackageShowPage.contentType).to.equal('Print');
-    });
-  });
-
-  describe('creating a new package with custom coverages', () => {
-    beforeEach(() => {
-      return PackageCreatePage
-        .fillName('My Package')
-        .addCoverage()
-        .dateRangeRowList(0).fillDates('12/16/2018', '12/18/2018')
-        .save();
-    });
-
-    it('redirects to the new package with custom coverages', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
-      expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
-    });
-  });
-
-  describe.skip('clicking cancel', () => {
-    beforeEach(() => {
-      return PackageCreatePage.cancel();
-    });
-
-    it('redirects to the previous page', function () {
-      expect(this.app.history.location.pathname).to.not.equal('/eholdings/packages/new');
-    });
-  });
-
-  describe.skip('clicking cancel after filling in data', () => {
-    beforeEach(() => {
-      return PackageCreatePage
-        .fillName('My Package')
-        .cancel();
-    });
-
-    it('shows a navigations confirmation modal', () => {
-      expect(NavigationModal.$root).to.exist;
-    });
-  });
-
-  describe('getting an error when creating a new package', () => {
+  describe('canceling when there is router history', () => {
     beforeEach(function () {
-      this.server.post('/packages', {
-        errors: [{
-          title: 'There was an error'
-        }]
-      }, 500);
-
-      return PackageCreatePage
-        .fillName('My Package')
-        .save();
+      return this.visit('/eholdings/?searchType=packages', () => {
+        expect(PackageSearchPage.$root).to.exist;
+      });
     });
 
-    it.always('does not create the new package', function () {
-      expect(this.app.history.location.pathname).to.equal('/eholdings/packages/new');
-    });
+    describe('clicking a cancel action', () => {
+      beforeEach(function () {
+        return PackageSearchPage.clickNewButton();
+      });
 
-    it('shows an error toast message', () => {
-      expect(PackageShowPage.toast.errorText).to.equal('There was an error');
-    });
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return PackageCreatePage.cancel();
+        });
 
-    it('enables the save button', () => {
-      expect(PackageCreatePage.isSaveDisabled).to.be.false;
+        it('redirects to the previous page', function () {
+          expect(this.app.history.location.pathname).to.not.equal('/eholdings/packages/new');
+        });
+      });
+
+      describe('clicking cancel after filling in data', () => {
+        beforeEach(() => {
+          return PackageCreatePage
+            .fillName('My Package')
+            .cancel();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(NavigationModal.$root).to.exist;
+        });
+      });
     });
   });
 });

--- a/test/bigtest/tests/title-create-test.js
+++ b/test/bigtest/tests/title-create-test.js
@@ -207,7 +207,7 @@ describeApplication('TitleCreate', () => {
     });
   });
 
-  describe('clicking cancel', () => {
+  describe.skip('clicking cancel', () => {
     beforeEach(() => {
       return TitleCreatePage.cancel();
     });
@@ -217,7 +217,7 @@ describeApplication('TitleCreate', () => {
     });
   });
 
-  describe('clicking cancel after filling in data', () => {
+  describe.skip('clicking cancel after filling in data', () => {
     beforeEach(() => {
       return TitleCreatePage
         .fillName('My Title')

--- a/test/bigtest/tests/title-create-test.js
+++ b/test/bigtest/tests/title-create-test.js
@@ -4,255 +4,276 @@ import { expect } from 'chai';
 import { describeApplication } from '../helpers/describe-application';
 import TitleCreatePage from '../interactors/title-create';
 import TitleShowPage from '../interactors/title-show';
+import TitleSearchPage from '../interactors/title-search';
 import NavigationModal from '../interactors/navigation-modal';
 
 describeApplication('TitleCreate', () => {
   let packages;
 
-  beforeEach(function () {
-    packages = this.server.createList('package', 2, {
-      name: i => `Custom Package ${i + 1}`,
-      provider: this.server.create('provider'),
-      isCustom: true
+  describe('submitting the form', () => {
+    beforeEach(function () {
+      packages = this.server.createList('package', 2, {
+        name: i => `Custom Package ${i + 1}`,
+        provider: this.server.create('provider'),
+        isCustom: true
+      });
+
+      return this.visit('/eholdings/titles/new', () => {
+        expect(TitleCreatePage.$root).to.exist;
+      });
     });
 
-    return this.visit('/eholdings/titles/new', () => {
-      expect(TitleCreatePage.$root).to.exist;
+    it('has a title name field', () => {
+      expect(TitleCreatePage.hasName).to.be.true;
     });
-  });
 
-  it('has a title name field', () => {
-    expect(TitleCreatePage.hasName).to.be.true;
-  });
+    it('has an add contributor button', () => {
+      expect(TitleCreatePage.hasContributorBtn).to.be.true;
+    });
 
-  it('has an add contributor button', () => {
-    expect(TitleCreatePage.hasContributorBtn).to.be.true;
-  });
+    it('has an edition field', () => {
+      expect(TitleCreatePage.hasEdition).to.be.true;
+    });
 
-  it('has an edition field', () => {
-    expect(TitleCreatePage.hasEdition).to.be.true;
-  });
+    it('has a publisher name field', () => {
+      expect(TitleCreatePage.hasPublisher).to.be.true;
+    });
 
-  it('has a publisher name field', () => {
-    expect(TitleCreatePage.hasPublisher).to.be.true;
-  });
+    it('has a publication type field', () => {
+      expect(TitleCreatePage.hasPublicationType).to.be.true;
+      expect(TitleCreatePage.publicationType).to.equal('Unspecified');
+    });
 
-  it('has a publication type field', () => {
-    expect(TitleCreatePage.hasPublicationType).to.be.true;
-    expect(TitleCreatePage.publicationType).to.equal('Unspecified');
-  });
+    it('has an add identifier button', () => {
+      expect(TitleCreatePage.hasIdentifiersBtn).to.be.true;
+    });
 
-  it('has an add identifier button', () => {
-    expect(TitleCreatePage.hasIdentifiersBtn).to.be.true;
-  });
+    it('has a description field', () => {
+      expect(TitleCreatePage.hasDescription).to.be.true;
+    });
 
-  it('has a description field', () => {
-    expect(TitleCreatePage.hasDescription).to.be.true;
-  });
+    it('has a package select field', () => {
+      expect(TitleCreatePage.hasPackageSelect).to.be.true;
+      expect(TitleCreatePage.packagesCount).to.equal(2);
+    });
 
-  it('has a package select field', () => {
-    expect(TitleCreatePage.hasPackageSelect).to.be.true;
-    expect(TitleCreatePage.packagesCount).to.equal(2);
-  });
-
-  it('has a peer reviewed toggle', () => {
-    expect(TitleCreatePage.hasPeerReviewed).to.be.true;
-    expect(TitleCreatePage.isPeerReviewed).to.be.false;
-  });
-
-  it('disables the save button', () => {
-    expect(TitleCreatePage.isSaveDisabled).to.be.true;
-  });
-
-  describe('creating a new title', () => {
-    beforeEach(() => {
-      return TitleCreatePage
-        .fillName('My Title')
-        .selectPackage(packages[0].id)
-        .save();
+    it('has a peer reviewed toggle', () => {
+      expect(TitleCreatePage.hasPeerReviewed).to.be.true;
+      expect(TitleCreatePage.isPeerReviewed).to.be.false;
     });
 
     it('disables the save button', () => {
       expect(TitleCreatePage.isSaveDisabled).to.be.true;
     });
 
-    it('redirects to the new title show page', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
-      expect(TitleShowPage.titleName).to.equal('My Title');
-      expect(TitleShowPage.packageList(0).name).to.equal('Custom Package 1');
+    it('does not have a back button', () => {
+      expect(TitleCreatePage.hasBackButton).to.be.false;
     });
 
-    it('shows a success toast message', () => {
-      expect(TitleShowPage.toast.successText).to.equal('Custom title created.');
+    describe('creating a new title', () => {
+      beforeEach(() => {
+        return TitleCreatePage
+          .fillName('My Title')
+          .selectPackage(packages[0].id)
+          .save();
+      });
+
+      it('disables the save button', () => {
+        expect(TitleCreatePage.isSaveDisabled).to.be.true;
+      });
+
+      it('redirects to the new title show page', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+        expect(TitleShowPage.titleName).to.equal('My Title');
+        expect(TitleShowPage.packageList(0).name).to.equal('Custom Package 1');
+      });
+
+      it('shows a success toast message', () => {
+        expect(TitleShowPage.toast.successText).to.equal('Custom title created.');
+      });
+    });
+
+    describe('creating a new title with a contributor', () => {
+      beforeEach(() => {
+        return TitleCreatePage
+          .fillName('My Title')
+          .addContributor('author', 'Me')
+          .selectPackage(packages[0].id)
+          .save();
+      });
+
+      it('redirects to the new title show page with the specified contributor', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+        expect(TitleShowPage.contributorsList(0).text).to.equal('AuthorMe');
+      });
+    });
+
+    describe('creating a new title with an edition', () => {
+      beforeEach(() => {
+        return TitleCreatePage
+          .fillName('My Title')
+          .fillEdition('My Edition')
+          .selectPackage(packages[0].id)
+          .save();
+      });
+
+      it('redirects to the new title show page with the specified edition', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+        expect(TitleShowPage.edition).to.equal('My Edition');
+      });
+    });
+
+    describe('creating a new title with a publisher', () => {
+      beforeEach(() => {
+        return TitleCreatePage
+          .fillName('My Title')
+          .fillPublisher('Me')
+          .selectPackage(packages[0].id)
+          .save();
+      });
+
+      it('redirects to the new title show page with the specified publisher', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+        expect(TitleShowPage.publisherName).to.equal('Me');
+      });
+    });
+
+    describe('creating a new title with a specified publication type', () => {
+      beforeEach(() => {
+        return TitleCreatePage
+          .fillName('My Title')
+          .choosePublicationType('Book')
+          .selectPackage(packages[0].id)
+          .save();
+      });
+
+      it('redirects to the new package with the specified content type', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+        expect(TitleShowPage.publicationType).to.equal('Book');
+      });
+    });
+
+    describe('creating a new title with an identifier', () => {
+      beforeEach(() => {
+        return TitleCreatePage
+          .fillName('My Title')
+          .addIdentifier('ISBN (Print)', '90210')
+          .selectPackage(packages[0].id)
+          .save();
+      });
+
+      it('redirects to the new title show page with the specified identifier', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+        expect(TitleShowPage.identifiersList(0).text).to.equal('ISBN (Print)90210');
+      });
+    });
+
+    describe('creating a new title with a description', () => {
+      beforeEach(() => {
+        return TitleCreatePage
+          .fillName('My Title')
+          .fillDescription('This is my title')
+          .selectPackage(packages[0].id)
+          .save();
+      });
+
+      it('redirects to the new package with the specified description', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+        expect(TitleShowPage.descriptionText).to.equal('This is my title');
+      });
+    });
+
+    describe('creating a new title with a different package', () => {
+      beforeEach(() => {
+        return TitleCreatePage
+          .fillName('My Title')
+          .selectPackage(packages[1].id)
+          .save();
+      });
+
+      it('redirects to the new package with the specified package', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+        expect(TitleShowPage.packageList(0).name).to.equal('Custom Package 2');
+      });
+    });
+
+    describe('creating a new title and specifying peer reviewed status', () => {
+      beforeEach(() => {
+        return TitleCreatePage
+          .fillName('My Title')
+          .fillPublisher('Me')
+          .togglePeerReviewed()
+          .selectPackage(packages[0].id)
+          .save();
+      });
+
+      it('redirects to the new package with the specified content type', function () {
+        expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
+        expect(TitleShowPage.peerReviewedStatus).to.equal('Yes');
+      });
+    });
+
+    describe('getting an error when creating a new title', () => {
+      beforeEach(function () {
+        this.server.post('/titles', {
+          errors: [{
+            title: 'There was an error'
+          }]
+        }, 500);
+
+        return TitleCreatePage
+          .fillName('My Title')
+          .selectPackage(packages[0].id)
+          .save();
+      });
+
+      it.always('does not create the title', function () {
+        expect(this.app.history.location.pathname).to.equal('/eholdings/titles/new');
+      });
+
+      it('shows an error toast message', () => {
+        expect(TitleShowPage.toast.errorText).to.equal('There was an error');
+      });
+
+      it('enables the save button', () => {
+        expect(TitleCreatePage.isSaveDisabled).to.be.false;
+      });
     });
   });
 
-  describe('creating a new title with a contributor', () => {
-    beforeEach(() => {
-      return TitleCreatePage
-        .fillName('My Title')
-        .addContributor('author', 'Me')
-        .selectPackage(packages[0].id)
-        .save();
-    });
-
-    it('redirects to the new title show page with the specified contributor', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
-      expect(TitleShowPage.contributorsList(0).text).to.equal('AuthorMe');
-    });
-  });
-
-  describe('creating a new title with an edition', () => {
-    beforeEach(() => {
-      return TitleCreatePage
-        .fillName('My Title')
-        .fillEdition('My Edition')
-        .selectPackage(packages[0].id)
-        .save();
-    });
-
-    it('redirects to the new title show page with the specified edition', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
-      expect(TitleShowPage.edition).to.equal('My Edition');
-    });
-  });
-
-  describe('creating a new title with a publisher', () => {
-    beforeEach(() => {
-      return TitleCreatePage
-        .fillName('My Title')
-        .fillPublisher('Me')
-        .selectPackage(packages[0].id)
-        .save();
-    });
-
-    it('redirects to the new title show page with the specified publisher', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
-      expect(TitleShowPage.publisherName).to.equal('Me');
-    });
-  });
-
-  describe('creating a new title with a specified publication type', () => {
-    beforeEach(() => {
-      return TitleCreatePage
-        .fillName('My Title')
-        .choosePublicationType('Book')
-        .selectPackage(packages[0].id)
-        .save();
-    });
-
-    it('redirects to the new package with the specified content type', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
-      expect(TitleShowPage.publicationType).to.equal('Book');
-    });
-  });
-
-  describe('creating a new title with an identifier', () => {
-    beforeEach(() => {
-      return TitleCreatePage
-        .fillName('My Title')
-        .addIdentifier('ISBN (Print)', '90210')
-        .selectPackage(packages[0].id)
-        .save();
-    });
-
-    it('redirects to the new title show page with the specified identifier', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
-      expect(TitleShowPage.identifiersList(0).text).to.equal('ISBN (Print)90210');
-    });
-  });
-
-  describe('creating a new title with a description', () => {
-    beforeEach(() => {
-      return TitleCreatePage
-        .fillName('My Title')
-        .fillDescription('This is my title')
-        .selectPackage(packages[0].id)
-        .save();
-    });
-
-    it('redirects to the new package with the specified description', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
-      expect(TitleShowPage.descriptionText).to.equal('This is my title');
-    });
-  });
-
-  describe('creating a new title with a different package', () => {
-    beforeEach(() => {
-      return TitleCreatePage
-        .fillName('My Title')
-        .selectPackage(packages[1].id)
-        .save();
-    });
-
-    it('redirects to the new package with the specified package', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
-      expect(TitleShowPage.packageList(0).name).to.equal('Custom Package 2');
-    });
-  });
-
-  describe('creating a new title and specifying peer reviewed status', () => {
-    beforeEach(() => {
-      return TitleCreatePage
-        .fillName('My Title')
-        .fillPublisher('Me')
-        .togglePeerReviewed()
-        .selectPackage(packages[0].id)
-        .save();
-    });
-
-    it('redirects to the new package with the specified content type', function () {
-      expect(this.app.history.location.pathname).to.match(/^\/eholdings\/titles\/\d{1,}/);
-      expect(TitleShowPage.peerReviewedStatus).to.equal('Yes');
-    });
-  });
-
-  describe.skip('clicking cancel', () => {
-    beforeEach(() => {
-      return TitleCreatePage.cancel();
-    });
-
-    it('redirects to the previous page', function () {
-      expect(this.app.history.location.pathname).to.not.equal('/eholdings/titles/new');
-    });
-  });
-
-  describe.skip('clicking cancel after filling in data', () => {
-    beforeEach(() => {
-      return TitleCreatePage
-        .fillName('My Title')
-        .cancel();
-    });
-
-    it('shows a navigations confirmation modal', () => {
-      expect(NavigationModal.$root).to.exist;
-    });
-  });
-
-  describe('getting an error when creating a new title', () => {
+  describe('canceling when there is router history', () => {
     beforeEach(function () {
-      this.server.post('/titles', {
-        errors: [{
-          title: 'There was an error'
-        }]
-      }, 500);
-
-      return TitleCreatePage
-        .fillName('My Title')
-        .selectPackage(packages[0].id)
-        .save();
+      return this.visit('/eholdings/?searchType=titles', () => {
+        expect(TitleSearchPage.$root).to.exist;
+      });
     });
 
-    it.always('does not create the title', function () {
-      expect(this.app.history.location.pathname).to.equal('/eholdings/titles/new');
-    });
+    describe('clicking a cancel action', () => {
+      beforeEach(function () {
+        return TitleSearchPage.clickNewButton();
+      });
 
-    it('shows an error toast message', () => {
-      expect(TitleShowPage.toast.errorText).to.equal('There was an error');
-    });
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return TitleCreatePage.cancel();
+        });
 
-    it('enables the save button', () => {
-      expect(TitleCreatePage.isSaveDisabled).to.be.false;
+        it('redirects to the previous page', function () {
+          expect(this.app.history.location.pathname).to.not.equal('/eholdings/titles/new');
+        });
+      });
+
+      describe('clicking cancel after filling in data', () => {
+        beforeEach(() => {
+          return TitleCreatePage
+            .fillName('My Title')
+            .cancel();
+        });
+
+        it('shows a navigation confirmation modal', () => {
+          expect(NavigationModal.$root).to.exist;
+        });
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,6 +495,19 @@
   version "8.10.29"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.29.tgz#b3a13b58dd7b0682bf1b42022bef4a5a9718f687"
 
+"@types/prop-types@*", "@types/prop-types@^15.5.3":
+  version "15.5.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.4.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.14.tgz#47c604c8e46ed674bbdf4aabf82b34b9041c6a04"
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/zen-observable@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
@@ -2918,6 +2931,10 @@ csso@^3.5.0:
   resolved "https://registry.yarnpkg.com/csso/-/csso-3.5.1.tgz#7b9eb8be61628973c1b261e169d2f024008e758b"
   dependencies:
     css-tree "1.0.0-alpha.29"
+
+csstype@^2.2.0:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.7.tgz#bf9235d5872141eccfb2d16d82993c6b149179ff"
 
 cuint@^0.2.2:
   version "0.2.2"
@@ -8288,6 +8305,13 @@ react-router-dom@^4.0.0, react-router-dom@^4.1.1:
     prop-types "^15.6.1"
     react-router "^4.3.1"
     warning "^4.0.1"
+
+react-router-prop-types@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-router-prop-types/-/react-router-prop-types-1.0.4.tgz#74716e92d014bb51ee4376ee198f34903cf8dc1d"
+  dependencies:
+    "@types/prop-types" "^15.5.3"
+    prop-types "^15.6.1"
 
 react-router@^4.0.0, react-router@^4.1.1, react-router@^4.2.0, react-router@^4.3.1:
   version "4.3.1"


### PR DESCRIPTION
## Purpose
Only do routing mutations in route components.

## Approach
Whenever a component tried to do `history.push()`, `history.goBack()`, etc, instead fire an action up to the parent route. The parent route will handle the `history` event. Data down, actions up.

### Benefits
- We no directly longer use any old React context API (`react-intl` and `react-router` still do under the hood).
- Got rid of the final deprecated `componentWillReceiveProps`.
- Only routes need to know about `history`, `location`, and `match`. Since they're direct children of the router, they don't even have to receive those through context - they're props on routes. I used `react-router-prop-types` for those three props.
- Routing changes are more isolated, for future router upgrades or replacements.

There are two exceptions: `<DetailsView>` and `<NavigationModal>`. Both of those are very much router-aware components. I used `react-router`'s `withRouter()` higher-order component with those instead of `context.router`.

## Learning
Builds on the data flow standards communicated in https://github.com/folio-org/ui-eholdings/blob/master/docs/routing-architecture/routing-architecture.md

## Next Steps
The toaster notification pattern still doesn't feel quite right. That could use another iteration.