### PR TITLE
UIEH-595: fix incorrect warning message on delete resource

### DIFF
--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -380,15 +380,17 @@ class ResourceEditCustomTitle extends Component {
               selects and then immediately deselects the
               resource
             */
-            model.package.titleCount <= 1 ? (
-              <span data-test-eholdings-deselect-final-title-warning>
-                <FormattedMessage id="ui-eholdings.resource.modal.body.isCustom.lastTitle" />
-              </span>
-            ) : (
-              <span data-test-eholdings-deselect-title-warning>
-                <FormattedMessage id="ui-eholdings.resource.modal.body" />
-              </span>
-            )
+            model.package.titleCount <= 1
+              ? (
+                <span data-test-eholdings-deselect-final-title-warning>
+                  <FormattedMessage id="ui-eholdings.resource.modal.body.isCustom.lastTitle" />
+                </span>
+              )
+              : (
+                <span data-test-eholdings-deselect-title-warning>
+                  <FormattedMessage id="ui-eholdings.resource.modal.body" />
+                </span>
+              )
           }
         </Modal>
       </div>

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -380,7 +380,7 @@ class ResourceEditCustomTitle extends Component {
               selects and then immediately deselects the
               resource
             */
-            model.title.resources.length <= 1 ? (
+            model.package.titleCount <= 1 ? (
               <span data-test-eholdings-deselect-final-title-warning>
                 <FormattedMessage id="ui-eholdings.resource.modal.body.isCustom.lastTitle" />
               </span>

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -482,15 +482,17 @@ class ResourceShow extends Component {
                selects and then immediately deselects the
                resource
             */
-            (model.package.titleCount <= 1 && model.title.isTitleCustom) ? (
-              <span data-test-eholdings-deselect-final-title-warning>
-                <FormattedMessage id="ui-eholdings.resource.modal.body.isCustom.lastTitle" />
-              </span>
-            ) : (
-              <span data-test-eholdings-deselect-title-warning>
-                <FormattedMessage id="ui-eholdings.resource.show.modal.body" />
-              </span>
-            )
+            model.package.titleCount <= 1 && model.title.isTitleCustom
+              ? (
+                <span data-test-eholdings-deselect-final-title-warning>
+                  <FormattedMessage id="ui-eholdings.resource.modal.body.isCustom.lastTitle" />
+                </span>
+              )
+              : (
+                <span data-test-eholdings-deselect-title-warning>
+                  <FormattedMessage id="ui-eholdings.resource.show.modal.body" />
+                </span>
+              )
           }
         </Modal>
       </div>

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -482,7 +482,7 @@ class ResourceShow extends Component {
                selects and then immediately deselects the
                resource
             */
-            (model.title.resources.length <= 1 && model.title.isTitleCustom) ? (
+            (model.package.titleCount <= 1 && model.title.isTitleCustom) ? (
               <span data-test-eholdings-deselect-final-title-warning>
                 <FormattedMessage id="ui-eholdings.resource.modal.body.isCustom.lastTitle" />
               </span>

--- a/test/bigtest/interactors/resource-edit.js
+++ b/test/bigtest/interactors/resource-edit.js
@@ -40,8 +40,8 @@ import Datepicker from './datepicker';
 }
 
 @interactor class ResourceEditDropDownMenu {
-  clickRemoveFromHoldings = clickable('.tether-element [data-test-eholdings-remove-resource-from-holdings]');
-  clickCancel = clickable('.tether-element [data-test-eholdings-resource-cancel-action]');
+  clickRemoveFromHoldings = clickable('[data-test-eholdings-remove-resource-from-holdings]');
+  clickCancel = clickable('[data-test-eholdings-resource-cancel-action]');
 }
 
 @interactor class ResourceEditToggleSectionButton {

--- a/test/bigtest/interactors/resource-edit.js
+++ b/test/bigtest/interactors/resource-edit.js
@@ -27,6 +27,8 @@ import Datepicker from './datepicker';
 }
 
 @interactor class ResourceEditModal {
+  hasDeselectTitleWarning = isPresent('[data-test-eholdings-deselect-title-warning]');
+  hasDeselectFinalTitleWarning = isPresent('[data-test-eholdings-deselect-final-title-warning]');
   confirmDeselection = clickable('[data-test-eholdings-resource-deselection-confirmation-modal-yes]');
   cancelDeselection = clickable('[data-test-eholdings-resource-deselection-confirmation-modal-no]');
   confirmButtonText = text('[data-test-eholdings-resource-deselection-confirmation-modal-yes]');
@@ -38,6 +40,7 @@ import Datepicker from './datepicker';
 }
 
 @interactor class ResourceEditDropDownMenu {
+  clickRemoveFromHoldings = clickable('.tether-element [data-test-eholdings-remove-resource-from-holdings]');
   clickCancel = clickable('.tether-element [data-test-eholdings-resource-cancel-action]');
 }
 

--- a/test/bigtest/tests/custom-resource-edit-selection-test.js
+++ b/test/bigtest/tests/custom-resource-edit-selection-test.js
@@ -57,11 +57,11 @@ describe('CustomResourceHoldingSelection', () => {
 
     describe('deselecting a custom resource', () => {
       describe('when the package has more than 1 title', () => {
-        beforeEach(function () {
+        beforeEach(async function () {
           providerPackage.titleCount = 20;
           this.visit(`/eholdings/resources/${resource.titleId}/edit`);
 
-          return ResourceEditPage
+          await ResourceEditPage
             .dropDown.clickDropDownButton()
             .dropDownMenu.clickRemoveFromHoldings();
         });
@@ -74,11 +74,11 @@ describe('CustomResourceHoldingSelection', () => {
       });
 
       describe('when deselecting the last title in the package', () => {
-        beforeEach(function () {
+        beforeEach(async function () {
           providerPackage.titleCount = 1;
           this.visit(`/eholdings/resources/${resource.titleId}/edit`);
 
-          return ResourceEditPage
+          await ResourceEditPage
             .dropDown.clickDropDownButton()
             .dropDownMenu.clickRemoveFromHoldings();
         });

--- a/test/bigtest/tests/resource-deselection-test.js
+++ b/test/bigtest/tests/resource-deselection-test.js
@@ -59,10 +59,10 @@ describe('ResourceDeselection', () => {
       });
 
       describe('deselecting custom title', () => {
-        beforeEach(function () {
+        beforeEach(async function () {
           title.isTitleCustom = true;
           this.visit(`/eholdings/resources/${resource.id}`);
-          return ResourcePage.dropDownMenu.clickRemoveFromHoldings();
+          await ResourcePage.dropDownMenu.clickRemoveFromHoldings();
         });
 
         describe('deselection modal', () => {

--- a/test/bigtest/tests/resource-deselection-test.js
+++ b/test/bigtest/tests/resource-deselection-test.js
@@ -46,13 +46,29 @@ describe('ResourceDeselection', () => {
         expect(ResourcePage.isResourceSelected).to.equal('Selected');
       });
 
-      describe('deselecting', () => {
+      describe('deselecting managed title', () => {
         beforeEach(() => {
           return ResourcePage.dropDownMenu.clickRemoveFromHoldings();
         });
 
-        it('warns the user they are deselecting the final title in the package', () => {
-          expect(ResourcePage.deselectionModal.hasDeselectTitleWarning).to.be.true;
+        describe('deselection modal', () => {
+          it('warns the user they are deselecting a title', () => {
+            expect(ResourcePage.deselectionModal.hasDeselectTitleWarning).to.be.true;
+          });
+        });
+      });
+
+      describe('deselecting custom title', () => {
+        beforeEach(function () {
+          title.isTitleCustom = true;
+          this.visit(`/eholdings/resources/${resource.id}`);
+          return ResourcePage.dropDownMenu.clickRemoveFromHoldings();
+        });
+
+        describe('deselection modal', () => {
+          it('warns the user they are deselecting the final title in the package', () => {
+            expect(ResourcePage.deselectionModal.hasDeselectFinalTitleWarning).to.be.true;
+          });
         });
       });
     });


### PR DESCRIPTION
Currently, when trying to remove a title, a warning message is always saying that we are going to delete the last title in the package, even if there are other titles in the package. The PR fixes this behavior.
[Related story](https://issues.folio.org/browse/UIEH-595)