### PR TITLE
UIEH:584: Issue with package selection when creating custom title

### DIFF
--- a/src/components/title/_fields/package-select/package-select-field.js
+++ b/src/components/title/_fields/package-select/package-select-field.js
@@ -31,7 +31,7 @@ function PackageSelectField({ options }) {
             )}
           </FormattedMessage>
         )}
-        {options.map(({ disabled, label, value }) => (
+        {options.filter(option => option.label !== '').map(({ disabled, label, value }) => (
           <option disabled={disabled} key={value} value={value}>{label}</option>
         ))}
       </Field>

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -76,7 +76,7 @@ class PackageCreateRoute extends Component {
 
 export default connect(
   ({ eholdings: { data } }) => ({
-    createRequest: createResolver(data).getRequest('create', { type: 'packages' })
+    createRequest: createResolver(data).getRequest('create', { type: 'packages', pageSize: 100 })
   }), {
     createPackage: attrs => Package.create(attrs)
   }

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -92,14 +92,16 @@ export default connect(
       createRequest: resolver.getRequest('create', { type: 'titles' }),
       customPackages: resolver.query('packages', {
         filter: { custom: true },
-        count: 100
+        count: 100,
+        pageSize: 100,
       })
     };
   }, {
     createTitle: attrs => Title.create(attrs),
     getCustomPackages: () => Package.query({
       filter: { custom: true },
-      count: 100
+      count: 100,
+      pageSize: 100,
     })
   }
 )(TitleCreateRoute);


### PR DESCRIPTION
## Purpose
In UIEH, when user navigates to create a new title -> for example -> https://folio.frontside.io/eholdings/titles/new, they should be able to "Choose a package" to associate the creation of this title with a package. The drop down to choose a package has issues in populating the list. 

Populating with the empty fields was associated to the fact that the count of records was bigger than the page size and was no filtering for the empty records.

## Approach
Basically filtering of the empty records was added and increased the page size to 100

#### TODOS and Open Questions
As already discussed with Khalilah it is a temporary solution. The new component for the dropdown select should be developed that will support pagination and filtering.

## Screenshots
![2019-01-09 10 31 27](https://user-images.githubusercontent.com/15856488/50886855-41e83700-13fa-11e9-965c-741acc8ee76d.gif)
