### PR TITLE
Adjust search pane styles

### DIFF
--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -5,10 +5,6 @@
   min-width: 200px;
   max-width: 640px;
   padding: 1em;
-
-  & hr {
-    margin: 1.5rem 0;
-  }
 }
 
 .search-switcher {

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -279,7 +279,7 @@
     "search.apply": "Apply",
     "search.addNew": "+ New",
     "search.loading": "Loading...",
-    "search.searchAndFilter": "Search \u0026 Filter",
+    "search.searchAndFilter": "Search \u0026 filter",
     "search.enterQuery": "Enter a query to show search results.",
     "search.searchType": "Search {searchType}",
     "search.searchLink": "search {type}",


### PR DESCRIPTION
Makes eHoldings look more like the `SearchAndSort` changes in https://github.com/folio-org/stripes-smart-components/pull/307

### Before
![localhost_3000_eholdings_searchtype packages pixel 2](https://user-images.githubusercontent.com/230597/46637784-5e3ab600-cb23-11e8-8c62-624132196b3e.png)

### After
![localhost_3000_ pixel 2](https://user-images.githubusercontent.com/230597/46637793-62ff6a00-cb23-11e8-8f10-75544a467d51.png)
