### PR TITLE
 Use new ModalFooter syntax

### DIFF
--- a/src/components/navigation-modal/navigation-modal.js
+++ b/src/components/navigation-modal/navigation-modal.js
@@ -2,7 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { withRouter } from 'react-router';
-import { Modal, ModalFooter } from '@folio/stripes/components';
+import {
+  Button,
+  Modal,
+  ModalFooter,
+} from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
 class NavigationModal extends Component {
@@ -105,18 +109,21 @@ class NavigationModal extends Component {
           wrappingElement="form"
           onSubmit={this.submit}
           footer={(
-            <ModalFooter
-              primaryButton={{
-                'label': <FormattedMessage id="ui-eholdings.navModal.dismissLabel" />,
-                'type': 'submit',
-                'data-test-navigation-modal-dismiss': true
-              }}
-              secondaryButton={{
-                'label': <FormattedMessage id="ui-eholdings.navModal.continueLabel" />,
-                'onClick': this.continue,
-                'data-test-navigation-modal-continue': true
-              }}
-            />
+            <ModalFooter>
+              <Button
+                data-test-navigation-modal-dismiss
+                buttonStyle="primary"
+                type="submit"
+              >
+                <FormattedMessage id="ui-eholdings.navModal.dismissLabel" />
+              </Button>
+              <Button
+                data-test-navigation-modal-continue
+                onClick={this.continue}
+              >
+                <FormattedMessage id="ui-eholdings.navModal.continueLabel" />
+              </Button>
+            </ModalFooter>
           )}
         >
           <FormattedMessage id="ui-eholdings.navModal.unsavedChangesMsg" />

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -373,21 +373,24 @@ export default class CustomPackageEdit extends Component {
               label={<FormattedMessage id="ui-eholdings.package.modal.header.isCustom" />}
               id="eholdings-package-confirmation-modal"
               footer={(
-                <ModalFooter
-                  primaryButton={{
-                    'label': model.destroy.isPending ?
+                <ModalFooter>
+                  <Button
+                    data-test-eholdings-package-deselection-confirmation-modal-yes
+                    buttonStyle="primary"
+                    disabled={model.destroy.isPending}
+                    onClick={this.commitSelectionToggle}
+                  >
+                    {(model.destroy.isPending ?
                       <FormattedMessage id="ui-eholdings.package.modal.buttonWorking.isCustom" /> :
-                      <FormattedMessage id="ui-eholdings.package.modal.buttonConfirm.isCustom" />,
-                    'onClick': this.commitSelectionToggle,
-                    'disabled': model.destroy.isPending,
-                    'data-test-eholdings-package-deselection-confirmation-modal-yes': true
-                  }}
-                  secondaryButton={{
-                    'label': <FormattedMessage id="ui-eholdings.package.modal.buttonCancel.isCustom" />,
-                    'onClick': () => this.cancelSelectionToggle(change),
-                    'data-test-eholdings-package-deselection-confirmation-modal-no': true
-                  }}
-                />
+                      <FormattedMessage id="ui-eholdings.package.modal.buttonConfirm.isCustom" />)}
+                  </Button>
+                  <Button
+                    data-test-eholdings-package-deselection-confirmation-modal-no
+                    onClick={() => this.cancelSelectionToggle(change)}
+                  >
+                    <FormattedMessage id="ui-eholdings.package.modal.buttonCancel.isCustom" />
+                  </Button>
+                </ModalFooter>
               )}
             >
               <FormattedMessage id="ui-eholdings.package.modal.body.isCustom" />

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -422,21 +422,24 @@ export default class ManagedPackageEdit extends Component {
               label={<FormattedMessage id="ui-eholdings.package.modal.header" />}
               id="eholdings-package-confirmation-modal"
               footer={(
-                <ModalFooter
-                  primaryButton={{
-                    'label': model.update.isPending ?
+                <ModalFooter>
+                  <Button
+                    data-test-eholdings-package-deselection-confirmation-modal-yes
+                    buttonStyle="primary"
+                    disabled={model.update.isPending}
+                    onClick={this.commitSelectionToggle}
+                  >
+                    {(model.update.isPending ?
                       <FormattedMessage id="ui-eholdings.package.modal.buttonWorking" /> :
-                      <FormattedMessage id="ui-eholdings.package.modal.buttonConfirm" />,
-                    'onClick': this.commitSelectionToggle,
-                    'disabled': model.update.isPending,
-                    'data-test-eholdings-package-deselection-confirmation-modal-yes': true
-                  }}
-                  secondaryButton={{
-                    'label': <FormattedMessage id="ui-eholdings.package.modal.buttonCancel" />,
-                    'onClick': () => this.cancelSelectionToggle(change),
-                    'data-test-eholdings-package-deselection-confirmation-modal-no': true
-                  }}
-                />
+                      <FormattedMessage id="ui-eholdings.package.modal.buttonConfirm" />)}
+                  </Button>
+                  <Button
+                    data-test-eholdings-package-deselection-confirmation-modal-no
+                    onClick={() => this.cancelSelectionToggle(change)}
+                  >
+                    <FormattedMessage id="ui-eholdings.package.modal.buttonCancel" />
+                  </Button>
+                </ModalFooter>
               )}
             >
               <FormattedMessage id="ui-eholdings.package.modal.body" />

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -469,18 +469,21 @@ class PackageShow extends Component {
           label={modalMessage.header}
           id="eholdings-package-confirmation-modal"
           footer={(
-            <ModalFooter
-              primaryButton={{
-                'label': modalMessage.buttonConfirm,
-                'onClick': this.commitSelectionToggle,
-                'data-test-eholdings-package-deselection-confirmation-modal-yes': true
-              }}
-              secondaryButton={{
-                'label': modalMessage.buttonCancel,
-                'onClick': this.cancelSelectionToggle,
-                'data-test-eholdings-package-deselection-confirmation-modal-no': true
-              }}
-            />
+            <ModalFooter>
+              <Button
+                data-test-eholdings-package-deselection-confirmation-modal-yes
+                buttonStyle="primary"
+                onClick={this.commitSelectionToggle}
+              >
+                {modalMessage.buttonConfirm}
+              </Button>
+              <Button
+                data-test-eholdings-package-deselection-confirmation-modal-no
+                onClick={this.cancelSelectionToggle}
+              >
+                {modalMessage.buttonCancel}
+              </Button>
+            </ModalFooter>
           )}
         >
           {modalMessage.body}

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -352,22 +352,24 @@ class ResourceEditCustomTitle extends Component {
           label={<FormattedMessage id="ui-eholdings.resource.modal.header" />}
           id="eholdings-resource-confirmation-modal"
           footer={(
-            <ModalFooter
-              primaryButton={{
-                'label': model.destroy.isPending ?
-                  (<FormattedMessage id="ui-eholdings.resource.modal.buttonWorking" />)
-                  :
-                  (<FormattedMessage id="ui-eholdings.resource.modal.buttonConfirm" />),
-                'onClick': this.commitSelectionToggle,
-                'disabled': model.destroy.isPending,
-                'data-test-eholdings-resource-deselection-confirmation-modal-yes': true
-              }}
-              secondaryButton={{
-                'label': <FormattedMessage id="ui-eholdings.resource.modal.buttonCancel" />,
-                'onClick': this.cancelSelectionToggle,
-                'data-test-eholdings-resource-deselection-confirmation-modal-no': true
-              }}
-            />
+            <ModalFooter>
+              <Button
+                data-test-eholdings-resource-deselection-confirmation-modal-yes
+                buttonStyle="primary"
+                disabled={model.destroy.isPending}
+                onClick={this.commitSelectionToggle}
+              >
+                {(model.destroy.isPending ?
+                  <FormattedMessage id="ui-eholdings.resource.modal.buttonWorking" /> :
+                  <FormattedMessage id="ui-eholdings.resource.modal.buttonConfirm" />)}
+              </Button>
+              <Button
+                data-test-eholdings-resource-deselection-confirmation-modal-no
+                onClick={this.cancelSelectionToggle}
+              >
+                <FormattedMessage id="ui-eholdings.resource.modal.buttonCancel" />
+              </Button>
+            </ModalFooter>
           )}
         >
           {

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -380,22 +380,24 @@ class ResourceEditManagedTitle extends Component {
           label={<FormattedMessage id="ui-eholdings.resource.modal.header" />}
           id="eholdings-resource-confirmation-modal"
           footer={(
-            <ModalFooter
-              primaryButton={{
-                'label': model.update.isPending ?
-                  (<FormattedMessage id="ui-eholdings.resource.modal.buttonWorking" />)
-                  :
-                  (<FormattedMessage id="ui-eholdings.resource.modal.buttonConfirm" />),
-                'onClick': this.commitSelectionToggle,
-                'disabled': model.update.isPending,
-                'data-test-eholdings-resource-deselection-confirmation-modal-yes': true
-              }}
-              secondaryButton={{
-                'label': <FormattedMessage id="ui-eholdings.resource.modal.buttonCancel" />,
-                'onClick': this.cancelSelectionToggle,
-                'data-test-eholdings-resource-deselection-confirmation-modal-no': true
-              }}
-            />
+            <ModalFooter>
+              <Button
+                data-test-eholdings-resource-deselection-confirmation-modal-yes
+                buttonStyle="primary"
+                disabled={model.update.isPending}
+                onClick={this.commitSelectionToggle}
+              >
+                {(model.update.isPending ?
+                  <FormattedMessage id="ui-eholdings.resource.modal.buttonWorking" /> :
+                  <FormattedMessage id="ui-eholdings.resource.modal.buttonConfirm" />)}
+              </Button>
+              <Button
+                data-test-eholdings-resource-deselection-confirmation-modal-no
+                onClick={this.cancelSelectionToggle}
+              >
+                <FormattedMessage id="ui-eholdings.resource.modal.buttonCancel" />
+              </Button>
+            </ModalFooter>
           )}
         >
           <FormattedMessage id="ui-eholdings.resource.modal.body" />

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -462,18 +462,21 @@ class ResourceShow extends Component {
           label={<FormattedMessage id="ui-eholdings.resource.show.modal.header" />}
           id="eholdings-resource-deselection-confirmation-modal"
           footer={(
-            <ModalFooter
-              primaryButton={{
-                'label': <FormattedMessage id="ui-eholdings.resource.modal.buttonConfirm" />,
-                'onClick': this.commitSelectionToggle,
-                'data-test-eholdings-resource-deselection-confirmation-modal-yes': true
-              }}
-              secondaryButton={{
-                'label': <FormattedMessage id="ui-eholdings.resource.modal.buttonCancel" />,
-                'onClick': this.cancelSelectionToggle,
-                'data-test-eholdings-resource-deselection-confirmation-modal-no': true
-              }}
-            />
+            <ModalFooter>
+              <Button
+                data-test-eholdings-resource-deselection-confirmation-modal-yes
+                buttonStyle="primary"
+                onClick={this.commitSelectionToggle}
+              >
+                <FormattedMessage id="ui-eholdings.resource.modal.buttonConfirm" />
+              </Button>
+              <Button
+                data-test-eholdings-resource-deselection-confirmation-modal-no
+                onClick={this.cancelSelectionToggle}
+              >
+                <FormattedMessage id="ui-eholdings.resource.modal.buttonCancel" />
+              </Button>
+            </ModalFooter>
           )}
         >
           {

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -4,6 +4,7 @@ import isEqual from 'lodash/isEqual';
 import { FormattedMessage } from 'react-intl';
 
 import {
+  Button,
   Modal,
   ModalFooter,
 } from '@folio/stripes/components';
@@ -143,20 +144,23 @@ class SearchModal extends React.PureComponent {
             closeOnBackgroundClick
             dismissible
             footer={
-              <ModalFooter
-                primaryButton={{
-                  'label': <FormattedMessage id="ui-eholdings.label.search" />,
-                  'onClick': this.updateSearch,
-                  'disabled': !hasChanges,
-                  'data-test-eholdings-modal-search-button': true
-                }}
-                secondaryButton={{
-                  'label': <FormattedMessage id="ui-eholdings.filter.resetAll" />,
-                  'onClick': this.resetSearch,
-                  'disabled': isEqual(normalize({}), this.state.query),
-                  'data-test-eholdings-modal-reset-all-button': true
-                }}
-              />
+              <ModalFooter>
+                <Button
+                  data-test-eholdings-modal-search-button
+                  buttonStyle="primary"
+                  disabled={!hasChanges}
+                  onClick={this.updateSearch}
+                >
+                  <FormattedMessage id="ui-eholdings.label.search" />
+                </Button>
+                <Button
+                  data-test-eholdings-modal-reset-all-button
+                  disabled={isEqual(normalize({}), this.state.query)}
+                  onClick={this.resetSearch}
+                >
+                  <FormattedMessage id="ui-eholdings.filter.resetAll" />
+                </Button>
+              </ModalFooter>
             }
           >
             <SearchForm

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -302,7 +302,7 @@ class TitleShow extends Component {
                     disabled={request.isPending}
                     type="submit"
                   >
-                    {request.isPending ? (modalMessage.saving) : (modalMessage.submit)}
+                    {request.isPending ? modalMessage.saving : modalMessage.submit}
                   </Button>
                   <Button
                     data-test-eholdings-custom-package-modal-cancel

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -295,20 +295,23 @@ class TitleShow extends Component {
               onSubmit={handleSubmit}
               wrappingElement="form"
               footer={(
-                <ModalFooter
-                  primaryButton={{
-                    'label': request.isPending ? (modalMessage.saving) : (modalMessage.submit),
-                    'type': 'submit',
-                    'disabled': request.isPending,
-                    'data-test-eholdings-custom-package-modal-submit': true
-                  }}
-                  secondaryButton={{
-                    'label': <FormattedMessage id="ui-eholdings.cancel" />,
-                    'onClick': this.toggleCustomPackageModal,
-                    'disabled': request.isPending,
-                    'data-test-eholdings-custom-package-modal-cancel': true
-                  }}
-                />
+                <ModalFooter>
+                  <Button
+                    data-test-eholdings-custom-package-modal-submit
+                    buttonStyle="primary"
+                    disabled={request.isPending}
+                    type="submit"
+                  >
+                    {request.isPending ? (modalMessage.saving) : (modalMessage.submit)}
+                  </Button>
+                  <Button
+                    data-test-eholdings-custom-package-modal-cancel
+                    disabled={request.isPending}
+                    onClick={this.toggleCustomPackageModal}
+                  >
+                    <FormattedMessage id="ui-eholdings.cancel" />
+                  </Button>
+                </ModalFooter>
               )}
             >
               <AddTitleToPackage


### PR DESCRIPTION
Adopts patterns introduced in https://github.com/folio-org/stripes-components/pull/779.

Removes deprecation warnings re: using the `primaryButton` and `secondaryButton` props.

