### PR TITLE
UIEH-455: Apply accordions to edit custom/managed resource detail record

### DIFF
--- a/test/bigtest/interactors/resource-edit.js
+++ b/test/bigtest/interactors/resource-edit.js
@@ -13,6 +13,9 @@ import {
   computed,
   selectable
 } from '@bigtest/interactor';
+
+import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
+
 import { hasClassBeginningWith } from './helpers';
 
 import Toast from './toast';
@@ -38,6 +41,12 @@ import Datepicker from './datepicker';
   clickCancel = clickable('.tether-element [data-test-eholdings-resource-cancel-action]');
 }
 
+@interactor class ResourceEditToggleSectionButton {
+  exists = isPresent('[data-test-eholdings-details-view-collapse-all-button]]');
+  label = text('[data-test-eholdings-details-view-collapse-all-button]]');
+  click = clickable('[data-test-eholdings-details-view-collapse-all-button] button');
+}
+
 @interactor class ResourceEditPage {
   isLoaded = isPresent('[data-test-eholdings-details-view-pane-title]');
   whenLoaded() {
@@ -54,6 +63,11 @@ import Datepicker from './datepicker';
       .dropDownMenu.clickCancel();
   });
 
+  toggleSectionButton = new ResourceEditToggleSectionButton();
+  resourceHoldingStatusAccordion = new AccordionInteractor('#resourceShowHoldingStatus');
+  resourceSettingsAccordion = new AccordionInteractor('#resourceShowSettings');
+  resourceCoverageSettingsAccordion = new AccordionInteractor('#resourceShowCoverageSettings');
+
   clickSave = clickable('[data-test-eholdings-resource-save-button]');
   hasSaveButon = isPresent('[data-test-eholdings-resource-save-button]');
   hasCancelButton = isPresent('[data-test-eholdings-resource-cancel-button]');
@@ -63,7 +77,10 @@ import Datepicker from './datepicker';
   checkPeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button]');
   isResourceSelected = text('[data-test-eholdings-resource-holding-status] div');
+  isResourceSelectedBoolean = isPresent('[data-test-eholdings-resource-holding-status] div');
   isResourceVisible = property('[data-test-eholdings-resource-visibility-field] input[value="true"]', 'checked');
+  isResourceShowToPatronsVisible = isPresent('[data-test-eholdings-resource-visibility-field]');
+  isCoverageSettingsDatesField = isPresent('[data-test-eholdings-resource-coverage-fields]');
   isHiddenMessage = computed(function () {
     let $node = this.$('[data-test-eholdings-resource-visibility-field] input[value="false"] ~ span:last-child');
     return $node.textContent.replace(/^No(\s\((.*)\))?$/, '$2');

--- a/test/bigtest/tests/resource-edit-custom-title-test.js
+++ b/test/bigtest/tests/resource-edit-custom-title-test.js
@@ -93,6 +93,136 @@ describe('ResourceEditCustomTitle', () => {
       this.visit(`/eholdings/resources/${resource.titleId}/edit`);
     });
 
+    describe('section: holding status', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.label).to.equal('Holding status');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceHoldingStatusAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceHoldingStatusAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('reflects the desired state of holding status', () => {
+        expect(ResourceEditPage.isResourceSelectedBoolean).to.equal(true);
+      });
+
+      it('has hidden "Add to holdings" button', () => {
+        expect(ResourceEditPage.addToHoldingsButton).to.equal(false);
+      });
+    });
+
+    describe('section: resource settings', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.label).to.equal('Resource settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('has "Show to Patrons" field', () => {
+        expect(ResourceEditPage.isResourceShowToPatronsVisible).to.equal(true);
+      });
+    });
+
+    describe('section: coverage settings', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.label).to.equal('Resource settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('has "Dates" field', () => {
+        expect(ResourceEditPage.isCoverageSettingsDatesField).to.equal(true);
+      });
+    });
+
+    describe('clicking the "Collapse all" button', () => {
+      beforeEach(async () => {
+        await ResourceEditPage.toggleSectionButton.click();
+      });
+
+      it('collapses all sections', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(false);
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(false);
+        expect(ResourceEditPage.resourceCoverageSettingsAccordion.isOpen).to.equal(false);
+      });
+
+      describe('clicking the "Expand all" button ', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.toggleSectionButton.click();
+        });
+
+        it('expands all sections', () => {
+          expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(true);
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+          expect(ResourceEditPage.resourceCoverageSettingsAccordion.isOpen).to.equal(true);
+        });
+      });
+    });
+
     it('shows a form with coverage statement', () => {
       expect(ResourceEditPage.coverageStatement).to.equal('');
     });

--- a/test/bigtest/tests/resource-edit-managed-title-test.js
+++ b/test/bigtest/tests/resource-edit-managed-title-test.js
@@ -202,6 +202,136 @@ describe('ResourceEditManagedTitleInManagedPackage', () => {
       this.visit(`/eholdings/resources/${resource.titleId}/edit`);
     });
 
+    describe('section: holding status', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.label).to.equal('Holding status');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceHoldingStatusAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceHoldingStatusAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('reflects the desired state of holding status', () => {
+        expect(ResourceEditPage.isResourceSelectedBoolean).to.equal(true);
+      });
+
+      it('has hidden "Add to holdings" button', () => {
+        expect(ResourceEditPage.addToHoldingsButton).to.equal(false);
+      });
+    });
+
+    describe('section: resource settings', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.label).to.equal('Resource settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('has "Show to Patrons" field', () => {
+        expect(ResourceEditPage.isResourceShowToPatronsVisible).to.equal(true);
+      });
+    });
+
+    describe('section: coverage settings', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.label).to.equal('Resource settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('has "Dates" field', () => {
+        expect(ResourceEditPage.isCoverageSettingsDatesField).to.equal(true);
+      });
+    });
+
+    describe('clicking the "Collapse all" button', () => {
+      beforeEach(async () => {
+        await ResourceEditPage.toggleSectionButton.click();
+      });
+
+      it('collapses all sections', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(false);
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(false);
+        expect(ResourceEditPage.resourceCoverageSettingsAccordion.isOpen).to.equal(false);
+      });
+
+      describe('clicking the "Expand all" button ', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.toggleSectionButton.click();
+        });
+
+        it('expands all sections', () => {
+          expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(true);
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+          expect(ResourceEditPage.resourceCoverageSettingsAccordion.isOpen).to.equal(true);
+        });
+      });
+    });
+
     it('shows a form with the coverage field', () => {
       expect(ResourceEditPage.coverageStatement).to.equal('Use this one weird trick to get access.');
     });


### PR DESCRIPTION
## Purpose
According to [UIEH-455](https://issues.folio.org/browse/UIEH-455) librarians should be able to expand and collapse any section displayed on the Edit Custom/Managed Resource Detail Record so that they can easily view the section that they most want to review.

## Approach
- Add the Accordion component from Stripes-components
- Wrap sections of the selected custom/managed resource in edit mode. The names of the sections are "Holding Status", "Resource settings" and"Coverage settings"
- Create a property containing the status of the sections(whether a section is expanded) in a local state.
- Pass appropriate props to Accordion components.
- Add associated tests.

## Screenshots
![2018-10-19 15 25 19](https://user-images.githubusercontent.com/43647240/47218137-7926e900-d3b3-11e8-94e8-16c5972d6c98.gif)