### PR TITLE
Turn NavigationModal into a form

### DIFF
--- a/src/components/navigation-modal/navigation-modal.js
+++ b/src/components/navigation-modal/navigation-modal.js
@@ -11,10 +11,7 @@ class NavigationModal extends Component {
       PropTypes.func,
       PropTypes.node
     ]),
-    continueLabel: PropTypes.node.isRequired,
-    dismissLabel: PropTypes.node.isRequired,
     history: ReactRouterPropTypes.history.isRequired,
-    modalLabel: PropTypes.node.isRequired,
     when: PropTypes.bool.isRequired
   };
 
@@ -90,7 +87,7 @@ class NavigationModal extends Component {
   };
 
   render() {
-    let { when, modalLabel, continueLabel, dismissLabel, children } = this.props;
+    let { when, children } = this.props;
     let { showModal } = this.state;
 
     if (typeof children === 'function') {
@@ -103,19 +100,19 @@ class NavigationModal extends Component {
           id="navigation-modal"
           size="small"
           open={showModal}
-          label={modalLabel}
+          label={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
           onClose={this.dismiss}
           wrappingElement="form"
           onSubmit={this.submit}
           footer={(
             <ModalFooter
               primaryButton={{
-                'label': dismissLabel,
+                'label': <FormattedMessage id="ui-eholdings.navModal.dismissLabel" />,
                 'type': 'submit',
                 'data-test-navigation-modal-dismiss': true
               }}
               secondaryButton={{
-                'label': continueLabel,
+                'label': <FormattedMessage id="ui-eholdings.navModal.continueLabel" />,
                 'onClick': this.continue,
                 'data-test-navigation-modal-continue': true
               }}

--- a/src/components/navigation-modal/navigation-modal.js
+++ b/src/components/navigation-modal/navigation-modal.js
@@ -73,6 +73,11 @@ class NavigationModal extends Component {
     });
   };
 
+  submit = (event) => {
+    event.preventDefault();
+    this.dismiss();
+  }
+
   continue = () => {
     const { history } = this.props;
     const { nextLocation } = this.state;
@@ -100,11 +105,13 @@ class NavigationModal extends Component {
           open={showModal}
           label={modalLabel}
           onClose={this.dismiss}
+          wrappingElement="form"
+          onSubmit={this.submit}
           footer={(
             <ModalFooter
               primaryButton={{
                 'label': dismissLabel,
-                'onClick': this.dismiss,
+                'type': 'submit',
                 'data-test-navigation-modal-dismiss': true
               }}
               secondaryButton={{

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -120,12 +120,7 @@ class PackageCreate extends Component {
             </DetailsViewSection>
           </div>
         </form>
-        <NavigationModal
-          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-          when={!pristine && !request.isResolved}
-        />
+        <NavigationModal when={!pristine && !request.isResolved} />
       </div>
     );
   }

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -348,12 +348,7 @@ class CustomPackageEdit extends Component {
           />
         </form>
 
-        <NavigationModal
-          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-          when={!pristine && !model.update.isPending}
-        />
+        <NavigationModal when={!pristine && !model.update.isPending} />
 
         <Modal
           open={showSelectionModal}

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -343,17 +343,17 @@ class CustomPackageEdit extends Component {
                       <p><FormattedMessage id="ui-eholdings.package.customCoverage.notSelected" /></p>
                   )}
                 </Accordion>
-
-                <NavigationModal
-                  modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-                  continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-                  dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-                  when={!pristine && !model.update.isPending}
-                />
               </Fragment>
             )}
           />
         </form>
+
+        <NavigationModal
+          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
+          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
+          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
+          when={!pristine && !model.update.isPending}
+        />
 
         <Modal
           open={showSelectionModal}

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -383,17 +383,18 @@ class ManagedPackageEdit extends Component {
                     </Accordion>
                   </div>
                 )}
-
-                <NavigationModal
-                  modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-                  continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-                  dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-                  when={!pristine && !model.update.isPending}
-                />
               </Fragment>
             )}
           />
         </form>
+
+        <NavigationModal
+          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
+          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
+          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
+          when={!pristine && !model.update.isPending}
+        />
+
         <Modal
           open={showSelectionModal}
           size="small"

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -388,12 +388,7 @@ class ManagedPackageEdit extends Component {
           />
         </form>
 
-        <NavigationModal
-          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-          when={!pristine && !model.update.isPending}
-        />
+        <NavigationModal when={!pristine && !model.update.isPending} />
 
         <Modal
           open={showSelectionModal}

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -486,12 +486,7 @@ class PackageShow extends Component {
           {modalMessage.body}
         </Modal>
 
-        <NavigationModal
-          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-          when={isCoverageEditable}
-        />
+        <NavigationModal when={isCoverageEditable} />
       </div>
     );
   }

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -134,12 +134,7 @@ class ProviderEdit extends Component {
             )}
           />
         </form>
-        <NavigationModal
-          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-          when={!pristine && !model.update.isPending}
-        />
+        <NavigationModal when={!pristine && !model.update.isPending} />
       </Fragment>
     );
   }

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -130,16 +130,16 @@ class ProviderEdit extends Component {
                     </div>
                   )}
                 </DetailsViewSection>
-                <NavigationModal
-                  modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-                  continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-                  dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-                  when={!pristine && !model.update.isPending}
-                />
               </Fragment>
             )}
           />
         </form>
+        <NavigationModal
+          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
+          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
+          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
+          when={!pristine && !model.update.isPending}
+        />
       </Fragment>
     );
   }

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -338,17 +338,18 @@ class ResourceEditCustomTitle extends Component {
                     </p>
                   )}
                 </Accordion>
-
-                <NavigationModal
-                  modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-                  continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-                  dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-                  when={!pristine && !model.update.isPending}
-                />
               </Fragment>
             )}
           />
         </form>
+
+
+        <NavigationModal
+          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
+          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
+          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
+          when={!pristine && !model.update.isPending}
+        />
 
         <Modal
           open={showSelectionModal}

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -344,12 +344,7 @@ class ResourceEditCustomTitle extends Component {
         </form>
 
 
-        <NavigationModal
-          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-          when={!pristine && !model.update.isPending}
-        />
+        <NavigationModal when={!pristine && !model.update.isPending} />
 
         <Modal
           open={showSelectionModal}

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -372,12 +372,7 @@ class ResourceEditManagedTitle extends Component {
           />
         </form>
 
-        <NavigationModal
-          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-          when={!pristine && !model.update.isPending}
-        />
+        <NavigationModal when={!pristine && !model.update.isPending} />
 
         <Modal
           open={showSelectionModal}

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -367,17 +367,17 @@ class ResourceEditManagedTitle extends Component {
                     </p>
                   )}
                 </Accordion>
-
-                <NavigationModal
-                  modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-                  continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-                  dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-                  when={!pristine && !model.update.isPending}
-                />
               </Fragment>
             )}
           />
         </form>
+
+        <NavigationModal
+          modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
+          continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
+          dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
+          when={!pristine && !model.update.isPending}
+        />
 
         <Modal
           open={showSelectionModal}

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -148,12 +148,7 @@ export default class TitleCreate extends Component {
                 </div>
               </form>
 
-              <NavigationModal
-                modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-                continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-                dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-                when={!pristine && !request.isResolved}
-              />
+              <NavigationModal when={!pristine && !request.isResolved} />
             </Fragment>
           )}
         />

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -89,51 +89,54 @@ export default class TitleEdit extends Component {
           decorators={[focusOnErrors]}
           mutators={{ ...arrayMutators }}
           render={({ handleSubmit, pristine }) => (
-            <form onSubmit={handleSubmit}>
-              <DetailsView
-                type="title"
-                model={model}
-                paneTitle={model.name}
-                actionMenu={this.getActionMenu}
-                lastMenu={(
-                  <Fragment>
-                    {model.update.isPending && (
-                      <Icon icon="spinner-ellipsis" />
-                    )}
-                    <PaneHeaderButton
-                      disabled={pristine || model.update.isPending}
-                      type="submit"
-                      buttonStyle="primary"
-                      data-test-eholdings-title-save-button
-                    >
-                      {model.update.isPending ? (<FormattedMessage id="ui-eholdings.saving" />) : (<FormattedMessage id="ui-eholdings.save" />)}
-                    </PaneHeaderButton>
-                  </Fragment>
-                )}
-                bodyContent={(
-                  <Fragment>
-                    <DetailsViewSection
-                      label={<FormattedMessage id="ui-eholdings.title.titleInformation" />}
-                    >
-                      <NameField />
-                      <ContributorField />
-                      <EditionField />
-                      <PublisherNameField />
-                      <PublicationTypeField />
-                      <IdentifiersFields />
-                      <DescriptionField />
-                      <PeerReviewedField />
-                    </DetailsViewSection>
-                    <NavigationModal
-                      modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-                      continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-                      dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-                      when={!pristine && !updateRequest.isResolved}
-                    />
-                  </Fragment>
-                )}
+            <Fragment>
+              <form onSubmit={handleSubmit}>
+                <DetailsView
+                  type="title"
+                  model={model}
+                  paneTitle={model.name}
+                  actionMenu={this.getActionMenu}
+                  lastMenu={(
+                    <Fragment>
+                      {model.update.isPending && (
+                        <Icon icon="spinner-ellipsis" />
+                      )}
+                      <PaneHeaderButton
+                        disabled={pristine || model.update.isPending}
+                        type="submit"
+                        buttonStyle="primary"
+                        data-test-eholdings-title-save-button
+                      >
+                        {model.update.isPending ? (<FormattedMessage id="ui-eholdings.saving" />) : (<FormattedMessage id="ui-eholdings.save" />)}
+                      </PaneHeaderButton>
+                    </Fragment>
+                  )}
+                  bodyContent={(
+                    <Fragment>
+                      <DetailsViewSection
+                        label={<FormattedMessage id="ui-eholdings.title.titleInformation" />}
+                      >
+                        <NameField />
+                        <ContributorField />
+                        <EditionField />
+                        <PublisherNameField />
+                        <PublicationTypeField />
+                        <IdentifiersFields />
+                        <DescriptionField />
+                        <PeerReviewedField />
+                      </DetailsViewSection>
+                    </Fragment>
+                  )}
+                />
+              </form>
+
+              <NavigationModal
+                modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
+                continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
+                dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
+                when={!pristine && !updateRequest.isResolved}
               />
-            </form>
+            </Fragment>
           )}
         />
       </Fragment>

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -130,12 +130,7 @@ export default class TitleEdit extends Component {
                 />
               </form>
 
-              <NavigationModal
-                modalLabel={<FormattedMessage id="ui-eholdings.navModal.modalLabel" />}
-                continueLabel={<FormattedMessage id="ui-eholdings.navModal.continueLabel" />}
-                dismissLabel={<FormattedMessage id="ui-eholdings.navModal.dismissLabel" />}
-                when={!pristine && !updateRequest.isResolved}
-              />
+              <NavigationModal when={!pristine && !updateRequest.isResolved} />
             </Fragment>
           )}
         />


### PR DESCRIPTION
## Purpose
We can improve the user experience of the "you have unsaved changes" modal by separating out `<NavigationModal>` into its own `<form>`.

## Approach
- Isolate `<NavigationModal>` outside of any other `<form>`.
- Every use of `<NavigationModal>` had the same copy, so I DRYed that up.
- I was hoping this work would wire up pressing Enter/Return on the keyboard to select "Keep editing", but it doesn't appear the focus is in the right spot when the modal opens to pull that off. I'll keep investigating.