### PR TITLE
STCOM-387 Eject from Settings smart component

### DIFF
--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -1,0 +1,64 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
+import { FormattedMessage } from 'react-intl';
+import { IfPermission } from '@folio/stripes/core';
+import {
+  Headline,
+  NavList,
+  NavListItem,
+  NavListSection,
+  Pane,
+  PaneBackLink,
+} from '@folio/stripes/components';
+
+class Settings extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    location: ReactRouterPropTypes.location.isRequired
+  }
+
+  render() {
+    const {
+      children,
+      location: { pathname }
+    } = this.props;
+
+    return (
+      <Fragment>
+        <Pane
+          defaultWidth="fill"
+          paneTitle={
+            <Headline tag="h3" margin="none">
+              <FormattedMessage id="ui-eholdings.meta.title" />
+            </Headline>
+          }
+          firstMenu={
+            <PaneBackLink to="/settings" />
+          }
+        >
+          <NavList>
+            <NavListSection
+              activeLink={pathname}
+            >
+              <IfPermission perm="module.eholdings.enabled">
+                <NavListItem to="/settings/eholdings/knowledge-base">
+                  <FormattedMessage id="ui-eholdings.settings.kb" />
+                </NavListItem>
+              </IfPermission>
+
+              <IfPermission perm="module.eholdings.enabled">
+                <NavListItem to="/settings/eholdings/root-proxy">
+                  <FormattedMessage id="ui-eholdings.settings.rootProxy" />
+                </NavListItem>
+              </IfPermission>
+            </NavListSection>
+          </NavList>
+        </Pane>
+        {children}
+      </Fragment>
+    );
+  }
+}
+
+export default Settings;

--- a/src/index.js
+++ b/src/index.js
@@ -47,12 +47,10 @@ class EHoldings extends Component {
       match: { path: rootPath }
     } = this.props;
 
-    // The settings routes below are passed on to the SettingsRoute, which parses
-    // them into an array and sends them on to the stripes-components <Settings>
     return showSettings ? (
       <Route path={rootPath} component={SettingsRoute}>
-        <Route path="knowledge-base" exact component={SettingsKnowledgeBaseRoute} name="Knowledge base" />
-        <Route path="root-proxy" exact component={SettingsRootProxyRoute} name="Root proxy" />
+        <Route path={`${rootPath}/knowledge-base`} exact component={SettingsKnowledgeBaseRoute} />
+        <Route path={`${rootPath}/root-proxy`} exact component={SettingsRootProxyRoute} />
       </Route>
     ) : (
       <Route path={rootPath} component={ApplicationRoute}>

--- a/src/routes/settings-route.js
+++ b/src/routes/settings-route.js
@@ -3,35 +3,24 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { TitleManager } from '@folio/stripes/core';
 
-import { Settings as View } from '@folio/stripes/smart-components';
+import View from '../components/settings';
 import ApplicationRoute from './application';
 
 class SettingsRoute extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
     location: ReactRouterPropTypes.location.isRequired,
-    match: ReactRouterPropTypes.match.isRequired
   };
 
   render() {
-    let { children, location, match } = this.props;
-
-    let pages = React.Children.map(children, child => ({
-      route: child.props.path,
-      label: child.props.name,
-      component: child.props.component
-    }));
+    const { children, location } = this.props;
 
     return (
       <ApplicationRoute showSettings>
         <TitleManager page="eHoldings settings">
-          <View
-            paneTitle="eHoldings"
-            activeLink={location.pathname}
-            match={match}
-            location={location}
-            pages={pages}
-          />
+          <View location={location}>
+            {children}
+          </View>
         </TitleManager>
       </ApplicationRoute>
     );


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STCOM-387

The `<Settings>` smart component contains routing glue, which is at odds with the routing-based architecture strategy outlined in https://issues.folio.org/browse/STRIPES-589.

## Approach
We have all the UI we need from `stripes-components` to be able to construct this functionality with the `<Settings>` smart component, in a way that `ui-eholdings` is in complete control of its settings routing.

### Breaking change
The `<Settings>` smart component attempts to programmatically alphabetize the items in each `<NavListSection>` - this PR does not maintain that functionality.