### PR TITLE
UIEH-593: fix embargo period placeholder

### DIFF
--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -45,12 +45,16 @@ class CustomEmbargoFields extends Component {
           data-test-eholdings-custom-embargo-textfield
           className={styles['custom-embargo-text-field']}
         >
-          <Field
-            name="customEmbargoValue"
-            component={TextField}
-            placeholder={<FormattedMessage id="ui-eholdings.number" />}
-            autoFocus={initialValue.customEmbargoValue === 0}
-          />
+          <FormattedMessage id="ui-eholdings.number">
+            {placeholder => (
+              <Field
+                name="customEmbargoValue"
+                component={TextField}
+                placeholder={placeholder}
+                autoFocus={initialValue.customEmbargoValue === 0}
+              />
+            )}
+          </FormattedMessage>
         </div>
 
         <div


### PR DESCRIPTION
This PR fixes embargo period placeholder which displays '[object Object]'.
[Related story](https://issues.folio.org/browse/UIEH-593) 