### PR TITLE
UIEH-562: Apply aria markup for the Provider/Package/Title search t…

### DIFF
--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -113,11 +113,16 @@ class SearchForm extends Component {
 
     return (
       <div className={styles['search-form-container']} data-test-search-form={searchType}>
-        { displaySearchTypeSwitcher && (
-          <div className={styles['search-switcher']} data-test-search-form-type-switcher>
+        {displaySearchTypeSwitcher && (
+          <div className={styles['search-switcher']} role='tablist' data-test-search-form-type-switcher>
             {validSearchTypes.map(type => (
               <Link
+                role='tab'
+                aria-selected={searchType === type}
+                aria-controls={type + '-panel'}
+                id={type + '-tab'}
                 key={type}
+                tabIndex={searchType === type ? undefined : -1}
                 title={intl.formatMessage({ id: 'ui-eholdings.search.searchLink' }, { type })}
                 to={searchTypeUrls[type]}
                 className={searchType === type ? styles['is-active'] : undefined}
@@ -128,7 +133,13 @@ class SearchForm extends Component {
             ))}
           </div>
         )}
-        <form onSubmit={this.handleSearchSubmit}>
+        <form
+          onSubmit={this.handleSearchSubmit}
+          role='tabpanel'
+          aria-labelledby={searchType + '-tab'}
+          id={searchType + '-panel'}
+          tabIndex='0'
+        >
           {(searchType === 'titles') ? (
             <div data-test-title-search-field>
               <SearchField


### PR DESCRIPTION
## Purpose

- Add applicable ARIA tab roles and attributes so that the following occurs
-- Screenreader (JAWS/NVDA/Apple VoiceOver) reads Provider/Package/Title Search toggles markup as tabs
-- Screenreader (JAWS/NVDA/Apple VoiceOver) indicates which toggle is active  
- No change to the UI display 

  JIRA issue URL: https://issues.folio.org/browse/UIEH-562

## Approach
Adopted the Providers/Packages/Title tabs to follow the markup according to the [WAI-ARIA tabs design pattern | https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html]

## Screenshots
Please see screenshots with turned on VoiceOver screenreader:
 
![screen shot 2018-10-23 at 16 26 19](https://user-images.githubusercontent.com/15856488/47364148-40ec1700-d6e1-11e8-9e70-c1cdb6018855.png)
![screen shot 2018-10-23 at 16 30 58](https://user-images.githubusercontent.com/15856488/47364149-40ec1700-d6e1-11e8-8615-4a38e976abe8.png)
![screen shot 2018-10-23 at 16 27 05](https://user-images.githubusercontent.com/15856488/47364150-40ec1700-d6e1-11e8-9b63-cb4d579b3caa.png)
![screen shot 2018-10-23 at 16 28 07](https://user-images.githubusercontent.com/15856488/47364152-40ec1700-d6e1-11e8-89eb-7f06da2e70f6.png)
