### PR TITLE
UIEH-636: update title edit to updating titles data through titles endpoint

### DIFF
--- a/src/redux/title.js
+++ b/src/redux/title.js
@@ -2,16 +2,20 @@ import model, { hasMany } from './model';
 
 class Title {
   name = '';
-  edition = '';
-  publisherName = '';
+  isPeerReviewed = false;
+  isSelected = false;
+  isTitleCustom = false;
   publicationType = '';
-  subjects = [];
+  publisherName = '';
+  edition = '';
+  description = '';
   contributors = [];
   identifiers = [];
+  subjects = [];
   resources = hasMany();
-  isTitleCustom = false;
-  isPeerReviewed = false;
-  description = '';
+  tags = {
+    tagList: [],
+  };
 
   // slightly customized serializer that adds included resources to
   // new title record payloads
@@ -21,11 +25,17 @@ class Title {
     let payload = { data };
 
     data.attributes = Object.keys(attributes).reduce((attrs, attr) => {
+      const isAttributeExcluded = this[attr] === null;
+
+      if (isAttributeExcluded) return attrs;
+
       return Object.assign(attrs, { [attr]: this[attr] });
     }, {});
 
-    // when serizing a new title we need to include any new resources
-    if (!this.id && resources) {
+    // when serializing a new title we need to include any new resources
+    const isTitleNew = !this.id;
+
+    if (isTitleNew && resources) {
       payload.included = resources.map((resource) => ({
         type: 'resource',
         attributes: resource

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -8,7 +8,6 @@ import { TitleManager } from '@folio/stripes/core';
 
 import { createResolver } from '../redux';
 import Title from '../redux/title';
-import Resource from '../redux/resource';
 
 import View from '../components/title/edit';
 
@@ -20,7 +19,7 @@ class TitleEditRoute extends Component {
     match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired,
     updateRequest: PropTypes.object,
-    updateResource: PropTypes.func.isRequired
+    updateTitle: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -135,12 +134,23 @@ class TitleEditRoute extends Component {
   }
 
   titleEditSubmitted = (values) => {
-    let { model, updateResource } = this.props;
-    let resource = model.resources.records[0];
-    updateResource(Object.assign(resource, {
+    const {
+      model,
+      updateTitle,
+    } = this.props;
+
+    const excludedAttrs = {
+      subjects: null,
+      isTitleCustom: null,
+    };
+
+    const newValues = {
       ...values,
-      identifiers: this.expandIdentifiers(values.identifiers)
-    }));
+      identifiers: this.expandIdentifiers(values.identifiers),
+      ...excludedAttrs,
+    };
+
+    updateTitle(Object.assign(model, newValues));
   }
 
   render() {
@@ -176,9 +186,9 @@ class TitleEditRoute extends Component {
 export default connect(
   ({ eholdings: { data } }, { match }) => ({
     model: createResolver(data).find('titles', match.params.titleId),
-    updateRequest: createResolver(data).getRequest('update', { type: 'resources' })
+    updateRequest: createResolver(data).getRequest('update', { type: 'titles' })
   }), {
     getTitle: id => Title.find(id, { include: 'resources' }),
-    updateResource: model => Resource.save(model)
+    updateTitle: model => Title.save(model)
   }
 )(TitleEditRoute);

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -280,6 +280,19 @@ export default function config() {
     return title;
   });
 
+  this.put('/titles/:id', (schema, request) => {
+    const body = JSON.parse(request.requestBody);
+
+    return {
+      data: {
+        ...body.data,
+        attributes: {
+          ...body.data.attributes,
+        }
+      },
+    };
+  });
+
   // Resources
   this.get('/packages/:id/resources', nestedResourceRouteFor('package', 'resources', (resource, req) => {
     let title = resource.title;

--- a/test/bigtest/network/models/title.js
+++ b/test/bigtest/network/models/title.js
@@ -1,5 +1,5 @@
 import { Model, hasMany } from '@bigtest/mirage';
 
 export default Model.extend({
-  resources: hasMany()
+  resources: hasMany(),
 });

--- a/test/bigtest/tests/custom-title-edit-test.js
+++ b/test/bigtest/tests/custom-title-edit-test.js
@@ -43,7 +43,11 @@ describe('CustomTitleEdit', () => {
           id: '11133394'
         }
       ],
-      isTitleCustom: true
+      isTitleCustom: true,
+      description: 'custom description',
+      tags: {
+        tagList: [],
+      },
     });
 
     title.save();
@@ -71,7 +75,7 @@ describe('CustomTitleEdit', () => {
     });
 
     it('shows a description field', () => {
-      expect(TitleEditPage.descriptionField).to.equal('');
+      expect(TitleEditPage.descriptionField).to.equal('custom description');
     });
 
     it('shows a contributor field', () => {
@@ -321,7 +325,7 @@ describe('CustomTitleEdit', () => {
 
   describe('encountering a server error when PUTting', () => {
     beforeEach(function () {
-      this.server.put('/resources/:id', {
+      this.server.put('/titles/:id', {
         errors: [{
           title: 'There was an error'
         }]


### PR DESCRIPTION
https://issues.folio.org/browse/UIEH-636

## Purpose
  BE added an endpoint for updating titles separately from resources. It is necessary to change titles updating logic on FE side.

## Approach
- In `titles-edit` component replace `updateResource` method with  `updateTitle`.
- Exclude unnecessary model params(mark as null and exclude them in titles serializer) before sending a request for updating the titles.
- Add put endpoint to mirage