### PR TITLE
UIEH-598: Fixed title create description length

### DIFF
--- a/src/components/title/_fields/description/description-field.js
+++ b/src/components/title/_fields/description/description-field.js
@@ -5,7 +5,7 @@ import { TextArea } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
 function validate(value) {
-  return value && value.length > 1500 ?
+  return value && value.length > 400 ?
     <FormattedMessage id="ui-eholdings.validate.errors.title.description.length" /> : undefined;
 }
 

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -237,7 +237,7 @@
 
     "validate.errors.customTitle.name": "Custom titles must have a name.",
     "validate.errors.customTitle.name.length": "Must be less than 400 characters.",
-    "validate.errors.title.description.length": "The value entered exceeds the 1500 character limit. Please enter a value that does not exceed 1500 characters.",
+    "validate.errors.title.description.length": "The value entered exceeds the 400 character limit. Please enter a value that does not exceed 400 characters.",
     "validate.errors.customPackage.name": "Custom packages must have a name.",
     "validate.errors.customPackage.name.length": "Must not exceed {amount} characters.",
     "validate.errors.coverageStatement.length": "Statement must be 350 characters or less.",


### PR DESCRIPTION
## Purpose
Similarly to https://issues.folio.org/browse/UIEH-597, 
on title creation page (https://folio.frontside.io/eholdings/titles/new), it is possible to input description with length of up to 1500, but KB can only save description with length 400.

Expected behavior:
UI validation shouldn't allow description longer than 400 characters.

Revise error message from 
The value entered exceeds the 1500 character limit. Please enter a value that does not exceed 1500 characters.

TO 
The value entered exceeds the 400 character limit. Please enter a value that does not exceed 400 characters.

## Approach
Changed validation for the description field
Corrected error message

