### PR TITLE
STCOM-405 Remove actionMenuItems prop from Paneset fork

### DIFF
--- a/src/components/paneset/Pane.js
+++ b/src/components/paneset/Pane.js
@@ -79,7 +79,6 @@ export default class Pane extends Component {
   render() {
     const {
       actionMenu,
-      actionMenuItems,
       appIcon,
       aside,
       children,
@@ -169,7 +168,6 @@ export default class Pane extends Component {
                     appIcon={appIcon}
                     firstMenu={firstMenu}
                     lastMenu={lastMenu}
-                    actionMenuItems={actionMenuItems}
                     actionMenu={actionMenu}
                   />
                 </div>


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-405

`actionMenuItems` has been completely replaced by `actionMenu` upstream.