### PR TITLE
Fix broken test for deselection logic in resource edit component

### DIFF
--- a/test/bigtest/tests/resource-edit-deselection-test.js
+++ b/test/bigtest/tests/resource-edit-deselection-test.js
@@ -67,9 +67,19 @@ describe('ResourceEditDeselection', () => {
         let resolveRequest;
 
         beforeEach(function () {
-          this.server.put('/resources/:id', () => {
+          this.server.put('/resources/:id', ({ resources }, request) => {
             return new Promise((resolve) => {
-              resolveRequest = resolve;
+              resolveRequest = () => {
+                const body = JSON.parse(request.requestBody);
+                const matchingResource = resources.find(body.data.id);
+                const {
+                  isSelected,
+                } = body.data.attributes;
+
+                matchingResource.update('isSelected', isSelected);
+
+                resolve();
+              };
             });
           });
 


### PR DESCRIPTION
## Purpose
While developing UIEH-241, I found that there is one broken test which should check whether a resource deselects after removing it from holdings.

## Approach
Add mock of the PUT request for sending data to deselect resource. 
