### PR TITLE
UIEH-544: Correct Error Message for empty coverage statement

### DIFF
--- a/src/components/coverage-date-list/coverage-date-list.js
+++ b/src/components/coverage-date-list/coverage-date-list.js
@@ -10,8 +10,8 @@ class CoverageDateList extends React.Component {
     isYearOnly: PropTypes.bool
   };
 
-  compareCoverage(coverageObj1, coverageObj2) {
-    return coverageObj1.beginCoverage < coverageObj2.beginCoverage;
+  compareCoveragesToBeSortedInDescOrder(coverageObj1, coverageObj2) {
+    return new Date(coverageObj2.beginCoverage) - new Date(coverageObj1.beginCoverage);
   }
 
   formatCoverageFullDate({ beginCoverage, endCoverage }) {
@@ -57,12 +57,16 @@ class CoverageDateList extends React.Component {
 
     return (
       <div id={id} data-test-eholdings-display-coverage-list>
-        { coverageArray
-          .concat() // clones original array so we aren't mutating upstream
-          .sort((coverageObj1, coverageObj2) => this.compareCoverage(coverageObj1, coverageObj2))
-          .map(coverageArrayObj => (isYearOnly ?
-            this.formatCoverageYear(coverageArrayObj) :
-            this.formatCoverageFullDate(coverageArrayObj))).join(', ')}
+        {
+          [...coverageArray]
+            .sort(this.compareCoveragesToBeSortedInDescOrder)
+            .map(coverageArrayObj => (
+              isYearOnly
+                ? this.formatCoverageYear(coverageArrayObj)
+                : this.formatCoverageFullDate(coverageArrayObj)
+            ))
+            .join(', ')
+        }
       </div>
     );
   }

--- a/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
+++ b/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
@@ -65,7 +65,7 @@ export function validate(values, { intl }) {
 
   if (values.hasCoverageStatement === 'yes' && values.coverageStatement.length === 0) {
     errors.coverageStatement = intl.formatMessage({
-      id: 'validate.errors.coverageStatement.blank'
+      id: 'ui-eholdings.validate.errors.coverageStatement.blank'
     });
   }
 

--- a/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
+++ b/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
@@ -18,26 +18,28 @@ class CoverageStatementFields extends Component {
 
     return (
       <fieldset>
-        <Field
-          name="hasCoverageStatement"
-          component={RadioButton}
-          type="radio"
-          label={intl.formatMessage({ id:'ui-eholdings.label.dates' })}
-          value="no"
-          onChange={() => {
-            change('coverageStatement', '');
-          }}
-        />
-        <div className={styles['coverage-statement-fields-category']}>
-          {coverageDates}
+        <div data-test-eholdings-has-coverage-statement>
+          <Field
+            name="hasCoverageStatement"
+            component={RadioButton}
+            type="radio"
+            label={intl.formatMessage({ id:'ui-eholdings.label.dates' })}
+            value="no"
+            onChange={() => {
+              change('coverageStatement', '');
+            }}
+          />
+          <div className={styles['coverage-statement-fields-category']}>
+            {coverageDates}
+          </div>
+          <Field
+            name="hasCoverageStatement"
+            component={RadioButton}
+            type="radio"
+            label={intl.formatMessage({ id:'ui-eholdings.label.coverageStatement' })}
+            value="yes"
+          />
         </div>
-        <Field
-          name="hasCoverageStatement"
-          component={RadioButton}
-          type="radio"
-          label={intl.formatMessage({ id:'ui-eholdings.label.coverageStatement' })}
-          value="yes"
-        />
         <div data-test-eholdings-coverage-statement-textarea className={styles['coverage-statement-fields-category']}>
           <Field
             name="coverageStatement"

--- a/src/components/title-search-filters.js
+++ b/src/components/title-search-filters.js
@@ -17,6 +17,14 @@ function TitleSearchFilters(props) {
     <SearchFilters
       searchType="titles"
       availableFilters={[{
+        name: 'sort',
+        label: intl.formatMessage({ id: 'ui-eholdings.label.sortOptions' }),
+        defaultValue: 'relevance',
+        options: [
+          { label: intl.formatMessage({ id: 'ui-eholdings.filter.sortOptions.relevance' }), value: 'relevance' },
+          { label: intl.formatMessage({ id: 'ui-eholdings.label.title' }), value: 'name' }
+        ]
+      }, {
         name: 'selected',
         label: intl.formatMessage({ id: 'ui-eholdings.label.selectionStatus' }),
         defaultValue: 'all',

--- a/test/bigtest/interactors/resource-edit.js
+++ b/test/bigtest/interactors/resource-edit.js
@@ -126,6 +126,10 @@ import Datepicker from './datepicker';
   coverageStatementHasError = hasClassBeginningWith('[data-test-eholdings-coverage-statement-textarea] textarea', 'hasError--');
   validationErrorOnCoverageStatement = text('[data-test-eholdings-coverage-statement-textarea] [class^="feedbackError--"]');
 
+  clickCoverageStatementRadio = action(function (val) {
+    return this.click(`[data-test-eholdings-has-coverage-statement] [value="${val}"]`);
+  });
+
   inputCoverageStatement = action(function (statement) {
     return this
       .fillCoverageStatement(statement)

--- a/test/bigtest/interactors/resource-edit.js
+++ b/test/bigtest/interactors/resource-edit.js
@@ -13,6 +13,9 @@ import {
   computed,
   selectable
 } from '@bigtest/interactor';
+
+import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
+
 import { hasClassBeginningWith } from './helpers';
 
 import Toast from './toast';
@@ -38,6 +41,12 @@ import Datepicker from './datepicker';
   clickCancel = clickable('.tether-element [data-test-eholdings-resource-cancel-action]');
 }
 
+@interactor class ResourceEditToggleSectionButton {
+  exists = isPresent('[data-test-eholdings-details-view-collapse-all-button]]');
+  label = text('[data-test-eholdings-details-view-collapse-all-button]]');
+  click = clickable('[data-test-eholdings-details-view-collapse-all-button] button');
+}
+
 @interactor class ResourceEditPage {
   isLoaded = isPresent('[data-test-eholdings-details-view-pane-title]');
   whenLoaded() {
@@ -54,6 +63,11 @@ import Datepicker from './datepicker';
       .dropDownMenu.clickCancel();
   });
 
+  toggleSectionButton = new ResourceEditToggleSectionButton();
+  resourceHoldingStatusAccordion = new AccordionInteractor('#resourceShowHoldingStatus');
+  resourceSettingsAccordion = new AccordionInteractor('#resourceShowSettings');
+  resourceCoverageSettingsAccordion = new AccordionInteractor('#resourceShowCoverageSettings');
+
   clickSave = clickable('[data-test-eholdings-resource-save-button]');
   hasSaveButon = isPresent('[data-test-eholdings-resource-save-button]');
   hasCancelButton = isPresent('[data-test-eholdings-resource-cancel-button]');
@@ -63,7 +77,10 @@ import Datepicker from './datepicker';
   checkPeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button]');
   isResourceSelected = text('[data-test-eholdings-resource-holding-status] div');
+  isResourceSelectedBoolean = isPresent('[data-test-eholdings-resource-holding-status] div');
   isResourceVisible = property('[data-test-eholdings-resource-visibility-field] input[value="true"]', 'checked');
+  isResourceShowToPatronsVisible = isPresent('[data-test-eholdings-resource-visibility-field]');
+  isCoverageSettingsDatesField = isPresent('[data-test-eholdings-resource-coverage-fields]');
   isHiddenMessage = computed(function () {
     let $node = this.$('[data-test-eholdings-resource-visibility-field] input[value="false"] ~ span:last-child');
     return $node.textContent.replace(/^No(\s\((.*)\))?$/, '$2');

--- a/test/bigtest/interactors/search-modal.js
+++ b/test/bigtest/interactors/search-modal.js
@@ -19,6 +19,8 @@ export default @interactor class SearchModal {
   selectSearchField = selectable('[data-test-title-search-field] select');
   searchDisabled = property('[data-test-search-submit]', 'disabled')
   clickSearch = clickable('[data-test-eholdings-modal-search-button]');
+  sortBy = value('[data-test-eholdings-search-filters="titles"] input[name="sort"]:checked');
+  resetSortFilter = clickable('#filter-titles-sort button[icon="clearX"]');
 
   clickFilter = action(function (name, val) {
     return this.click(`[data-test-eholdings-search-filters] input[name="${name}"][value="${val}"]`);

--- a/test/bigtest/interactors/title-search.js
+++ b/test/bigtest/interactors/title-search.js
@@ -12,10 +12,12 @@ import {
   is
 } from '@bigtest/interactor';
 import { hasClassBeginningWith } from './helpers';
+import SearchBadge from './search-badge';
 
 @interactor class TitleSearchPage {
   fillSearch = fillable('[data-test-title-search-field] input[name="search"]');
   submitSearch = clickable('[data-test-search-submit]');
+  isSearchDisabled = property('[data-test-search-submit]', 'disabled');
   isSearchButtonDisabled = property('[data-test-search-submit]', 'disabled');
   fillSearch = fillable('[data-test-title-search-field] input[name="search"]');
   submitSearch = clickable('[data-test-search-submit]');
@@ -27,6 +29,7 @@ import { hasClassBeginningWith } from './helpers';
   totalResults = text('[data-test-eholdings-search-results-header] p');
   paneTitleHasFocus = is('[data-test-eholdings-search-results-header] h2 [tabindex]', ':focus');
   titlePreviewPaneIsPresent = isPresent('[data-test-preview-pane="titles"]');
+  sortBy = value('[data-test-eholdings-search-filters="titles"] input[name="sort"]:checked');
   providerPreviewPaneIsPresent = isPresent('[data-test-preview-pane="providers"]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button]');
   clickSearchVignette = clickable('[data-test-search-vignette]');
@@ -36,6 +39,7 @@ import { hasClassBeginningWith } from './helpers';
   selectedSearchType = collection('[data-test-search-form-type-switcher] a[class^="is-active--"]');
   isSearchVignetteHidden = hasClassBeginningWith('[data-test-search-vignette]', 'is-hidden--');
   clickCloseButton = clickable('[data-test-eholdings-details-view-close-button]');
+  searchBadge = new SearchBadge('[data-test-eholdings-results-pane-search-badge]');
   hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
   clickNewButton = clickable('[data-test-eholdings-search-new-button]');
 

--- a/test/bigtest/network/helpers.js
+++ b/test/bigtest/network/helpers.js
@@ -36,7 +36,7 @@ export function relevanceCompare(query) {
         return compareName.toLowerCase().includes(word) ? total + 1 : total;
       }, 0);
       if (modelCount !== modelCompareCount) {
-        return modelCount < modelCompareCount;
+        return modelCompareCount - modelCount;
       }
 
       return nameCompare(model, modelCompare);

--- a/test/bigtest/tests/package-show-titles-search-test.js
+++ b/test/bigtest/tests/package-show-titles-search-test.js
@@ -177,6 +177,64 @@ describe('Package Show Title Search', () => {
     });
   });
 
+  describe('title sort functionality', () => {
+    beforeEach(function () {
+      this.visit(
+        {
+          pathname: `/eholdings/packages/${providerPackage.id}`,
+          state: { eholdings: true }
+        }
+      );
+    });
+    describe('when no sort options are chosen by user', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch();
+      });
+      describe('search form', () => {
+        it('should show "relevance" sort option as the default', () => {
+          expect(PackageShowPage.searchModal.sortBy).to.equal('relevance');
+        });
+      });
+    });
+
+    describe('when "name" sort oprion is chosen by user', () => {
+      beforeEach(() => {
+        return PackageShowPage.clickListSearch()
+          .searchModal.clickFilter('sort', 'name');
+      });
+      describe('search form', () => {
+        it('should show "name" sort option', () => {
+          expect(PackageShowPage.searchModal.sortBy).to.equal('name');
+        });
+      });
+
+      describe('then performing a search and opening the search modal again', () => {
+        beforeEach(() => {
+          return PackageShowPage.searchModal.searchTitles('title')
+            .searchModal.clickSearch()
+            .clickListSearch();
+        });
+        describe('search form', () => {
+          it('should keep previous sort option', () => {
+            expect(PackageShowPage.searchModal.sortBy).to.equal('name');
+          });
+        });
+      });
+
+      describe('then reset to default sort option', () => {
+        beforeEach(() => {
+          return PackageShowPage.searchModal.resetSortFilter();
+        });
+
+        describe('search form', () => {
+          it('should show "relevance" sort option as the default', () => {
+            expect(PackageShowPage.searchModal.sortBy).to.equal('relevance');
+          });
+        });
+      });
+    });
+  });
+
   describe('navigating to package show page with over 10k related resources', () => {
     beforeEach(function () {
       let largeProviderPackage = this.server.create(
@@ -192,9 +250,11 @@ describe('Package Show Title Search', () => {
       );
 
       this.server.get(`packages/${largeProviderPackage.id}/resources`,
-        { 'data':[],
-          'meta':{ 'totalResults': 10000 },
-          'jsonapi':{ 'version':'1.0' } }, 200);
+        {
+          'data': [],
+          'meta': { 'totalResults': 10000 },
+          'jsonapi': { 'version': '1.0' }
+        }, 200);
 
       this.visit(
         {

--- a/test/bigtest/tests/resource-edit-custom-title-test.js
+++ b/test/bigtest/tests/resource-edit-custom-title-test.js
@@ -502,6 +502,27 @@ describe('ResourceEditCustomTitle', () => {
     });
   });
 
+  describe('visiting the resource edit page with a coverage statement', () => {
+    beforeEach(function () {
+      resource.coverageStatement = 'test coverage statement';
+      resource.save();
+      this.visit(`/eholdings/resources/${resource.titleId}/edit`);
+    });
+
+    describe('entering an empty coverage statement', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .clickCoverageStatementRadio('yes')
+          .inputCoverageStatement('')
+          .clickCoverageStatementRadio('yes');
+      });
+
+      it('displays a validation error message for empty coverage statement', () => {
+        expect(ResourceEditPage.validationErrorOnCoverageStatement).to.equal('Statement field cannot be blank if selected.');
+      });
+    });
+  });
+
   describe('encountering a server error when GETting', () => {
     beforeEach(function () {
       this.server.get('/resources/:id', {

--- a/test/bigtest/tests/resource-edit-custom-title-test.js
+++ b/test/bigtest/tests/resource-edit-custom-title-test.js
@@ -93,6 +93,136 @@ describe('ResourceEditCustomTitle', () => {
       this.visit(`/eholdings/resources/${resource.titleId}/edit`);
     });
 
+    describe('section: holding status', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.label).to.equal('Holding status');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceHoldingStatusAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceHoldingStatusAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('reflects the desired state of holding status', () => {
+        expect(ResourceEditPage.isResourceSelectedBoolean).to.equal(true);
+      });
+
+      it('has hidden "Add to holdings" button', () => {
+        expect(ResourceEditPage.addToHoldingsButton).to.equal(false);
+      });
+    });
+
+    describe('section: resource settings', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.label).to.equal('Resource settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('has "Show to Patrons" field', () => {
+        expect(ResourceEditPage.isResourceShowToPatronsVisible).to.equal(true);
+      });
+    });
+
+    describe('section: coverage settings', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.label).to.equal('Resource settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('has "Dates" field', () => {
+        expect(ResourceEditPage.isCoverageSettingsDatesField).to.equal(true);
+      });
+    });
+
+    describe('clicking the "Collapse all" button', () => {
+      beforeEach(async () => {
+        await ResourceEditPage.toggleSectionButton.click();
+      });
+
+      it('collapses all sections', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(false);
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(false);
+        expect(ResourceEditPage.resourceCoverageSettingsAccordion.isOpen).to.equal(false);
+      });
+
+      describe('clicking the "Expand all" button ', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.toggleSectionButton.click();
+        });
+
+        it('expands all sections', () => {
+          expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(true);
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+          expect(ResourceEditPage.resourceCoverageSettingsAccordion.isOpen).to.equal(true);
+        });
+      });
+    });
+
     it('shows a form with coverage statement', () => {
       expect(ResourceEditPage.coverageStatement).to.equal('');
     });

--- a/test/bigtest/tests/resource-edit-managed-title-test.js
+++ b/test/bigtest/tests/resource-edit-managed-title-test.js
@@ -202,6 +202,136 @@ describe('ResourceEditManagedTitleInManagedPackage', () => {
       this.visit(`/eholdings/resources/${resource.titleId}/edit`);
     });
 
+    describe('section: holding status', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.label).to.equal('Holding status');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceHoldingStatusAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceHoldingStatusAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('reflects the desired state of holding status', () => {
+        expect(ResourceEditPage.isResourceSelectedBoolean).to.equal(true);
+      });
+
+      it('has hidden "Add to holdings" button', () => {
+        expect(ResourceEditPage.addToHoldingsButton).to.equal(false);
+      });
+    });
+
+    describe('section: resource settings', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.label).to.equal('Resource settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('has "Show to Patrons" field', () => {
+        expect(ResourceEditPage.isResourceShowToPatronsVisible).to.equal(true);
+      });
+    });
+
+    describe('section: coverage settings', () => {
+      it('displays the title', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.label).to.equal('Resource settings');
+      });
+
+      it('is expanded by default', () => {
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+      });
+
+      describe('clicking the header', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+        });
+
+        it('collapses the section', () => {
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.false;
+        });
+
+        describe('clicking the header again', () => {
+          beforeEach(async () => {
+            await ResourceEditPage.resourceSettingsAccordion.clickHeader();
+          });
+
+          it('expands the section', () => {
+            expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.be.true;
+          });
+        });
+      });
+
+      it('has "Dates" field', () => {
+        expect(ResourceEditPage.isCoverageSettingsDatesField).to.equal(true);
+      });
+    });
+
+    describe('clicking the "Collapse all" button', () => {
+      beforeEach(async () => {
+        await ResourceEditPage.toggleSectionButton.click();
+      });
+
+      it('collapses all sections', () => {
+        expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(false);
+        expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(false);
+        expect(ResourceEditPage.resourceCoverageSettingsAccordion.isOpen).to.equal(false);
+      });
+
+      describe('clicking the "Expand all" button ', () => {
+        beforeEach(async () => {
+          await ResourceEditPage.toggleSectionButton.click();
+        });
+
+        it('expands all sections', () => {
+          expect(ResourceEditPage.resourceHoldingStatusAccordion.isOpen).to.equal(true);
+          expect(ResourceEditPage.resourceSettingsAccordion.isOpen).to.equal(true);
+          expect(ResourceEditPage.resourceCoverageSettingsAccordion.isOpen).to.equal(true);
+        });
+      });
+    });
+
     it('shows a form with the coverage field', () => {
       expect(ResourceEditPage.coverageStatement).to.equal('Use this one weird trick to get access.');
     });

--- a/test/bigtest/tests/resource-edit-managed-title-test.js
+++ b/test/bigtest/tests/resource-edit-managed-title-test.js
@@ -437,6 +437,28 @@ describe('ResourceEditManagedTitleInManagedPackage', () => {
       });
     });
   });
+
+  describe('visiting the resource edit page with a coverage statement', () => {
+    beforeEach(function () {
+      resource.coverageStatement = 'test coverage statement';
+      resource.save();
+      this.visit(`/eholdings/resources/${resource.titleId}/edit`);
+    });
+
+    describe('entering an empty coverage statement', () => {
+      beforeEach(() => {
+        return ResourceEditPage
+          .clickCoverageStatementRadio('yes')
+          .inputCoverageStatement('')
+          .clickCoverageStatementRadio('yes');
+      });
+
+      it('displays a validation error message for empty coverage statement', () => {
+        expect(ResourceEditPage.validationErrorOnCoverageStatement).to.equal('Statement field cannot be blank if selected.');
+      });
+    });
+  });
+
   describe('encountering a server error when GETting', () => {
     beforeEach(function () {
       this.server.get('/resources/:id', {

--- a/test/bigtest/tests/title-search-test.js
+++ b/test/bigtest/tests/title-search-test.js
@@ -519,6 +519,199 @@ describe('TitleSearch', () => {
     });
   });
 
+  describe('title sort functionality', () => {
+    beforeEach(function () {
+      this.server.create('title', {
+        name: 'Football Digest',
+        type: 'TLI',
+        subject: 'football football'
+      });
+      this.server.create('title', {
+        name: 'Biz of Football',
+        type: 'TLI',
+        subject: 'football football'
+      });
+      this.server.create('title', {
+        name: 'Science and Medicine in Football',
+        type: 'TLI',
+        subject: 'football asd'
+      });
+      this.server.create('title', {
+        name: 'UNT Legends: a Century of Mean Green Football',
+        type: 'TLI',
+        subject: '123'
+      });
+      this.server.create('title', {
+        name: 'Analytics for everyone'
+      });
+      this.server.create('title', {
+        name: 'My Health Analytics'
+      });
+    });
+
+    describe('search form', () => {
+      it('should have search filters', () => {
+        expect(TitleSearchPage.hasSearchFilters).to.be.true;
+      });
+    });
+
+    describe('when searching for titles', () => {
+      beforeEach(() => {
+        return TitleSearchPage.search('football');
+      });
+
+      describe('when no sort options were chosen by user', () => {
+        describe('search form', () => {
+          it('should display "relevance" sort filter as the default', () => {
+            expect(TitleSearchPage.sortBy).to.equal('relevance');
+          });
+
+          it.always('should not reflect the default sort=relevance in url', function () {
+            expect(this.location.search).to.not.include('sort=relevance');
+          });
+        });
+
+        describe('the list of search results', () => {
+          it('should display title entries related to "football"', () => { // ???
+            expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+          });
+        });
+      });
+
+      describe('when "name" sort option is chosen by user', () => {
+        beforeEach(() => {
+          return TitleSearchPage.clickFilter('sort', 'name');
+        });
+
+        describe('search form', () => {
+          it('should show the sort filter of name', () => {
+            expect(TitleSearchPage.sortBy).to.equal('name');
+          });
+
+          it('should reflect the sort in the URL query params', function () {
+            expect(this.location.search).to.include('sort=name');
+          });
+
+          it('should show search filters on smaller screen sizes (due to filter change only)', () => {
+            expect(TitleSearchPage.isSearchVignetteHidden).to.equal(false);
+          });
+        });
+
+        describe('the list of search results', () => {
+          it('should show the same number of found titles', () => { // ???
+            expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+          });
+        });
+
+        describe('then searching for other titles', () => {
+          beforeEach(() => {
+            return TitleSearchPage.search('analytics');
+          });
+
+          describe('search form', () => {
+            it('should keep "name" sort filter active', () => {
+              expect(TitleSearchPage.sortBy).to.equal('name');
+            });
+
+            it('should reflect the sort in the URL query params', function () {
+              expect(this.location.search).to.include('sort=name');
+            });
+          });
+
+          describe('the list of search results', () => {
+            it('should display the titles related to "analytics"', () => { // ???
+              expect(TitleSearchPage.titleList()).to.have.lengthOf(2);
+            });
+          });
+
+          describe('then navigating to package search', () => {
+            beforeEach(() => {
+              return TitleSearchPage.changeSearchType('packages');
+            });
+
+            describe('the list of search results', () => {
+              it('should be empty', () => {
+                expect(TitleSearchPage.titleList()).to.have.lengthOf(0);
+              });
+            });
+
+            describe('then navigating back to title search', () => {
+              beforeEach(() => {
+                return TitleSearchPage.changeSearchType('titles');
+              });
+
+              describe('search form', () => {
+                it('should keep the sort filter of name', () => {
+                  expect(TitleSearchPage.sortBy).to.equal('name');
+                });
+
+                it('should reflect the sort=name in the URL query params', function () {
+                  expect(this.location.search).to.include('sort=name');
+                });
+              });
+
+              describe('the list of search results', () => {
+                it('should display the results of previous search', () => {
+                  expect(TitleSearchPage.titleList()).to.have.lengthOf(2);
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe('when visiting the page with an existing sort', () => {
+      beforeEach(function () {
+        this.visit('/eholdings/?searchType=titles&q=football&sort=name');
+        // the search pane is ending up hidden by default
+        return TitleSearchPage.searchBadge.clickIcon();
+      });
+
+      describe('search field', () => {
+        it('should be filled with proper value', () => {
+          expect(TitleSearchPage.searchFieldValue).to.equal('football');
+        });
+      });
+
+      describe('search form', () => {
+        it('should display "name" sort filter chosen', () => {
+          expect(TitleSearchPage.sortBy).to.equal('name');
+        });
+      });
+
+      describe('the list of search results', () => {
+        it('shuold display expected results', () => {
+          expect(TitleSearchPage.titleList()).to.have.lengthOf(4);
+        });
+      });
+    });
+
+    describe('when clearing the search field', () => {
+      beforeEach(() => {
+        return TitleSearchPage.fillSearch('');
+      });
+
+      describe('search button', () => {
+        it('should be disabled', () => {
+          expect(TitleSearchPage.isSearchDisabled).to.be.true;
+        });
+      });
+    });
+
+    describe('when selecting a filter without a value in the search field', () => {
+      beforeEach(() => {
+        return TitleSearchPage.clickFilter('sort', 'name');
+      });
+
+      describe('presearch pane', () => {
+        it('should be present', () => {
+          expect(TitleSearchPage.hasPreSearchPane).to.be.true;
+        });
+      });
+    });
+  });
+
   describe('with multiple pages of titles', () => {
     beforeEach(function () {
       this.server.createList('title', 75, {


### PR DESCRIPTION
## Purpose
Per  https://issues.folio.org/browse/UIEH-544, resource edit page displays an incorrect validation error message `validate.errors.coverageStatement.blank` when coverage statement is blank. It should instead display a properly translated message - for example `Statement field cannot be blank if selected.`

## Approach
- Corrected translation id for error message -- was using `validate.errors.coverageStatement.blank` instead of `ui-eholdings.validate.errors.coverageStatement.blank`
- Added unit tests for both managed and custom resources to confirm display of correct message
- To recreate interactions for blank message to appear- needed to select radio button for coverage statement, clear text area and then re-select radio button for coverage statement

## Screenshots
Before:
![2018-10-12 09 04 40](https://user-images.githubusercontent.com/19415226/47302934-b5935880-d5f0-11e8-9533-de88ca1922b4.gif)

After:
![2018-10-22 11 45 15](https://user-images.githubusercontent.com/19415226/47302731-3e5dc480-d5f0-11e8-9b9c-0ac3747d295a.gif)
