### PR TITLE
UIEH-614: Fix CoverageDateList warning

### DIFF
--- a/test/bigtest/tests/resource-managed-coverage-test.js
+++ b/test/bigtest/tests/resource-managed-coverage-test.js
@@ -62,22 +62,6 @@ describe('ResourceManagedCoverage', () => {
     });
   });
 
-  describe('visiting the resource page with single managed coverage (endCoverage null)', () => {
-    beforeEach(function () {
-      resource.managedCoverages = this.server.createList('managed-coverage', 1, {
-        beginCoverage: '1969-07-16',
-        endCoverage: null
-      }).map(m => m.toJSON());
-
-      resource.save();
-      this.visit(`/eholdings/resources/${resource.id}`);
-    });
-
-    it('display the managed coverage section for single date (begin date and no end date)', () => {
-      expect(ResourceShowPage.managedCoverageList).to.equal('7/16/1969 - Present');
-    });
-  });
-
   describe('visiting the resource page with single managed coverage (endCoverage empty)', () => {
     beforeEach(function () {
       resource.managedCoverages = this.server.createList('managed-coverage', 1, {


### PR DESCRIPTION
## Purpose
The issue appeared due to the wrong test for endCoverage to be null.

Recently the custom propType was added to not allow endCoverage to be other than a string 

This change was in this PR https://github.com/folio-org/ui-eholdings/pull/636/files#diff-5f007f8c99c2c04b8db2b098c898a30aR7

So, there is no need in the test as the null case for the endCoverage is contradicts to the propTypes validation.