### PR TITLE
UIEH-597: Change package name length to 200 characters

### DIFF
--- a/src/components/package/_fields/name/package-name-field.js
+++ b/src/components/package/_fields/name/package-name-field.js
@@ -4,6 +4,8 @@ import { FormattedMessage } from 'react-intl';
 
 import { TextField } from '@folio/stripes/components';
 
+const MAX_CHARACTER_LENGTH = 200;
+
 const validate = (value) => {
   let errors;
 
@@ -11,8 +13,13 @@ const validate = (value) => {
     errors = <FormattedMessage id="ui-eholdings.validate.errors.customPackage.name" />;
   }
 
-  if (value.length >= 300) {
-    errors = <FormattedMessage id="ui-eholdings.validate.errors.customPackage.name.length" />;
+  if (value.length >= MAX_CHARACTER_LENGTH) {
+    errors = (
+      <FormattedMessage
+        id="ui-eholdings.validate.errors.customPackage.name.length"
+        values={{ amount: MAX_CHARACTER_LENGTH }}
+      />
+    );
   }
 
   return errors;

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -239,7 +239,7 @@
     "validate.errors.customTitle.name.length": "Must be less than 400 characters.",
     "validate.errors.title.description.length": "The value entered exceeds the 1500 character limit. Please enter a value that does not exceed 1500 characters.",
     "validate.errors.customPackage.name": "Custom packages must have a name.",
-    "validate.errors.customPackage.name.length": "Must be less than 300 characters.",
+    "validate.errors.customPackage.name.length": "Must be less than {amount} characters.",
     "validate.errors.coverageStatement.length": "Statement must be 350 characters or less.",
     "validate.errors.coverageStatement.blank": "Statement field cannot be blank if selected.",
 


### PR DESCRIPTION
## Purpose
[UIEH-597](https://issues.folio.org/browse/UIEH-597): to decrease character's limit for package name field as it causes a failure on back end. Because actual maximum string length that can be saved to KB is 200 characters.

## Approach
- change validation for the field from 300 to 200

## Screenshots
![2018-12-27 12 08 15](https://user-images.githubusercontent.com/43647240/50476245-26c80100-09d0-11e9-87cf-49379a423d69.gif)
