### PR TITLE
UIEH-546: Update number of records found when results limited to first 10K

### DIFF
--- a/src/components/details-view/accordion-list-header.js
+++ b/src/components/details-view/accordion-list-header.js
@@ -1,18 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedNumber, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage, FormattedNumber, injectIntl, intlShape } from 'react-intl';
 import { KeyValue } from '@folio/stripes-components';
 import AccordionHeader from '@folio/stripes-components/lib/Accordion/headers/DefaultAccordionHeader';
 import styles from './accordion-list-header.css';
 
 function AccordionListHeader(props) {
   let { intl } = props;
+  let showOver = props.metaLength > props.resultsLength;
   return (
     <div className={styles['accordion-list-header']}>
       <AccordionHeader {...props} />
       {props.open && (
         <KeyValue label={intl.formatMessage({ id: 'ui-eholdings.label.accordionList' })}>
           <div data-test-eholdings-details-view-results-count>
+            {showOver && (
+            <span>
+              <FormattedMessage id="ui-eholdings.over" />
+              &nbsp;
+            </span>
+            )}
             <FormattedNumber value={props.resultsLength} />
           </div>
         </KeyValue>
@@ -23,6 +30,7 @@ function AccordionListHeader(props) {
 
 AccordionListHeader.propTypes = {
   intl: intlShape.isRequired,
+  metaLength: PropTypes.number,
   open: PropTypes.bool,
   resultsLength: PropTypes.number
 };

--- a/src/components/details-view/accordion-list-header.js
+++ b/src/components/details-view/accordion-list-header.js
@@ -9,7 +9,7 @@ function AccordionListHeader(props) {
   let { intl } = props;
   // RM API does not return exact number of results when count is over 10K
   // For title lists, resultsLength of 10000 indicates this.
-  // For other lists (package and vendor) resultsLength of 10001 indicates this.
+  // For other lists (package and provider) resultsLength of 10001 indicates this.
   let overCount = props.listType === 'titles' ? 10000 : 10001;
   let showOver = props.resultsLength === overCount;
   let displayOverCount = 10000;

--- a/src/components/details-view/accordion-list-header.js
+++ b/src/components/details-view/accordion-list-header.js
@@ -7,20 +7,28 @@ import styles from './accordion-list-header.css';
 
 function AccordionListHeader(props) {
   let { intl } = props;
-  let showOver = props.metaLength > props.resultsLength;
+  // RM API does not return exact number of results when count is over 10K
+  // For title lists, resultsLength of 10000 indicates this.
+  // For other lists (package and vendor) resultsLength of 10001 indicates this.
+  let overCount = props.listType === 'titles' ? 10000 : 10001;
+  let showOver = props.resultsLength === overCount;
+  let displayOverCount = 10000;
   return (
     <div className={styles['accordion-list-header']}>
       <AccordionHeader {...props} />
       {props.open && (
         <KeyValue label={intl.formatMessage({ id: 'ui-eholdings.label.accordionList' })}>
           <div data-test-eholdings-details-view-results-count>
-            {showOver && (
-            <span>
-              <FormattedMessage id="ui-eholdings.over" />
-              &nbsp;
-            </span>
-            )}
-            <FormattedNumber value={props.resultsLength} />
+            {showOver ? (
+              <span>
+                <FormattedMessage id="ui-eholdings.over" />
+                &nbsp;
+                <FormattedNumber value={displayOverCount} />
+              </span>
+            )
+              :
+              (<FormattedNumber value={props.resultsLength} />)
+            }
           </div>
         </KeyValue>
       )}
@@ -30,7 +38,7 @@ function AccordionListHeader(props) {
 
 AccordionListHeader.propTypes = {
   intl: intlShape.isRequired,
-  metaLength: PropTypes.number,
+  listType: PropTypes.node,
   open: PropTypes.bool,
   resultsLength: PropTypes.number
 };

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -39,6 +39,7 @@ class DetailsView extends Component {
     lastMenu: PropTypes.node,
     listSectionId: PropTypes.string,
     listType: PropTypes.node,
+    metaLength: PropTypes.number,
     model: PropTypes.shape({
       isLoaded: PropTypes.bool.isRequired,
       isLoading: PropTypes.bool.isRequired,
@@ -196,6 +197,7 @@ class DetailsView extends Component {
       paneSub,
       actionMenuItems,
       lastMenu,
+      metaLength,
       resultsLength,
       searchModal,
       sections,
@@ -300,6 +302,7 @@ class DetailsView extends Component {
                     label={capitalize(listType)}
                     displayWhenOpen={searchModal}
                     resultsLength={resultsLength}
+                    metaLength={metaLength}
                     contentRef={(n) => { this.$list = n; measureRef(n); }}
                     open={isListAccordionOpen}
                     id={listSectionId}

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -39,7 +39,6 @@ class DetailsView extends Component {
     lastMenu: PropTypes.node,
     listSectionId: PropTypes.string,
     listType: PropTypes.node,
-    metaLength: PropTypes.number,
     model: PropTypes.shape({
       isLoaded: PropTypes.bool.isRequired,
       isLoading: PropTypes.bool.isRequired,
@@ -197,7 +196,6 @@ class DetailsView extends Component {
       paneSub,
       actionMenuItems,
       lastMenu,
-      metaLength,
       resultsLength,
       searchModal,
       sections,
@@ -302,11 +300,11 @@ class DetailsView extends Component {
                     label={capitalize(listType)}
                     displayWhenOpen={searchModal}
                     resultsLength={resultsLength}
-                    metaLength={metaLength}
                     contentRef={(n) => { this.$list = n; measureRef(n); }}
                     open={isListAccordionOpen}
                     id={listSectionId}
                     onToggle={onListToggle}
+                    listType={listType}
                   >
                     {renderList(isSticky)}
                   </Accordion>

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -420,7 +420,6 @@ class PackageShow extends Component {
           listSectionId="packageShowTitles"
           onListToggle={this.handleSectionToggle}
           resultsLength={model.resources.length}
-          metaLength={model.titleCount}
           renderList={scrollable => (
             <QueryList
               type="package-titles"

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -420,6 +420,7 @@ class PackageShow extends Component {
           listSectionId="packageShowTitles"
           onListToggle={this.handleSectionToggle}
           resultsLength={model.resources.length}
+          metaLength={model.titleCount}
           renderList={scrollable => (
             <QueryList
               type="package-titles"

--- a/test/bigtest/tests/package-show-titles-search-test.js
+++ b/test/bigtest/tests/package-show-titles-search-test.js
@@ -179,26 +179,21 @@ describeApplication('Package Show Title Search', () => {
     });
   });
 
-  describe.skip('navigating to package show page with over 10k titles in package related resources meta totalResults', () => {
+  describe.only('navigating to package show page with over 10k titles in resources totalResults', () => {
     beforeEach(function () {
       let largeProviderPackage = this.server.create(
         'package',
-        'withTitles',
         {
           provider,
           name: 'Cool Large Package',
           contentType: 'E-Book',
           isSelected: false,
-          titleCount: 1,
+          titleCount: 1500000,
           packageType: 'Complete'
         }
       );
 
-      // let largeResources = this.server.schema.where('resource', {
-      //  packageId: largeProviderPackage.id
-      // }).models;
-
-      this.server.get(`packages/${largeProviderPackage.id}/resources?page=1`,
+      this.server.get(`packages/${largeProviderPackage.id}/resources`,
         { 'data':[],
           'meta':{ 'totalResults': 10000 },
           'jsonapi':{ 'version':'1.0' } }, 200);
@@ -215,7 +210,11 @@ describeApplication('Package Show Title Search', () => {
       );
     });
 
-    it('displays Over 10,000 as number of title records', () => {
+    it('displays the number of title records in package details', () => {
+      expect(PackageShowPage.numTitles).to.equal('1,500,000');
+    });
+
+    it('displays Over 10,000 as number of title records in list header', () => {
       expect(PackageShowPage.searchResultsCount).to.contain('Over');
       expect(PackageShowPage.searchResultsCount).to.contain('10,000');
     });

--- a/test/bigtest/tests/package-show-titles-search-test.js
+++ b/test/bigtest/tests/package-show-titles-search-test.js
@@ -179,98 +179,45 @@ describeApplication('Package Show Title Search', () => {
     });
   });
 
-  describe.skip('navigating to package show page with over 10k titles in package', () => {
+  describe.skip('navigating to package show page with over 10k titles in package related resources meta totalResults', () => {
     beforeEach(function () {
-      this.server.get('/packages/19-5207', () => {
-        return new Response(200, {}, { 'data':{ 'id':'19-5207',
-          'type':'packages',
-          'attributes':{ 'contentType':'E-Book',
-            'customCoverage':{ 'beginCoverage':'', 'endCoverage':'' },
-            'isCustom':false,
-            'isSelected':true,
-            'name':'EBSCO eBooks',
-            'packageId':5207,
-            'packageType':'Selectable',
-            'providerId':19,
-            'providerName':'EBSCO',
-            'selectedCount':1,
-            'titleCount':1554086,
-            'vendorId':19,
-            'vendorName':'EBSCO',
-            'visibilityData':{ 'isHidden':false, 'reason':'' },
-            'allowKbToAddTitles':false,
-            'packageToken':null,
-            'proxy':{ 'id':'EZProxy', 'inherited':true } },
-          'relationships':{ 'resources':{ 'meta':{ 'included':false } }, 'vendor':{ 'meta':{ 'included':false } }, 'provider':{ 'meta':{ 'included':false } } } },
-        'jsonapi':{ 'version':'1.0' } })
-          .then(() => {
-            this.server.get('packages/19-5207/resources?page=1', () => {
-              return new Response(200, {}, { 'data':[],
-                'meta':{ 'totalResults': 10000 },
-                'jsonapi':{ 'version':'1.0' } });
-            });
-          });
-      });
+      let largeProviderPackage = this.server.create(
+        'package',
+        'withTitles',
+        {
+          provider,
+          name: 'Cool Large Package',
+          contentType: 'E-Book',
+          isSelected: false,
+          titleCount: 1,
+          packageType: 'Complete'
+        }
+      );
 
-      return this.visit('/eholdings/packages/19-5207', () => {
-        expect(PackageShowPage.$root).to.exist;
-      });
-    });
+      // let largeResources = this.server.schema.where('resource', {
+      //  packageId: largeProviderPackage.id
+      // }).models;
 
-    it('displays the proper title count', () => {
-      expect(PackageShowPage.numTitles).to.equal('1,554,086');
-    });
-
-    it('displays the proper title count', () => {
-      expect(PackageShowPage.titleList().length).to.equal(10000);
-    });
-
-    it('displays the number of relevant title records', () => {
-      expect(PackageShowPage.searchResultsCount).to.equal('Over 10,000');
-    });
-  });
-
-  describe('navigating to package show page with over 10k titles in package', () => {
-    beforeEach(function () {
-      this.server.get('/packages/19-5207', { 'data':{ 'id':'19-5207',
-        'type':'packages',
-        'attributes':{ 'contentType':'E-Book',
-          'customCoverage':{ 'beginCoverage':'', 'endCoverage':'' },
-          'isCustom':false,
-          'isSelected':true,
-          'name':'EBSCO eBooks',
-          'packageId':5207,
-          'packageType':'Selectable',
-          'providerId':19,
-          'providerName':'EBSCO',
-          'selectedCount':1,
-          'titleCount':1554086,
-          'vendorId':19,
-          'vendorName':'EBSCO',
-          'visibilityData':{ 'isHidden':false, 'reason':'' },
-          'allowKbToAddTitles':false,
-          'packageToken':null,
-          'proxy':{ 'id':'EZProxy', 'inherited':true } },
-        'relationships':{ 'resources':{ 'meta':{ 'included':false } }, 'vendor':{ 'meta':{ 'included':false } }, 'provider':{ 'meta':{ 'included':false } } } },
-      'jsonapi':{ 'version':'1.0' } }, 200);
-    });
-    describe('with a package that has only 10K titles in resource list', () => {
-      beforeEach(() => {
-        this.server.get('packages/19-5207/resources?page=1', { 'data':[],
+      this.server.get(`packages/${largeProviderPackage.id}/resources?page=1`,
+        { 'data':[],
           'meta':{ 'totalResults': 10000 },
           'jsonapi':{ 'version':'1.0' } }, 200);
-      });
-      it('displays the proper title count', () => {
-        expect(PackageShowPage.numTitles).to.equal('1,554,086');
-      });
 
-      it('displays the proper title count', () => {
-        expect(PackageShowPage.titleList().length).to.equal(10000);
-      });
+      return this.visit(
+        {
+          pathname: `/eholdings/packages/${largeProviderPackage.id}`,
+          // our internal link component automatically sets the location state
+          state: { eholdings: true }
+        },
+        () => {
+          expect(PackageShowPage.$root).to.exist;
+        }
+      );
+    });
 
-      it('displays the number of relevant title records', () => {
-        expect(PackageShowPage.searchResultsCount).to.equal('Over 10,000');
-      });
+    it('displays Over 10,000 as number of title records', () => {
+      expect(PackageShowPage.searchResultsCount).to.contain('Over');
+      expect(PackageShowPage.searchResultsCount).to.contain('10,000');
     });
   });
 });

--- a/test/bigtest/tests/package-show-titles-search-test.js
+++ b/test/bigtest/tests/package-show-titles-search-test.js
@@ -84,6 +84,10 @@ describeApplication('Package Show Title Search', () => {
       expect(PackageShowPage.searchModalBadge.filterText).to.equal('');
     });
 
+    it('displays the number of relevant title records', () => {
+      expect(PackageShowPage.searchResultsCount).to.equal('3');
+    });
+
     describe('searching for a title', () => {
       beforeEach(() => {
         return PackageShowPage.clickListSearch()
@@ -171,6 +175,101 @@ describeApplication('Package Show Title Search', () => {
         it('properly filters to one result', () => {
           expect(PackageShowPage.titleList().length).to.equal(3);
         });
+      });
+    });
+  });
+
+  describe.skip('navigating to package show page with over 10k titles in package', () => {
+    beforeEach(function () {
+      this.server.get('/packages/19-5207', () => {
+        return new Response(200, {}, { 'data':{ 'id':'19-5207',
+          'type':'packages',
+          'attributes':{ 'contentType':'E-Book',
+            'customCoverage':{ 'beginCoverage':'', 'endCoverage':'' },
+            'isCustom':false,
+            'isSelected':true,
+            'name':'EBSCO eBooks',
+            'packageId':5207,
+            'packageType':'Selectable',
+            'providerId':19,
+            'providerName':'EBSCO',
+            'selectedCount':1,
+            'titleCount':1554086,
+            'vendorId':19,
+            'vendorName':'EBSCO',
+            'visibilityData':{ 'isHidden':false, 'reason':'' },
+            'allowKbToAddTitles':false,
+            'packageToken':null,
+            'proxy':{ 'id':'EZProxy', 'inherited':true } },
+          'relationships':{ 'resources':{ 'meta':{ 'included':false } }, 'vendor':{ 'meta':{ 'included':false } }, 'provider':{ 'meta':{ 'included':false } } } },
+        'jsonapi':{ 'version':'1.0' } })
+          .then(() => {
+            this.server.get('packages/19-5207/resources?page=1', () => {
+              return new Response(200, {}, { 'data':[],
+                'meta':{ 'totalResults': 10000 },
+                'jsonapi':{ 'version':'1.0' } });
+            });
+          });
+      });
+
+      return this.visit('/eholdings/packages/19-5207', () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    it('displays the proper title count', () => {
+      expect(PackageShowPage.numTitles).to.equal('1,554,086');
+    });
+
+    it('displays the proper title count', () => {
+      expect(PackageShowPage.titleList().length).to.equal(10000);
+    });
+
+    it('displays the number of relevant title records', () => {
+      expect(PackageShowPage.searchResultsCount).to.equal('Over 10,000');
+    });
+  });
+
+  describe('navigating to package show page with over 10k titles in package', () => {
+    beforeEach(function () {
+      this.server.get('/packages/19-5207', { 'data':{ 'id':'19-5207',
+        'type':'packages',
+        'attributes':{ 'contentType':'E-Book',
+          'customCoverage':{ 'beginCoverage':'', 'endCoverage':'' },
+          'isCustom':false,
+          'isSelected':true,
+          'name':'EBSCO eBooks',
+          'packageId':5207,
+          'packageType':'Selectable',
+          'providerId':19,
+          'providerName':'EBSCO',
+          'selectedCount':1,
+          'titleCount':1554086,
+          'vendorId':19,
+          'vendorName':'EBSCO',
+          'visibilityData':{ 'isHidden':false, 'reason':'' },
+          'allowKbToAddTitles':false,
+          'packageToken':null,
+          'proxy':{ 'id':'EZProxy', 'inherited':true } },
+        'relationships':{ 'resources':{ 'meta':{ 'included':false } }, 'vendor':{ 'meta':{ 'included':false } }, 'provider':{ 'meta':{ 'included':false } } } },
+      'jsonapi':{ 'version':'1.0' } }, 200);
+    });
+    describe('with a package that has only 10K titles in resource list', () => {
+      beforeEach(() => {
+        this.server.get('packages/19-5207/resources?page=1', { 'data':[],
+          'meta':{ 'totalResults': 10000 },
+          'jsonapi':{ 'version':'1.0' } }, 200);
+      });
+      it('displays the proper title count', () => {
+        expect(PackageShowPage.numTitles).to.equal('1,554,086');
+      });
+
+      it('displays the proper title count', () => {
+        expect(PackageShowPage.titleList().length).to.equal(10000);
+      });
+
+      it('displays the number of relevant title records', () => {
+        expect(PackageShowPage.searchResultsCount).to.equal('Over 10,000');
       });
     });
   });

--- a/test/bigtest/tests/package-show-titles-search-test.js
+++ b/test/bigtest/tests/package-show-titles-search-test.js
@@ -179,7 +179,7 @@ describeApplication('Package Show Title Search', () => {
     });
   });
 
-  describe.only('navigating to package show page with over 10k titles in resources totalResults', () => {
+  describe('navigating to package show page with over 10k related resources', () => {
     beforeEach(function () {
       let largeProviderPackage = this.server.create(
         'package',

--- a/test/bigtest/tests/provider-show-package-search-test.js
+++ b/test/bigtest/tests/provider-show-package-search-test.js
@@ -225,4 +225,39 @@ describeApplication('ProviderShow package search', () => {
       });
     });
   });
+
+  describe('navigating to provider show page with over 10k related packages', () => {
+    beforeEach(function () {
+      let largeProvider = this.server.create('provider',
+        {
+          name: 'Large Provider Test',
+          packagesTotal: 1500000
+        });
+
+      this.server.get(`providers/${largeProvider.id}/packages`,
+        { 'data':[],
+          'meta':{ 'totalResults': 10001 },
+          'jsonapi':{ 'version':'1.0' } }, 200);
+
+      return this.visit(
+        {
+          pathname: `/eholdings/providers/${largeProvider.id}`,
+          // our internal link component automatically sets the location state
+          state: { eholdings: true }
+        },
+        () => {
+          expect(ProviderShowPage.$root).to.exist;
+        }
+      );
+    });
+
+    it('displays the number of package records in provider details', () => {
+      expect(ProviderShowPage.numPackages).to.equal('1,500,000');
+    });
+
+    it('displays Over 10,000 as number of title records in list header', () => {
+      expect(ProviderShowPage.searchResultsCount).to.contain('Over');
+      expect(ProviderShowPage.searchResultsCount).to.contain('10,000');
+    });
+  });
 });

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -305,5 +305,6 @@
     "number": "Number",
     "hidden": "Hidden",
     "name.isRequired": "Name *",
-    "resultCount": "{count, number} {count, plural, one {search result} other {search results}}"
-}
+    "resultCount": "{count, number} {count, plural, one {search result} other {search results}}",
+    "over": "Over"
+  }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose

Per https://issues.folio.org/browse/UIEH-546, there is currently a discrepancy in the 
total number of titles displayed in package detail information and number of records found in the title result list accordion. This specifically happens for a package when the number of related records (ie titles) found is greater than 10,000. This is currently a limitation in RM API as it does not return the exact number of titles and returns 10,000 instead. In these cases, UI should display `Over 10,000` as the number of records found to indicate this fact.

## Approach

- Check `totalResults` which is returned from a package's related resources request
For example - `eholdings/packages/19-5207/resources?page=1`
- Total results is available as `model.resources.length` in PackageShow Page. Package associated resources are obtained from a request to `getPackageTitles: (id, params) => Package.queryRelated(id, 'resources', params)` in PackageShow route.
- If totalResults is 10,000 for titles or 10,001 for providers or packages, pre-pend `Over` to count.
- Update to apply `Over` is made in accordion-list-header component
- This approach has limitation of potentially displaying Over 10,000 titles if a title list has exactly 10,000 titles.
- Added checks for providers and packages list (total results = 10,001) although these scenarios are unlikely due to number of providers and packages that are available
- Added tests for both Package and Provider show pages.

Original approach was to compare the number of titles (as returned from package details request meta data ) to the number of results (as returned from request to get related titles for a package). If package meta data is greater than number of results returned from list, add `Over` to the accordion header display. This approach unfortunately does not work as we only get package details and associated count for the entire package. If the package resources list is filtered  this case will not be handled 

#### TODOS and Open Questions
- [x] Create unit tests -- how to simulate large result list?

Need to adjust `json.meta.totalResults` for related resources - currently it gets set based on number of records in resources array (we need to be 10K)
https://github.com/folio-org/ui-eholdings/blob/71c8c748fbf6b28401f0098bb0a2d3e4fc874d4f/test/bigtest/network/helpers.js#L154

Tried overriding the response for retrieving a package's related resources in unit test. but not successful 
```
  this.server.get(`packages/${largeProviderPackage.id}/resources?page=1`,
        { 'data':[],
          'meta':{ 'totalResults': 10000 },
          'jsonapi':{ 'version':'1.0' } }, 200);
```
Was able to successfully override request (needed to exclude `?page=1`)

```
this.server.get(`packages/${largeProviderPackage.id}/resources`,
        { 'data':[],
          'meta':{ 'totalResults': 10000 },
          'jsonapi':{ 'version':'1.0' } }, 200);
```

- [x] AccordionListHeader is used in multiple places (as part of DetailsView). Understand impact of adding a new parameter to determine if Over gets displayed.
Added handling for titles and other cases 
- [x] Should over apply to only titles list and if the count is 10,000?
TotalResuts of of 10,000 applies to titles, 10,001 applies to packages and providers. 

## Learning

Sample package details request to mod-kb-ebsco 
`GET packages/19-5207`

Note - response includes Package details with titleCount  attribute: "titleCount":1552561 and indicates the total number of titles in a package

```{"data":{"id":"19-5207","type":"packages","attributes":{"contentType":"E-Book","customCoverage":{"beginCoverage":"","endCoverage":""},"isCustom":false,"isSelected":true,"name":"EBSCO eBooks","packageId":5207,"packageType":"Selectable","providerId":19,"providerName":"EBSCO","selectedCount":1,"titleCount":1554086,"vendorId":19,"vendorName":"EBSCO","visibilityData":{"isHidden":false,"reason":""},"allowKbToAddTitles":false,"packageToken":null,"proxy":{"id":"EZProxy","inherited":true}},"relationships":{"resources":{"meta":{"included":false}},"vendor":{"meta":{"included":false}},"provider":{"meta":{"included":false}}}},"jsonapi":{"version":"1.0"}}```

Sample request to GET package associated resources
`GET packages/19-5207/resources?page=1`

Note - response includes an array of package's related resources and totalResults  meta data:
"totalResults":10000 - indicates total number of titles for the search  and is capped at 10,000

```{"data":[{"id":"19-5207-4187001","type":"resources","attributes":{"description":null,"edition":null,"isPeerReviewed":null,"isTitleCustom":false,"publisherName":"Unspecified","titleId":4187001,"contributors":[],"identifiers":[{"id":"978-1-4619-6039-3","type":"ISBN","subtype":"Online"}],"meta":{"totalResults":10000},"jsonapi":{"version":"1.0"}}```

## Screenshots
Before:
<img width="1667" alt="screen shot 2018-09-23 at 8 59 56 pm" src="https://user-images.githubusercontent.com/19415226/45934983-ada1b380-bf73-11e8-921a-f2deb35c28a4.png">
After:
<img width="1680" alt="screen shot 2018-09-23 at 9 02 59 pm" src="https://user-images.githubusercontent.com/19415226/45934998-1b4ddf80-bf74-11e8-9c6e-27af5be35d3e.png">


