### PR TITLE
UIEH-121: add title search results sorting

### DIFF
--- a/src/components/title-search-filters.js
+++ b/src/components/title-search-filters.js
@@ -17,6 +17,14 @@ function TitleSearchFilters(props) {
     <SearchFilters
       searchType="titles"
       availableFilters={[{
+        name: 'sort',
+        label: intl.formatMessage({ id: 'ui-eholdings.label.sortOptions' }),
+        defaultValue: 'relevance',
+        options: [
+          { label: intl.formatMessage({ id: 'ui-eholdings.filter.sortOptions.relevance' }), value: 'relevance' },
+          { label: intl.formatMessage({ id: 'ui-eholdings.label.title' }), value: 'name' }
+        ]
+      }, {
         name: 'selected',
         label: intl.formatMessage({ id: 'ui-eholdings.label.selectionStatus' }),
         defaultValue: 'all',

--- a/test/bigtest/interactors/search-modal.js
+++ b/test/bigtest/interactors/search-modal.js
@@ -19,6 +19,8 @@ export default @interactor class SearchModal {
   selectSearchField = selectable('[data-test-title-search-field] select');
   searchDisabled = property('[data-test-search-submit]', 'disabled')
   clickSearch = clickable('[data-test-eholdings-modal-search-button]');
+  sortBy = value('[data-test-eholdings-search-filters="titles"] input[name="sort"]:checked');
+  resetSortFilter = clickable('#filter-titles-sort button[icon="clearX"]');
 
   clickFilter = action(function (name, val) {
     return this.click(`[data-test-eholdings-search-filters] input[name="${name}"][value="${val}"]`);

--- a/test/bigtest/interactors/title-search.js
+++ b/test/bigtest/interactors/title-search.js
@@ -12,10 +12,12 @@ import {
   is
 } from '@bigtest/interactor';
 import { hasClassBeginningWith } from './helpers';
+import SearchBadge from './search-badge';
 
 @interactor class TitleSearchPage {
   fillSearch = fillable('[data-test-title-search-field] input[name="search"]');
   submitSearch = clickable('[data-test-search-submit]');
+  isSearchDisabled = property('[data-test-search-submit]', 'disabled');
   isSearchButtonDisabled = property('[data-test-search-submit]', 'disabled');
   fillSearch = fillable('[data-test-title-search-field] input[name="search"]');
   submitSearch = clickable('[data-test-search-submit]');
@@ -27,6 +29,7 @@ import { hasClassBeginningWith } from './helpers';
   totalResults = text('[data-test-eholdings-search-results-header] p');
   paneTitleHasFocus = is('[data-test-eholdings-search-results-header] h2 [tabindex]', ':focus');
   titlePreviewPaneIsPresent = isPresent('[data-test-preview-pane="titles"]');
+  sortBy = value('[data-test-eholdings-search-filters="titles"] input[name="sort"]:checked');
   providerPreviewPaneIsPresent = isPresent('[data-test-preview-pane="providers"]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button]');
   clickSearchVignette = clickable('[data-test-search-vignette]');
@@ -36,6 +39,7 @@ import { hasClassBeginningWith } from './helpers';
   selectedSearchType = collection('[data-test-search-form-type-switcher] a[class^="is-active--"]');
   isSearchVignetteHidden = hasClassBeginningWith('[data-test-search-vignette]', 'is-hidden--');
   clickCloseButton = clickable('[data-test-eholdings-details-view-close-button]');
+  searchBadge = new SearchBadge('[data-test-eholdings-results-pane-search-badge]');
   hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
   clickNewButton = clickable('[data-test-eholdings-search-new-button]');
 

--- a/test/bigtest/tests/package-show-titles-search-test.js
+++ b/test/bigtest/tests/package-show-titles-search-test.js
@@ -177,6 +177,64 @@ describe('Package Show Title Search', () => {
     });
   });
 
+  describe('title sort functionality', () => {
+    beforeEach(function () {
+      this.visit(
+        {
+          pathname: `/eholdings/packages/${providerPackage.id}`,
+          state: { eholdings: true }
+        }
+      );
+    });
+    describe('when no sort options are chosen by user', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch();
+      });
+      describe('search form', () => {
+        it('should show "relevance" sort option as the default', () => {
+          expect(PackageShowPage.searchModal.sortBy).to.equal('relevance');
+        });
+      });
+    });
+
+    describe('when "name" sort oprion is chosen by user', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch()
+          .searchModal.clickFilter('sort', 'name');
+      });
+      describe('search form', () => {
+        it('should show "name" sort option', () => {
+          expect(PackageShowPage.searchModal.sortBy).to.equal('name');
+        });
+      });
+
+      describe('then performing a search and opening the search modal again', () => {
+        beforeEach(() => {
+          return PackageShowPage.searchModal.searchTitles('title')
+            .searchModal.clickSearch()
+            .clickListSearch();
+        });
+        describe('search form', () => {
+          it('should keep previous sort option', () => {
+            expect(PackageShowPage.searchModal.sortBy).to.equal('name');
+          });
+        });
+      });
+
+      describe('then reset to default sort option', () => {
+        beforeEach(() => {
+          return PackageShowPage.searchModal.resetSortFilter();
+        });
+
+        describe('search form', () => {
+          it('should show "relevance" sort option as the default', () => {
+            expect(PackageShowPage.searchModal.sortBy).to.equal('relevance');
+          });
+        });
+      });
+    });
+  });
+
   describe('navigating to package show page with over 10k related resources', () => {
     beforeEach(function () {
       let largeProviderPackage = this.server.create(
@@ -192,9 +250,11 @@ describe('Package Show Title Search', () => {
       );
 
       this.server.get(`packages/${largeProviderPackage.id}/resources`,
-        { 'data':[],
-          'meta':{ 'totalResults': 10000 },
-          'jsonapi':{ 'version':'1.0' } }, 200);
+        {
+          'data': [],
+          'meta': { 'totalResults': 10000 },
+          'jsonapi': { 'version': '1.0' }
+        }, 200);
 
       this.visit(
         {

--- a/test/bigtest/tests/title-search-test.js
+++ b/test/bigtest/tests/title-search-test.js
@@ -519,7 +519,7 @@ describe('TitleSearch', () => {
     });
   });
 
-  describe('sorting titles', () => {
+  describe('title sort functionality', () => {
     beforeEach(function () {
       this.server.create('title', {
         name: 'Football Digest',
@@ -549,46 +549,58 @@ describe('TitleSearch', () => {
       });
     });
 
-    describe('searching for titles', () => {
+    describe('search form', () => {
+      it('should have search filters', () => {
+        expect(TitleSearchPage.hasSearchFilters).to.be.true;
+      });
+    });
+
+    describe('when searching for titles', () => {
       beforeEach(() => {
         return TitleSearchPage.search('football');
       });
 
-      it('has search filters', () => {
-        expect(TitleSearchPage.hasSearchFilters).to.be.true;
+      describe('when no sort options were chosen by user', () => {
+        describe('search form', () => {
+          it('should display "relevance" sort filter as the default', () => {
+            expect(TitleSearchPage.sortBy).to.equal('relevance');
+          });
+
+          it.always('should not reflect the default sort=relevance in url', function () {
+            expect(this.location.search).to.not.include('sort=relevance');
+          });
+        });
+
+        describe('the list of search results', () => {
+          it('should display title entries related to "football"', () => { // ???
+            expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+          });
+        });
       });
 
-      it('shows the default sort filter of relevance in the search form', () => {
-        expect(TitleSearchPage.sortBy).to.equal('relevance');
-      });
-
-      it('displays title entries related to "football"', () => {
-        expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
-      });
-
-      it.always('does not reflect the default sort=relevance in url', function () {
-        expect(this.location.search).to.not.include('sort=relevance');
-      });
-
-      describe('then filtering by sort options', () => {
+      describe('when "name" sort option is chosen by user', () => {
         beforeEach(() => {
           return TitleSearchPage.clickFilter('sort', 'name');
         });
 
-        it('shows the same number of found titles', () => {
-          expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+        describe('search form', () => {
+          it('should show the sort filter of name', () => {
+            expect(TitleSearchPage.sortBy).to.equal('name');
+          });
+
+          it('should reflect the sort in the URL query params', function () {
+            expect(this.location.search).to.include('sort=name');
+          });
+
+          it('should show search filters on smaller screen sizes (due to filter change only)', () => {
+            expect(TitleSearchPage.isSearchVignetteHidden).to.equal(false);
+          });
         });
 
-        it('shows the sort filter of name in the search form', () => {
-          expect(TitleSearchPage.sortBy).to.equal('name');
-        });
-
-        it('reflects the sort in the URL query params', function () {
-          expect(this.location.search).to.include('sort=name');
-        });
-
-        it('shows search filters on smaller screen sizes (due to filter change only)', () => {
-          expect(TitleSearchPage.isSearchVignetteHidden).to.equal(false);
+        describe('the list of search results', () => {
+          it('should show the same number of found titles', () => { // ???
+            expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+          });
         });
 
         describe('then searching for other titles', () => {
@@ -596,42 +608,52 @@ describe('TitleSearch', () => {
             return TitleSearchPage.search('analytics');
           });
 
-          it('keeps the sort filter of name in the search form', () => {
-            expect(TitleSearchPage.sortBy).to.equal('name');
+          describe('search form', () => {
+            it('should keep "name" sort filter active', () => {
+              expect(TitleSearchPage.sortBy).to.equal('name');
+            });
+
+            it('should reflect the sort in the URL query params', function () {
+              expect(this.location.search).to.include('sort=name');
+            });
           });
 
-          it('displays the titles related to "analytics"', () => {
-            expect(TitleSearchPage.titleList()).to.have.lengthOf(2);
+          describe('the list of search results', () => {
+            it('should display the titles related to "analytics"', () => { // ???
+              expect(TitleSearchPage.titleList()).to.have.lengthOf(2);
+            });
           });
 
-          it('shows the sort filter of name in the search form', () => {
-            expect(TitleSearchPage.sortBy).to.equal('name');
-          });
-
-          describe('then clicking another search type', () => {
+          describe('then navigating to package search', () => {
             beforeEach(() => {
               return TitleSearchPage.changeSearchType('packages');
             });
 
-            it('does not display any results', () => {
-              expect(TitleSearchPage.titleList()).to.have.lengthOf(0);
+            describe('the list of search results', () => {
+              it('should be empty', () => {
+                expect(TitleSearchPage.titleList()).to.have.lengthOf(0);
+              });
             });
 
-            describe('navigating back to title search', () => {
+            describe('then navigating back to title search', () => {
               beforeEach(() => {
                 return TitleSearchPage.changeSearchType('titles');
               });
 
-              it('keeps the sort filter of name in the search form', () => {
-                expect(TitleSearchPage.sortBy).to.equal('name');
+              describe('search form', () => {
+                it('should keep the sort filter of name', () => {
+                  expect(TitleSearchPage.sortBy).to.equal('name');
+                });
+
+                it('should reflect the sort=name in the URL query params', function () {
+                  expect(this.location.search).to.include('sort=name');
+                });
               });
 
-              it('displays the last results', () => {
-                expect(TitleSearchPage.titleList()).to.have.lengthOf(2);
-              });
-
-              it('reflects the sort=name in the URL query params', function () {
-                expect(this.location.search).to.include('sort=name');
+              describe('the list of search results', () => {
+                it('should display the results of previous search', () => {
+                  expect(TitleSearchPage.titleList()).to.have.lengthOf(2);
+                });
               });
             });
           });
@@ -639,48 +661,52 @@ describe('TitleSearch', () => {
       });
     });
 
-    describe('visiting the page with an existing sort', () => {
+    describe('when visiting the page with an existing sort', () => {
       beforeEach(function () {
         this.visit('/eholdings/?searchType=titles&q=football&sort=name');
         // the search pane is ending up hidden by default
         return TitleSearchPage.searchBadge.clickIcon();
       });
 
-      it('displays search field populated', () => {
-        expect(TitleSearchPage.searchFieldValue).to.equal('football');
+      describe('search field', () => {
+        it('should be filled with proper value', () => {
+          expect(TitleSearchPage.searchFieldValue).to.equal('football');
+        });
       });
 
-      it('displays the sort filter of name as selected in the search form', () => {
-        expect(TitleSearchPage.sortBy).to.equal('name');
+      describe('search form', () => {
+        it('should display "name" sort filter chosen', () => {
+          expect(TitleSearchPage.sortBy).to.equal('name');
+        });
       });
 
-      it('displays the expected results', () => {
-        expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+      describe('the list of search results', () => {
+        it('shuold display expected results', () => {
+          expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+        });
       });
     });
 
-    describe('clearing the search field', () => {
+    describe('when clearing the search field', () => {
       beforeEach(() => {
         return TitleSearchPage.fillSearch('');
       });
 
-      it('has disabled search button', () => {
-        expect(TitleSearchPage.isSearchDisabled).to.be.true;
+      describe('search button', () => {
+        it('should be disabled', () => {
+          expect(TitleSearchPage.isSearchDisabled).to.be.true;
+        });
       });
     });
 
-    describe('selecting a filter without a value in the search field', () => {
+    describe('when selecting a filter without a value in the search field', () => {
       beforeEach(() => {
         return TitleSearchPage.clickFilter('sort', 'name');
       });
 
-      it('should not perform an empty search', () => {
-        expect(TitleSearchPage.hasPreSearchPane).to.be.true;
-      });
-
-      describe('then adding a search term', () => {
-        beforeEach(() => {
-          return TitleSearchPage.search('football');
+      describe('presearch pane', () => {
+        it('should be present', () => {
+          expect(TitleSearchPage.hasPreSearchPane).to.be.true;
         });
       });
     });

--- a/test/bigtest/tests/title-search-test.js
+++ b/test/bigtest/tests/title-search-test.js
@@ -519,6 +519,173 @@ describe('TitleSearch', () => {
     });
   });
 
+  describe('sorting titles', () => {
+    beforeEach(function () {
+      this.server.create('title', {
+        name: 'Football Digest',
+        type: 'TLI',
+        subject: 'football football'
+      });
+      this.server.create('title', {
+        name: 'Biz of Football',
+        type: 'TLI',
+        subject: 'football football'
+      });
+      this.server.create('title', {
+        name: 'Science and Medicine in Football',
+        type: 'TLI',
+        subject: 'football asd'
+      });
+      this.server.create('title', {
+        name: 'UNT Legends: a Century of Mean Green Football',
+        type: 'TLI',
+        subject: '123'
+      });
+      this.server.create('title', {
+        name: 'Analytics for everyone'
+      });
+      this.server.create('title', {
+        name: 'My Health Analytics'
+      });
+    });
+
+    describe('searching for titles', () => {
+      beforeEach(() => {
+        return TitleSearchPage.search('football');
+      });
+
+      it('has search filters', () => {
+        expect(TitleSearchPage.hasSearchFilters).to.be.true;
+      });
+
+      it('shows the default sort filter of relevance in the search form', () => {
+        expect(TitleSearchPage.sortBy).to.equal('relevance');
+      });
+
+      it('displays title entries related to "football"', () => {
+        expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+      });
+
+      it.always('does not reflect the default sort=relevance in url', function () {
+        expect(this.location.search).to.not.include('sort=relevance');
+      });
+
+      describe('then filtering by sort options', () => {
+        beforeEach(() => {
+          return TitleSearchPage.clickFilter('sort', 'name');
+        });
+
+        it('shows the same number of found titles', () => {
+          expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+        });
+
+        it('shows the sort filter of name in the search form', () => {
+          expect(TitleSearchPage.sortBy).to.equal('name');
+        });
+
+        it('reflects the sort in the URL query params', function () {
+          expect(this.location.search).to.include('sort=name');
+        });
+
+        it('shows search filters on smaller screen sizes (due to filter change only)', () => {
+          expect(TitleSearchPage.isSearchVignetteHidden).to.equal(false);
+        });
+
+        describe('then searching for other titles', () => {
+          beforeEach(() => {
+            return TitleSearchPage.search('analytics');
+          });
+
+          it('keeps the sort filter of name in the search form', () => {
+            expect(TitleSearchPage.sortBy).to.equal('name');
+          });
+
+          it('displays the titles related to "analytics"', () => {
+            expect(TitleSearchPage.titleList()).to.have.lengthOf(2);
+          });
+
+          it('shows the sort filter of name in the search form', () => {
+            expect(TitleSearchPage.sortBy).to.equal('name');
+          });
+
+          describe('then clicking another search type', () => {
+            beforeEach(() => {
+              return TitleSearchPage.changeSearchType('packages');
+            });
+
+            it('does not display any results', () => {
+              expect(TitleSearchPage.titleList()).to.have.lengthOf(0);
+            });
+
+            describe('navigating back to title search', () => {
+              beforeEach(() => {
+                return TitleSearchPage.changeSearchType('titles');
+              });
+
+              it('keeps the sort filter of name in the search form', () => {
+                expect(TitleSearchPage.sortBy).to.equal('name');
+              });
+
+              it('displays the last results', () => {
+                expect(TitleSearchPage.titleList()).to.have.lengthOf(2);
+              });
+
+              it('reflects the sort=name in the URL query params', function () {
+                expect(this.location.search).to.include('sort=name');
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe('visiting the page with an existing sort', () => {
+      beforeEach(function () {
+        this.visit('/eholdings/?searchType=titles&q=football&sort=name');
+        // the search pane is ending up hidden by default
+        return TitleSearchPage.searchBadge.clickIcon();
+      });
+
+      it('displays search field populated', () => {
+        expect(TitleSearchPage.searchFieldValue).to.equal('football');
+      });
+
+      it('displays the sort filter of name as selected in the search form', () => {
+        expect(TitleSearchPage.sortBy).to.equal('name');
+      });
+
+      it('displays the expected results', () => {
+        expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+      });
+    });
+
+    describe('clearing the search field', () => {
+      beforeEach(() => {
+        return TitleSearchPage.fillSearch('');
+      });
+
+      it('has disabled search button', () => {
+        expect(TitleSearchPage.isSearchDisabled).to.be.true;
+      });
+    });
+
+    describe('selecting a filter without a value in the search field', () => {
+      beforeEach(() => {
+        return TitleSearchPage.clickFilter('sort', 'name');
+      });
+
+      it('should not perform an empty search', () => {
+        expect(TitleSearchPage.hasPreSearchPane).to.be.true;
+      });
+
+      describe('then adding a search term', () => {
+        beforeEach(() => {
+          return TitleSearchPage.search('football');
+        });
+      });
+    });
+  });
+
   describe('with multiple pages of titles', () => {
     beforeEach(function () {
       this.server.createList('title', 75, {


### PR DESCRIPTION
## Purpose
Users should have the ability to choose in which manner to sort title search results (by relevance or alphabetically)

## Approach
* Adjust TitleSearchFilters component so that sorting filter appears among other filters 
* Write related tests

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/43514877/47219338-36ffa680-d3b7-11e8-8c0b-4034598b9652.png)
### After: 
![2018-10-19 16 08 03](https://user-images.githubusercontent.com/43514877/47220042-4aac0c80-d3b9-11e8-8c1b-db1285fb0596.gif)



