### PR TITLE
UIEH-610: Fixed search panel initial state to be open

### DIFF
--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -54,7 +54,7 @@ class SearchRoute extends Component {
       searchString: params.q,
       searchFilter: params.filter,
       searchField: params.searchfield,
-      hideFilters: !!params.q
+      hideFilters: false,
     };
   }
 


### PR DESCRIPTION
## Purpose
According to the https://issues.folio.org/browse/UIEH-610,

The search panel should be opened.

Before it depended on the search query and the results list and the logic was to hide the search panel for the initial load if results list is not empty.

## Approach
Changed the initial state of the search panel to be always visible at the initial load