### PR TITLE
Passing <AppIcon> to 'appIcon'-prop on <Pane>

### DIFF
--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -2,16 +2,22 @@ import React, { Component, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import { IfPermission } from '@folio/stripes-core';
+import capitalize from 'lodash/capitalize';
+
+import {
+  IfPermission,
+  AppIcon,
+} from '@folio/stripes-core';
+
 import {
   Button,
   PaneMenu,
 } from '@folio/stripes/components';
 
 import Paneset, { Pane } from '../paneset';
+import SearchBadge from '../search-modal/search-badge';
 
 import styles from './search-paneset.css';
-import SearchBadge from '../search-modal/search-badge';
 
 export default class SearchPaneset extends Component {
   static propTypes = {
@@ -100,7 +106,6 @@ export default class SearchPaneset extends Component {
   render() {
     let {
       searchForm,
-      resultsLabel,
       resultsType,
       resultsView,
       totalResults,
@@ -164,8 +169,8 @@ export default class SearchPaneset extends Component {
           static
           flexGrow={5}
           padContent={false}
-          appIcon={{ app: 'eholdings' }}
-          paneTitle={resultsLabel}
+          appIcon={<AppIcon app="eholdings" />}
+          paneTitle={capitalize(resultsType)}
           paneSub={resultsView && resultsPaneSub}
           paneTitleRef={this.$title}
           firstMenu={resultsView ? (

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -27,7 +27,6 @@ export default class SearchPaneset extends Component {
     isLoading: PropTypes.bool,
     location: PropTypes.object.isRequired,
     onClosePreview: PropTypes.func.isRequired,
-    resultsLabel: PropTypes.element,
     resultsType: PropTypes.string,
     resultsView: PropTypes.node,
     searchForm: PropTypes.node,

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -4,7 +4,6 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import capitalize from 'lodash/capitalize';
 import isEqual from 'lodash/isEqual';
-import { FormattedMessage } from 'react-intl';
 import { TitleManager } from '@folio/stripes/core';
 
 import { qs, transformQueryParams } from '../components/utilities';
@@ -305,7 +304,6 @@ class SearchRoute extends Component {
               filterCount={filterCount}
               hideFilters={hideFilters}
               resultsType={searchType}
-              resultsLabel={<FormattedMessage id={`ui-eholdings.search.searchType.${searchType}`} />}
               resultsView={this.renderResults()}
               detailsView={!hideDetails && children}
               totalResults={results.length}


### PR DESCRIPTION
The implementation of AppIcon's in Pane/PaneHeader's has changed in stripes-components.

In this PR I changed the search results component to reflect that change.