### PR TITLE
UIEH-598: Moved limit number from translation to placeholder

### DIFF
--- a/src/components/title/_fields/description/description-field.js
+++ b/src/components/title/_fields/description/description-field.js
@@ -4,9 +4,14 @@ import { Field } from 'react-final-form';
 import { TextArea } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
+const MAX_CHARACTER_LENGTH = 400;
+
 function validate(value) {
-  return value && value.length > 400 ?
-    <FormattedMessage id="ui-eholdings.validate.errors.title.description.length" /> : undefined;
+  return value && value.length > MAX_CHARACTER_LENGTH ?
+    <FormattedMessage
+      id="ui-eholdings.validate.errors.title.description.length"
+      values={{ amount: MAX_CHARACTER_LENGTH }}
+    /> : undefined;
 }
 
 export default function DescriptionField() {

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -237,7 +237,7 @@
 
     "validate.errors.customTitle.name": "Custom titles must have a name.",
     "validate.errors.customTitle.name.length": "Must be less than 400 characters.",
-    "validate.errors.title.description.length": "The value entered exceeds the 400 character limit. Please enter a value that does not exceed 400 characters.",
+    "validate.errors.title.description.length": "The value entered exceeds the {amount} character limit. Please enter a value that does not exceed {amount} characters.",
     "validate.errors.customPackage.name": "Custom packages must have a name.",
     "validate.errors.customPackage.name.length": "Must not exceed {amount} characters.",
     "validate.errors.coverageStatement.length": "Statement must be 350 characters or less.",


### PR DESCRIPTION
## Purpose
This PR relates to https://github.com/folio-org/ui-eholdings/pull/675

As the translation engine can not distinguish change in the numbers I mowed the characters limit number from the translation to the placeholder

