### PR TITLE
UIEH-621: change Resource serializer to not send unrecognized data

### DIFF
--- a/src/redux/resource.js
+++ b/src/redux/resource.js
@@ -33,18 +33,24 @@ class Resource {
   description = '';
 
   serialize() {
-    let data = {
+    const data = {
       id: this.id,
       type: this.type,
       attributes: {
-        name: this.name,
+        packageId: this.packageId,
         titleId: this.titleId,
+        url: this.url,
+      },
+    };
+
+    if (this.data.attributes.name) {
+      data.attributes = {
+        ...data.attributes,
+        name: this.name,
         providerId: this.providerId,
         providerName: this.providerName,
-        packageId: this.packageId,
         packageName: this.packageName,
         isSelected: this.isSelected,
-        url: this.url,
         managedCoverages: this.managedCoverages,
         customCoverages: this.customCoverages,
         managedEmbargoPeriod: this.managedEmbargoPeriod,
@@ -55,15 +61,14 @@ class Resource {
         publisherName: this.publisherName,
         edition: this.edition,
         publicationType: this.publicationType,
-        contentType: this.contentType,
         subjects: this.subjects,
         contributors: this.contributors,
         identifiers: this.identifiers,
         isTitleCustom: this.isTitleCustom,
         isPeerReviewed: this.isPeerReviewed,
         description: this.description,
-      }
-    };
+      };
+    }
 
     return { data };
   }


### PR DESCRIPTION
Resource serializer needs to be changed in order to not send unrecognized data which caused the following bugs:
https://issues.folio.org/browse/UIEH-621
https://issues.folio.org/browse/UIEH-622
https://issues.folio.org/browse/UIEH-623

## Purpose
Duck typing is used to decide what fields should be added to the request payload