### PR TITLE
Move react-router-prop-types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "qs": "^6.5.1",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "react-router-prop-types": "^1.0.4",
     "react-transition-group": "^2.2.1",
     "react-trigger-change": "^1.0.2",
     "stylelint": "^9.5.0",
@@ -54,6 +53,7 @@
     "inflected": "^2.0.3",
     "react-intl": "^2.4.0",
     "react-measure": "^2.1.0",
+    "react-router-prop-types": "^1.0.4",
     "redux-actions": "^2.2.1",
     "rxjs": "^5.5.12"
   },


### PR DESCRIPTION
`react-router-prop-types` needs to be a `dependency` for when eHoldings gets pulled into a FOLIO platform.

```
ERROR in ./node_modules/@folio/eholdings/src/components/navigation-modal/navigation-modal.js
Module not found: Error: Can't resolve 'react-router-prop-types' in '/home/jenkins/folio-testing-platform/node_modules/@folio/eholdings/src/components/navigation-modal'
 @ ./node_modules/@folio/eholdings/src/components/navigation-modal/navigation-modal.js 13:0-59 151:11-31
 @ ./node_modules/@folio/eholdings/src/components/navigation-modal/index.js
 @ ./node_modules/@folio/eholdings/src/components/resource/edit-custom-title/resource-edit-custom-title.js
 @ ./node_modules/@folio/eholdings/src/components/resource/edit-custom-title/index.js
 @ ./node_modules/@folio/eholdings/src/components/resource/edit.js
 @ ./node_modules/@folio/eholdings/src/routes/resource-edit.js
 @ ./node_modules/@folio/eholdings/src/index.js
 @ ./node_modules/stripes-config.js
 @ ./node_modules/@folio/stripes-core/src/App.js
 @ ./node_modules/@folio/stripes-core/src/HotApp.js
 @ ./node_modules/@folio/stripes-core/src/index.js
 @ multi typeface-source-sans-pro @folio/stripes-components/lib/global.css ./node_modules/@folio/stripes-core/src/index
```