### PR TITLE
Use upstream ButtonGroup for search type tabs

### DIFF
--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -7,37 +7,6 @@
   padding: 1em;
 }
 
-.search-switcher {
-  display: inline-flex;
-  justify-content: space-between;
-  width: 100%;
-
-  & > * {
-    width: 100%;
-  }
-
-  & > :first-child,
-  & > :first-child::before {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  & > :last-child,
-  & > :last-child::before {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-
-  & > :not(:first-child) {
-    margin-left: -1px;
-  }
-
-  & > :not(:first-child):not(:last-child),
-  & > :not(:first-child):not(:last-child)::before {
-    border-radius: 0;
-  }
-}
-
 .search-results-list {
   margin: 1em 0;
   padding-left: 0;
@@ -55,29 +24,4 @@
 
 .search-field {
   margin-bottom: calc(var(--control-margin-bottom) / 2);
-}
-
-[dir="rtl"] {
-  & .search-switcher {
-    & > :first-child,
-    & > :first-child::before {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-      border-top-right-radius: var(--radius);
-      border-bottom-right-radius: var(--radius);
-    }
-
-    & > :last-child,
-    & > :last-child::before {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-      border-top-left-radius: var(--radius);
-      border-bottom-left-radius: var(--radius);
-    }
-
-    & > :not(:first-child) {
-      margin-left: 0;
-      margin-right: -1px;
-    }
-  }
 }

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import capitalize from 'lodash/capitalize';
 import {
   Button,
+  ButtonGroup,
   SearchField,
   Select
 } from '@folio/stripes/components';
@@ -105,7 +106,11 @@ class SearchForm extends Component {
     return (
       <div className={styles['search-form-container']} data-test-search-form={searchType}>
         {displaySearchTypeSwitcher && (
-          <div className={styles['search-switcher']} role='tablist' data-test-search-form-type-switcher>
+          <ButtonGroup
+            data-test-search-form-type-switcher
+            fullWidth
+            role='tablist'
+          >
             {validSearchTypes.map(type => (
               <Button
                 role='tab'
@@ -120,7 +125,7 @@ class SearchForm extends Component {
                 {capitalize(type)}
               </Button>
             ))}
-          </div>
+          </ButtonGroup>
         )}
         <form
           onSubmit={this.handleSearchSubmit}


### PR DESCRIPTION
Switches the search type tabs to use `<ButtonGroup>` from `stripes-components` (introduced in https://github.com/folio-org/stripes-components/pull/761).

![localhost_3000_eholdings_searchtype providers iphone 5_se](https://user-images.githubusercontent.com/230597/51542764-9ee3e400-1e21-11e9-9e58-522419fc0b60.png)
