### PR TITLE
UIEH-605 Use React Final Form with packages

### DIFF
--- a/src/components/package/_fields/content-type/package-content-type-field.js
+++ b/src/components/package/_fields/content-type/package-content-type-field.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Field } from 'redux-form';
+import { Field } from 'react-final-form';
 
 import { Select } from '@folio/stripes/components';
 

--- a/src/components/package/_fields/custom-coverage/index.js
+++ b/src/components/package/_fields/custom-coverage/index.js
@@ -1,1 +1,1 @@
-export { default, validate } from './package-coverage-fields';
+export { default } from './package-coverage-fields';

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
-import { Field, FieldArray } from 'redux-form';
-import PropTypes from 'prop-types';
+import { Field } from 'react-final-form';
+import { FieldArray } from 'react-final-form-arrays';
 import moment from 'moment';
 import {
   FormattedMessage,
@@ -18,13 +18,28 @@ import styles from './package-coverage-fields.css';
 
 class PackageCoverageFields extends Component {
   static propTypes = {
-    initial: PropTypes.array,
     intl: intlShape,
   };
 
-  static defaultProps = {
-    initial: [],
-  };
+  validateDateRange = (values) => {
+    const errorArray = [];
+
+    values.forEach(({ beginCoverage, endCoverage }) => {
+      const errors = {};
+
+      if (endCoverage && !moment.utc(endCoverage).isAfter(moment.utc(beginCoverage))) {
+        errors.beginCoverage = <FormattedMessage id="ui-eholdings.validate.errors.dateRange.startDateBeforeEndDate" />;
+      }
+
+      errorArray.push(errors);
+    });
+
+    if (errorArray.some(object => Object.keys(object).length)) {
+      return errorArray;
+    } else {
+      return undefined;
+    }
+  }
 
   validateCoverageDate = (value) => {
     const { intl } = this.props;
@@ -79,9 +94,7 @@ class PackageCoverageFields extends Component {
     );
   }
 
-  renderRepeatableField = ({ fields, name }) => {
-    const { initial } = this.props;
-
+  renderRepeatableField = ({ fields, name, meta: { initial } }) => {
     const hasAddButton = fields.length === 0 || (fields.length === 1 && !initial[0]);
     const hasEmptyMessage = initial.length > 0 && initial[0].beginCoverage;
     const addLabel = hasAddButton
@@ -111,6 +124,7 @@ class PackageCoverageFields extends Component {
         <FieldArray
           component={this.renderRepeatableField}
           name="customCoverages"
+          validate={this.validateDateRange}
         />
       </div>
     );
@@ -118,22 +132,3 @@ class PackageCoverageFields extends Component {
 }
 
 export default injectIntl(PackageCoverageFields);
-
-export function validate(values) {
-  let errors = {};
-
-  values.customCoverages.forEach((dateRange, index) => {
-    let dateRangeErrors = {};
-
-    const isCorrectDateCoverage = dateRange.endCoverage
-      && moment.utc(dateRange.beginCoverage).isAfter(moment.utc(dateRange.endCoverage));
-
-    if (isCorrectDateCoverage) {
-      dateRangeErrors.beginCoverage = <FormattedMessage id="ui-eholdings.validate.errors.dateRange.startDateBeforeEndDate" />;
-    }
-
-    errors[index] = dateRangeErrors;
-  });
-
-  return { customCoverages: errors };
-}

--- a/src/components/package/_fields/name/package-name-field.js
+++ b/src/components/package/_fields/name/package-name-field.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Field } from 'redux-form';
+import { Field } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 
 import { TextField } from '@folio/stripes/components';
@@ -9,11 +9,11 @@ const MAX_CHARACTER_LENGTH = 200;
 const validate = (value) => {
   let errors;
 
-  if (value === '') {
+  if (!value) {
     errors = <FormattedMessage id="ui-eholdings.validate.errors.customPackage.name" />;
   }
 
-  if (value.length >= MAX_CHARACTER_LENGTH) {
+  if (value && value.length >= MAX_CHARACTER_LENGTH) {
     errors = (
       <FormattedMessage
         id="ui-eholdings.validate.errors.customPackage.name.length"

--- a/src/components/package/_fields/proxy-select/index.js
+++ b/src/components/package/_fields/proxy-select/index.js
@@ -1,0 +1,1 @@
+export { default } from './proxy-select-field';

--- a/src/components/package/_fields/proxy-select/proxy-select-field.js
+++ b/src/components/package/_fields/proxy-select/proxy-select-field.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form';
+import { Field } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 
 import { Select } from '@folio/stripes/components';

--- a/src/components/package/_fields/token/index.js
+++ b/src/components/package/_fields/token/index.js
@@ -1,0 +1,1 @@
+export { default } from './token-field';

--- a/src/components/package/_fields/token/token-field.js
+++ b/src/components/package/_fields/token/token-field.js
@@ -1,0 +1,77 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Field } from 'react-final-form';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Button,
+  Icon,
+  TextArea
+} from '@folio/stripes/components';
+
+export default class TokenField extends Component {
+  static propTypes = {
+    token: PropTypes.object,
+    tokenValue: PropTypes.string,
+    type: PropTypes.string
+  };
+
+  state = {
+    showInputs: this.props.tokenValue
+  };
+
+  toggleInputs = () => {
+    this.setState(({ showInputs }) => ({
+      showInputs: !showInputs
+    }));
+  }
+
+  validate(value) {
+    return value && value.length > 500 ? (
+      <FormattedMessage id="ui-eholdings.validate.errors.token.length" />
+    ) : undefined;
+  }
+
+  render() {
+    /* eslint-disable react/no-danger */
+    let { token, type } = this.props;
+    let { showInputs } = this.state;
+    let helpTextMarkup = { __html: token.helpText };
+
+    return (showInputs) ? (
+      <div>
+        <div
+          data-test-eholdings-token-fields-help-text={type}
+          dangerouslySetInnerHTML={helpTextMarkup}
+        />
+        <div data-test-eholdings-token-fields-prompt={type}>
+          {token.prompt}
+        </div>
+        <div data-test-eholdings-token-value-textarea={type}>
+          {type === 'provider' ? (
+            <Field name="providerTokenValue" component={TextArea} validate={this.validate} />
+          ) : (
+            <Field name="packageTokenValue" component={TextArea} validate={this.validate} />
+          )}
+        </div>
+      </div>
+    ) : (
+      <div
+        data-test-eholdings-token-add-button={type}
+      >
+        <Button
+          type="button"
+          onClick={this.toggleInputs}
+        >
+          <Icon icon="plus-sign">
+            {type === 'provider' ? (
+              <FormattedMessage id="ui-eholdings.provider.token.addToken" />
+            ) : (
+              <FormattedMessage id="ui-eholdings.package.token.addToken" />
+            )}
+          </Icon>
+        </Button>
+      </div>
+    );
+  }
+}

--- a/src/components/package/edit-custom/custom-package-edit.css
+++ b/src/components/package/edit-custom/custom-package-edit.css
@@ -1,7 +1,3 @@
 .visibility-radios {
-  margin-top: 2em;
-
-  & fieldset {
-    padding: 0;
-  }
+  margin: 1em 0;
 }

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -1,6 +1,10 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { reduxForm, Field } from 'redux-form';
+import {
+  Field,
+  Form
+} from 'react-final-form';
+import arrayMutators from 'final-form-arrays';
 import { FormattedMessage } from 'react-intl';
 
 import {
@@ -12,37 +16,33 @@ import {
   Modal,
   ModalFooter,
   RadioButton,
-  RadioButtonGroup
 } from '@folio/stripes/components';
 
 import { processErrors } from '../../utilities';
 
 import DetailsView from '../../details-view';
 import NameField from '../_fields/name';
-import CoverageFields, { validate as validateCoverageDates } from '../_fields/custom-coverage';
+import CoverageFields from '../_fields/custom-coverage';
 import ContentTypeField from '../_fields/content-type';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 import PaneHeaderButton from '../../pane-header-button';
 import SelectionStatus from '../selection-status';
-import ProxySelectField from '../../proxy-select';
+import ProxySelectField from '../_fields/proxy-select';
 import FullViewLink from '../../full-view-link';
 import styles from './custom-package-edit.css';
 
-class CustomPackageEdit extends Component {
+export default class CustomPackageEdit extends Component {
   static propTypes = {
     addPackageToHoldings: PropTypes.func.isRequired,
-    change: PropTypes.func,
     fullViewLink: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object
     ]),
-    handleSubmit: PropTypes.func,
     initialValues: PropTypes.object.isRequired,
     model: PropTypes.object.isRequired,
     onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
-    pristine: PropTypes.bool,
     provider: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired
   };
@@ -94,12 +94,12 @@ class CustomPackageEdit extends Component {
     }, () => { this.handleOnSubmit(this.state.formValues); });
   };
 
-  cancelSelectionToggle = () => {
+  cancelSelectionToggle = (change) => {
     this.setState({
       showSelectionModal: false,
       packageSelected: true,
     }, () => {
-      this.props.change('isSelected', true);
+      change('isSelected', true);
     });
   };
 
@@ -192,8 +192,6 @@ class CustomPackageEdit extends Component {
     let {
       model,
       initialValues,
-      handleSubmit,
-      pristine,
       proxyTypes,
       provider
     } = this.props;
@@ -207,182 +205,196 @@ class CustomPackageEdit extends Component {
     let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
 
     return (
-      <div>
-        <Toaster toasts={processErrors(model)} position="bottom" />
-        <form onSubmit={handleSubmit(this.handleOnSubmit)}>
-          <DetailsView
-            type="package"
-            model={model}
-            paneTitle={model.name}
-            actionMenu={this.getActionMenu}
-            handleExpandAll={this.toggleAllSections}
-            sections={sections}
-            lastMenu={(
-              <Fragment>
-                {model.update.isPending && (
-                  <Icon icon="spinner-ellipsis" />
+      <Form
+        onSubmit={this.handleOnSubmit}
+        mutators={{ ...arrayMutators }}
+        initialValues={initialValues}
+        render={({ handleSubmit, pristine, form: { change } }) => (
+          <div>
+            <Toaster toasts={processErrors(model)} position="bottom" />
+            <form onSubmit={handleSubmit}>
+              <DetailsView
+                type="package"
+                model={model}
+                paneTitle={model.name}
+                actionMenu={this.getActionMenu}
+                handleExpandAll={this.toggleAllSections}
+                sections={sections}
+                lastMenu={(
+                  <Fragment>
+                    {model.update.isPending && (
+                      <Icon icon="spinner-ellipsis" />
+                    )}
+                    <PaneHeaderButton
+                      disabled={pristine || model.update.isPending}
+                      type="submit"
+                      buttonStyle="primary"
+                      data-test-eholdings-package-save-button
+                    >
+                      {model.update.isPending ?
+                        (<FormattedMessage id="ui-eholdings.saving" />)
+                        :
+                        (<FormattedMessage id="ui-eholdings.save" />)}
+                    </PaneHeaderButton>
+                  </Fragment>
                 )}
-                <PaneHeaderButton
-                  disabled={pristine || model.update.isPending}
-                  type="submit"
-                  buttonStyle="primary"
-                  data-test-eholdings-package-save-button
-                >
-                  {model.update.isPending ?
-                    (<FormattedMessage id="ui-eholdings.saving" />)
-                    :
-                    (<FormattedMessage id="ui-eholdings.save" />)}
-                </PaneHeaderButton>
-              </Fragment>
-            )}
-            bodyContent={(
-              <Fragment>
-                <Accordion
-                  label={this.getSectionHeader('ui-eholdings.label.holdingStatus')}
-                  open={sections.packageHoldingStatus}
-                  id="packageHoldingStatus"
-                  onToggle={this.toggleSection}
-                >
-                  <SelectionStatus
-                    model={model}
-                    onAddToHoldings={this.props.addPackageToHoldings}
-                  />
-                </Accordion>
+                bodyContent={(
+                  <Fragment>
+                    <Accordion
+                      label={this.getSectionHeader('ui-eholdings.label.holdingStatus')}
+                      open={sections.packageHoldingStatus}
+                      id="packageHoldingStatus"
+                      onToggle={this.toggleSection}
+                    >
+                      <SelectionStatus
+                        model={model}
+                        onAddToHoldings={this.props.addPackageToHoldings}
+                      />
+                    </Accordion>
 
-                <Accordion
-                  label={this.getSectionHeader('ui-eholdings.label.packageInformation')}
-                  open={sections.packageInfo}
-                  id="packageInfo"
-                  onToggle={this.toggleSection}
-                >
-                  {packageSelected ? (
-                    <NameField />
-                  ) : (
-                    <KeyValue label={<FormattedMessage id="ui-eholdings.package.name" />}>
-                      <div data-test-eholdings-package-readonly-name-field>
-                        {model.name}
-                      </div>
-                    </KeyValue>
-                  )}
+                    <Accordion
+                      label={this.getSectionHeader('ui-eholdings.label.packageInformation')}
+                      open={sections.packageInfo}
+                      id="packageInfo"
+                      onToggle={this.toggleSection}
+                    >
+                      {packageSelected ? (
+                        <NameField />
+                      ) : (
+                        <KeyValue label={<FormattedMessage id="ui-eholdings.package.name" />}>
+                          <div data-test-eholdings-package-readonly-name-field>
+                            {model.name}
+                          </div>
+                        </KeyValue>
+                      )}
 
-                  {packageSelected ? (
-                    <ContentTypeField />
-                  ) : (
-                    <KeyValue label={<FormattedMessage id="ui-eholdings.package.contentType" />}>
-                      <div data-test-eholdings-package-details-readonly-content-type>
-                        {model.contentType}
-                      </div>
-                    </KeyValue>
-                  )}
-                </Accordion>
+                      {packageSelected ? (
+                        <ContentTypeField />
+                      ) : (
+                        <KeyValue label={<FormattedMessage id="ui-eholdings.package.contentType" />}>
+                          <div data-test-eholdings-package-details-readonly-content-type>
+                            {model.contentType}
+                          </div>
+                        </KeyValue>
+                      )}
+                    </Accordion>
 
-                <Accordion
-                  label={this.getSectionHeader('ui-eholdings.package.packageSettings')}
-                  open={sections.packageSettings}
-                  id="packageSettings"
-                  onToggle={this.toggleSection}
-                >
-                  {packageSelected ? (
-                    <div className={styles['visibility-radios']}>
-                      {this.props.initialValues.isVisible != null ? (
-                        <Fragment>
-                          <div data-test-eholdings-package-visibility-field>
-                            <Field
-                              label={<FormattedMessage id="ui-eholdings.package.visibility" />}
-                              name="isVisible"
-                              component={RadioButtonGroup}
+                    <Accordion
+                      label={this.getSectionHeader('ui-eholdings.package.packageSettings')}
+                      open={sections.packageSettings}
+                      id="packageSettings"
+                      onToggle={this.toggleSection}
+                    >
+                      {packageSelected ? (
+                        <div className={styles['visibility-radios']}>
+                          {this.props.initialValues.isVisible != null ? (
+                            <fieldset
+                              data-test-eholdings-package-visibility-field
+                              className={styles['visibility-radios']}
                             >
-                              <RadioButton label={<FormattedMessage id="ui-eholdings.yes" />} value="true" />
-                              <RadioButton
+                              <Headline tag="legend" size="small" margin="x-large">
+                                <FormattedMessage id="ui-eholdings.package.visibility" />
+                              </Headline>
+
+                              <Field
+                                component={RadioButton}
+                                format={value => value.toString()}
+                                label={<FormattedMessage id="ui-eholdings.yes" />}
+                                name="isVisible"
+                                parse={value => value === 'true'}
+                                type="radio"
+                                value="true"
+                              />
+
+                              <Field
+                                component={RadioButton}
+                                format={value => value.toString()}
                                 label={
                                   <FormattedMessage
                                     id="ui-eholdings.package.visibility.no"
                                     values={{ visibilityMessage }}
                                   />
                                 }
+                                name="isVisible"
+                                parse={value => value === 'true'}
+                                type="radio"
                                 value="false"
                               />
-                            </Field>
-                          </div>
-                        </Fragment>
-                      ) : (
-                        <div
-                          data-test-eholdings-package-details-visibility
-                          htmlFor="managed-package-details-visibility-switch"
-                        >
-                          <Icon icon="spinner-ellipsis" />
+
+                            </fieldset>
+                          ) : (
+                            <div
+                              data-test-eholdings-package-details-visibility
+                              htmlFor="managed-package-details-visibility-switch"
+                            >
+                              <Icon icon="spinner-ellipsis" />
+                            </div>
+
+                          )}
+                          {(proxyTypes.request.isResolved && provider.data.isLoaded) ? (
+                            <div data-test-eholdings-package-proxy-select-field>
+                              <ProxySelectField
+                                proxyTypes={proxyTypes}
+                                inheritedProxyId={provider.proxy.id}
+                              />
+                            </div>
+                          ) : (
+                            <Icon icon="spinner-ellipsis" />
+                          )}
                         </div>
-
-                      )}
-                      {(proxyTypes.request.isResolved && provider.data.isLoaded) ? (
-                        <div data-test-eholdings-package-proxy-select-field>
-                          <ProxySelectField
-                            proxyTypes={proxyTypes}
-                            inheritedProxyId={provider.proxy.id}
-                          />
-                        </div>
                       ) : (
-                        <Icon icon="spinner-ellipsis" />
+                        <p><FormattedMessage id="ui-eholdings.package.packageSettings.notSelected" /></p>
                       )}
-                    </div>
-                  ) : (
-                    <p><FormattedMessage id="ui-eholdings.package.packageSettings.notSelected" /></p>
-                  )}
-                </Accordion>
+                    </Accordion>
 
-                <Accordion
-                  label={this.getSectionHeader('ui-eholdings.package.coverageSettings')}
-                  open={sections.packageCoverageSettings}
-                  id="packageCoverageSettings"
-                  onToggle={this.toggleSection}
-                >
-                  {packageSelected ? (
-                    <CoverageFields
-                      initial={initialValues.customCoverages}
-                    />) : (
-                      <p><FormattedMessage id="ui-eholdings.package.customCoverage.notSelected" /></p>
-                  )}
-                </Accordion>
-              </Fragment>
-            )}
-          />
-        </form>
+                    <Accordion
+                      label={this.getSectionHeader('ui-eholdings.package.coverageSettings')}
+                      open={sections.packageCoverageSettings}
+                      id="packageCoverageSettings"
+                      onToggle={this.toggleSection}
+                    >
+                      {packageSelected ? (
+                        <CoverageFields
+                          initial={initialValues.customCoverages}
+                        />) : (
+                          <p><FormattedMessage id="ui-eholdings.package.customCoverage.notSelected" /></p>
+                      )}
+                    </Accordion>
+                  </Fragment>
+                )}
+              />
+            </form>
 
-        <NavigationModal when={!pristine && !model.update.isPending} />
+            <NavigationModal when={!pristine && !model.update.isPending} />
 
-        <Modal
-          open={showSelectionModal}
-          size="small"
-          label={<FormattedMessage id="ui-eholdings.package.modal.header.isCustom" />}
-          id="eholdings-package-confirmation-modal"
-          footer={(
-            <ModalFooter
-              primaryButton={{
-                'label': model.destroy.isPending ?
-                  <FormattedMessage id="ui-eholdings.package.modal.buttonWorking.isCustom" /> :
-                  <FormattedMessage id="ui-eholdings.package.modal.buttonConfirm.isCustom" />,
-                'onClick': this.commitSelectionToggle,
-                'disabled': model.destroy.isPending,
-                'data-test-eholdings-package-deselection-confirmation-modal-yes': true
-              }}
-              secondaryButton={{
-                'label': <FormattedMessage id="ui-eholdings.package.modal.buttonCancel.isCustom" />,
-                'onClick': this.cancelSelectionToggle,
-                'data-test-eholdings-package-deselection-confirmation-modal-no': true
-              }}
-            />
-          )}
-        >
-          <FormattedMessage id="ui-eholdings.package.modal.body.isCustom" />
-        </Modal>
-      </div>
+            <Modal
+              open={showSelectionModal}
+              size="small"
+              label={<FormattedMessage id="ui-eholdings.package.modal.header.isCustom" />}
+              id="eholdings-package-confirmation-modal"
+              footer={(
+                <ModalFooter
+                  primaryButton={{
+                    'label': model.destroy.isPending ?
+                      <FormattedMessage id="ui-eholdings.package.modal.buttonWorking.isCustom" /> :
+                      <FormattedMessage id="ui-eholdings.package.modal.buttonConfirm.isCustom" />,
+                    'onClick': this.commitSelectionToggle,
+                    'disabled': model.destroy.isPending,
+                    'data-test-eholdings-package-deselection-confirmation-modal-yes': true
+                  }}
+                  secondaryButton={{
+                    'label': <FormattedMessage id="ui-eholdings.package.modal.buttonCancel.isCustom" />,
+                    'onClick': () => this.cancelSelectionToggle(change),
+                    'data-test-eholdings-package-deselection-confirmation-modal-no': true
+                  }}
+                />
+              )}
+            >
+              <FormattedMessage id="ui-eholdings.package.modal.body.isCustom" />
+            </Modal>
+          </div>
+        )}
+      />
     );
   }
 }
-
-export default reduxForm({
-  validate: validateCoverageDates,
-  form: 'CustomPackageEdit',
-  enableReinitialize: true,
-  destroyOnUnmount: false,
-})(CustomPackageEdit);

--- a/src/components/package/edit-managed/managed-package-edit.css
+++ b/src/components/package/edit-managed/managed-package-edit.css
@@ -1,8 +1,4 @@
 .visibility-radios,
 .title-management-radios {
-  margin-top: 2em;
-
-  & fieldset {
-    padding: 0;
-  }
+  margin: 1em 0;
 }

--- a/src/components/proxy-select/proxy-select-field.css
+++ b/src/components/proxy-select/proxy-select-field.css
@@ -1,3 +1,0 @@
-.proxy-select-field {
-  max-width: 50em;
-}

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -69,11 +69,6 @@ class PackageCreateRoute extends Component {
           onSubmit={this.packageCreateSubmitted}
           onCancel={onCancel}
           removeCreateRequests={removeCreateRequests}
-          initialValues={{
-            name: '',
-            contentType: 'Unknown',
-            customCoverages: []
-          }}
         />
       </TitleManager>
     );

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -134,11 +134,11 @@ class PackageEditRoute extends Component {
       }
 
       if ('isVisible' in values) {
-        model.visibilityData.isHidden = !(values.isVisible === 'true'); // turn string into boolean
+        model.visibilityData.isHidden = !values.isVisible;
       }
 
       if ('allowKbToAddTitles' in values) {
-        model.allowKbToAddTitles = values.allowKbToAddTitles === 'true'; // turn string into boolean
+        model.allowKbToAddTitles = values.allowKbToAddTitles;
       }
 
       if ('name' in values) {
@@ -161,6 +161,7 @@ class PackageEditRoute extends Component {
       if ('providerTokenValue' in values) {
         this.providerEditSubmitted(values);
       }
+
       updatePackage(model);
     }
   };


### PR DESCRIPTION
## Purpose
Switches package edit and creation forms to use React Final Form instead of Redux Form. Part of https://issues.folio.org/browse/UIEH-605.

## Approach
- I was able to completely move `validate()` for package coverage dates to be encapsulated in its accompanying component, so it no longer has to be exported and consumed by parent forms. That's a huge architectural win I'm very excited about with `react-final-form` - `<FieldArray>` has a working `validate` prop!
- I had problems using `<RadioButtonGroup>` from `stripes-components` with React Final Form's `<Field>`; instead I just converted the the relevant fields to sets of individual `<Field>`s that have `component` prop `RadioButton`.
- Just like https://github.com/folio-org/ui-eholdings/pull/669, I duplicated the proxy and token fields. I'll DRY that up with the sequel to this PR, moving resource editing to React Final Form.

There are several more simple architectural enhancements that could be made here, but this gets the package forms successfully migrated to React Final Form.

