### PR TITLE
Expand use of new <Pane>

### DIFF
--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -8,9 +8,9 @@ import {
   Button,
   Icon,
   IconButton,
-  PaneHeader
 } from '@folio/stripes/components';
 
+import Paneset, { Pane } from '../../paneset';
 import DetailsViewSection from '../../details-view-section';
 import NameField from '../_fields/name';
 import CoverageFields from '../_fields/custom-coverage';
@@ -82,8 +82,11 @@ export default class PackageCreate extends Component {
               }))}
             />
 
-            <form onSubmit={handleSubmit}>
-              <PaneHeader
+            <Paneset>
+              <Pane
+                onSubmit={handleSubmit}
+                tagName="form"
+                flexGrow={1}
                 paneTitle={<FormattedMessage id="ui-eholdings.package.create.custom" />}
                 actionMenu={this.getActionMenu}
                 firstMenu={onCancel && (
@@ -116,23 +119,24 @@ export default class PackageCreate extends Component {
                     </PaneHeaderButton>
                   </Fragment>
                 )}
-              />
+              >
+                <div className={styles['package-create-form-container']}>
+                  <DetailsViewSection
+                    label={<FormattedMessage id="ui-eholdings.package.packageInformation" />}
+                    separator={false}
+                  >
+                    <NameField />
+                    <ContentTypeField />
+                  </DetailsViewSection>
+                  <DetailsViewSection
+                    label={<FormattedMessage id="ui-eholdings.label.coverageSettings" />}
+                  >
+                    <CoverageFields />
+                  </DetailsViewSection>
+                </div>
+              </Pane>
+            </Paneset>
 
-              <div className={styles['package-create-form-container']}>
-                <DetailsViewSection
-                  label={<FormattedMessage id="ui-eholdings.package.packageInformation" />}
-                  separator={false}
-                >
-                  <NameField />
-                  <ContentTypeField />
-                </DetailsViewSection>
-                <DetailsViewSection
-                  label={<FormattedMessage id="ui-eholdings.label.coverageSettings" />}
-                >
-                  <CoverageFields />
-                </DetailsViewSection>
-              </div>
-            </form>
             <NavigationModal when={!pristine && !request.isResolved} />
           </div>
         )}

--- a/src/components/paneset/Pane.css
+++ b/src/components/paneset/Pane.css
@@ -64,6 +64,10 @@
   height: 100%;
   overflow: auto;
   width: 100%;
+
+  &.hasPadding {
+    padding: 1rem;
+  }
 }
 
 .vignette {

--- a/src/components/paneset/Pane.js
+++ b/src/components/paneset/Pane.js
@@ -14,11 +14,6 @@ export default class Pane extends Component {
     // eslint-disable-next-line react/forbid-foreign-prop-types
     ...PaneHeader.propTypes,
 
-    // used for panes that animate from the opposite direction and are
-    // only tangentially related to the main content (such as
-    // navigation in settings, or filters in search)
-    aside: PropTypes.bool,
-
     // pane contents
     children: PropTypes.node,
 
@@ -49,6 +44,10 @@ export default class Pane extends Component {
     // subheader
     subheader: PropTypes.node,
 
+    // should be set to "aside" for panes that
+    // animate from the opposite direction and are
+    // only tangentially related to the main content (such as
+    // navigation in settings, or filters in search)
     tagName: PropTypes.string,
 
     // toggles the pane visibility. when mounting for the first time,
@@ -87,7 +86,6 @@ export default class Pane extends Component {
     const {
       actionMenu,
       appIcon,
-      aside,
       children,
       className,
       firstMenu,
@@ -114,7 +112,7 @@ export default class Pane extends Component {
       entered
     } = this.state;
 
-    let Element = aside ? 'aside' : tagName;
+    let Element = tagName;
     let animDuration = 300;
 
     return (
@@ -133,7 +131,7 @@ export default class Pane extends Component {
             }}
           >
             <div
-              className={cx('vignette', { aside })}
+              className={cx('vignette', { aside: tagName === 'aside' })}
               onClick={onDismiss}
               aria-hidden="true"
               data-test-pane-vignette
@@ -161,7 +159,7 @@ export default class Pane extends Component {
         >
           <Element
             className={cx('pane', {
-              aside,
+              aside: tagName === 'aside',
               static: isStatic
             }, className)}
             style={entered ? { flexGrow } : null}

--- a/src/components/paneset/Pane.js
+++ b/src/components/paneset/Pane.js
@@ -39,12 +39,17 @@ export default class Pane extends Component {
     onExited: PropTypes.func,
     onExiting: PropTypes.func,
 
+    // determines whether the pane content has padding
+    padContent: PropTypes.bool,
+
     // used for panes which will always be visible. this is usually
     // just a single pane such as the results pane in search
     static: PropTypes.bool,
 
     // subheader
     subheader: PropTypes.node,
+
+    tagName: PropTypes.string,
 
     // toggles the pane visibility. when mounting for the first time,
     // the pane will mount in its desired state, only animating when
@@ -53,6 +58,8 @@ export default class Pane extends Component {
   };
 
   static defaultProps = {
+    padContent: true,
+    tagName: 'section',
     visible: true
   };
 
@@ -93,11 +100,13 @@ export default class Pane extends Component {
       onExit,
       onExiting, // eslint-disable-line no-unused-vars
       onExited,
+      padContent,
       paneSub,
       paneTitle,
       paneTitleRef,
       static: isStatic,
       subheader,
+      tagName,
       visible,
       ...rest
     } = this.props;
@@ -105,7 +114,7 @@ export default class Pane extends Component {
       entered
     } = this.state;
 
-    let Element = aside ? 'aside' : 'section';
+    let Element = aside ? 'aside' : tagName;
     let animDuration = 300;
 
     return (
@@ -175,7 +184,11 @@ export default class Pane extends Component {
 
               {subheader}
 
-              <div className={css.content}>
+              <div
+                className={cx('content', {
+                  hasPadding: padContent
+                })}
+              >
                 {children}
               </div>
             </div>

--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -4,7 +4,6 @@
   margin: 0 auto;
   min-width: 200px;
   max-width: 640px;
-  padding: 1em;
 }
 
 .search-results-list {

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -155,6 +155,7 @@ export default class SearchPaneset extends Component {
         <Pane
           static
           flexGrow={5}
+          padContent={false}
           appIcon={{ app: 'eholdings' }}
           paneTitle={capitalize(resultsType)}
           paneSub={resultsView && resultsPaneSub}
@@ -185,6 +186,7 @@ export default class SearchPaneset extends Component {
 
         <Pane
           flexGrow={11}
+          padContent={false}
           className={styles['search-detail-pane']}
           onDismiss={onClosePreview}
           onExited={this.clearDetailsView}

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -133,7 +133,7 @@ export default class SearchPaneset extends Component {
     return (
       <Paneset>
         <Pane
-          aside
+          tagName="aside"
           onDismiss={this.toggleFilters}
           visible={!hideFilters}
           className={styles['search-pane']}

--- a/src/components/settings-detail-pane/settings-detail-pane.css
+++ b/src/components/settings-detail-pane/settings-detail-pane.css
@@ -1,11 +1,4 @@
-@import '@folio/stripes-components/lib/variables';
-
 .settings-detail-pane-body {
-  max-width: 50em;
-}
-
-.settings-detail-pane-back-button {
-  @media (--medium-up) {
-    display: none;
-  }
+  margin: 0 auto;
+  max-width: 50rem;
 }

--- a/src/components/settings-detail-pane/settings-detail-pane.js
+++ b/src/components/settings-detail-pane/settings-detail-pane.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
-  IconButton,
-  Pane
+  PaneCloseLink,
 } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
+import { Pane } from '../paneset';
 import styles from './settings-detail-pane.css';
 
 class SettingsDetailPane extends Component {
@@ -24,16 +24,14 @@ class SettingsDetailPane extends Component {
     return (
       <Pane
         {...paneProps}
-        defaultWidth="fill"
         paneTitle={paneTitle}
+        flexGrow={3}
         firstMenu={(
           <FormattedMessage id="ui-eholdings.settings.goBackToEholdings">
             {ariaLabel => (
-              <IconButton
-                icon="arrow-left"
-                href="/settings/eholdings"
+              <PaneCloseLink
                 ariaLabel={ariaLabel}
-                className={styles['settings-detail-pane-back-button']}
+                to="/settings/eholdings"
               />
             )}
           </FormattedMessage>

--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -8,9 +8,10 @@ import {
   NavList,
   NavListItem,
   NavListSection,
-  Pane,
   PaneBackLink,
 } from '@folio/stripes/components';
+
+import { Pane } from './paneset';
 
 class Settings extends Component {
   static propTypes = {
@@ -27,7 +28,8 @@ class Settings extends Component {
     return (
       <Fragment>
         <Pane
-          defaultWidth="fill"
+          static
+          flexGrow={1}
           paneTitle={
             <Headline tag="h3" margin="none">
               <FormattedMessage id="ui-eholdings.meta.title" />

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -8,10 +8,10 @@ import {
   Button,
   Icon,
   IconButton,
-  PaneHeader
 } from '@folio/stripes/components';
 
 import { FormattedMessage } from 'react-intl';
+import Paneset, { Pane } from '../../paneset';
 import DetailsViewSection from '../../details-view-section';
 import NameField from '../_fields/name';
 import EditionField from '../_fields/edition';
@@ -95,8 +95,11 @@ export default class TitleCreate extends Component {
           mutators={{ ...arrayMutators }}
           render={({ handleSubmit, pristine }) => (
             <Fragment>
-              <form onSubmit={handleSubmit}>
-                <PaneHeader
+              <Paneset>
+                <Pane
+                  onSubmit={handleSubmit}
+                  tagName="form"
+                  flexGrow={1}
                   paneTitle={<FormattedMessage id="ui-eholdings.title.create.paneTitle" />}
                   actionMenu={this.getActionMenu}
                   firstMenu={onCancel && (
@@ -129,29 +132,29 @@ export default class TitleCreate extends Component {
                       </PaneHeaderButton>
                     </Fragment>
                   )}
-                />
-
-                <div className={styles['title-create-form-container']}>
-                  <DetailsViewSection
-                    label={<FormattedMessage id="ui-eholdings.title.titleInformation" />}
-                    separator={false}
-                  >
-                    <NameField />
-                    <ContributorField />
-                    <EditionField />
-                    <PublisherNameField />
-                    <PublicationTypeField />
-                    <IdentifiersFields />
-                    <DescriptionField />
-                    <PeerReviewedField />
-                  </DetailsViewSection>
-                  <DetailsViewSection
-                    label={<FormattedMessage id="ui-eholdings.label.packageInformation" />}
-                  >
-                    <PackageSelectField options={packageOptions} />
-                  </DetailsViewSection>
-                </div>
-              </form>
+                >
+                  <div className={styles['title-create-form-container']}>
+                    <DetailsViewSection
+                      label={<FormattedMessage id="ui-eholdings.title.titleInformation" />}
+                      separator={false}
+                    >
+                      <NameField />
+                      <ContributorField />
+                      <EditionField />
+                      <PublisherNameField />
+                      <PublicationTypeField />
+                      <IdentifiersFields />
+                      <DescriptionField />
+                      <PeerReviewedField />
+                    </DetailsViewSection>
+                    <DetailsViewSection
+                      label={<FormattedMessage id="ui-eholdings.label.packageInformation" />}
+                    >
+                      <PackageSelectField options={packageOptions} />
+                    </DetailsViewSection>
+                  </div>
+                </Pane>
+              </Paneset>
 
               <NavigationModal when={!pristine && !request.isResolved} />
             </Fragment>


### PR DESCRIPTION
Expands use of new `<Pane>` introduced in https://github.com/folio-org/ui-eholdings/pull/634:
- added to knowledge base and root proxy forms
- added to eHoldings settings navigation
- added to custom package and custom title creation forms (those previously didn't have a fixed-position header)