### PR TITLE
UIEH-597: Change english translation for validate.errors.customPackag…

### DIFF
--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -239,7 +239,7 @@
     "validate.errors.customTitle.name.length": "Must be less than 400 characters.",
     "validate.errors.title.description.length": "The value entered exceeds the 1500 character limit. Please enter a value that does not exceed 1500 characters.",
     "validate.errors.customPackage.name": "Custom packages must have a name.",
-    "validate.errors.customPackage.name.length": "Must be less than {amount} characters.",
+    "validate.errors.customPackage.name.length": "Must not exceed {amount} characters.",
     "validate.errors.coverageStatement.length": "Statement must be 350 characters or less.",
     "validate.errors.coverageStatement.blank": "Statement field cannot be blank if selected.",
 


### PR DESCRIPTION
## Purpose
[UIEH-597](https://issues.folio.org/browse/UIEH-597): change error message from "Must be less than 200 characters." to "Must not exceed 200 characters."

## Approach
- change English translation