### PR TITLE
UIEH-592: add check for decimal numbers on custom embargo fields

### DIFF
--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -124,17 +124,28 @@ class CustomEmbargoFields extends Component {
 export default CustomEmbargoFields;
 
 export function validate(values) {
+  const {
+    customEmbargoValue,
+    customEmbargoUnit,
+  } = values;
+
   const errors = {};
+  const customEmbargoValueIsDemical = Number(values.customEmbargoValue) % 1 !== 0
+    || (customEmbargoValue && customEmbargoValue.toString().indexOf('.') !== -1);
 
-  if (Number.isNaN(Number(values.customEmbargoValue))) {
-    errors.customEmbargoValue = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.number" />;
-  }
-
-  if (values.customEmbargoValue <= 0) {
+  if (customEmbargoValue <= 0) {
     errors.customEmbargoValue = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.moreThanZero" />;
   }
 
-  if (values.customEmbargoValue > 0 && !values.customEmbargoUnit) {
+  if (customEmbargoValueIsDemical) {
+    errors.customEmbargoValue = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.demical" />;
+  }
+
+  if (Number.isNaN(Number(customEmbargoValue))) {
+    errors.customEmbargoValue = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.number" />;
+  }
+
+  if (!customEmbargoValueIsDemical && customEmbargoValue > 0 && !customEmbargoUnit) {
     errors.customEmbargoUnit = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.unit" />;
   }
   return errors;

--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -130,22 +130,22 @@ export function validate(values) {
   } = values;
 
   const errors = {};
-  const customEmbargoValueIsDemical = Number(values.customEmbargoValue) % 1 !== 0
+  const customEmbargoValueIsDecimal = Number(values.customEmbargoValue) % 1 !== 0
     || (customEmbargoValue && customEmbargoValue.toString().indexOf('.') !== -1);
 
   if (customEmbargoValue <= 0) {
     errors.customEmbargoValue = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.moreThanZero" />;
   }
 
-  if (customEmbargoValueIsDemical) {
-    errors.customEmbargoValue = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.demical" />;
+  if (customEmbargoValueIsDecimal) {
+    errors.customEmbargoValue = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.decimal" />;
   }
 
   if (Number.isNaN(Number(customEmbargoValue))) {
     errors.customEmbargoValue = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.number" />;
   }
 
-  if (!customEmbargoValueIsDemical && customEmbargoValue > 0 && !customEmbargoUnit) {
+  if (!customEmbargoValueIsDecimal && customEmbargoValue > 0 && !customEmbargoUnit) {
     errors.customEmbargoUnit = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.unit" />;
   }
   return errors;

--- a/test/bigtest/tests/custom-resource-edit-embargo-test.js
+++ b/test/bigtest/tests/custom-resource-edit-embargo-test.js
@@ -5,7 +5,7 @@ import setupApplication from '../helpers/setup-application';
 import ResourceEditPage from '../interactors/resource-edit';
 import ResourceShowPage from '../interactors/resource-show';
 
-describe('CustomResourceEditEmbargo', () => {
+describe.only('CustomResourceEditEmbargo', () => {
   setupApplication();
   let provider,
     providerPackage,
@@ -207,6 +207,19 @@ describe('CustomResourceEditEmbargo', () => {
 
             it('rejects embargo value', () => {
               expect(ResourceEditPage.validationErrorOnEmbargoTextField).to.equal('Must be a number');
+            });
+          });
+
+          describe('decimal custom embargo value should throw validation error', () => {
+            beforeEach(() => {
+              return ResourceEditPage
+                .inputEmbargoValue('1.5')
+                .selectEmbargoUnit('Months')
+                .clickSave();
+            });
+
+            it('rejects embargo value', () => {
+              expect(ResourceEditPage.validationErrorOnEmbargoTextField).to.equal('Decimal is not allowed');
             });
           });
 

--- a/test/bigtest/tests/custom-resource-edit-embargo-test.js
+++ b/test/bigtest/tests/custom-resource-edit-embargo-test.js
@@ -5,7 +5,7 @@ import setupApplication from '../helpers/setup-application';
 import ResourceEditPage from '../interactors/resource-edit';
 import ResourceShowPage from '../interactors/resource-show';
 
-describe.only('CustomResourceEditEmbargo', () => {
+describe('CustomResourceEditEmbargo', () => {
   setupApplication();
   let provider,
     providerPackage,

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -262,6 +262,7 @@
 
     "validate.errors.embargoPeriod.moreThanZero": "Enter number greater than 0",
     "validate.errors.embargoPeriod.number": "Must be a number",
+    "validate.errors.embargoPeriod.demical": "Decimal is not allowed",
     "validate.errors.embargoPeriod.unit": "Select a unit",
     "validate.errors.customUrl.length": "Custom URLs must be 600 characters or less.",
     "validate.errors.customUrl.include": "The URL should include http:// or https://",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -262,7 +262,7 @@
 
     "validate.errors.embargoPeriod.moreThanZero": "Enter number greater than 0",
     "validate.errors.embargoPeriod.number": "Must be a number",
-    "validate.errors.embargoPeriod.demical": "Decimal is not allowed",
+    "validate.errors.embargoPeriod.decimal": "Decimal is not allowed",
     "validate.errors.embargoPeriod.unit": "Select a unit",
     "validate.errors.customUrl.length": "Custom URLs must be 600 characters or less.",
     "validate.errors.customUrl.include": "The URL should include http:// or https://",


### PR DESCRIPTION
## Purpose
According to [this story](https://issues.folio.org/browse/UIEH-592), an error message should be displayed if user enters a decimal number when editing "Embargo period" field on edit resource page