### PR TITLE
UIEH-605 Rename initialValue to initial

### DIFF
--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -20,12 +20,12 @@ const COVERAGE_DATE_AMOUNT = 1;
 
 class PackageCoverageFields extends Component {
   static propTypes = {
-    initialValue: PropTypes.array,
+    initial: PropTypes.array,
     intl: intlShape,
   };
 
   static defaultProps = {
-    initialValue: [],
+    initial: [],
   };
 
   constructor(props) {
@@ -93,7 +93,7 @@ class PackageCoverageFields extends Component {
       name,
     } = fieldArrayProps;
 
-    const { initialValue } = this.props;
+    const { initial } = this.props;
     const { coverageDateAmount } = this.state;
 
     const onAddField = () => {
@@ -112,8 +112,8 @@ class PackageCoverageFields extends Component {
       }));
     };
 
-    const hasAddButton = coverageDateAmount === 0 || (coverageDateAmount === 1 && !initialValue[0]);
-    const hasEmptyMessage = initialValue.length > 0 && initialValue[0].beginCoverage;
+    const hasAddButton = coverageDateAmount === 0 || (coverageDateAmount === 1 && !initial[0]);
+    const hasEmptyMessage = initial.length > 0 && initial[0].beginCoverage;
     const addLabel = hasAddButton
       ? <Icon icon="plus-sign"><FormattedMessage id="ui-eholdings.package.coverage.addDateRange" /></Icon>
       : null;

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -338,7 +338,7 @@ class CustomPackageEdit extends Component {
                 >
                   {packageSelected ? (
                     <CoverageFields
-                      initialValue={initialValues.customCoverages}
+                      initial={initialValues.customCoverages}
                     />) : (
                       <p><FormattedMessage id="ui-eholdings.package.customCoverage.notSelected" /></p>
                   )}

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -379,7 +379,7 @@ class ManagedPackageEdit extends Component {
                       id="packageCoverageSettings"
                       onToggle={this.toggleSection}
                     >
-                      <CoverageFields initialValue={initialValues.customCoverages} />
+                      <CoverageFields initial={initialValues.customCoverages} />
                     </Accordion>
                   </div>
                 )}

--- a/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
@@ -14,11 +14,11 @@ import styles from './custom-coverage-fields.css';
 
 class ResourceCoverageFields extends Component {
   static propTypes = {
-    initialValue: PropTypes.array
+    initial: PropTypes.array
   };
 
   static defaultProps = {
-    initialValue: []
+    initial: []
   };
 
   renderField = (dateRange) => {
@@ -55,7 +55,7 @@ class ResourceCoverageFields extends Component {
   }
 
   render() {
-    const { initialValue } = this.props;
+    const { initial } = this.props;
 
     return (
       <div data-test-eholdings-resource-coverage-fields>
@@ -67,7 +67,7 @@ class ResourceCoverageFields extends Component {
           }
           component={RepeatableField}
           emptyMessage={
-            initialValue.length > 0 && initialValue[0].beginCoverage ?
+            initial.length > 0 && initial[0].beginCoverage ?
               <FormattedMessage id="ui-eholdings.package.noCoverageDates" /> : ''
           }
           name="customCoverages"

--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -15,7 +15,7 @@ import styles from './custom-embargo-fields.css';
 class CustomEmbargoFields extends Component {
   static propTypes = {
     change: PropTypes.func.isRequired,
-    initialValue: PropTypes.object,
+    initial: PropTypes.object,
     showInputs: PropTypes.bool
   };
 
@@ -36,7 +36,7 @@ class CustomEmbargoFields extends Component {
   }
 
   render() {
-    let { initialValue } = this.props;
+    let { initial } = this.props;
     let { showInputs } = this.state;
 
     return (showInputs) ? (
@@ -51,7 +51,7 @@ class CustomEmbargoFields extends Component {
                 name="customEmbargoValue"
                 component={TextField}
                 placeholder={placeholder}
-                autoFocus={initialValue.customEmbargoValue === 0}
+                autoFocus={initial.customEmbargoValue === 0}
               />
             )}
           </FormattedMessage>
@@ -101,7 +101,7 @@ class CustomEmbargoFields extends Component {
       </div>
     ) : (
       <div>
-        {initialValue.customEmbargoValue !== 0 && (
+        {initial.customEmbargoValue !== 0 && (
           <p data-test-eholdings-embargo-fields-saving-will-remove>
             <FormattedMessage id="ui-eholdings.resource.embargoPeriod.saveWillRemove" />
           </p>

--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -19,6 +19,10 @@ class CustomEmbargoFields extends Component {
     showInputs: PropTypes.bool
   };
 
+  static defaultProps = {
+    initial: []
+  };
+
   state = {
     showInputs: this.props.showInputs
   };

--- a/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
+++ b/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
@@ -17,12 +17,12 @@ import styles from './managed-coverage-fields.css';
 
 class ResourceCoverageFields extends Component {
   static propTypes = {
-    initialValue: PropTypes.array,
+    initial: PropTypes.array,
     model: PropTypes.object.isRequired
   };
 
   static defaultProps = {
-    initialValue: []
+    initial: []
   };
 
   renderField = (dateRange) => {
@@ -60,7 +60,7 @@ class ResourceCoverageFields extends Component {
 
   renderCoverageFields = (fieldArrayProps) => {
     let { fields } = fieldArrayProps;
-    let { initialValue, model } = this.props;
+    let { initial, model } = this.props;
     return (
       <fieldset>
         <div>
@@ -103,7 +103,7 @@ class ResourceCoverageFields extends Component {
                 </Icon>
               }
               emptyMessage={
-                initialValue.length > 0 && initialValue[0].beginCoverage ?
+                initial.length > 0 && initial[0].beginCoverage ?
                   <FormattedMessage id="ui-eholdings.package.noCoverageDates" /> : ''
               }
               fields={fields}

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -308,7 +308,7 @@ class ResourceEditCustomTitle extends Component {
                     <Fragment>
                       <Headline tag="h4"><FormattedMessage id="ui-eholdings.label.dates" /></Headline>
                       <CustomCoverageFields
-                        initialValue={initialValues.customCoverages}
+                        initial={initialValues.customCoverages}
                         model={model}
                       />
 
@@ -326,7 +326,7 @@ class ResourceEditCustomTitle extends Component {
                       <CustomEmbargoFields
                         change={change}
                         showInputs={(initialValues.customEmbargoValue > 0)}
-                        initialValue={{
+                        initial={{
                           customEmbargoValue: initialValues.customEmbargoValue,
                           customEmbargoUnit: initialValues.customEmbargoUnit
                         }}

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -337,7 +337,7 @@ class ResourceEditManagedTitle extends Component {
                         <FormattedMessage id="ui-eholdings.label.dates" />
                       </Headline>
                       <ManagedCoverageFields
-                        initialValue={initialValues.customCoverages}
+                        initial={initialValues.customCoverages}
                         model={model}
                       />
 
@@ -355,7 +355,7 @@ class ResourceEditManagedTitle extends Component {
                       <CustomEmbargoFields
                         change={change}
                         showInputs={(initialValues.customEmbargoValue > 0)}
-                        initialValue={{
+                        initial={{
                           customEmbargoValue: initialValues.customEmbargoValue,
                           customEmbargoUnit: initialValues.customEmbargoUnit
                         }}


### PR DESCRIPTION
## Purpose
Part of https://issues.folio.org/browse/UIEH-605

## Approach
Instead of passing in an `initialValue` to pre-packaged field components, we'll be able to pick it off `meta.initial` with React Final Form.
### Before this PR
```
renderRepeatableField = ({ fields, name }) => {
    const { initialValue } = this.props;

    const hasAddButton = fields.length === 0 || (fields.length === 1 && !initialValue[0]);
    const hasEmptyMessage = initialValue.length > 0 && initialValue[0].beginCoverage;
...
```

### After this PR
```
renderRepeatableField = ({ fields, name }) => {
    const { initial } = this.props;

    const hasAddButton = fields.length === 0 || (fields.length === 1 && !initial[0]);
    const hasEmptyMessage = initial.length > 0 && initial[0].beginCoverage;
...
```

### Later, with React Final Form
```
renderRepeatableField = ({ fields, name, meta: { initial } }) => {
    const hasAddButton = fields.length === 0 || (fields.length === 1 && !initial[0]);
    const hasEmptyMessage = initial.length > 0 && initial[0].beginCoverage;
...
```

Making this change now will reduce the changes needed with the full migration to React Final Form.