### PR TITLE
FOLIO-1549 Use stripes framework 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,22 +14,18 @@
     "stylelint": "stylelint \"src/**/*.css\""
   },
   "devDependencies": {
-    "@bigtest/convergence": "^0.10.0",
     "@bigtest/interactor": "^0.7.2",
     "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
+    "@folio/stripes": "^1.0.0",
     "@folio/stripes-cli": "^1.5.0",
-    "@folio/stripes-connect": "^3.2.0",
-    "@folio/stripes-core": "2.15.2",
-    "@folio/stripes-logger": "^0.0.2",
+    "@folio/stripes-core": "^2.15.3",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.0.2",
-    "chai-jquery": "^2.0.0",
     "eslint": "^5.5.0",
-    "jquery": "^3.2.1",
     "lodash": "^4.17.4",
     "mocha": "^5.2.0",
     "moment": "^2.22.2",
@@ -39,7 +35,6 @@
     "react-dom": "^16.4.2",
     "react-redux": "^5.0.7",
     "react-transition-group": "^2.2.1",
-    "react-trigger-change": "^1.0.2",
     "redux": "^3.0.0",
     "rxjs": "^5.0.0",
     "sinon": "^6.3.5",
@@ -49,20 +44,20 @@
     "webpack": "^4.0.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^4.0.0",
-    "@folio/stripes-smart-components": "^1.9.0",
     "classnames": "^2.2.5",
     "funcadelic": "^0.5.4",
     "impagination": "^1.0.0-alpha.3",
     "inflected": "^2.0.3",
     "react-intl": "^2.4.0",
     "react-measure": "^2.1.0",
+    "react-router": "^4.3.1",
+    "react-router-dom": "^4.3.1",
     "react-router-prop-types": "^1.0.4",
     "redux-actions": "^2.2.1",
+    "redux-form": "^7.4.2",
     "redux-observable": "^0.15.0"
   },
   "peerDependencies": {
-    "@folio/stripes-core": "^2.15.2",
     "react": "*"
   },
   "stripes": {

--- a/src/components/contributors-list.js
+++ b/src/components/contributors-list.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import capitalize from 'lodash/capitalize';
-import { KeyValue } from '@folio/stripes-components';
+import { KeyValue } from '@folio/stripes/components';
 
 export default function ContributorsList({ data }) {
   let contributorsByType = data.reduce((byType, contributor) => {

--- a/src/components/details-view-section/details-view-section.js
+++ b/src/components/details-view-section/details-view-section.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import { Headline } from '@folio/stripes-components';
+import { Headline } from '@folio/stripes/components';
 import styles from './details-view-section.css';
 
 const cx = classNames.bind(styles);

--- a/src/components/details-view/accordion-list-header.js
+++ b/src/components/details-view/accordion-list-header.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedNumber, injectIntl, intlShape } from 'react-intl';
-import { KeyValue } from '@folio/stripes-components';
-import AccordionHeader from '@folio/stripes-components/lib/Accordion/headers/DefaultAccordionHeader';
+import { DefaultAccordionHeader, KeyValue } from '@folio/stripes/components';
 import styles from './accordion-list-header.css';
 
 function AccordionListHeader(props) {
@@ -15,7 +14,7 @@ function AccordionListHeader(props) {
   let displayOverCount = 10000;
   return (
     <div className={styles['accordion-list-header']}>
-      <AccordionHeader {...props} />
+      <DefaultAccordionHeader {...props} />
       {props.open && (
         <div className={styles['accordion-list-count']}>
           <KeyValue label={intl.formatMessage({ id: 'ui-eholdings.label.accordionList' })}>

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -5,17 +5,17 @@ import { withRouter } from 'react-router';
 import { intlShape, injectIntl } from 'react-intl';
 import classNames from 'classnames/bind';
 import capitalize from 'lodash/capitalize';
-import { ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
 import Measure from 'react-measure';
 import queryString from 'qs';
 
 import {
   Accordion,
+  ExpandAllButton,
   Headline,
   Icon,
   IconButton,
   PaneHeader
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import AccordionListHeader from './accordion-list-header';
 import styles from './details-view.css';

--- a/src/components/error-screen/failed-backend.js
+++ b/src/components/error-screen/failed-backend.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { KeyValue } from '@folio/stripes-components';
+import { KeyValue } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 import styles from './error-screen.css';
 

--- a/src/components/error-screen/invalid-backend.js
+++ b/src/components/error-screen/invalid-backend.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { KeyValue } from '@folio/stripes-components';
+import { KeyValue } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 import styles from './error-screen.css';
 

--- a/src/components/error-screen/no-backend.js
+++ b/src/components/error-screen/no-backend.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { KeyValue } from '@folio/stripes-components';
+import { KeyValue } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 import styles from './error-screen.css';
 

--- a/src/components/external-link/external-link.js
+++ b/src/components/external-link/external-link.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon } from '@folio/stripes-components';
+import { Icon } from '@folio/stripes/components';
 import classNames from 'classnames/bind';
 import styles from './external-link.css';
 

--- a/src/components/identifiers-list.js
+++ b/src/components/identifiers-list.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { KeyValue } from '@folio/stripes-components';
+import { KeyValue } from '@folio/stripes/components';
 
 export default function IdentifiersList({ data }) {
   // get rid of identifiers we received that aren't ISSN or ISBN

--- a/src/components/inline-form/inline-form.js
+++ b/src/components/inline-form/inline-form.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Button, Icon } from '@folio/stripes-components';
+import { Button, Icon } from '@folio/stripes/components';
 import styles from './inline-form.css';
 
 export default class InlineForm extends Component {

--- a/src/components/navigation-modal/navigation-modal.js
+++ b/src/components/navigation-modal/navigation-modal.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { withRouter } from 'react-router';
-import { Modal, ModalFooter } from '@folio/stripes-components';
+import { Modal, ModalFooter } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
 class NavigationModal extends Component {

--- a/src/components/package-list-item/package-list-item.js
+++ b/src/components/package-list-item/package-list-item.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { FormattedNumber, FormattedMessage } from 'react-intl';
-import { Headline } from '@folio/stripes-components';
+import { Headline } from '@folio/stripes/components';
 
 import shouldFocus from '../should-focus';
 import styles from './package-list-item.css';

--- a/src/components/package/_fields/content-type/package-content-type-field.js
+++ b/src/components/package/_fields/content-type/package-content-type-field.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { injectIntl, intlShape } from 'react-intl';
 import { Field } from 'redux-form';
 
-import { Select } from '@folio/stripes-components';
+import { Select } from '@folio/stripes/components';
 
 class PackageContentTypeField extends Component {
   static propTypes = {

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -6,7 +6,7 @@ import { injectIntl, intlShape } from 'react-intl';
 
 import {
   Datepicker
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import RepeatableField from '../../../repeatable-field';
 import styles from './package-coverage-fields.css';

--- a/src/components/package/_fields/name/package-name-field.js
+++ b/src/components/package/_fields/name/package-name-field.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Field } from 'redux-form';
 import { injectIntl, intlShape } from 'react-intl';
 
-import { TextField } from '@folio/stripes-components';
+import { TextField } from '@folio/stripes/components';
 
 function PackageNameField({ intl }) {
   return (

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -7,7 +7,7 @@ import {
   Icon,
   IconButton,
   PaneHeader
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import DetailsViewSection from '../../details-view-section';
 import NameField, { validate as validatePackageName } from '../_fields/name';

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -10,7 +10,7 @@ import {
   ModalFooter,
   RadioButton,
   RadioButtonGroup
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { processErrors } from '../../utilities';
 
 import DetailsView from '../../details-view';

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -10,7 +10,7 @@ import {
   ModalFooter,
   RadioButton,
   RadioButtonGroup
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { processErrors } from '../../utilities';
 
 import DetailsView from '../../details-view';

--- a/src/components/package/selection-status.js
+++ b/src/components/package/selection-status.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Headline, Icon, Button } from '@folio/stripes-components';
+import { Headline, Icon, Button } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
 export default function SelectionStatus({ model, onAddToHoldings }) {

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -11,7 +11,7 @@ import {
   KeyValue,
   Modal,
   ModalFooter
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { intlShape, injectIntl, FormattedDate, FormattedNumber, FormattedMessage } from 'react-intl';
 import { processErrors } from '../../utilities';
 

--- a/src/components/pane-header-button/pane-header-button.js
+++ b/src/components/pane-header-button/pane-header-button.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import {
   Button
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import styles from './pane-header-button.css';
 

--- a/src/components/provider-list-item/provider-list-item.js
+++ b/src/components/provider-list-item/provider-list-item.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { FormattedNumber, FormattedMessage } from 'react-intl';
-import { Headline } from '@folio/stripes-components';
+import { Headline } from '@folio/stripes/components';
 
 import shouldFocus from '../should-focus';
 import styles from './provider-list-item.css';

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -5,7 +5,7 @@ import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import {
   Headline,
   Icon
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import { processErrors } from '../../utilities';
 import DetailsView from '../../details-view';

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import update from 'lodash/fp/update';
 import set from 'lodash/fp/set';
-import { Accordion, Headline, Icon, IconButton, KeyValue } from '@folio/stripes-components';
+import { Accordion, Headline, Icon, IconButton, KeyValue } from '@folio/stripes/components';
 import { intlShape, injectIntl, FormattedNumber, FormattedMessage } from 'react-intl';
 import capitalize from 'lodash/capitalize';
 

--- a/src/components/proxy-display.js
+++ b/src/components/proxy-display.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { KeyValue, Icon } from '@folio/stripes-components';
+import { KeyValue, Icon } from '@folio/stripes/components';
 
 export default function ProxyDisplay({ model, proxyTypes, inheritedProxyId }) {
   let proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;

--- a/src/components/proxy-select/proxy-select-field.js
+++ b/src/components/proxy-select/proxy-select-field.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import { intlShape, injectIntl } from 'react-intl';
 
-import { Select } from '@folio/stripes-components';
+import { Select } from '@folio/stripes/components';
 import styles from './proxy-select-field.css';
 
 function ProxySelectField({ proxyTypes, inheritedProxyId, intl }) {

--- a/src/components/repeatable-field/RepeatableField.js
+++ b/src/components/repeatable-field/RepeatableField.js
@@ -5,7 +5,7 @@ import {
   Button,
   Headline,
   IconButton
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import reduxFormFieldArray from './ReduxFormFieldArray';
 import css from './RepeatableField.css';
 

--- a/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
+++ b/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Field } from 'redux-form';
 import PropTypes from 'prop-types';
 
-import { RadioButton, TextArea } from '@folio/stripes-components';
+import { RadioButton, TextArea } from '@folio/stripes/components';
 import { injectIntl, intlShape } from 'react-intl';
 import styles from './coverage-statement-fields.css';
 

--- a/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
@@ -6,7 +6,7 @@ import { injectIntl, intlShape } from 'react-intl';
 
 import {
   Datepicker
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import RepeatableField from '../../../repeatable-field';
 import styles from './custom-coverage-fields.css';

--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -8,7 +8,7 @@ import {
   IconButton,
   Select,
   TextField
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import styles from './custom-embargo-fields.css';
 
 class CustomEmbargoFields extends Component {

--- a/src/components/resource/_fields/custom-url/custom-url-fields.js
+++ b/src/components/resource/_fields/custom-url/custom-url-fields.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Field } from 'redux-form';
 import { injectIntl, intlShape } from 'react-intl';
-import { TextField } from '@folio/stripes-components';
+import { TextField } from '@folio/stripes/components';
 
 class CustomUrlFields extends Component {
   static propTypes = {

--- a/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
+++ b/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
@@ -7,7 +7,7 @@ import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import {
   Datepicker,
   RadioButton
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import CoverageDateList from '../../../coverage-date-list';
 import { isBookPublicationType } from '../../../utilities';

--- a/src/components/resource/_fields/visibility/visibility-field.js
+++ b/src/components/resource/_fields/visibility/visibility-field.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
-import { RadioButton, RadioButtonGroup } from '@folio/stripes-components';
+import { RadioButton, RadioButtonGroup } from '@folio/stripes/components';
 import styles from './visibility-field.css';
 
 class VisibilityField extends Component {

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -9,7 +9,7 @@ import {
   Icon,
   Modal,
   ModalFooter
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { processErrors, isBookPublicationType } from '../../utilities';
 
 import DetailsView from '../../details-view';

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -10,7 +10,7 @@ import {
   Icon,
   Modal,
   ModalFooter
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { processErrors, isBookPublicationType } from '../../utilities';
 
 import DetailsView from '../../details-view';

--- a/src/components/resource/show.js
+++ b/src/components/resource/show.js
@@ -13,7 +13,7 @@ import {
   KeyValue,
   Modal,
   ModalFooter
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import DetailsView from '../details-view';
 import Link from '../link';

--- a/src/components/search-form/search-filters.js
+++ b/src/components/search-form/search-filters.js
@@ -6,7 +6,7 @@ import {
   Accordion,
   FilterAccordionHeader,
   RadioButton
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import styles from './search-form.css';
 
 export default function SearchFilters({

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -6,7 +6,7 @@ import capitalize from 'lodash/capitalize';
 import {
   Button,
   SearchField
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import ProviderSearchFilters from '../provider-search-filters';
 import PackageSearchFilters from '../package-search-filters';
 import TitleSearchFilters from '../title-search-filters';

--- a/src/components/search-modal/search-badge.js
+++ b/src/components/search-modal/search-badge.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import {
   IconButton
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 export default function SearchBadge({ filterCount = 0, onClick, ...rest }) {
   return (

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -6,7 +6,7 @@ import { injectIntl, intlShape } from 'react-intl';
 import {
   Modal,
   ModalFooter,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import SearchForm from '../search-form';
 import SearchBadge from './search-badge';

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -4,7 +4,7 @@ import {
   Button,
   PaneHeader,
   PaneMenu
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import capitalize from 'lodash/capitalize';
 import { FormattedMessage } from 'react-intl';
 

--- a/src/components/settings-detail-pane/settings-detail-pane.js
+++ b/src/components/settings-detail-pane/settings-detail-pane.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   IconButton,
   Pane
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { injectIntl, intlShape } from 'react-intl';
 
 import styles from './settings-detail-pane.css';

--- a/src/components/settings-knowledge-base/settings-knowledge-base.js
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.js
@@ -8,7 +8,7 @@ import {
   Icon,
   TextField,
   Select
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import SettingsDetailPane from '../settings-detail-pane';
 import { processErrors } from '../utilities';
 import Toaster from '../toaster';

--- a/src/components/settings-root-proxy/_fields/root-proxy-select/root-proxy-select-field.js
+++ b/src/components/settings-root-proxy/_fields/root-proxy-select/root-proxy-select-field.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import { intlShape, injectIntl } from 'react-intl';
 
-import { Select } from '@folio/stripes-components';
+import { Select } from '@folio/stripes/components';
 import styles from './root-proxy-select-field.css';
 
 function RootProxySelectField({ proxyTypes, intl }) {

--- a/src/components/settings-root-proxy/settings-root-proxy.js
+++ b/src/components/settings-root-proxy/settings-root-proxy.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
-import { Headline, Icon } from '@folio/stripes-components';
+import { Headline, Icon } from '@folio/stripes/components';
 import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
 
 import SettingsDetailPane from '../settings-detail-pane';

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { FormattedMessage } from 'react-intl';
-import { Headline } from '@folio/stripes-components';
+import { Headline } from '@folio/stripes/components';
 
 import shouldFocus from '../should-focus';
 import styles from './title-list-item.css';

--- a/src/components/title/_fields/contributor/contributor-field.js
+++ b/src/components/title/_fields/contributor/contributor-field.js
@@ -4,7 +4,7 @@ import { Field, FieldArray } from 'redux-form';
 import {
   Select,
   TextField
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { injectIntl, intlShape } from 'react-intl';
 import RepeatableField from '../../../repeatable-field';
 import styles from './contributor-field.css';

--- a/src/components/title/_fields/description/description-field.js
+++ b/src/components/title/_fields/description/description-field.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Field } from 'redux-form';
 
-import { TextArea } from '@folio/stripes-components';
+import { TextArea } from '@folio/stripes/components';
 import { injectIntl, intlShape } from 'react-intl';
 
 function DescriptionField({ intl }) {

--- a/src/components/title/_fields/edition/edition-field.js
+++ b/src/components/title/_fields/edition/edition-field.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Field } from 'redux-form';
 
-import { TextField } from '@folio/stripes-components';
+import { TextField } from '@folio/stripes/components';
 import { injectIntl, intlShape } from 'react-intl';
 
 function EditionField({ intl }) {

--- a/src/components/title/_fields/identifiers/identifiers-fields.js
+++ b/src/components/title/_fields/identifiers/identifiers-fields.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import {
   Select,
   TextField
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import { injectIntl, intlShape } from 'react-intl';
 import RepeatableField from '../../../repeatable-field';

--- a/src/components/title/_fields/name/title-name-field.js
+++ b/src/components/title/_fields/name/title-name-field.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Field } from 'redux-form';
 import { injectIntl, intlShape } from 'react-intl';
 
-import { TextField } from '@folio/stripes-components';
+import { TextField } from '@folio/stripes/components';
 
 function TitleNameField({ intl }) {
   return (

--- a/src/components/title/_fields/package-select/package-select-field.js
+++ b/src/components/title/_fields/package-select/package-select-field.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import { injectIntl, intlShape } from 'react-intl';
 
-import { Select } from '@folio/stripes-components';
+import { Select } from '@folio/stripes/components';
 
 function PackageSelectField({ intl, options }) {
   let optionsWithPlaceholder = [{

--- a/src/components/title/_fields/peer-reviewed/peer-reviewed-field.js
+++ b/src/components/title/_fields/peer-reviewed/peer-reviewed-field.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Field } from 'redux-form';
 
-import { Checkbox } from '@folio/stripes-components';
+import { Checkbox } from '@folio/stripes/components';
 import { injectIntl, intlShape } from 'react-intl';
 import styles from './peer-reviewed-field.css';
 

--- a/src/components/title/_fields/publication-type/publication-type.js
+++ b/src/components/title/_fields/publication-type/publication-type.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Field } from 'redux-form';
 
-import { Select } from '@folio/stripes-components';
+import { Select } from '@folio/stripes/components';
 import { injectIntl, intlShape } from 'react-intl';
 
 function PublicationTypeField({ intl }) {

--- a/src/components/title/_fields/publisher-name/publisher-name.js
+++ b/src/components/title/_fields/publisher-name/publisher-name.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Field } from 'redux-form';
 
-import { TextField } from '@folio/stripes-components';
+import { TextField } from '@folio/stripes/components';
 import { injectIntl, intlShape } from 'react-intl';
 
 function PublisherNameField({ intl }) {

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -6,7 +6,7 @@ import {
   Icon,
   IconButton,
   PaneHeader
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import { intlShape, injectIntl } from 'react-intl';
 import DetailsViewSection from '../../details-view-section';

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -4,7 +4,7 @@ import { reduxForm } from 'redux-form';
 
 import {
   Icon
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import DetailsView from '../../details-view';
 import NameField, { validate as validateName } from '../_fields/name';

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -10,7 +10,7 @@ import {
   KeyValue,
   Modal,
   ModalFooter
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
 import { processErrors } from '../../utilities';
 import DetailsView from '../../details-view';

--- a/src/components/toaster/toast.js
+++ b/src/components/toaster/toast.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
 import classNames from 'classnames';
-import Icon from '@folio/stripes-components/lib/Icon';
+import { Icon } from '@folio/stripes/components';
 import capitalize from 'lodash/capitalize';
 
 import style from './style.css';

--- a/src/components/token/token-field.js
+++ b/src/components/token/token-field.js
@@ -6,7 +6,7 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 import {
   Button,
   TextArea
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import styles from './token-field.css';
 
 class TokenField extends Component {

--- a/src/routes/application/application.js
+++ b/src/routes/application/application.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Icon } from '@folio/stripes-components';
+import { Icon } from '@folio/stripes/components';
 
 import { createResolver } from '../../redux';
 import { Status } from '../../redux/application';

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import Package from '../redux/package';

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import moment from 'moment';
 import queryString from 'qs';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 import { injectIntl, intlShape } from 'react-intl';
 import { createResolver } from '../redux';
 import { ProxyType } from '../redux/application';

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import { ProxyType } from '../redux/application';

--- a/src/routes/provider-edit.js
+++ b/src/routes/provider-edit.js
@@ -4,7 +4,7 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import queryString from 'qs';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import Provider from '../redux/provider';

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import Provider from '../redux/provider';

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -4,7 +4,7 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import moment from 'moment';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import { ProxyType } from '../redux/application';

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import Resource from '../redux/resource';

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -4,7 +4,7 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import capitalize from 'lodash/capitalize';
 import isEqual from 'lodash/isEqual';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { qs, transformQueryParams } from '../components/utilities';
 import { createResolver } from '../redux';

--- a/src/routes/settings-knowledge-base.js
+++ b/src/routes/settings-knowledge-base.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import { Configuration } from '../redux/application';

--- a/src/routes/settings-root-proxy.js
+++ b/src/routes/settings-root-proxy.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import { ProxyType, RootProxy } from '../redux/application';

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
-import { Settings as View } from '@folio/stripes-smart-components';
+import { Settings as View } from '@folio/stripes/smart-components';
 import ApplicationRoute from './application';
 
 class SettingsRoute extends Component {

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import Title from '../redux/title';

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -4,7 +4,7 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import queryString from 'qs';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import Title from '../redux/title';

--- a/src/routes/title-show.js
+++ b/src/routes/title-show.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
-import { TitleManager } from '@folio/stripes-core';
+import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import Title from '../redux/title';

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,7 +339,7 @@
     react-transition-group "^2.2.1"
     typeface-source-sans-pro "^0.0.44"
 
-"@folio/stripes-connect@^3.1.2", "@folio/stripes-connect@^3.2.0":
+"@folio/stripes-connect@^3.1.2", "@folio/stripes-connect@^3.3.0":
   version "3.3.0"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-connect/-/stripes-connect-3.3.0.tgz#13f735e76007cc91d874aebb95adbb5c6bbbe134"
   integrity sha512-h8pRVPmEgQPc2F3VKxtrRcfWs8Scev2iG4VPUVXgJIShnh0ZnS2Z1+NbriY3QLKmLjAykMekN4wl0Zo0sDlgoQ==
@@ -354,10 +354,10 @@
     redux-crud "^3.0.0"
     uuid "^3.0.1"
 
-"@folio/stripes-core@2.15.2", "@folio/stripes-core@^2.10.0", "@folio/stripes-core@^2.14.0", "@folio/stripes-core@^2.15.0", "@folio/stripes-core@^2.15.1":
-  version "2.15.2"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-core/-/stripes-core-2.15.2.tgz#85dd53d5a68e5a820f910ef8715780084a3a0b37"
-  integrity sha512-2/OmJwGxdDc3+i+vRF0E4uMpn7RoZgAmWTKP7fy/8gi+jJz3JNBxPiqGV3RokPmb0gAsWOwtzp0Nus9rlhNFhg==
+"@folio/stripes-core@^2.10.0", "@folio/stripes-core@^2.14.0", "@folio/stripes-core@^2.15.0", "@folio/stripes-core@^2.15.1", "@folio/stripes-core@^2.15.3":
+  version "2.15.3"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-core/-/stripes-core-2.15.3.tgz#c497f8c53ccadaeab3fd00d6993bb0b99bcbd27f"
+  integrity sha512-w3EKtK5hxi4zRbOvvNtU43+vRWiIEFJXEDww2cZPkkOSvZdX4769DlkW/YcRtsBmuEL/kDUFbahtt/nRnceVPg==
   dependencies:
     "@folio/react-intl-safe-html" "^1.0.2"
     "@folio/stripes-components" "^4.0.0"
@@ -441,7 +441,7 @@
     webpack-hot-middleware "^2.22.2"
     webpack-virtual-modules "^0.1.10"
 
-"@folio/stripes-form@^1.0.0":
+"@folio/stripes-form@^1.0.0", "@folio/stripes-form@^1.1.0":
   version "1.1.0"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-form/-/stripes-form-1.1.0.tgz#e9b5facfc55ab9f9580960c3d042dbf7f7f742b9"
   integrity sha512-Oa7V+9E+ux2YYDfTWm4FnhEGGQwCGO2OjfBegcjZDKqP6akNVd4ThfKi2+DPF4DhMKM63l46O1qilC5IFC/AsA==
@@ -453,11 +453,6 @@
     react-intl "^2.4.0"
     react-router "^4.1.1"
     redux-form "^7.0.3"
-
-"@folio/stripes-logger@^0.0.2":
-  version "0.0.2"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-logger/-/stripes-logger-0.0.2.tgz#7ca7bb45c6c3eea7c81f65abb93a45d1566b0ebb"
-  integrity sha1-fKe7RcbD7qfIH2WruTpF0VZrDrs=
 
 "@folio/stripes-logger@^1.0.0":
   version "1.0.0"
@@ -510,14 +505,28 @@
     mocha-jenkins-reporter "^0.3.12"
     nightmare "^2.10.0"
 
-"@folio/stripes-util@^1.0.0":
-  version "1.1.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-util/-/stripes-util-1.1.0.tgz#5ed6fe733c1cf5258b490538d3f16099364dc4b7"
-  integrity sha512-wyiBUYx+Kilc8qtXq5IZigt10zK1dCOGjtnjbSb0ETp6jtontor4+z0RL3ovs0tjXDAYrSQyJEnekqZTYo0iEA==
+"@folio/stripes-util@^1.0.0", "@folio/stripes-util@^1.1.0":
+  version "1.2.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-util/-/stripes-util-1.2.0.tgz#43293a2d88a894a42cecf6f59c45d4506e486b21"
+  integrity sha512-zEZFuHOUpHk4K+roxS8BDHOY8Pen+z9Eyh2FPpk4dlVMg7pHqV+xjXE3blxBXJvhl3S1gmCSHkhW6GfORIUxEg==
   dependencies:
     json2csv "^4.2.1"
     lodash "^4.17.4"
     query-string "^5.0.0"
+
+"@folio/stripes@^1.0.0":
+  version "1.0.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes/-/stripes-1.0.0.tgz#e6286babd3e25f2c37bd633bce4b686f7b81541d"
+  integrity sha512-2i00CPhRUVSVm4eLlW7S8klSGHB0c2w2klpM2SpVtkgDyA79JY5u6Fkpdr4uEfpCCp8bDPwoTSPxxArbI7Md4A==
+  dependencies:
+    "@folio/stripes-components" "^4.0.0"
+    "@folio/stripes-connect" "^3.3.0"
+    "@folio/stripes-core" "^2.15.0"
+    "@folio/stripes-form" "^1.1.0"
+    "@folio/stripes-logger" "^1.0.0"
+    "@folio/stripes-smart-components" "^1.9.0"
+    "@folio/stripes-util" "^1.1.0"
+    react "^16.3.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -2530,11 +2539,6 @@ ccount@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
   integrity sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==
-
-chai-jquery@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/chai-jquery/-/chai-jquery-2.0.0.tgz#0f43042308dd746332bd98164aaef4a4f45ba167"
-  integrity sha1-D0MEIwjddGMyvZgWSq70pPRboWc=
 
 chai@^4.0.2:
   version "4.2.0"
@@ -6566,11 +6570,6 @@ jpeg-js@^0.2.0:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.2.0.tgz#53e448ec9d263e683266467e9442d2c5a2ef5482"
   integrity sha1-U+RI7J0mPmgyZkZ+lELSxaLvVII=
 
-jquery@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
-
 js-base64@^2.1.9:
   version "2.4.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03"
@@ -9650,7 +9649,7 @@ react-redux@^5.0.2, react-redux@^5.0.7:
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
 
-react-router-dom@^4.0.0, react-router-dom@^4.1.1:
+react-router-dom@^4.0.0, react-router-dom@^4.1.1, react-router-dom@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.3.1.tgz#4c2619fc24c4fa87c9fd18f4fb4a43fe63fbd5c6"
   integrity sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==
@@ -9731,11 +9730,6 @@ react-transition-group@^2.0.0, react-transition-group@^2.2.0, react-transition-g
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
-
-react-trigger-change@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-trigger-change/-/react-trigger-change-1.0.2.tgz#af573398ecef2475362b84f8c08c07fea23914c3"
-  integrity sha1-r1czmOzvJHU2K4T4wIwH/qI5FMM=
 
 react@^16.3.0, react@^16.4.2:
   version "16.5.2"
@@ -9920,7 +9914,7 @@ redux-crud@^3.0.0:
     invariant "^2.1.0"
     ramda "^0.24.1"
 
-redux-form@^7.0.3:
+redux-form@^7.0.3, redux-form@^7.4.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-7.4.2.tgz#d6061088fb682eb9fc5fb9749bd8b102f03154b0"
   integrity sha512-QxC36s4Lelx5Cr8dbpxqvl23dwYOydeAX8c6YPmgkz/Dhj053C16S2qoyZN6LO6HJ2oUF00rKsAyE94GwOUhFA==
@@ -10001,9 +9995,9 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     safe-regex "^1.1.0"
 
 regexpp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.0.tgz#b2a7534a85ca1b033bcf5ce9ff8e56d4e0755365"
-  integrity sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
 regexpu-core@^1.0.0:
   version "1.0.0"
@@ -12213,9 +12207,9 @@ write@^0.2.1:
     mkdirp "^0.5.1"
 
 ws@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.0.0.tgz#eaa494aded00ac4289d455bac8d84c7c651cef35"
-  integrity sha512-c2UlYcAZp1VS8AORtpq6y4RJIkJ9dQz18W32SpR/qXGfLDZ2jU4y4wKvvZwqbi7U6gxFQTeE+urMbXU/tsDy4w==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.0.tgz#119a9dbf92c54e190ec18d10e871d55c95cf9373"
+  integrity sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
https://issues.folio.org/browse/FOLIO-1549

Remaining uses of `stripes-core`:
```
import { withRoot } from '@folio/stripes-core/src/components/Root/RootContext';
```
☝️ that's some craziness having to do with the way that `stripes-connect` ties into `stripes-core`; that should be untangled at some point soon
```
import setupStripesCore from '@folio/stripes-core/test/bigtest/helpers/setup-application';
```
```
import startMirage from '@folio/stripes-core/test/bigtest/network/start';
```