### PR TITLE
Accommodate lack of publisher name in title results

### DIFF
--- a/src/components/title-list-item/title-list-item.css
+++ b/src/components/title-list-item/title-list-item.css
@@ -54,19 +54,16 @@
   }
 
   &.is-publisher-and-type-visible {
-    /* 1. name  2. publisher  3. type */
+    /* 1. name  2. type and publisher */
     background-image:
       linear-gradient(#eee, #eee 0.9em, transparent 0.9em),
-      linear-gradient(#eee, #eee 0.8em, transparent 0.8em),
       linear-gradient(#eee, #eee 0.8em, transparent 0.8em);
     background-size:
       14em var(--font-size-medium),
-      10em var(--font-size-small),
-      5em var(--font-size-small);
+      10em var(--font-size-small);
     background-position:
       0 0.4rem,
-      0 1.67rem,
-      0 3.5em;
+      0 1.67rem;
   }
 
   /* shimmer effect */

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -51,20 +51,27 @@ function TitleListItem({
 
       {showPublisherAndType && (
         <div>
-          <span data-test-eholdings-title-list-item-publisher-name>
-            {item.publisherName}
-          </span>
-
-          <br />
-
-          <span data-test-eholdings-title-list-item-publication-type>
-            {item.publicationType}
-          </span>
+          {item.publicationType && (
+            <span data-test-eholdings-title-list-item-publication-type>
+              {item.publicationType}
+            </span>
+          )}
+          {item.publicationType && item.publisherName &&
+            '&nbsp;&bull;&nbsp;'
+          }
+          {item.publisherName && (
+            <span>
+              &nbsp;&bull;&nbsp;
+              <span data-test-eholdings-title-list-item-publisher-name>
+                {item.publisherName}
+              </span>
+            </span>
+          )}
         </div>
       )}
 
       {showSelected && (
-        <span>
+        <div>
           <span data-test-eholdings-title-list-item-title-selected>
             {item.isSelected ?
               <FormattedMessage id="ui-eholdings.selected" /> :
@@ -79,7 +86,7 @@ function TitleListItem({
               </span>
             </span>
           )}
-        </span>
+        </div>
       )}
     </InternalLink>
   );

--- a/src/components/title-search-list.js
+++ b/src/components/title-search-list.js
@@ -21,7 +21,7 @@ export default function TitleSearchList({
       fetch={fetch}
       collection={collection}
       onUpdateOffset={onUpdateOffset}
-      itemHeight={76}
+      itemHeight={60}
       notFoundMessage={(
         <FormattedMessage
           id="ui-eholdings.title.resultsNotFound"


### PR DESCRIPTION
## Purpose
When searching for a title, sometimes a result doesn't include a publisher name. That would result in blank lines.

## Approach
- Combine the publication type and publisher name into a single line.
- Show publication type first, since anecdotally the publication type seems to always be defined.
- If both the publication type and the publisher name are present, separate them with a bullet.
- Long publisher names get cut off with an ellipsis.
- Now that all title search results only have two lines, decrease the result height from 80px to 60px.
- Skeleton loading state for title search results updated to only include two lines.

## Screenshots
### Before
![localhost_3000_eholdings_searchtype titles q health iphone 5_se 1](https://user-images.githubusercontent.com/230597/47606825-0edafd80-d9de-11e8-9330-eafbce9e07f2.png)

### After
![localhost_3000_eholdings_searchtype titles q health iphone 5_se](https://user-images.githubusercontent.com/230597/47606824-0be00d00-d9de-11e8-89ce-101451cba786.png)