### PR TITLE
Fix search type picker styles

### DIFF
--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -8,57 +8,33 @@
 }
 
 .search-switcher {
-  display: block;
-  font-size: var(--font-size-small);
-  margin: 0 auto 1em;
-  position: relative;
-  vertical-align: middle;
+  display: inline-flex;
+  justify-content: space-between;
   width: 100%;
 
-  & a {
-    border: 1px solid var(--primary);
-    border-radius: 0.4em;
-    display: inline-block;
-    flex: 0 1 auto;
-    padding: 0.36em 0.57em;
-    position: relative;
-    text-align: center;
-    user-select: none;
-    text-decoration: none;
-    vertical-align: middle;
-    white-space: nowrap;
-    width: calc(100% / 3);
+  & > * {
+    width: 100%;
+  }
 
-    & a + a {
-      margin-left: -1px;
-    }
+  & > :first-child,
+  & > :first-child::before {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
 
-    &:visited {
-      color: var(--primary);
-    }
+  & > :last-child,
+  & > :last-child::before {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
 
-    &.is-active {
-      background-color: var(--primary);
-      color: #fff;
-    }
+  & > :not(:first-child) {
+    margin-left: -1px;
+  }
 
-    &:first-child {
-      margin-left: 0;
-
-      &:not(:last-child) {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-      }
-    }
-
-    &:last-child:not(:first-child) {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-    }
-
-    &:not(:first-child):not(:last-child) {
-      border-radius: 0;
-    }
+  & > :not(:first-child):not(:last-child),
+  & > :not(:first-child):not(:last-child)::before {
+    border-radius: 0;
   }
 }
 
@@ -79,4 +55,29 @@
 
 .search-field {
   margin-bottom: calc(var(--control-margin-bottom) / 2);
+}
+
+[dir="rtl"] {
+  & .search-switcher {
+    & > :first-child,
+    & > :first-child::before {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      border-top-right-radius: var(--radius);
+      border-bottom-right-radius: var(--radius);
+    }
+
+    & > :last-child,
+    & > :last-child::before {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+      border-top-left-radius: var(--radius);
+      border-bottom-left-radius: var(--radius);
+    }
+
+    & > :not(:first-child) {
+      margin-left: 0;
+      margin-right: -1px;
+    }
+  }
 }

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import Link from 'react-router-dom/Link';
 import capitalize from 'lodash/capitalize';
 import {
   Button,
@@ -108,19 +107,18 @@ class SearchForm extends Component {
         {displaySearchTypeSwitcher && (
           <div className={styles['search-switcher']} role='tablist' data-test-search-form-type-switcher>
             {validSearchTypes.map(type => (
-              <Link
+              <Button
                 role='tab'
                 aria-selected={searchType === type}
                 aria-controls={type + '-panel'}
                 id={type + '-tab'}
                 key={type}
-                title={<FormattedMessage id="ui-eholdings.search.searchLink" values={{ type }} />}
                 to={searchTypeUrls[type]}
-                className={searchType === type ? styles['is-active'] : undefined}
+                buttonStyle={searchType === type ? 'primary' : 'default'}
                 data-test-search-type-button={type}
               >
                 {capitalize(type)}
-              </Link>
+              </Button>
             ))}
           </div>
         )}

--- a/test/bigtest/interactors/package-search.js
+++ b/test/bigtest/interactors/package-search.js
@@ -33,7 +33,11 @@ import SearchBadge from './search-badge';
   hasErrors = isPresent('[data-test-query-list-error="packages"]');
   errorMessage = text('[data-test-query-list-error="packages"]');
   noResultsMessage = text('[data-test-query-list-not-found="packages"]');
-  selectedSearchType = collection('[data-test-search-form-type-switcher] a[class^="is-active--"]');
+  selectedSearchType = collection([
+    '[data-test-search-form-type-switcher] a[class^="primary--"]',
+    '[data-test-search-form-type-switcher] a[class*=" primary--"]'
+  ].join(','));
+
   sortBy = value('[data-test-eholdings-search-filters="packages"] input[name="sort"]:checked');
   clickCloseButton = clickable('[data-test-eholdings-details-view-close-button]');
   hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');

--- a/test/bigtest/interactors/provider-search.js
+++ b/test/bigtest/interactors/provider-search.js
@@ -30,7 +30,11 @@ import SearchBadge from './search-badge';
   hasErrors = isPresent('[data-test-query-list-error="providers"]');
   errorMessage = text('[data-test-query-list-error="providers"]');
   noResultsMessage = text('[data-test-query-list-not-found="providers"]');
-  selectedSearchType = collection('[data-test-search-form-type-switcher] a[class^="is-active--"]');
+  selectedSearchType = collection([
+    '[data-test-search-form-type-switcher] a[class^="primary--"]',
+    '[data-test-search-form-type-switcher] a[class*=" primary--"]'
+  ].join(','));
+
   sortBy = value('[data-test-eholdings-search-filters="providers"] input[name="sort"]:checked');
   isSearchButtonDisabled = property('[data-test-search-submit]', 'disabled');
   isSearchVignetteHidden = hasClassBeginningWith('[data-test-search-vignette]', 'is-hidden---');

--- a/test/bigtest/interactors/title-search.js
+++ b/test/bigtest/interactors/title-search.js
@@ -36,7 +36,11 @@ import SearchBadge from './search-badge';
   hasErrors = isPresent('[data-test-query-list-error="titles"]');
   errorMessage = text('[data-test-query-list-error="titles"]');
   noResultsMessage = text('[data-test-query-list-not-found="titles"]');
-  selectedSearchType = collection('[data-test-search-form-type-switcher] a[class^="is-active--"]');
+  selectedSearchType = collection([
+    '[data-test-search-form-type-switcher] a[class^="primary--"]',
+    '[data-test-search-form-type-switcher] a[class*=" primary--"]'
+  ].join(','));
+
   isSearchVignetteHidden = hasClassBeginningWith('[data-test-search-vignette]', 'is-hidden--');
   clickCloseButton = clickable('[data-test-eholdings-details-view-close-button]');
   searchBadge = new SearchBadge('[data-test-eholdings-results-pane-search-badge]');


### PR DESCRIPTION
## Purpose
The search type switcher element was highly custom, and not using the upstream `<SegmentedControl>`. This PR fixes some style inconsistencies as a band-aid until https://github.com/folio-org/stripes-components/pull/761 appears in a release.

## Approach
- Switch to using `stripes-components` `<Button>`s.
- Copy `<ButtonGroup>` CSS from https://github.com/folio-org/stripes-components/pull/761.
- Fixes the one extra pixel of border that had been upsetting me for months :)

## Screenshots
### Before
<img width="306" alt="screen shot 2018-12-07 at 8 56 51 am" src="https://user-images.githubusercontent.com/230597/49654807-74b79d80-f9fe-11e8-9e09-6c13c1a32bc3.png">

### After
<img width="306" alt="screen shot 2018-12-07 at 8 56 57 am" src="https://user-images.githubusercontent.com/230597/49654840-88630400-f9fe-11e8-861a-e4175e633172.png">

