### PR TITLE
UIEH-453: Apply accordions for selected managed/custom package in edit mode

### DIFF
--- a/test/bigtest/interactors/package-edit.js
+++ b/test/bigtest/interactors/package-edit.js
@@ -15,6 +15,9 @@ import {
   value,
   selectable,
 } from '@bigtest/interactor';
+
+import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
+
 import { hasClassBeginningWith } from './helpers';
 import Toast from './toast';
 import Datepicker from './datepicker';
@@ -41,6 +44,12 @@ import PackageSelectionStatus from './selection-status';
   addToHoldings = new Interactor('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
   removeFromHoldings = new Interactor('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
   cancel = new Interactor('.tether-element [data-test-eholdings-package-cancel-action]');
+}
+
+@interactor class SectionToggleButton {
+  exists = isPresent('[data-test-eholdings-details-view-collapse-all-button]]');
+  label = text('[data-test-eholdings-details-view-collapse-all-button]]');
+  click = clickable('[data-test-eholdings-details-view-collapse-all-button] button');
 }
 
 @interactor class PackageEditPage {
@@ -97,6 +106,10 @@ import PackageSelectionStatus from './selection-status';
   chooseProxy = selectable('[data-test-eholdings-package-proxy-select-field] select');
   dropDown = new PackageEditDropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   dropDownMenu = new PackageEditDropDownMenu();
+  sectionToggleButton = new SectionToggleButton();
+  holdingStatusSectionAccordion = new AccordionInteractor('#packageHoldingStatus');
+  settingsSectionAccordion = new AccordionInteractor('#packageSettings');
+  coverageSettingsSectionAccordion = new AccordionInteractor('#packageCoverageSettings');
   hasProviderTokenHelpText = isPresent('[data-test-eholdings-token-fields-help-text="provider"]');
   providerTokenHelpText = text('[data-test-eholdings-token-fields-help-text="provider"]');
   hasProviderTokenPrompt = isPresent('[data-test-eholdings-token-fields-prompt="provider"]');

--- a/test/bigtest/tests/custom-package-edit-selection-test.js
+++ b/test/bigtest/tests/custom-package-edit-selection-test.js
@@ -109,4 +109,228 @@ describe('CustomPackageEditSelection', () => {
       });
     });
   });
+
+  describe('visiting the package edit page with a totally selected package', () => {
+    beforeEach(function () {
+      providerPackage = this.server.create('package', {
+        provider,
+        name: 'Cool Package',
+        contentType: 'E-Book',
+        isSelected: true
+      });
+      this.visit(`/eholdings/packages/${providerPackage.id}/edit`);
+    });
+
+    describe('holding status section', () => {
+      it('displays title', () => {
+        expect(PackageEditPage.holdingStatusSectionAccordion.label).to.equal('Holding status');
+      });
+
+      it('is expanded by default', () => {
+        expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('reflects the desired state of holding status', () => {
+        expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
+      });
+
+      it('has hidden "Add to holdings" button', () => {
+        expect(PackageEditPage.selectionStatus.hasAddButton).to.equal(false);
+      });
+    });
+
+    describe('package settings section', () => {
+      it('displays title', () => {
+        expect(PackageEditPage.settingsSectionAccordion.label).to.equal('Package settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(PackageEditPage.settingsSectionAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('can toggle visibility', () => {
+        expect(PackageEditPage.isVisibilityFieldPresent).to.equal(true);
+      });
+
+      it('can select allow kb to add titles', () => {
+        expect(PackageEditPage.hasRadioForAllowKbToAddTitles).to.equal(true);
+      });
+    });
+
+    describe('coverage settings section', () => {
+      it('displays title', () => {
+        expect(PackageEditPage.coverageSettingsSectionAccordion.label).to.equal('Coverage settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(PackageEditPage.coverageSettingsSectionAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('can edit coverage', () => {
+        expect(PackageEditPage.hasCoverageDatesPresent).to.equal(true);
+      });
+    });
+
+    it('disables the save button', () => {
+      expect(PackageEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking the "collapse all" button', () => {
+      beforeEach(async () => {
+        await PackageEditPage.sectionToggleButton.click();
+      });
+
+      it('collapses all sections', () => {
+        expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.equal(false);
+        expect(PackageEditPage.settingsSectionAccordion.isOpen).to.equal(false);
+        expect(PackageEditPage.coverageSettingsSectionAccordion.isOpen).to.equal(false);
+      });
+
+      describe('clicking the "expand all" button ', () => {
+        beforeEach(async () => {
+          await PackageEditPage.sectionToggleButton.click();
+        });
+
+        it('expands all sections', () => {
+          expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.equal(true);
+          expect(PackageEditPage.settingsSectionAccordion.isOpen).to.equal(true);
+          expect(PackageEditPage.coverageSettingsSectionAccordion.isOpen).to.equal(true);
+        });
+      });
+    });
+
+    describe('clicking cancel', () => {
+      beforeEach(() => {
+        return PackageEditPage.clickCancel();
+      });
+
+      it('goes to the package show page', () => {
+        expect(PackageShowPage.$root).to.exist;
+      });
+    });
+
+    describe('deselecting the package', () => {
+      beforeEach(() => {
+        return PackageEditPage
+          .dropDown.clickDropDownButton()
+          .dropDownMenu.removeFromHoldings.click();
+      });
+
+      it('shows the deselection confirmation modal', () => {
+        expect(PackageEditPage.modal.isPresent).to.equal(true);
+      });
+
+      describe('clicking cancel', () => {
+        beforeEach(() => {
+          return PackageEditPage.modal.cancelDeselection();
+        });
+
+        it('should stay on the edit page', () => {
+          expect(PackageEditPage.isPresent).to.equal(true);
+        });
+
+        it('reflects the desired state of holding status', () => {
+          expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
+        });
+      });
+
+      describe('clicking confirm', () => {
+        let resolveRequest;
+
+        beforeEach(function () {
+          this.server.put('/packages/:id', () => {
+            return new Promise((resolve) => {
+              resolveRequest = resolve;
+            });
+          });
+
+          return PackageEditPage.modal.confirmDeselection();
+        });
+
+        it('should keep confirmation modal on screen until requests responds', () => {
+          expect(PackageEditPage.modal.isPresent).to.equal(true);
+        });
+
+        it('confirmation button now reads "removing"', () => {
+          expect(PackageEditPage.modal.confirmButtonText).to.equal('Removing...');
+          resolveRequest();
+        });
+
+        it('confirmation button is disabled', () => {
+          expect(PackageEditPage.modal.confirmButtonIsDisabled).to.equal(true);
+        });
+
+        describe('when request resolves', () => {
+          beforeEach(() => {
+            return resolveRequest();
+          });
+
+          it('goes to the resource show page', () => {
+            expect(PackageShowPage.$root).to.exist;
+            expect(PackageShowPage.hasTitleList).to.equal(true);
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/bigtest/tests/managed-package-edit-selection-test.js
+++ b/test/bigtest/tests/managed-package-edit-selection-test.js
@@ -119,28 +119,142 @@ describe('ManagedPackageEditSelection', () => {
       this.visit(`/eholdings/packages/${providerPackage.id}/edit`);
     });
 
-    it('reflects the desired state of holding status', () => {
-      expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
+    describe('holding status section', () => {
+      it('displays title', () => {
+        expect(PackageEditPage.holdingStatusSectionAccordion.label).to.equal('Holding status');
+      });
+
+      it('is expanded by default', () => {
+        expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('reflects the desired state of holding status', () => {
+        expect(PackageEditPage.selectionStatus.isSelected).to.equal(true);
+      });
+
+      it('has hidden "Add to holdings" button', () => {
+        expect(PackageEditPage.selectionStatus.hasAddButton).to.equal(false);
+      });
     });
 
-    it('hides "Add to holdings" button', () => {
-      expect(PackageEditPage.selectionStatus.hasAddButton).to.equal(false);
+    describe('package settings section', () => {
+      it('displays title', () => {
+        expect(PackageEditPage.settingsSectionAccordion.label).to.equal('Package settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(PackageEditPage.settingsSectionAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('can toggle visibility', () => {
+        expect(PackageEditPage.isVisibilityFieldPresent).to.equal(true);
+      });
+
+      it('can select allow kb to add titles', () => {
+        expect(PackageEditPage.hasRadioForAllowKbToAddTitles).to.equal(true);
+      });
     });
 
-    it('can toggle visibility', () => {
-      expect(PackageEditPage.isVisibilityFieldPresent).to.equal(true);
-    });
+    describe('coverage settings section', () => {
+      it('displays title', () => {
+        expect(PackageEditPage.coverageSettingsSectionAccordion.label).to.equal('Coverage settings');
+      });
 
-    it('can select allow kb to add titles', () => {
-      expect(PackageEditPage.hasRadioForAllowKbToAddTitles).to.equal(true);
-    });
+      it('is expanded by default', () => {
+        expect(PackageEditPage.coverageSettingsSectionAccordion.isOpen).to.equal(true);
+      });
 
-    it('can edit coverage', () => {
-      expect(PackageEditPage.hasCoverageDatesPresent).to.equal(true);
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await PackageEditPage.holdingStatusSectionAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('can edit coverage', () => {
+        expect(PackageEditPage.hasCoverageDatesPresent).to.equal(true);
+      });
     });
 
     it('disables the save button', () => {
       expect(PackageEditPage.isSaveDisabled).to.be.true;
+    });
+
+    describe('clicking the "collapse all" button', () => {
+      beforeEach(async () => {
+        await PackageEditPage.sectionToggleButton.click();
+      });
+
+      it('collapses all sections', () => {
+        expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.equal(false);
+        expect(PackageEditPage.settingsSectionAccordion.isOpen).to.equal(false);
+        expect(PackageEditPage.coverageSettingsSectionAccordion.isOpen).to.equal(false);
+      });
+
+      describe('clicking the "expand all" button ', () => {
+        beforeEach(async () => {
+          await PackageEditPage.sectionToggleButton.click();
+        });
+
+        it('expands all sections', () => {
+          expect(PackageEditPage.holdingStatusSectionAccordion.isOpen).to.equal(true);
+          expect(PackageEditPage.settingsSectionAccordion.isOpen).to.equal(true);
+          expect(PackageEditPage.coverageSettingsSectionAccordion.isOpen).to.equal(true);
+        });
+      });
     });
 
     describe('clicking cancel', () => {


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-453, users should be able to collapse and expand the sections of custom/managed package edit pages.

## Approach
- Add the Accordion component from Stripes-components
- Wrap sections of the selected custom/managed package in edit mode. The names of the sections: "Holding Status", "Package settings", "Coverage settings"
- In local state create property containing the status of the sections(whether a section is expanded)
- Pass appropriate props to Accordion components
- Add associated tests

## Screenshots
![custom package edit page](https://user-images.githubusercontent.com/43621626/47017981-5353d700-d15c-11e8-8636-42ffa2154184.gif)

![managed package edit page](https://user-images.githubusercontent.com/43621626/47017991-56e75e00-d15c-11e8-89b0-19aaff41bbfc.gif)
