### PR TITLE
UIEH-582 Don’t show edit link for managed titles

### DIFF
--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -78,7 +78,7 @@ class TitleShow extends Component {
   get lastMenu() {
     let { model, editLink } = this.props;
 
-    if (editLink) {
+    if (editLink && model.isTitleCustom) {
       return (
         <FormattedMessage
           id="ui-eholdings.title.editCustomTitle"

--- a/test/bigtest/interactors/title-show.js
+++ b/test/bigtest/interactors/title-show.js
@@ -66,6 +66,7 @@ import Toast from './toast';
   peerReviewedStatus = text('[data-test-eholdings-peer-reviewed-field]');
   descriptionText = text('[data-test-eholdings-description-field]');
   clickEditButton = clickable('[data-test-eholdings-title-edit-link]');
+  hasEditButton = isPresent('[data-test-eholdings-title-edit-link]');
 
   toast = Toast
 

--- a/test/bigtest/tests/title-show-test.js
+++ b/test/bigtest/tests/title-show-test.js
@@ -56,7 +56,7 @@ describe('TitleShow', () => {
       expect(TitleShowPage.nameHasFocus).to.be.true;
     });
 
-    it('does not display the edit button for a managed title', () => {
+    it.always('does not display the edit button for a managed title', () => {
       expect(TitleShowPage.hasEditButton).to.be.false;
     });
 

--- a/test/bigtest/tests/title-show-test.js
+++ b/test/bigtest/tests/title-show-test.js
@@ -56,6 +56,10 @@ describe('TitleShow', () => {
       expect(TitleShowPage.nameHasFocus).to.be.true;
     });
 
+    it('does not display the edit button for a managed title', () => {
+      expect(TitleShowPage.hasEditButton).to.be.false;
+    });
+
     it('displays the collapse all button', () => {
       expect(TitleShowPage.hasCollapseAllButton).to.be.true;
     });
@@ -272,6 +276,24 @@ describe('TitleShow', () => {
         // the 5th item, is the topmost visible item in the list
         expect(TitleShowPage.packageList(4).name).to.equal('Title Package 26');
       });
+    });
+  });
+
+  describe('viewing a custom title', () => {
+    beforeEach(function () {
+      title = this.server.create('title', {
+        name: 'Cool Title',
+        edition: 'Cool Edition',
+        publisherName: 'Cool Publisher',
+        publicationType: 'UnknownPublicationType',
+        isTitleCustom: true
+      });
+
+      this.visit(`/eholdings/titles/${title.id}`);
+    });
+
+    it('displays the edit button for a custom title', () => {
+      expect(TitleShowPage.hasEditButton).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Purpose
Managed title pages shouldn't link to an edit page, since there's nothing editable.

Regression introduced in https://github.com/folio-org/ui-eholdings/pull/569.

## Approach
Only show the edit link when the title is custom.

Tests added to verify fixed regression.