### PR TITLE
UIEH-577: Fix Keyboard navigation issues

### DIFF
--- a/src/components/search-form/search-filters.js
+++ b/src/components/search-form/search-filters.js
@@ -29,26 +29,33 @@ export default function SearchFilters({
           onClearFilter={() => onUpdate({ ...activeFilters, [name]: undefined })}
           id={`filter-${searchType}-${name}`}
         >
-          {options.map(({ label, value }, i) => ( // eslint-disable-line no-shadow
-            <RadioButton
-              key={i}
-              name={name}
-              id={`eholdings-search-filters-${searchType}-${name}-${value}`}
-              label={label}
-              value={value}
-              checked={value === (activeFilters[name] || defaultValue)}
-              onChange={() => {
-                let replaced = {
-                  ...activeFilters,
-                  // if this option is a default, clear the filter
-                  [name]: value === defaultValue ? undefined : value
-                };
-                let withoutDefault = filter(item => item.value !== undefined, replaced);
+          {options.map(({ label: radioBtnLabel, value }, i) => {
+            const isChecked = value === (activeFilters[name] || defaultValue);
 
-                return onUpdate(withoutDefault);
-              }}
-            />
-          ))}
+            return (
+              <RadioButton
+                role="radio"
+                aria-checked={isChecked}
+                tabIndex={isChecked ? 0 : -1}
+                key={i}
+                name={name}
+                id={`eholdings-search-filters-${searchType}-${name}-${value}`}
+                label={radioBtnLabel}
+                value={value}
+                checked={isChecked}
+                onChange={() => {
+                  let replaced = {
+                    ...activeFilters,
+                    // if this option is a default, clear the filter
+                    [name]: value === defaultValue ? undefined : value
+                  };
+                  let withoutDefault = filter(item => item.value !== undefined, replaced);
+
+                  return onUpdate(withoutDefault);
+                }}
+              />
+            );
+          })}
         </Accordion>
       ))}
     </div>

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -114,7 +114,6 @@ class SearchForm extends Component {
                 aria-controls={type + '-panel'}
                 id={type + '-tab'}
                 key={type}
-                tabIndex={searchType === type ? undefined : -1}
                 title={<FormattedMessage id="ui-eholdings.search.searchLink" values={{ type }} />}
                 to={searchTypeUrls[type]}
                 className={searchType === type ? styles['is-active'] : undefined}
@@ -130,7 +129,6 @@ class SearchForm extends Component {
           role='tabpanel'
           aria-labelledby={searchType + '-tab'}
           id={searchType + '-panel'}
-          tabIndex='0'
         >
           {(searchType === 'titles') ? (
             <div data-test-title-search-field>


### PR DESCRIPTION
## Purpose
Regarding [UIEH-577](https://issues.folio.org/browse/UIEH-577) a user should be able to focus on the Provider/Package/Title tabs to toggle when using a keyboard (TAB) and to easily navigate filters and options. 

In addition, when the user clicks filter options the whole form shouldn't be highlighted. Only the the current option should be outlined.

## Approach
- Delete tabIndex for title tabs.
- Remove tabIndex of filters' pane, so it won't be focused ever.
- Add role/aria-label and tabIndex to `<RadioButton/>`

## Screenshots BEFORE
![2018-12-04 11 13 43](https://user-images.githubusercontent.com/43647240/49431369-041e4000-f7b6-11e8-8434-ff707e4c4f4b.gif)

## Screenshots NOW
![2018-12-06 14 46 46](https://user-images.githubusercontent.com/43647240/49585123-2fe02800-f966-11e8-842f-904a6a42ee03.gif)
