### PR TITLE
UIEH-600: Results list displays space html code

### DIFF
--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -56,9 +56,6 @@ function TitleListItem({
               {item.publicationType}
             </span>
           )}
-          {item.publicationType && item.publisherName &&
-            '&nbsp;&bull;&nbsp;'
-          }
           {item.publisherName && (
             <span>
               &nbsp;&bull;&nbsp;


### PR DESCRIPTION
## Purpose
Cleared up non necessary space html code separator in the title list item.

## Screenshots
![2019-01-09 10 45 55](https://user-images.githubusercontent.com/15856488/50887599-4ada0800-13fc-11e9-9f9f-d3ed9958c5ef.gif)

