### PR TITLE
UIEH-594: fix bug on setting coverage statement for the first time

### DIFF
--- a/src/redux/resource.js
+++ b/src/redux/resource.js
@@ -10,7 +10,7 @@ class Resource {
   package = belongsTo();
   title = belongsTo();
   isSelected = false;
-  url = '';
+  url = null;
   managedCoverages = [];
   customCoverages = [];
   managedEmbargoPeriod = {};
@@ -31,6 +31,42 @@ class Resource {
   isTitleCustom = false;
   isPeerReviewed = false;
   description = '';
+
+  serialize() {
+    let data = {
+      id: this.id,
+      type: this.type,
+      attributes: {
+        name: this.name,
+        titleId: this.titleId,
+        providerId: this.providerId,
+        providerName: this.providerName,
+        packageId: this.packageId,
+        packageName: this.packageName,
+        isSelected: this.isSelected,
+        url: this.url,
+        managedCoverages: this.managedCoverages,
+        customCoverages: this.customCoverages,
+        managedEmbargoPeriod: this.managedEmbargoPeriod,
+        customEmbargoPeriod: this.customEmbargoPeriod,
+        visibilityData: this.visibilityData,
+        coverageStatement: this.coverageStatement,
+        proxy: this.proxy,
+        publisherName: this.publisherName,
+        edition: this.edition,
+        publicationType: this.publicationType,
+        contentType: this.contentType,
+        subjects: this.subjects,
+        contributors: this.contributors,
+        identifiers: this.identifiers,
+        isTitleCustom: this.isTitleCustom,
+        isPeerReviewed: this.isPeerReviewed,
+        description: this.description,
+      }
+    };
+
+    return { data };
+  }
 }
 
 export default model({


### PR DESCRIPTION
## Purpose
Currently, if mod-kb-ebsco-java module is deployed and we want to set the coverage statement for the first time, the coverage statement field is not included to the request payload.


## Approach
The serialize method from the BaseModel was redefined in the Resource class to include all needed fields to the request payload.