### PR TITLE
FOLIO-1753 - Release v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eholdings",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "FOLIO UI module for eHoldings",
   "main": "src/index.js",
   "repository": "https://github.com/folio-org/ui-eholdings",
@@ -79,7 +79,7 @@
       }
     ],
     "okapiInterfaces": {
-      "eholdings": "0.1"
+      "eholdings": "1.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Purpose
As part of  https://issues.folio.org/browse/FOLIO-1753 we are releasing mod-kb-ebsco-java module so that it can be included in environments and we can start deprecating the use of mod-kb-ebsco (Ruby Version). The Java module provides eholdings interface version 1.0, the Ruby module provides eholdings interface version 0.1.  
This PR provides for a new release of ui-eholdings -- includes an update version number (1.4.0) and an updated eholdings interface version (1.0)

## Approach
- Update version and interface
- Once PR has been merged, create release 

## Learning
Followed release procedures as noted at https://github.com/folio-org/stripes/blob/master/doc/release-procedure.md
