### PR TITLE
UIEH-588: fix bug on creating configuration with mod-kb-ebsco-java

### DIFF
--- a/src/routes/settings-knowledge-base.js
+++ b/src/routes/settings-knowledge-base.js
@@ -23,9 +23,9 @@ class SettingsKnowledgeBaseRoute extends Component {
   updateConfig = ({ rmapiBaseUrl, customerId, apiKey }) => {
     let { config, updateBackendConfig } = this.props;
 
-    config.rmapiBaseUrl = rmapiBaseUrl;
-    config.customerId = customerId;
-    config.apiKey = apiKey;
+    config.data.attributes.rmapiBaseUrl = rmapiBaseUrl;
+    config.data.attributes.customerId = customerId;
+    config.data.attributes.apiKey = apiKey;
 
     updateBackendConfig(config);
   };


### PR DESCRIPTION
When we submit the form in Settings -> eHoldings -> Knowledge base, the request payload does not contain all needed form values.

What is currently sent in the request payload: 
```
{
  "data": {
    "id": "configuration",
    "type": "configurations",
    "attributes": {
      "rmapiBaseUrl": "https://sandbox.ebsco.io"
    }
  }
}
```
What should be sent in the request payload:
```
{
  "data": {
    "id": "configuration",
    "type": "configurations",
    "attributes": {
      "apiKey": "****************************************"
      "customerId": "apidvgvmt",
      "rmapiBaseUrl": "https://sandbox.ebsco.io"
    }
  }
}
```
This PR fix this. [Related story](https://issues.folio.org/browse/UIEH-588)