### PR TITLE
UIEH-568: Fix sorting functionality in CoverageDateList component and…

### DIFF
--- a/src/components/coverage-date-list/coverage-date-list.js
+++ b/src/components/coverage-date-list/coverage-date-list.js
@@ -10,8 +10,8 @@ class CoverageDateList extends React.Component {
     isYearOnly: PropTypes.bool
   };
 
-  compareCoverage(coverageObj1, coverageObj2) {
-    return coverageObj1.beginCoverage < coverageObj2.beginCoverage;
+  compareCoveragesToBeSortedInDescOrder(coverageObj1, coverageObj2) {
+    return new Date(coverageObj2.beginCoverage) - new Date(coverageObj1.beginCoverage);
   }
 
   formatCoverageFullDate({ beginCoverage, endCoverage }) {
@@ -57,12 +57,16 @@ class CoverageDateList extends React.Component {
 
     return (
       <div id={id} data-test-eholdings-display-coverage-list>
-        { coverageArray
-          .concat() // clones original array so we aren't mutating upstream
-          .sort((coverageObj1, coverageObj2) => this.compareCoverage(coverageObj1, coverageObj2))
-          .map(coverageArrayObj => (isYearOnly ?
-            this.formatCoverageYear(coverageArrayObj) :
-            this.formatCoverageFullDate(coverageArrayObj))).join(', ')}
+        {
+          [...coverageArray]
+            .sort(this.compareCoveragesToBeSortedInDescOrder)
+            .map(coverageArrayObj => (
+              isYearOnly
+                ? this.formatCoverageYear(coverageArrayObj)
+                : this.formatCoverageFullDate(coverageArrayObj)
+            ))
+            .join(', ')
+        }
       </div>
     );
   }

--- a/test/bigtest/network/helpers.js
+++ b/test/bigtest/network/helpers.js
@@ -36,7 +36,7 @@ export function relevanceCompare(query) {
         return compareName.toLowerCase().includes(word) ? total + 1 : total;
       }, 0);
       if (modelCount !== modelCompareCount) {
-        return modelCount < modelCompareCount;
+        return modelCompareCount - modelCount;
       }
 
       return nameCompare(model, modelCompare);


### PR DESCRIPTION
UIEH-568: Fix UI tests failed after update of the Chrome browser to 70 version

## Purpose
  Chrome was updated to 70 version and 5 UI tests failed. The general reason is a wrong realization of compare function inside Array.prototype.sort method in "CoverageDateList" component and inside "relevanceCompare" helper. Compare function should return number values instead of boolean to be sure that sorting will perform correctly.
  https://issues.folio.org/browse/UIEH-568

## Approach
  This refactors the realization of compare functions used inside Array.prototype.sort method according to MDN documentation.

## Learning
  Here is a link with an explanation of how to write "compare functions" for sort method https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
