### PR TITLE
UIEH-605 Use React Final Form for provider edit

### DIFF
--- a/src/components/provider/_fields/proxy-select/index.js
+++ b/src/components/provider/_fields/proxy-select/index.js
@@ -1,0 +1,1 @@
+export { default } from './proxy-select-field';

--- a/src/components/provider/_fields/proxy-select/proxy-select-field.css
+++ b/src/components/provider/_fields/proxy-select/proxy-select-field.css
@@ -1,0 +1,3 @@
+.proxy-select-field {
+  max-width: 50em;
+}

--- a/src/components/provider/_fields/proxy-select/proxy-select-field.js
+++ b/src/components/provider/_fields/proxy-select/proxy-select-field.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Field } from 'react-final-form';
+import { FormattedMessage } from 'react-intl';
+
+import { Select } from '@folio/stripes/components';
+import styles from './proxy-select-field.css';
+
+function ProxySelectField({ proxyTypes, inheritedProxyId }) {
+  let proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
+
+  let checkIfInherited = proxyTypeId => (inheritedProxyId && inheritedProxyId.toLowerCase() === proxyTypeId.toLowerCase());
+
+  let options = [];
+
+  options = proxyTypesRecords && Object.values(proxyTypesRecords)
+    .map(proxyType => (
+      <FormattedMessage
+        key={proxyType.id}
+        id="ui-eholdings.proxy.inherited"
+        values={{
+          proxy: proxyType.attributes.name
+        }}
+      >
+        {(message) => (
+          <option value={proxyType.id}>
+            {checkIfInherited(proxyType.id) ? message : `${proxyType.attributes.name}`}
+          </option>
+        )}
+      </FormattedMessage>
+    ));
+
+  return (
+    <div
+      data-test-eholdings-proxy-select-field
+      className={styles['proxy-select-field']}
+    >
+      <Field
+        id="eholdings-proxy-id"
+        name="proxyId"
+        component={Select}
+        label={<FormattedMessage id="ui-eholdings.proxy" />}
+        disabled={options.length < 2}
+      >
+        {options}
+      </Field>
+    </div>
+  );
+}
+
+ProxySelectField.propTypes = {
+  inheritedProxyId: PropTypes.string.isRequired,
+  proxyTypes: PropTypes.object.isRequired
+};
+
+export default ProxySelectField;

--- a/src/components/provider/_fields/token/index.js
+++ b/src/components/provider/_fields/token/index.js
@@ -1,0 +1,1 @@
+export { default } from './token-field';

--- a/src/components/provider/_fields/token/token-field.js
+++ b/src/components/provider/_fields/token/token-field.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form';
+import { Field } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 
 import {

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { reduxForm } from 'redux-form';
+import { Form } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 import {
   Button,
@@ -13,22 +13,20 @@ import DetailsView from '../../details-view';
 import DetailsViewSection from '../../details-view-section';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
-import ProxySelectField from '../../proxy-select';
-import TokenField from '../../token';
+import ProxySelectField from '../_fields/proxy-select';
+import TokenField from '../_fields/token';
 import PaneHeaderButton from '../../pane-header-button';
 import FullViewLink from '../../full-view-link';
 
-class ProviderEdit extends Component {
+export default class ProviderEdit extends Component {
   static propTypes = {
     fullViewLink: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object
     ]),
-    handleSubmit: PropTypes.func,
     model: PropTypes.object.isRequired,
     onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
-    pristine: PropTypes.bool,
     proxyTypes: PropTypes.object.isRequired,
     rootProxy: PropTypes.object.isRequired
   };
@@ -64,84 +62,85 @@ class ProviderEdit extends Component {
       model,
       proxyTypes,
       rootProxy,
-      handleSubmit,
       onSubmit,
-      pristine,
     } = this.props;
 
     let supportsTokens = model.providerToken && model.providerToken.prompt;
     let hasTokenValue = model.providerToken && model.providerToken.value;
 
     return (
-      <Fragment>
-        <Toaster toasts={processErrors(model)} position="bottom" />
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <DetailsView
-            type="provider"
-            model={model}
-            key={model.id}
-            paneTitle={model.name}
-            actionMenu={this.getActionMenu}
-            lastMenu={(
-              <Fragment>
-                {model.update.isPending && (
-                <Icon icon="spinner-ellipsis" />
-                )}
-                <PaneHeaderButton
-                  disabled={pristine || model.update.isPending}
-                  type="submit"
-                  buttonStyle="primary"
-                  data-test-eholdings-provider-save-button
-                >
-                  {model.update.isPending ?
-                    (<FormattedMessage id="ui-eholdings.saving" />)
-                    :
-                    (<FormattedMessage id="ui-eholdings.save" />)}
-                </PaneHeaderButton>
-              </Fragment>
-          )}
-            bodyContent={(
-              <Fragment>
-                <DetailsViewSection
-                  label={<FormattedMessage id="ui-eholdings.provider.providerSettings" />}
-                >
-                  {model.packagesSelected > 0 ? (
-                    <div>
-                      {(!proxyTypes.request.isResolved || !rootProxy.request.isResolved) ? (
-                        <Icon icon="spinner-ellipsis" />
+      <Form
+        onSubmit={onSubmit}
+        initialValues={{
+          proxyId: model.proxy.id,
+          providerTokenValue: model.providerToken.value
+        }}
+        render={({ handleSubmit, pristine }) => (
+          <Fragment>
+            <Toaster toasts={processErrors(model)} position="bottom" />
+            <form onSubmit={handleSubmit}>
+              <DetailsView
+                type="provider"
+                model={model}
+                key={model.id}
+                paneTitle={model.name}
+                actionMenu={this.getActionMenu}
+                lastMenu={(
+                  <Fragment>
+                    {model.update.isPending && (
+                    <Icon icon="spinner-ellipsis" />
+                    )}
+                    <PaneHeaderButton
+                      disabled={pristine || model.update.isPending}
+                      type="submit"
+                      buttonStyle="primary"
+                      data-test-eholdings-provider-save-button
+                    >
+                      {model.update.isPending ?
+                        (<FormattedMessage id="ui-eholdings.saving" />)
+                        :
+                        (<FormattedMessage id="ui-eholdings.save" />)}
+                    </PaneHeaderButton>
+                  </Fragment>
+              )}
+                bodyContent={(
+                  <Fragment>
+                    <DetailsViewSection
+                      label={<FormattedMessage id="ui-eholdings.provider.providerSettings" />}
+                    >
+                      {model.packagesSelected > 0 ? (
+                        <div>
+                          {(!proxyTypes.request.isResolved || !rootProxy.request.isResolved) ? (
+                            <Icon icon="spinner-ellipsis" />
+                          ) : (
+                            <div data-test-eholdings-provider-proxy-select>
+                              <ProxySelectField proxyTypes={proxyTypes} inheritedProxyId={rootProxy.data.attributes.proxyTypeId} />
+                            </div>
+                          )}
+
+                          {supportsTokens && (
+                            <fieldset>
+                              <Headline tag="legend">
+                                <FormattedMessage id="ui-eholdings.provider.token" />
+                              </Headline>
+                              <TokenField token={model.providerToken} tokenValue={hasTokenValue} type="provider" />
+                            </fieldset>
+                          )}
+                        </div>
                       ) : (
-                        <div data-test-eholdings-provider-proxy-select>
-                          <ProxySelectField proxyTypes={proxyTypes} inheritedProxyId={rootProxy.data.attributes.proxyTypeId} />
+                        <div data-test-eholdings-provider-package-not-selected>
+                          <FormattedMessage id="ui-eholdings.provider.noPackagesSelected" />
                         </div>
                       )}
-
-                      {supportsTokens && (
-                        <fieldset>
-                          <Headline tag="legend">
-                            <FormattedMessage id="ui-eholdings.provider.token" />
-                          </Headline>
-                          <TokenField token={model.providerToken} tokenValue={hasTokenValue} type="provider" />
-                        </fieldset>
-                      )}
-                    </div>
-                  ) : (
-                    <div data-test-eholdings-provider-package-not-selected>
-                      <FormattedMessage id="ui-eholdings.provider.noPackagesSelected" />
-                    </div>
-                  )}
-                </DetailsViewSection>
-              </Fragment>
-            )}
-          />
-        </form>
-        <NavigationModal when={!pristine && !model.update.isPending} />
-      </Fragment>
+                    </DetailsViewSection>
+                  </Fragment>
+                )}
+              />
+            </form>
+            <NavigationModal when={!pristine && !model.update.isPending} />
+          </Fragment>
+        )}
+      />
     );
   }
 }
-
-export default reduxForm({
-  enableReinitialize: true,
-  form: 'ProviderEdit',
-  destroyOnUnmount: false,
-})(ProviderEdit);

--- a/src/components/token/token-field.css
+++ b/src/components/token/token-field.css
@@ -1,1 +1,0 @@
-@import '@folio/stripes-components/lib/variables';

--- a/src/routes/provider-edit.js
+++ b/src/routes/provider-edit.js
@@ -78,10 +78,6 @@ class ProviderEditRoute extends Component {
             search: location.search,
             state: { eholdings: true }
           })}
-          initialValues={{
-            proxyId: model.proxy.id,
-            providerTokenValue: model.providerToken.value
-          }}
           proxyTypes={proxyTypes}
           rootProxy={rootProxy}
           fullViewLink={searchType && {


### PR DESCRIPTION
## Purpose
Switches provider edit form to use React Final Form instead of Redux Form. Part of https://issues.folio.org/browse/UIEH-605.

## Approach
- Temporarily duplicated `ProxySelectField` and `TokenField` into `provider` directory. When resources and packages are also switched over to React Final Form, we can DRY that back up.
- Stripped CSS out of `TokenField`, since it was just classes with no styles defined.