### PR TITLE
Turn on hot reloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "inflected": "^2.0.3",
     "prop-types": "^15.6.2",
     "react-final-form": "^3.6.7",
+    "react-hot-loader": "^4.3.12",
     "react-intl": "^2.4.0",
     "react-measure": "^2.1.0",
     "react-router": "^4.3.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withRoot } from '@folio/stripes-core/src/components/Root/RootContext';
+import { hot } from 'react-hot-loader';
 
 import { Route, Switch, Redirect } from './router';
 import { reducer, epics } from './redux';
@@ -75,4 +76,4 @@ class EHoldings extends Component {
   }
 }
 
-export default withRoot(EHoldings);
+export default hot(module)(withRoot(EHoldings));

--- a/yarn.lock
+++ b/yarn.lock
@@ -9584,7 +9584,7 @@ react-highlighter@^0.4.2:
     escape-string-regexp "^1.0.5"
     prop-types "^15.6.0"
 
-react-hot-loader@^4.3.10:
+react-hot-loader@^4.3.10, react-hot-loader@^4.3.12:
   version "4.3.12"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.3.12.tgz#0d56688884e7330c63a00a17217866280616b07a"
   integrity sha512-GMM4TsqUVss2QPe+Y33NlgydA5/+7tAVQxR0rZqWvBpapM8JhD7p6ymMwSZzr5yxjoXXlK/6P6qNQBOqm1dqdg==


### PR DESCRIPTION
On for `stripes-core`, but each individual FOLIO module will need to export as hot.

<img width="427" alt="screen shot 2018-11-07 at 11 45 48 am" src="https://user-images.githubusercontent.com/230597/48149815-b1b73580-e282-11e8-8016-c68d6eb64054.png">
