### PR TITLE
UIEH-579: Disallow adding multiple date ranges

### DIFF
--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -2,11 +2,15 @@ import React, { Component, Fragment } from 'react';
 import { Field, FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+  intlShape,
+} from 'react-intl';
 
 import {
   Datepicker,
-  RepeatableField
+  RepeatableField,
 } from '@folio/stripes/components';
 
 import styles from './package-coverage-fields.css';
@@ -14,12 +18,18 @@ import styles from './package-coverage-fields.css';
 class PackageCoverageFields extends Component {
   static propTypes = {
     initialValue: PropTypes.array,
-    intl: intlShape
+    intl: intlShape,
   };
 
   static defaultProps = {
-    initialValue: []
+    initialValue: [],
   };
+
+  constructor(props) {
+    super(props);
+
+    this.state = { coverageDateAmount: 1 };
+  }
 
   validateCoverageDate = (value) => {
     const { intl } = this.props;
@@ -28,13 +38,19 @@ class PackageCoverageFields extends Component {
     let errors;
 
     if (value && !moment.utc(value).isValid()) {
-      errors = <FormattedMessage id="ui-eholdings.validate.errors.dateRange.format" values={{ dateFormat }} />;
+      errors = (
+        <FormattedMessage
+          id="ui-eholdings.validate.errors.dateRange.format"
+          values={{ dateFormat }}
+        />);
     }
 
     return errors;
   }
 
   renderField = (dateRange) => {
+    const formatField = (value) => (value ? moment.utc(value) : '');
+
     return (
       <Fragment>
         <div
@@ -46,7 +62,7 @@ class PackageCoverageFields extends Component {
             type="text"
             component={Datepicker}
             label={<FormattedMessage id="ui-eholdings.date.startDate" />}
-            format={(value) => (value ? moment.utc(value) : '')}
+            format={formatField}
             validate={this.validateCoverageDate}
           />
         </div>
@@ -59,7 +75,7 @@ class PackageCoverageFields extends Component {
             type="text"
             component={Datepicker}
             label={<FormattedMessage id="ui-eholdings.date.endDate" />}
-            format={(value) => (value ? moment.utc(value) : '')}
+            format={formatField}
             validate={this.validateCoverageDate}
           />
         </div>
@@ -67,20 +83,57 @@ class PackageCoverageFields extends Component {
     );
   }
 
-  render() {
-    const { initialValue } = this.props;
+  renderRepeatableField = (fieldArrayProps) => {
+    const {
+      fields,
+      name,
+    } = fieldArrayProps;
 
+    const { initialValue } = this.props;
+    const { coverageDateAmount } = this.state;
+
+    const onAddField = () => {
+      fields.push({});
+
+      this.setState((prevState) => ({
+        coverageDateAmount: prevState.coverageDateAmount + 1,
+      }));
+    };
+
+    const onRemoveField = (index) => {
+      fields.remove(index);
+
+      this.setState((prevState) => ({
+        coverageDateAmount: prevState.coverageDateAmount - 1,
+      }));
+    };
+
+    const hasAddButton = coverageDateAmount === 0 || (coverageDateAmount === 1 && !initialValue[0]);
+
+    return (
+      <RepeatableField
+        addLabel={hasAddButton
+          ? <FormattedMessage id="ui-eholdings.package.coverage.addDateRange" />
+          : null}
+        emptyMessage={
+          initialValue.length > 0 && initialValue[0].beginCoverage ?
+            <FormattedMessage id="ui-eholdings.package.noCoverageDates" /> : null
+        }
+        fields={fields}
+        name={name}
+        onAdd={onAddField}
+        onRemove={onRemoveField}
+        renderField={this.renderField}
+      />
+    );
+  };
+
+  render() {
     return (
       <div data-test-eholdings-package-coverage-fields>
         <FieldArray
-          addLabel={<FormattedMessage id="ui-eholdings.package.coverage.addDateRange" />}
-          component={RepeatableField}
-          emptyMessage={
-            initialValue.length > 0 && initialValue[0].beginCoverage ?
-              <FormattedMessage id="ui-eholdings.package.noCoverageDates" /> : ''
-          }
+          component={this.renderRepeatableField}
           name="customCoverages"
-          renderField={this.renderField}
         />
       </div>
     );
@@ -95,7 +148,10 @@ export function validate(values) {
   values.customCoverages.forEach((dateRange, index) => {
     let dateRangeErrors = {};
 
-    if (dateRange.endCoverage && moment.utc(dateRange.beginCoverage).isAfter(moment.utc(dateRange.endCoverage))) {
+    const isCorrectDateCoverage = dateRange.endCoverage
+      && moment.utc(dateRange.beginCoverage).isAfter(moment.utc(dateRange.endCoverage));
+
+    if (isCorrectDateCoverage) {
       dateRangeErrors.beginCoverage = <FormattedMessage id="ui-eholdings.validate.errors.dateRange.startDateBeforeEndDate" />;
     }
 

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -42,14 +42,15 @@ class PackageCoverageFields extends Component {
         <FormattedMessage
           id="ui-eholdings.validate.errors.dateRange.format"
           values={{ dateFormat }}
-        />);
+        />
+      );
     }
 
     return errors;
   }
 
   renderField = (dateRange) => {
-    const formatField = (value) => (value ? moment.utc(value) : '');
+    const formatField = value => (value ? moment.utc(value) : '');
 
     return (
       <Fragment>
@@ -109,16 +110,19 @@ class PackageCoverageFields extends Component {
     };
 
     const hasAddButton = coverageDateAmount === 0 || (coverageDateAmount === 1 && !initialValue[0]);
+    const hasEmptyMessage = initialValue.length > 0 && initialValue[0].beginCoverage;
+    const addLabel = hasAddButton
+      ? <FormattedMessage id="ui-eholdings.package.coverage.addDateRange" />
+      : null;
+
+    const emptyMessage = hasEmptyMessage
+      ? <FormattedMessage id="ui-eholdings.package.noCoverageDates" />
+      : null;
 
     return (
       <RepeatableField
-        addLabel={hasAddButton
-          ? <FormattedMessage id="ui-eholdings.package.coverage.addDateRange" />
-          : null}
-        emptyMessage={
-          initialValue.length > 0 && initialValue[0].beginCoverage ?
-            <FormattedMessage id="ui-eholdings.package.noCoverageDates" /> : null
-        }
+        addLabel={addLabel}
+        emptyMessage={emptyMessage}
         fields={fields}
         name={name}
         onAdd={onAddField}

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -15,6 +15,8 @@ import {
 
 import styles from './package-coverage-fields.css';
 
+const COVERAGE_DATE_AMOUNT = 1;
+
 class PackageCoverageFields extends Component {
   static propTypes = {
     initialValue: PropTypes.array,
@@ -28,7 +30,7 @@ class PackageCoverageFields extends Component {
   constructor(props) {
     super(props);
 
-    this.state = { coverageDateAmount: 1 };
+    this.state = { coverageDateAmount: COVERAGE_DATE_AMOUNT };
   }
 
   validateCoverageDate = (value) => {

--- a/test/bigtest/tests/package-create-test.js
+++ b/test/bigtest/tests/package-create-test.js
@@ -87,6 +87,10 @@ describe('PackageCreate', () => {
         expect(this.location.pathname).to.match(/^\/eholdings\/packages\/\d{1,}/);
         expect(PackageShowPage.customCoverage).to.equal('12/16/2018 - 12/18/2018');
       });
+
+      it('has not the add coverage button', () => {
+        expect(PackageCreatePage.hasAddCoverageButton).to.be.false;
+      });
     });
 
     describe('getting an error when creating a new package', () => {


### PR DESCRIPTION
## Purpose
According to [UIEH-579](https://issues.folio.org/browse/UIEH-579) the user won't be able to add multiple date range in package-edit and package-create.

## Additional
This PR resolves [UIEH-580](https://issues.folio.org/browse/UIEH-580).

## Screenshots
![screen shot 2018-12-06 at 18 42 42](https://user-images.githubusercontent.com/43647240/49598380-2a470a00-f987-11e8-8e15-b3a3657f4518.png)
![screen shot 2018-12-06 at 18 43 51](https://user-images.githubusercontent.com/43647240/49598381-2adfa080-f987-11e8-84b5-a10800c9f0ba.png)
![2018-12-06 18 41 45](https://user-images.githubusercontent.com/43647240/49598438-52366d80-f987-11e8-93c9-236eb4887ae1.gif)
![2018-12-06 18 39 37](https://user-images.githubusercontent.com/43647240/49598533-7eea8500-f987-11e8-9f3b-b1dfe0d16e82.gif)





