### PR TITLE
Use field-level validation on package form

### DIFF
--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import { Field, FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 
 import {
   Datepicker,
@@ -13,12 +13,26 @@ import styles from './package-coverage-fields.css';
 
 class PackageCoverageFields extends Component {
   static propTypes = {
-    initialValue: PropTypes.array
+    initialValue: PropTypes.array,
+    intl: intlShape
   };
 
   static defaultProps = {
     initialValue: []
   };
+
+  validateCoverageDate = (value) => {
+    const { intl } = this.props;
+    moment.locale(intl.locale);
+    let dateFormat = moment.localeData()._longDateFormat.L;
+    let errors;
+
+    if (value && !moment.utc(value).isValid()) {
+      errors = <FormattedMessage id="ui-eholdings.validate.errors.dateRange.format" values={{ dateFormat }} />;
+    }
+
+    return errors;
+  }
 
   renderField = (dateRange) => {
     return (
@@ -33,6 +47,7 @@ class PackageCoverageFields extends Component {
             component={Datepicker}
             label={<FormattedMessage id="ui-eholdings.date.startDate" />}
             format={(value) => (value ? moment.utc(value) : '')}
+            validate={this.validateCoverageDate}
           />
         </div>
         <div
@@ -45,6 +60,7 @@ class PackageCoverageFields extends Component {
             component={Datepicker}
             label={<FormattedMessage id="ui-eholdings.date.endDate" />}
             format={(value) => (value ? moment.utc(value) : '')}
+            validate={this.validateCoverageDate}
           />
         </div>
       </Fragment>
@@ -71,24 +87,13 @@ class PackageCoverageFields extends Component {
   }
 }
 
-export default PackageCoverageFields;
+export default injectIntl(PackageCoverageFields);
 
-export function validate(values, props) {
-  let { intl } = props;
-  moment.locale(intl.locale);
-  let dateFormat = moment.localeData()._longDateFormat.L;
+export function validate(values) {
   const errors = {};
 
   values.customCoverages.forEach((dateRange, index) => {
     let dateRangeErrors = {};
-
-    if (dateRange.beginCoverage && !moment.utc(dateRange.beginCoverage).isValid()) {
-      dateRangeErrors.beginCoverage = <FormattedMessage id="ui-eholdings.validate.errors.dateRange.format" values={{ dateFormat }} />;
-    }
-
-    if (dateRange.endCoverage && !dateRange.beginCoverage) {
-      dateRangeErrors.beginCoverage = <FormattedMessage id="ui-eholdings.validate.errors.dateRange.format" values={{ dateFormat }} />;
-    }
 
     if (dateRange.endCoverage && moment.utc(dateRange.beginCoverage).isAfter(moment.utc(dateRange.endCoverage))) {
       dateRangeErrors.beginCoverage = <FormattedMessage id="ui-eholdings.validate.errors.dateRange.startDateBeforeEndDate" />;

--- a/src/components/package/_fields/name/index.js
+++ b/src/components/package/_fields/name/index.js
@@ -1,1 +1,1 @@
-export { default, validate } from './package-name-field';
+export { default } from './package-name-field';

--- a/src/components/package/_fields/name/package-name-field.js
+++ b/src/components/package/_fields/name/package-name-field.js
@@ -4,7 +4,21 @@ import { FormattedMessage } from 'react-intl';
 
 import { TextField } from '@folio/stripes/components';
 
-function PackageNameField() {
+const validate = (value) => {
+  let errors;
+
+  if (value === '') {
+    errors = <FormattedMessage id="ui-eholdings.validate.errors.customPackage.name" />;
+  }
+
+  if (value.length >= 300) {
+    errors = <FormattedMessage id="ui-eholdings.validate.errors.customPackage.name.length" />;
+  }
+
+  return errors;
+};
+
+export default function PackageNameField() {
   return (
     <div data-test-eholdings-package-name-field>
       <Field
@@ -12,23 +26,8 @@ function PackageNameField() {
         type="text"
         component={TextField}
         label={<FormattedMessage id="ui-eholdings.label.name.isRequired" />}
+        validate={validate}
       />
     </div>
   );
-}
-
-export default PackageNameField;
-
-export function validate(values) {
-  let errors = {};
-
-  if (values.name === '') {
-    errors.name = <FormattedMessage id="ui-eholdings.validate.errors.customPackage.name" />;
-  }
-
-  if (values.name.length >= 300) {
-    errors.name = <FormattedMessage id="ui-eholdings.validate.errors.customPackage.name.length" />;
-  }
-
-  return errors;
 }

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -1,8 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'redux';
 import { reduxForm } from 'redux-form';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Icon,
@@ -11,7 +10,7 @@ import {
 } from '@folio/stripes/components';
 
 import DetailsViewSection from '../../details-view-section';
-import NameField, { validate as validatePackageName } from '../_fields/name';
+import NameField from '../_fields/name';
 import CoverageFields, { validate as validateCoverageDates } from '../_fields/custom-coverage';
 import ContentTypeField from '../_fields/content-type';
 import NavigationModal from '../../navigation-modal';
@@ -121,16 +120,9 @@ class PackageCreate extends Component {
   }
 }
 
-const validate = (values, props) => {
-  return Object.assign({}, validatePackageName(values), validateCoverageDates(values, props));
-};
-
-export default compose(
-  injectIntl,
-  reduxForm({
-    validate,
-    enableReinitialize: true,
-    form: 'PackageCreate',
-    destroyOnUnmount: false
-  })
-)(PackageCreate);
+export default reduxForm({
+  validate: validateCoverageDates,
+  enableReinitialize: true,
+  form: 'PackageCreate',
+  destroyOnUnmount: false
+})(PackageCreate);

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -1,8 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'redux';
 import { reduxForm, Field } from 'redux-form';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Accordion,
@@ -18,7 +17,7 @@ import {
 import { processErrors } from '../../utilities';
 
 import DetailsView from '../../details-view';
-import NameField, { validate as validatePackageName } from '../_fields/name';
+import NameField from '../_fields/name';
 import CoverageFields, { validate as validateCoverageDates } from '../_fields/custom-coverage';
 import ContentTypeField from '../_fields/content-type';
 import NavigationModal from '../../navigation-modal';
@@ -370,17 +369,9 @@ class CustomPackageEdit extends Component {
   }
 }
 
-const validate = (values, props) => {
-  return Object.assign({}, validatePackageName(values), validateCoverageDates(values, props));
-};
-
-
-export default compose(
-  injectIntl,
-  reduxForm({
-    validate,
-    form: 'CustomPackageEdit',
-    enableReinitialize: true,
-    destroyOnUnmount: false,
-  })
-)(CustomPackageEdit);
+export default reduxForm({
+  validate: validateCoverageDates,
+  form: 'CustomPackageEdit',
+  enableReinitialize: true,
+  destroyOnUnmount: false,
+})(CustomPackageEdit);

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -1,8 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'redux';
 import { reduxForm, Field } from 'redux-form';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Accordion,
@@ -23,7 +22,7 @@ import Toaster from '../../toaster';
 import PaneHeaderButton from '../../pane-header-button';
 import SelectionStatus from '../selection-status';
 import ProxySelectField from '../../proxy-select';
-import TokenField, { validate as validateToken } from '../../token';
+import TokenField from '../../token';
 import styles from './managed-package-edit.css';
 
 class ManagedPackageEdit extends Component {
@@ -401,16 +400,9 @@ class ManagedPackageEdit extends Component {
   }
 }
 
-const validate = (values, props) => {
-  return Object.assign({}, validateCoverageDates(values, props), validateToken(values));
-};
-
-export default compose(
-  injectIntl,
-  reduxForm({
-    validate,
-    enableReinitialize: true,
-    form: 'ManagedPackageEdit',
-    destroyOnUnmount: false,
-  })
-)(ManagedPackageEdit);
+export default reduxForm({
+  validate: validateCoverageDates,
+  enableReinitialize: true,
+  form: 'ManagedPackageEdit',
+  destroyOnUnmount: false,
+})(ManagedPackageEdit);

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -13,7 +13,7 @@ import DetailsViewSection from '../../details-view-section';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 import ProxySelectField from '../../proxy-select';
-import TokenField, { validate as validateToken } from '../../token';
+import TokenField from '../../token';
 import PaneHeaderButton from '../../pane-header-button';
 import styles from './provider-edit.css';
 
@@ -136,12 +136,7 @@ class ProviderEdit extends Component {
   }
 }
 
-const validate = (values) => {
-  return validateToken(values);
-};
-
 export default reduxForm({
-  validate,
   enableReinitialize: true,
   form: 'ProviderEdit',
   destroyOnUnmount: false,

--- a/src/components/token/index.js
+++ b/src/components/token/index.js
@@ -1,1 +1,1 @@
-export { default, validate } from './token-field';
+export { default } from './token-field';

--- a/src/components/token/token-field.js
+++ b/src/components/token/token-field.js
@@ -9,7 +9,7 @@ import {
 } from '@folio/stripes/components';
 import styles from './token-field.css';
 
-class TokenField extends Component {
+export default class TokenField extends Component {
   static propTypes = {
     token: PropTypes.object,
     tokenValue: PropTypes.string,
@@ -26,6 +26,11 @@ class TokenField extends Component {
     }));
   }
 
+  validate(value) {
+    return value && value.length > 500 ? (
+      <FormattedMessage id="ui-eholdings.validate.errors.token.length" />
+    ) : undefined;
+  }
 
   render() {
     /* eslint-disable react/no-danger */
@@ -44,7 +49,11 @@ class TokenField extends Component {
           {token.prompt}
         </div>
         <div data-test-eholdings-token-value-textarea={type} className={styles['token-value-textarea']}>
-          {type === 'provider' ? (<Field name="providerTokenValue" component={TextArea} />) : (<Field name="packageTokenValue" component={TextArea} />)}
+          {type === 'provider' ? (
+            <Field name="providerTokenValue" component={TextArea} validate={this.validate} />
+          ) : (
+            <Field name="packageTokenValue" component={TextArea} validate={this.validate} />
+          )}
         </div>
       </div>
     ) : (
@@ -61,19 +70,4 @@ class TokenField extends Component {
       </div>
     );
   }
-}
-
-export default TokenField;
-
-export function validate(values) {
-  const errors = {};
-
-  if ((values.providerTokenValue && values.providerTokenValue.length > 500)) {
-    errors.providerTokenValue = <FormattedMessage id="ui-eholdings.validate.errors.token.length" />;
-  }
-
-  if ((values.packageTokenValue && values.packageTokenValue.length > 500)) {
-    errors.packageTokenValue = <FormattedMessage id="ui-eholdings.validate.errors.token.length" />;
-  }
-  return errors;
 }


### PR DESCRIPTION
## Purpose
Most of the validations we're doing in forms are solely on the field level, but we're registering them all at the global level of each `redux-form`. That leads to some clunkier-than-necessary exports of `validate()` functions and `injectIntl()` happening one level higher than it needs to.

## Approach
Use field-level validations where possible.

I ran into one exception: validating that a coverage end date is after its begin date. Redux Form provides a `<Fields>` component that could handle that in an elegant way, but the `stripes-components` `<Datepicker>` is still too hard-wired to being the child of a `<Field>` to be able to pull that off. When https://issues.folio.org/browse/STCOM-325 is done, we can make that better.

## Next steps
Apply this same pattern to title and resource forms.