### PR TITLE
UIEH-627: fix form fields reverting to previous values on form submit

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -50,11 +50,6 @@ export default class CustomPackageEdit extends Component {
     const { initialValues } = prevState;
     const {
       isSelected,
-      name,
-      contentType,
-      customCoverage,
-      proxy,
-      visibilityData,
       destroy,
     } = nextProps.model;
 
@@ -62,17 +57,7 @@ export default class CustomPackageEdit extends Component {
 
     if (selectionStatusChanged) {
       stateUpdates = {
-        initialValues: {
-          isSelected,
-          name,
-          contentType,
-          customCoverages: [{
-            beginCoverage: customCoverage.beginCoverage,
-            endCoverage: customCoverage.endCoverage
-          }],
-          proxyId: proxy.id,
-          isVisible: !visibilityData.isHidden
-        },
+        initialValues: CustomPackageEdit.getInitialValues(nextProps.model),
         packageSelected: isSelected
       };
     }
@@ -84,21 +69,7 @@ export default class CustomPackageEdit extends Component {
     return stateUpdates;
   }
 
-  state = {
-    showSelectionModal: false,
-    allowFormToSubmit: false,
-    packageSelected: this.props.model.isSelected,
-    formValues: {},
-    initialValues: this.getInitialValuesFromModel(),
-    sections: {
-      packageHoldingStatus: true,
-      packageInfo: true,
-      packageSettings: true,
-      packageCoverageSettings: true,
-    }
-  };
-
-  getInitialValuesFromModel() {
+  static getInitialValues(model) {
     const {
       name,
       contentType,
@@ -106,20 +77,33 @@ export default class CustomPackageEdit extends Component {
       customCoverage,
       proxy,
       visibilityData,
-    } = this.props.model;
+    } = model;
 
     return {
       name,
       contentType,
       isSelected,
       customCoverages: [{
-        beginCoverage: customCoverage.beginCoverage,
-        endCoverage: customCoverage.endCoverage
+        ...customCoverage
       }],
       proxyId: proxy.id,
       isVisible: !visibilityData.isHidden
     };
   }
+
+  state = {
+    showSelectionModal: false,
+    allowFormToSubmit: false,
+    packageSelected: this.props.model.isSelected,
+    formValues: {},
+    initialValues: CustomPackageEdit.getInitialValues(this.props.model),
+    sections: {
+      packageHoldingStatus: true,
+      packageInfo: true,
+      packageSettings: true,
+      packageCoverageSettings: true,
+    }
+  };
 
   handleDeleteAction = () => {
     this.setState({

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -47,29 +47,37 @@ export default class CustomPackageEdit extends Component {
 
   static getDerivedStateFromProps(nextProps, prevState) {
     let stateUpdates = {};
-    const { model } = nextProps;
     const { initialValues } = prevState;
+    const {
+      isSelected,
+      name,
+      contentType,
+      customCoverage,
+      proxy,
+      visibilityData,
+      destroy,
+    } = nextProps.model;
 
-    const selectionStatusChanged = model.isSelected !== initialValues.isSelected;
+    const selectionStatusChanged = isSelected !== initialValues.isSelected;
 
     if (selectionStatusChanged) {
       stateUpdates = {
         initialValues: {
-          isSelected: model.isSelected,
-          name: model.name,
-          contentType: model.contentType,
+          isSelected,
+          name,
+          contentType,
           customCoverages: [{
-            beginCoverage: model.customCoverage.beginCoverage,
-            endCoverage: model.customCoverage.endCoverage
+            beginCoverage: customCoverage.beginCoverage,
+            endCoverage: customCoverage.endCoverage
           }],
-          proxyId: model.proxy.id,
-          isVisible: !model.visibilityData.isHidden
+          proxyId: proxy.id,
+          isVisible: !visibilityData.isHidden
         },
-        packageSelected: model.isSelected
+        packageSelected: isSelected
       };
     }
 
-    if (model.destroy.errors.length) {
+    if (destroy.errors.length) {
       stateUpdates.showSelectionModal = false;
     }
 
@@ -91,18 +99,25 @@ export default class CustomPackageEdit extends Component {
   };
 
   getInitialValuesFromModel() {
-    const { model } = this.props;
+    const {
+      name,
+      contentType,
+      isSelected,
+      customCoverage,
+      proxy,
+      visibilityData,
+    } = this.props.model;
 
     return {
-      name: model.name,
-      contentType: model.contentType,
-      isSelected: model.isSelected,
+      name,
+      contentType,
+      isSelected,
       customCoverages: [{
-        beginCoverage: model.customCoverage.beginCoverage,
-        endCoverage: model.customCoverage.endCoverage
+        beginCoverage: customCoverage.beginCoverage,
+        endCoverage: customCoverage.endCoverage
       }],
-      proxyId: model.proxy.id,
-      isVisible: !model.visibilityData.isHidden
+      proxyId: proxy.id,
+      isVisible: !visibilityData.isHidden
     };
   }
 

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -47,32 +47,40 @@ export default class ManagedPackageEdit extends Component {
     let stateUpdates = {};
     const { initialValues } = prevState;
     const {
-      model,
-      provider,
+      model: {
+        isSelected,
+        customCoverage,
+        proxy,
+        packageToken,
+        visibilityData,
+        allowKbToAddTitles,
+        update,
+      },
+      provider: { providerToken },
     } = nextProps;
 
-    const providerTokenWasLoaded = !initialValues.providerTokenValue && provider.providerToken.value;
-    const selectionStatusChanged = model.isSelected !== initialValues.isSelected;
+    const providerTokenWasLoaded = !initialValues.providerTokenValue && providerToken.value;
+    const selectionStatusChanged = isSelected !== initialValues.isSelected;
 
     if (selectionStatusChanged || providerTokenWasLoaded) {
       stateUpdates = {
         initialValues: {
-          isSelected: model.isSelected,
+          isSelected,
           customCoverages: [{
-            beginCoverage: model.customCoverage.beginCoverage,
-            endCoverage: model.customCoverage.endCoverage
+            beginCoverage: customCoverage.beginCoverage,
+            endCoverage: customCoverage.endCoverage
           }],
-          proxyId: model.proxy.id,
-          providerTokenValue: provider.providerToken.value,
-          packageTokenValue: model.packageToken.value,
-          isVisible: !model.visibilityData.isHidden,
-          allowKbToAddTitles: model.allowKbToAddTitles
+          proxyId: proxy.id,
+          providerTokenValue: providerToken.value,
+          packageTokenValue: packageToken.value,
+          isVisible: !visibilityData.isHidden,
+          allowKbToAddTitles,
         },
-        packageSelected: model.isSelected
+        packageSelected: isSelected
       };
     }
 
-    if (model.update.errors.length) {
+    if (update.errors.length) {
       stateUpdates.showSelectionModal = false;
     }
 
@@ -94,21 +102,28 @@ export default class ManagedPackageEdit extends Component {
 
   getInitialValuesFromModel() {
     const {
-      model,
-      provider,
+      model: {
+        isSelected,
+        customCoverage,
+        proxy,
+        packageToken,
+        visibilityData,
+        allowKbToAddTitles,
+      },
+      provider: { providerToken },
     } = this.props;
 
     return {
-      isSelected: model.isSelected,
+      isSelected,
       customCoverages: [{
-        beginCoverage: model.customCoverage.beginCoverage,
-        endCoverage: model.customCoverage.endCoverage
+        beginCoverage: customCoverage.beginCoverage,
+        endCoverage: customCoverage.endCoverage
       }],
-      proxyId: model.proxy.id,
-      providerTokenValue: provider.providerToken.value,
-      packageTokenValue: model.packageToken.value,
-      isVisible: !model.visibilityData.isHidden,
-      allowKbToAddTitles: model.allowKbToAddTitles
+      proxyId: proxy.id,
+      providerTokenValue: providerToken.value,
+      packageTokenValue: packageToken.value,
+      isVisible: !visibilityData.isHidden,
+      allowKbToAddTitles,
     };
   }
 

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -49,11 +49,6 @@ export default class ManagedPackageEdit extends Component {
     const {
       model: {
         isSelected,
-        customCoverage,
-        proxy,
-        packageToken,
-        visibilityData,
-        allowKbToAddTitles,
         update,
       },
       provider: { providerToken },
@@ -64,18 +59,7 @@ export default class ManagedPackageEdit extends Component {
 
     if (selectionStatusChanged || providerTokenWasLoaded) {
       stateUpdates = {
-        initialValues: {
-          isSelected,
-          customCoverages: [{
-            beginCoverage: customCoverage.beginCoverage,
-            endCoverage: customCoverage.endCoverage
-          }],
-          proxyId: proxy.id,
-          providerTokenValue: providerToken.value,
-          packageTokenValue: packageToken.value,
-          isVisible: !visibilityData.isHidden,
-          allowKbToAddTitles,
-        },
+        initialValues: ManagedPackageEdit.getInitialValues(nextProps.model, nextProps.provider),
         packageSelected: isSelected
       };
     }
@@ -87,37 +71,21 @@ export default class ManagedPackageEdit extends Component {
     return stateUpdates;
   }
 
-  state = {
-    showSelectionModal: false,
-    allowFormToSubmit: false,
-    packageSelected: this.props.model.isSelected,
-    formValues: {},
-    initialValues: this.getInitialValuesFromModel(),
-    sections: {
-      packageHoldingStatus: true,
-      packageSettings: true,
-      packageCoverageSettings: true,
-    }
-  };
-
-  getInitialValuesFromModel() {
+  static getInitialValues(model, { providerToken }) {
     const {
-      model: {
-        isSelected,
-        customCoverage,
-        proxy,
-        packageToken,
-        visibilityData,
-        allowKbToAddTitles,
-      },
-      provider: { providerToken },
-    } = this.props;
+      isSelected,
+      customCoverage,
+      proxy,
+      packageToken,
+      visibilityData,
+      allowKbToAddTitles,
+
+    } = model;
 
     return {
       isSelected,
       customCoverages: [{
-        beginCoverage: customCoverage.beginCoverage,
-        endCoverage: customCoverage.endCoverage
+        ...customCoverage,
       }],
       proxyId: proxy.id,
       providerTokenValue: providerToken.value,
@@ -126,6 +94,19 @@ export default class ManagedPackageEdit extends Component {
       allowKbToAddTitles,
     };
   }
+
+  state = {
+    showSelectionModal: false,
+    allowFormToSubmit: false,
+    packageSelected: this.props.model.isSelected,
+    formValues: {},
+    initialValues: ManagedPackageEdit.getInitialValues(this.props.model, this.props.provider),
+    sections: {
+      packageHoldingStatus: true,
+      packageSettings: true,
+      packageCoverageSettings: true,
+    }
+  };
 
   handleSelectionAction = () => {
     this.setState({

--- a/src/components/package/package-edit.js
+++ b/src/components/package/package-edit.js
@@ -12,6 +12,29 @@ export default class PackageEdit extends React.Component {
     provider: PropTypes.object.isRequired
   };
 
+  renderRequestErrorMessage() {
+    const { model } = this.props;
+
+    return (
+      <p data-test-eholdings-package-edit-error>
+        {model.request.errors[0].title}
+      </p>
+    );
+  }
+
+  indicateModelIsNotLoaded() {
+    const { model } = this.props;
+
+    return model.request.isRejected
+      ? this.renderRequestErrorMessage()
+      : (
+        <Icon
+          icon="spinner-ellipsis"
+          iconSize="small"
+        />
+      );
+  }
+
   renderView() {
     const {
       model,
@@ -37,9 +60,6 @@ export default class PackageEdit extends React.Component {
 
     return model.isLoaded
       ? this.renderView()
-      : <Icon
-        icon="spinner-ellipsis"
-        iconSize="small"
-      />;
+      : this.indicateModelIsNotLoaded();
   }
 }

--- a/src/components/package/package-edit.js
+++ b/src/components/package/package-edit.js
@@ -1,53 +1,45 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Icon } from '@folio/stripes-components';
+
 import ManagedPackageEdit from './edit-managed';
 import CustomPackageEdit from './edit-custom';
 
-export default function PackageEdit({ model, provider, ...props }) {
-  let initialValues = {};
-  let View;
+export default class PackageEdit extends React.Component {
+  static propTypes = {
+    model: PropTypes.object.isRequired,
+    provider: PropTypes.object.isRequired
+  };
 
-  if (model.isCustom) {
-    View = CustomPackageEdit;
-    initialValues = {
-      name: model.name,
-      contentType: model.contentType,
-      isSelected: model.isSelected,
-      customCoverages: [{
-        beginCoverage: model.customCoverage.beginCoverage,
-        endCoverage: model.customCoverage.endCoverage
-      }],
-      proxyId: model.proxy.id,
-      isVisible: !model.visibilityData.isHidden
-    };
-  } else {
-    View = ManagedPackageEdit;
-    initialValues = {
-      isSelected: model.isSelected,
-      customCoverages: [{
-        beginCoverage: model.customCoverage.beginCoverage,
-        endCoverage: model.customCoverage.endCoverage
-      }],
-      proxyId: model.proxy.id,
-      providerTokenValue: provider.providerToken.value,
-      packageTokenValue: model.packageToken.value,
-      isVisible: !model.visibilityData.isHidden,
-      allowKbToAddTitles: model.allowKbToAddTitles
-    };
+  renderView() {
+    const {
+      model,
+      provider,
+      ...props
+    } = this.props;
+
+    const View = model.isCustom
+      ? CustomPackageEdit
+      : ManagedPackageEdit;
+
+    return (
+      <View
+        model={model}
+        provider={provider}
+        {...props}
+      />
+    );
   }
 
-  return (
-    <View
-      model={model}
-      provider={provider}
-      initialValues={initialValues}
-      {...props}
-    />
-  );
-}
+  render() {
+    const { model } = this.props;
 
-PackageEdit.propTypes = {
-  model: PropTypes.object.isRequired,
-  provider: PropTypes.object.isRequired
-};
+    return model.isLoaded
+      ? this.renderView()
+      : <Icon
+        icon="spinner-ellipsis"
+        iconSize="small"
+      />;
+  }
+}

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -35,6 +35,10 @@ export default class TitleEdit extends Component {
     updateRequest: PropTypes.object.isRequired,
   };
 
+  state = {
+    initialValues: this.props.initialValues,
+  }
+
   getActionMenu = ({ onToggle }) => {
     const {
       onFullView,
@@ -71,11 +75,12 @@ export default class TitleEdit extends Component {
 
   render() {
     let {
-      initialValues,
       model,
       onSubmit,
       updateRequest
     } = this.props;
+
+    const { initialValues } = this.state;
 
     return (
       <Fragment>

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -35,10 +35,6 @@ export default class TitleEdit extends Component {
     updateRequest: PropTypes.object.isRequired,
   };
 
-  state = {
-    initialValues: this.props.initialValues,
-  }
-
   getActionMenu = ({ onToggle }) => {
     const {
       onFullView,
@@ -77,10 +73,9 @@ export default class TitleEdit extends Component {
     let {
       model,
       onSubmit,
-      updateRequest
+      updateRequest,
+      initialValues,
     } = this.props;
-
-    const { initialValues } = this.state;
 
     return (
       <Fragment>
@@ -95,6 +90,7 @@ export default class TitleEdit extends Component {
         <Form
           onSubmit={onSubmit}
           initialValues={initialValues}
+          initialValuesEqual={() => true}
           decorators={[focusOnErrors]}
           mutators={{ ...arrayMutators }}
           render={({ handleSubmit, pristine }) => (

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -4,7 +4,9 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import queryString from 'qs';
+
 import { TitleManager } from '@folio/stripes/core';
+import { Icon } from '@folio/stripes-components';
 
 import { createResolver } from '../redux';
 import Title from '../redux/title';
@@ -153,8 +155,8 @@ class TitleEditRoute extends Component {
     updateTitle(Object.assign(model, newValues));
   }
 
-  render() {
-    let {
+  renderView() {
+    const {
       model,
       updateRequest,
     } = this.props;
@@ -180,6 +182,17 @@ class TitleEditRoute extends Component {
         />
       </TitleManager>
     );
+  }
+
+  render() {
+    let { model } = this.props;
+
+    return model.isLoaded
+      ? this.renderView()
+      : <Icon
+        icon="spinner-ellipsis"
+        iconSize="small"
+      />;
   }
 }
 

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -184,15 +184,35 @@ class TitleEditRoute extends Component {
     );
   }
 
+  indicateModelIsNotLoaded() {
+    const { model } = this.props;
+
+    return model.request.isRejected
+      ? this.renderRequestErrorMessage()
+      : (
+        <Icon
+          icon="spinner-ellipsis"
+          iconSize="small"
+        />
+      );
+  }
+
+  renderRequestErrorMessage() {
+    const { model } = this.props;
+
+    return (
+      <p data-test-eholdings-title-edit-error>
+        {model.request.errors[0].title}
+      </p>
+    );
+  }
+
   render() {
     let { model } = this.props;
 
     return model.isLoaded
       ? this.renderView()
-      : <Icon
-        icon="spinner-ellipsis"
-        iconSize="small"
-      />;
+      : this.indicateModelIsNotLoaded();
   }
 }
 

--- a/test/bigtest/interactors/package-edit.js
+++ b/test/bigtest/interactors/package-edit.js
@@ -69,7 +69,7 @@ import PackageSelectionStatus from './selection-status';
   clickSave = clickable('[data-test-eholdings-package-save-button]');
   isSavePresent = isPresent('[data-test-eholdings-package-save-button]');
   isSaveDisabled = property('[data-test-eholdings-package-save-button]', 'disabled');
-  hasErrors = isPresent('[data-test-eholdings-details-view-error="package"]');
+  hasErrors = isPresent('[data-test-eholdings-package-edit-error]');
   modal = new PackageEditModal('#eholdings-package-confirmation-modal');
   selectionStatus = new PackageSelectionStatus();
   clickAddButton = clickable('[data-test-eholdings-package-add-to-holdings-button]');
@@ -185,4 +185,4 @@ import PackageSelectionStatus from './selection-status';
   });
 }
 
-export default new PackageEditPage('[data-test-eholdings-details-view="package"]');
+export default new PackageEditPage();

--- a/test/bigtest/interactors/title-edit.js
+++ b/test/bigtest/interactors/title-edit.js
@@ -33,7 +33,7 @@ import Toast from './toast';
 
   clickSave = clickable('[data-test-eholdings-title-save-button]');
   isSaveDisabled = property('[data-test-eholdings-title-save-button]', 'disabled');
-  hasErrors = isPresent('[data-test-eholdings-details-view-error="title"]');
+  hasErrors = isPresent('[data-test-eholdings-title-edit-error]');
   isPeerReviewed = property('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]', 'checked');
   checkPeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
 
@@ -86,4 +86,4 @@ import Toast from './toast';
   dropDownMenu = new TitleEditDropDownMenu();
 }
 
-export default new TitleEditPage('[data-test-eholdings-details-view="title"]');
+export default new TitleEditPage();


### PR DESCRIPTION
## Purpose
Currently, when we edit a title or a package and hit save button, the form fields briefly revert back to their previous values which are no longer relevant

## Approach
Previously, the forms' obtained their initial values from props and rendered it. They always rendered what props provided them with. The problem is that props don't usually contain relevant data.
Now, the form values, coming with props, are first saved to the component's local state and the state is used as the source of data to render. This way can decide if we want to update the state with the props' data on the basis of the props' data relevance 

[Jira ticket](https://issues.folio.org/browse/UIEH-627)