### PR TITLE
UIEH-548: Move text placement in settings

### DIFF
--- a/src/components/settings-knowledge-base/settings-knowledge-base.js
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.js
@@ -134,8 +134,6 @@ class SettingsKnowledgeBase extends Component {
                 />
               </div>
 
-              <p><FormattedMessage id="ui-eholdings.settings.kb.url.ebsco.customer.message" /></p>
-
               <div
                 data-test-eholdings-settings-customerid
               >
@@ -161,6 +159,8 @@ class SettingsKnowledgeBase extends Component {
                   autoComplete="off"
                 />
               </div>
+
+              <p><FormattedMessage id="ui-eholdings.settings.kb.url.ebsco.customer.message" /></p>
             </Fragment>
           )}
         </SettingsDetailPane>


### PR DESCRIPTION
## Purpose
After reviewing implemented functionality for UIEH-548, PO suggested that we move the note to customers from its existing location to below all components. This PR addresses that change.

## Approach
- Move text to below components. 

## Screenshots
*Before*
![update-url](https://user-images.githubusercontent.com/33662516/45973570-d88c1600-c00c-11e8-87c3-47c7a1aa1950.gif)
*After*
![after-change](https://user-images.githubusercontent.com/33662516/45973583-e0e45100-c00c-11e8-924e-13935ec74a82.gif)

