### PR TITLE
Remove unnecessary CLI defaults

### DIFF
--- a/.stripesclirc.js
+++ b/.stripesclirc.js
@@ -36,8 +36,6 @@ const servePlugin = {
 
 module.exports = {
   // Assign defaults to existing CLI options
-  tenant: "fs",
-  install: true,
   hasAllPerms: true,
   logCategories: '',
 


### PR DESCRIPTION
These configs are no longer necessary. `folio-ui-eholdings-deploy` handles the tenant for the folio.frontside.io deployment. Removing that default makes it really easy to point to a different cluster with a different tenant, like `yarn start --okapi http://folio-testing-backend01.aws.indexdata.com:9130`