### PR TITLE
UIEH-582 Prevent visits to managed title edit form

### DIFF
--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -34,6 +34,14 @@ class TitleEditRoute extends Component {
     let { match, getTitle, history, location, model } = this.props;
     let { titleId } = match.params;
 
+    // prevent being able to visit an edit form for uneditable managed titles
+    if (model.isLoaded && !model.isTitleCustom) {
+      history.replace({
+        pathname: `/eholdings/titles/${model.id}`,
+        search: location.search,
+      }, { eholdings: true });
+    }
+
     if (!prevProps.updateRequest.isResolved && this.props.updateRequest.isResolved) {
       this.props.history.push(
         `/eholdings/titles/${this.props.model.id}`,

--- a/test/bigtest/tests/managed-title-edit-test.js
+++ b/test/bigtest/tests/managed-title-edit-test.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+
+import setupApplication from '../helpers/setup-application';
+import TitleShowPage from '../interactors/title-show';
+
+describe('ManagedTitleEdit', () => {
+  setupApplication();
+  let title;
+
+  beforeEach(function () {
+    title = this.server.create('title', {
+      name: 'Best Title Ever',
+      isTitleCustom: false
+    });
+  });
+
+  describe('trying to edit a managed title', () => {
+    beforeEach(function () {
+      this.visit(`/eholdings/titles/${title.id}/edit`);
+    });
+
+    it('redirects to the title show page', () => {
+      expect(TitleShowPage.$root).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Resolves https://issues.folio.org/browse/UIEH-582

## Approach
As soon as we know that the title's not custom at `/eholdings/titles/:id/edit`, redirect to `/eholdings/titles/:id`.