### PR TITLE
Fix moment usage to UTC

### DIFF
--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -85,7 +85,7 @@ export function validate(values, props) {
   values.customCoverages.forEach((dateRange, index) => {
     let dateRangeErrors = {};
 
-    if (dateRange.beginCoverage && !moment(dateRange.beginCoverage).isValid()) {
+    if (dateRange.beginCoverage && !moment.utc(dateRange.beginCoverage).isValid()) {
       dateRangeErrors.beginCoverage = intl.formatMessage({ id: 'ui-eholdings.validate.errors.dateRange.format' }, { dateFormat });
     }
 
@@ -93,7 +93,7 @@ export function validate(values, props) {
       dateRangeErrors.beginCoverage = intl.formatMessage({ id: 'ui-eholdings.validate.errors.dateRange.format' }, { dateFormat });
     }
 
-    if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
+    if (dateRange.endCoverage && moment.utc(dateRange.beginCoverage).isAfter(moment.utc(dateRange.endCoverage))) {
       dateRangeErrors.beginCoverage = intl.formatMessage({ id: 'ui-eholdings.validate.errors.dateRange.startDateBeforeEndDate' });
     }
 

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -35,7 +35,7 @@ class PackageCoverageFields extends Component {
             type="text"
             component={Datepicker}
             label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
-            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+            format={(value) => (value ? moment.utc(value) : '')}
           />
         </div>
         <div
@@ -47,7 +47,7 @@ class PackageCoverageFields extends Component {
             type="text"
             component={Datepicker}
             label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
-            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+            format={(value) => (value ? moment.utc(value) : '')}
           />
         </div>
       </Fragment>

--- a/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
@@ -36,7 +36,7 @@ class ResourceCoverageFields extends Component {
             component={Datepicker}
             label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
             id="begin-coverage"
-            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+            format={(value) => (value ? moment.utc(value) : '')}
           />
         </div>
         <div
@@ -49,7 +49,7 @@ class ResourceCoverageFields extends Component {
             component={Datepicker}
             label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
             id="end-coverage"
-            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+            format={(value) => (value ? moment.utc(value) : '')}
           />
         </div>
       </Fragment>

--- a/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
@@ -86,7 +86,7 @@ export default injectIntl(ResourceCoverageFields);
 const validateStartDateBeforeEndDate = (dateRange, intl) => {
   const message = intl.formatMessage({ id: 'ui-eholdings.validate.errors.dateRange.startDateBeforeEndDate' });
 
-  if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
+  if (dateRange.endCoverage && moment.utc(dateRange.beginCoverage).isAfter(moment.utc(dateRange.endCoverage))) {
     return { beginCoverage: message };
   }
 
@@ -103,7 +103,7 @@ const validateDateFormat = (dateRange, intl) => {
   let dateFormat = moment.localeData()._longDateFormat.L;
   const message = intl.formatMessage({ id: 'ui-eholdings.validate.errors.dateRange.format' }, { dateFormat });
 
-  if (!dateRange.beginCoverage || !moment(dateRange.beginCoverage).isValid()) {
+  if (!dateRange.beginCoverage || !moment.utc(dateRange.beginCoverage).isValid()) {
     return { beginCoverage: message };
   }
 
@@ -120,18 +120,18 @@ const validateDateFormat = (dateRange, intl) => {
 const validateWithinPackageRange = (dateRange, packageCoverage, intl) => {
   // javascript/moment has no mechanism for "infinite", so we
   // use an absurd future date to represent the concept of "present"
-  let present = moment('9999-09-09T05:00:00.000Z');
+  let present = moment.utc('9999-09-09T05:00:00.000Z');
   if (packageCoverage && packageCoverage.beginCoverage) {
     let {
       beginCoverage: packageBeginCoverage,
       endCoverage: packageEndCoverage
     } = packageCoverage;
 
-    let beginCoverageDate = moment(dateRange.beginCoverage);
-    let endCoverageDate = dateRange.endCoverage ? moment(dateRange.endCoverage) : present;
+    let beginCoverageDate = moment.utc(dateRange.beginCoverage);
+    let endCoverageDate = dateRange.endCoverage ? moment.utc(dateRange.endCoverage) : present;
 
-    let packageBeginCoverageDate = moment(packageBeginCoverage);
-    let packageEndCoverageDate = packageEndCoverage ? moment(packageEndCoverage) : moment();
+    let packageBeginCoverageDate = moment.utc(packageBeginCoverage);
+    let packageEndCoverageDate = packageEndCoverage ? moment.utc(packageEndCoverage) : moment.utc();
     let packageRange = moment.range(packageBeginCoverageDate, packageEndCoverageDate);
 
     let startDate = intl.formatDate(
@@ -146,7 +146,7 @@ const validateWithinPackageRange = (dateRange, packageCoverage, intl) => {
 
     let endDate = packageEndCoverage ?
       intl.formatDate(
-        packageEndCoverage,
+        packageEndCoverageDate,
         {
           timeZone: 'UTC',
           year: 'numeric',
@@ -180,10 +180,10 @@ const validateWithinPackageRange = (dateRange, packageCoverage, intl) => {
  * @returns {} - an error object if errors are found, or `false` otherwise
  */
 const validateNoRangeOverlaps = (dateRange, customCoverages, index, intl) => {
-  let present = moment('9999-09-09T05:00:00.000Z');
+  let present = moment.utc('9999-09-09T05:00:00.000Z');
 
-  let beginCoverageDate = moment(dateRange.beginCoverage);
-  let endCoverageDate = dateRange.endCoverage ? moment(dateRange.endCoverage) : present;
+  let beginCoverageDate = moment.utc(dateRange.beginCoverage);
+  let endCoverageDate = dateRange.endCoverage ? moment.utc(dateRange.endCoverage) : present;
   let coverageRange = moment.range(beginCoverageDate, endCoverageDate);
 
   for (let overlapIndex = 0, len = customCoverages.length; overlapIndex < len; overlapIndex++) {
@@ -194,8 +194,8 @@ const validateNoRangeOverlaps = (dateRange, customCoverages, index, intl) => {
       continue; // eslint-disable-line no-continue
     }
 
-    let overlapCoverageBeginDate = moment(overlapRange.beginCoverage);
-    let overlapCoverageEndDate = overlapRange.endCoverage ? moment(overlapRange.endCoverage) : present;
+    let overlapCoverageBeginDate = moment.utc(overlapRange.beginCoverage);
+    let overlapCoverageEndDate = overlapRange.endCoverage ? moment.utc(overlapRange.endCoverage) : present;
     let overlapCoverageRange = moment.range(overlapCoverageBeginDate, overlapCoverageEndDate);
 
     let startDate = intl.formatDate(

--- a/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
+++ b/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
@@ -40,7 +40,7 @@ class ResourceCoverageFields extends Component {
             component={Datepicker}
             label={intl.formatMessage({ id: 'ui-eholdings.date.startDate' })}
             id="begin-coverage"
-            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+            format={(value) => (value ? moment.utc(value) : '')}
           />
         </div>
         <div
@@ -53,7 +53,7 @@ class ResourceCoverageFields extends Component {
             component={Datepicker}
             label={intl.formatMessage({ id: 'ui-eholdings.date.endDate' })}
             id="end-coverage"
-            format={(value) => (value ? intl.formatDate(value, { timeZone: 'UTC' }) : '')}
+            format={(value) => (value ? moment.utc(value) : '')}
           />
         </div>
       </Fragment>

--- a/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
+++ b/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
@@ -135,7 +135,7 @@ export default injectIntl(ResourceCoverageFields);
 const validateStartDateBeforeEndDate = (dateRange, intl) => {
   const message = intl.formatMessage({ id: 'ui-eholdings.validate.errors.dateRange.startDateBeforeEndDate' });
 
-  if (dateRange.endCoverage && moment(dateRange.beginCoverage).isAfter(moment(dateRange.endCoverage))) {
+  if (dateRange.endCoverage && moment.utc(dateRange.beginCoverage).isAfter(moment.utc(dateRange.endCoverage))) {
     return { beginCoverage: message };
   }
 
@@ -152,7 +152,7 @@ const validateDateFormat = (dateRange, intl) => {
   let dateFormat = moment.localeData()._longDateFormat.L;
   const message = intl.formatMessage({ id: 'ui-eholdings.validate.errors.dateRange.format' }, { dateFormat });
 
-  if (!dateRange.beginCoverage || !moment(dateRange.beginCoverage).isValid()) {
+  if (!dateRange.beginCoverage || !moment.utc(dateRange.beginCoverage).isValid()) {
     return { beginCoverage: message };
   }
 
@@ -169,18 +169,18 @@ const validateDateFormat = (dateRange, intl) => {
 const validateWithinPackageRange = (dateRange, packageCoverage, intl) => {
   // javascript/moment has no mechanism for "infinite", so we
   // use an absurd future date to represent the concept of "present"
-  let present = moment('9999-09-09T05:00:00.000Z');
+  let present = moment.utc('9999-09-09T05:00:00.000Z');
   if (packageCoverage && packageCoverage.beginCoverage) {
     let {
       beginCoverage: packageBeginCoverage,
       endCoverage: packageEndCoverage
     } = packageCoverage;
 
-    let beginCoverageDate = moment(dateRange.beginCoverage);
-    let endCoverageDate = dateRange.endCoverage ? moment(dateRange.endCoverage) : present;
+    let beginCoverageDate = moment.utc(dateRange.beginCoverage);
+    let endCoverageDate = dateRange.endCoverage ? moment.utc(dateRange.endCoverage) : present;
 
-    let packageBeginCoverageDate = moment(packageBeginCoverage);
-    let packageEndCoverageDate = packageEndCoverage ? moment(packageEndCoverage) : moment();
+    let packageBeginCoverageDate = moment.utc(packageBeginCoverage);
+    let packageEndCoverageDate = packageEndCoverage ? moment.utc(packageEndCoverage) : moment.utc();
     let packageRange = moment.range(packageBeginCoverageDate, packageEndCoverageDate);
 
     let startDate = intl.formatDate(
@@ -195,7 +195,7 @@ const validateWithinPackageRange = (dateRange, packageCoverage, intl) => {
 
     let endDate = packageEndCoverage ?
       intl.formatDate(
-        packageEndCoverage,
+        packageEndCoverageDate,
         {
           timeZone: 'UTC',
           year: 'numeric',
@@ -229,10 +229,10 @@ const validateWithinPackageRange = (dateRange, packageCoverage, intl) => {
  * @returns {} - an error object if errors are found, or `false` otherwise
  */
 const validateNoRangeOverlaps = (dateRange, customCoverages, index, intl) => {
-  let present = moment('9999-09-09T05:00:00.000Z');
+  let present = moment.utc('9999-09-09T05:00:00.000Z');
 
-  let beginCoverageDate = moment(dateRange.beginCoverage);
-  let endCoverageDate = dateRange.endCoverage ? moment(dateRange.endCoverage) : present;
+  let beginCoverageDate = moment.utc(dateRange.beginCoverage);
+  let endCoverageDate = dateRange.endCoverage ? moment.utc(dateRange.endCoverage) : present;
   let coverageRange = moment.range(beginCoverageDate, endCoverageDate);
 
   for (let overlapIndex = 0, len = customCoverages.length; overlapIndex < len; overlapIndex++) {
@@ -243,8 +243,8 @@ const validateNoRangeOverlaps = (dateRange, customCoverages, index, intl) => {
       continue; // eslint-disable-line no-continue
     }
 
-    let overlapCoverageBeginDate = moment(overlapRange.beginCoverage);
-    let overlapCoverageEndDate = overlapRange.endCoverage ? moment(overlapRange.endCoverage) : present;
+    let overlapCoverageBeginDate = moment.utc(overlapRange.beginCoverage);
+    let overlapCoverageEndDate = overlapRange.endCoverage ? moment.utc(overlapRange.endCoverage) : present;
     let overlapCoverageRange = moment.range(overlapCoverageBeginDate, overlapCoverageEndDate);
 
     let startDate = intl.formatDate(

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -25,10 +25,10 @@ export function isBookPublicationType(publicationType) {
 
 export function isValidCoverage(coverageObj) {
   if (coverageObj.beginCoverage) {
-    if (!moment(coverageObj.beginCoverage, 'YYYY-MM-DD').isValid()) { return false; }
+    if (!moment.utc(coverageObj.beginCoverage, 'YYYY-MM-DD').isValid()) { return false; }
   }
   if (coverageObj.endCoverage) {
-    if (!moment(coverageObj.endCoverage, 'YYYY-MM-DD').isValid()) { return false; }
+    if (!moment.utc(coverageObj.endCoverage, 'YYYY-MM-DD').isValid()) { return false; }
   }
   return true;
 }

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -33,9 +33,9 @@ class PackageCreateRoute extends Component {
     if (values.customCoverages[0]) {
       attrs.customCoverage = {
         beginCoverage: !values.customCoverages[0].beginCoverage ? '' :
-          moment(values.customCoverages[0].beginCoverage).tz('UTC').format('YYYY-MM-DD'),
+          moment.utc(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD'),
         endCoverage: !values.customCoverages[0].endCoverage ? '' :
-          moment(values.customCoverages[0].endCoverage).tz('UTC').format('YYYY-MM-DD')
+          moment.utc(values.customCoverages[0].endCoverage).format('YYYY-MM-DD')
       };
     }
 

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -121,8 +121,8 @@ class PackageEditRoute extends Component {
       let endCoverage = '';
 
       if (values.customCoverages[0]) {
-        beginCoverage = !values.customCoverages[0].beginCoverage ? '' : moment(values.customCoverages[0].beginCoverage).tz('UTC').format('YYYY-MM-DD');
-        endCoverage = !values.customCoverages[0].endCoverage ? '' : moment(values.customCoverages[0].endCoverage).tz('UTC').format('YYYY-MM-DD');
+        beginCoverage = !values.customCoverages[0].beginCoverage ? '' : moment.utc(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD');
+        endCoverage = !values.customCoverages[0].endCoverage ? '' : moment.utc(values.customCoverages[0].endCoverage).format('YYYY-MM-DD');
       }
 
       model.customCoverage = {

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -95,8 +95,8 @@ class ResourceEditRoute extends Component {
       updateResource(model);
     } else {
       model.customCoverages = customCoverages.map((dateRange) => {
-        let beginCoverage = !dateRange.beginCoverage ? null : moment(dateRange.beginCoverage).tz('UTC').format('YYYY-MM-DD');
-        let endCoverage = !dateRange.endCoverage ? null : moment(dateRange.endCoverage).tz('UTC').format('YYYY-MM-DD');
+        let beginCoverage = !dateRange.beginCoverage ? null : moment.utc(dateRange.beginCoverage).format('YYYY-MM-DD');
+        let endCoverage = !dateRange.endCoverage ? null : moment.utc(dateRange.endCoverage).format('YYYY-MM-DD');
 
         return {
           beginCoverage,


### PR DESCRIPTION
## Purpose

This is related to [STCOR-265](https://issues.folio.org/browse/STCOR-265) to get tests to run in consistent timezones.

While investigating, I found that the app _is_ running in the UTC timezone during testing. Poking around in eholdings revealed that it was actually `moment` which was causing the dates to be incorrect.

## Approach

In other places in eholdings, we are using `.tz('UTC')` to set the timezone to be consistent for manipulation or comparison. We were **not** doing this for the date validation functions.

Moment has a `.utc()` method to set the moment object to UTC mode for every manipulation. All instances of `moment()` were replaced with `moment.utc()` and the existing places that used `.tz()` were also updated to `.utc()`.

It should be safe to do this for manipulation and comparison of dates within the code and just let `intl` handle adjusting the timezone for display. However correct me if I'm wrong, and we can try to come up with some other solution to fix this issue.

### Update

There were some failing tests related to `Datepicker` (see below). This is because the datepicker component uses `moment(value, dateFormat)` which assumes local time. But we are using UTC time because that's how the server stores those dates. There is no way to tell the datepicker component which timezone or format we are providing to it, so the work-around is instead of providing the date string to `Datepicker`, use a `moment.utc` object which will not be converted to local time by `moment()`.

## Learning

- [Moment docs on UTC mode](http://momentjs.com/docs/#/parsing/utc/)