### PR TITLE
UIEH-571: Fixed Settings - Knowledge Base and Root Proxy Buttons

### DIFF
--- a/src/routes/application/application.css
+++ b/src/routes/application/application.css
@@ -1,3 +1,4 @@
 .eholdings-application {
   width: 100%;
+  display: flex;
 }


### PR DESCRIPTION
## Purpose
The bug appeared due to the `Settings` component change.

As the `Paneset` was deleted from it.


## Approach
As the result `flex` item was not wrapped in the `flex` container

## Screenshots

![2018-11-20 16 45 02](https://user-images.githubusercontent.com/15856488/48781037-d9c38180-ece3-11e8-8d90-eb0a078a8ddc.gif)
