### PR TITLE
Clean up SonarCloud bug report

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -68,7 +68,7 @@ class CustomPackageEdit extends Component {
       });
     }
 
-    return Object.keys(stateUpdates) ? stateUpdates : null;
+    return stateUpdates;
   }
 
   handleDeleteAction = () => {

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -67,7 +67,7 @@ class ManagedPackageEdit extends Component {
       });
     }
 
-    return Object.keys(stateUpdates) ? stateUpdates : null;
+    return stateUpdates;
   }
 
   handleSelectionAction = () => {

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -63,7 +63,7 @@ class ResourceEditCustomTitle extends Component {
       });
     }
 
-    return Object.keys(stateUpdates) ? stateUpdates : null;
+    return stateUpdates;
   }
 
   handleRemoveResourceFromHoldings = () => {

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -63,7 +63,7 @@ class ResourceEditManagedTitle extends Component {
       });
     }
 
-    return Object.keys(stateUpdates) ? stateUpdates : null;
+    return stateUpdates;
   }
 
   handleSelectionToggle = (e) => {

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -309,8 +309,7 @@ class BaseModel {
    * @param {Object} attrs - the record's attributes
    */
   static create(attrs) {
-    let BaseModelClass = this;
-    let newModel = new BaseModelClass();
+    let newModel = new (this)();
     newModel.data.attributes = attrs;
 
     return create(this.type, newModel.serialize(), {

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -309,7 +309,8 @@ class BaseModel {
    * @param {Object} attrs - the record's attributes
    */
   static create(attrs) {
-    let newModel = new this();
+    let BaseModelClass = this;
+    let newModel = new BaseModelClass();
     newModel.data.attributes = attrs;
 
     return create(this.type, newModel.serialize(), {

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -309,7 +309,7 @@ class BaseModel {
    * @param {Object} attrs - the record's attributes
    */
   static create(attrs) {
-    let newModel = new (this)();
+    let newModel = new this.prototype.constructor();
     newModel.data.attributes = attrs;
 
     return create(this.type, newModel.serialize(), {


### PR DESCRIPTION
SonarCloud reported two classes of bugs for `ui-eholdings`:

**Change this condition so that it does not always evaluate to "true"; some subsequent code is never executed.**
The instances of `getDerivedStateFromProps` where this came up can return an empty object instead of `null`.

**Replace this with a constructor function.**
I made the instantiation a little wordier to compensate for it not liking `new this()`.
