### PR TITLE
UIEH-581: Fix displaying of the comma separator for custom date ranges

### DIFF
--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -146,9 +146,16 @@ class ResourceEditCustomTitle extends Component {
       coverageDates = customCoverageDateValues;
     }
 
+    const nonEmptyCoverageDates = coverageDates
+      .filter((currentCoverageDate) => Object.keys(currentCoverageDate).length !== 0);
+
+    if (nonEmptyCoverageDates.length === 0) {
+      return null;
+    }
+
     return (
       <CoverageDateList
-        coverageArray={coverageDates}
+        coverageArray={nonEmptyCoverageDates}
         isYearOnly={isBookPublicationType(model.publicationType)}
       />
     );

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -151,9 +151,16 @@ class ResourceEditManagedTitle extends Component {
       coverageDates = customCoverageDateValues;
     }
 
+    const nonEmptyCoverageDates = coverageDates
+      .filter((currentCoverageDate) => Object.keys(currentCoverageDate).length !== 0);
+
+    if (nonEmptyCoverageDates.length === 0) {
+      return null;
+    }
+
     return (
       <CoverageDateList
-        coverageArray={coverageDates}
+        coverageArray={nonEmptyCoverageDates}
         isYearOnly={isBookPublicationType(model.publicationType)}
       />
     );

--- a/test/bigtest/interactors/resource-edit.js
+++ b/test/bigtest/interactors/resource-edit.js
@@ -11,7 +11,7 @@ import {
   text,
   value,
   computed,
-  selectable
+  selectable,
 } from '@bigtest/interactor';
 
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
@@ -116,6 +116,9 @@ import Datepicker from './datepicker';
         .endDate.fillAndBlur(endDate);
     }
   });
+
+  coverageDisplayDates = text('[data-test-eholdings-display-coverage-list]');
+  isCoverageDisplayDatesExists = isPresent('[data-test-eholdings-display-coverage-list]');
 
   hasSavingWillRemoveMessage = isPresent('[data-test-eholdings-resource-coverage-fields] [data-test-repeatable-field-empty-message]');
   hasCoverageStatementArea = isPresent('[data-test-eholdings-coverage-statement-textarea] textarea');

--- a/test/bigtest/tests/resource-edit-custom-title-test.js
+++ b/test/bigtest/tests/resource-edit-custom-title-test.js
@@ -429,6 +429,56 @@ describe('ResourceEditCustomTitle', () => {
       });
     });
 
+    describe('when there are only empty custom coverage date ranges', () => {
+      beforeEach(function () {
+        const customCoverages = [
+          this.server.create('custom-coverage', {}),
+          this.server.create('custom-coverage', {}),
+        ];
+        resource.update('customCoverages', customCoverages.map(item => item.toJSON()));
+      });
+
+      it('should display dates row as empty', () => {
+        expect(ResourceEditPage.isCoverageDisplayDatesExists).to.equal(false);
+      });
+    });
+
+    describe('when there is only 1 filled custom coverage date range', () => {
+      beforeEach(function () {
+        const customCoverages = [
+          this.server.create('custom-coverage', {
+            beginCoverage: '2018-01-01',
+            endCoverage: '2019-12-31',
+          }),
+        ];
+        resource.update('customCoverages', customCoverages.map(item => item.toJSON()));
+      });
+
+      it('should display the date range without a separator', () => {
+        expect(ResourceEditPage.coverageDisplayDates).to.equal('2018 - 2019');
+      });
+    });
+
+    describe('when there are at least 2 ranges are filled', () => {
+      beforeEach(function () {
+        const customCoverages = [
+          this.server.create('custom-coverage', {
+            beginCoverage: '2018-01-01',
+            endCoverage: '2019-07-31'
+          }),
+          this.server.create('custom-coverage', {
+            beginCoverage: '2019-01-01',
+            endCoverage: '2020-12-31'
+          }),
+        ];
+        resource.update('customCoverages', customCoverages.map(item => item.toJSON()));
+      });
+
+      it('should display ranges separated with comma', () => {
+        expect(ResourceEditPage.coverageDisplayDates).to.equal('2019 - 2020, 2018 - 2019');
+      });
+    });
+
     describe('entering invalid data', () => {
       beforeEach(() => {
         return ResourceEditPage


### PR DESCRIPTION
https://issues.folio.org/browse/UIEH-581

## Purpose

  There is an issue related to comma separator for custom coverage date ranges on custom and managed title edit pages. The Comma is displaying when there are empty date ranges. The reason is empty objects which are passing to the CoverageDateList component. So the component renders them as empty strings with a comma separator.


## Approach

 - Filter empty date ranges and pass to the CoverageDateList component only filled date ranges.
 - Add tests
 - Add property type check to CoverageDateList


## Screenshots
<img width="856" alt="managed title 1" src="https://user-images.githubusercontent.com/43621626/49862707-71aa1c00-fe07-11e8-8bbb-cb8d88c3cd71.png">

<img width="856" alt="managed title 2" src="https://user-images.githubusercontent.com/43621626/49862708-7242b280-fe07-11e8-8cd6-61587c02e122.png">

<img width="856" alt="managed title 3" src="https://user-images.githubusercontent.com/43621626/49862709-7242b280-fe07-11e8-93a4-f75018cb8029.png">

<img width="856" alt="custom title 1" src="https://user-images.githubusercontent.com/43621626/49862712-72db4900-fe07-11e8-8a0f-547c6df2de14.png">

<img width="856" alt="custom title 2" src="https://user-images.githubusercontent.com/43621626/49862711-72db4900-fe07-11e8-84ec-96303d97c677.png">

<img width="856" alt="custom title 3" src="https://user-images.githubusercontent.com/43621626/49862710-7242b280-fe07-11e8-9f79-64508f596441.png">

