### PR TITLE
UIEH-637: fix bug on closing unsaved form

### DIFF
--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -17,7 +17,7 @@ export const actionTypes = {
   RESOLVE: '@@ui-eholdings/db/RESOLVE',
   REJECT: '@@ui-eholdings/db/REJECT',
   UNLOAD: '@@ui-eholdings/db/UNLOAD',
-  REMOVE_CREATE_REQUESTS: '@@ui-eholdings/db/REMOVE_CREATE_REQUESTS'
+  REMOVE_REQUESTS: '@@ui-eholdings/db/REMOVE_REQUESTS',
 };
 
 /**
@@ -179,10 +179,11 @@ const reject = (request, errors, data) => ({
  * for specific resource type
  * @param {String} type - resource type
  */
-export const removeCreateRequests = (type) => ({
-  type: actionTypes.REMOVE_CREATE_REQUESTS,
+export const removeRequests = (resourceType, requestType) => ({
+  type: actionTypes.REMOVE_REQUESTS,
   data: {
-    type,
+    resourceType,
+    requestType,
   }
 });
 
@@ -306,16 +307,17 @@ const handlers = {
   /**
    * Handles reducing the data store when removing the create requests
    * @param {Object} state - data store state
-   * @param {Object} action.data - include the data about the ctrate request type
+   * @param {String} action.data.resourceType - the type of recource whose requests should be removed
+   * @param {String} action.data.requestType - the type of requests which should be removed
    */
-  [actionTypes.REMOVE_CREATE_REQUESTS]: (state, { data }) => {
-    return reduceData(data.type, state, store => ({
+  [actionTypes.REMOVE_REQUESTS]: (state, { data }) => {
+    return reduceData(data.resourceType, state, store => ({
 
       requests: Object.keys(store.requests).reduce((reqs, timestamp) => {
         let request = store.requests[timestamp];
 
-        // if the request does not create one - keep it
-        if (request.type !== 'create') {
+        // keep the request only if it's not of the type which we want to remove
+        if (request.type !== data.requestType) {
           reqs[timestamp] = request;
         }
         return reqs;

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -8,7 +8,7 @@ import {
   unload,
   destroy,
   create,
-  removeCreateRequests,
+  removeRequests,
 } from './data';
 
 /**
@@ -283,8 +283,8 @@ class BaseModel {
   /**
    * Action creator for removing create requests for specific model's resource
    */
-  static removeCreateRequests() {
-    return removeCreateRequests(this.type);
+  static removeRequests(requestType) {
+    return removeRequests(this.type, requestType);
   }
 
   /**

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -281,7 +281,7 @@ class BaseModel {
   }
 
   /**
-   * Action creator for removing create requests for specific model's resource
+   * Action creator for removing requests of given type for specific model's resource
    */
   static removeRequests(requestType) {
     return removeRequests(this.type, requestType);

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -80,6 +80,6 @@ export default connect(
     createRequest: createResolver(data).getRequest('create', { type: 'packages', pageSize: 100 })
   }), {
     createPackage: attrs => Package.create(attrs),
-    removeCreateRequests: () => Package.removeCreateRequests(),
+    removeCreateRequests: () => Package.removeRequests('create'),
   }
 )(PackageCreateRoute);

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -27,6 +27,7 @@ class PackageEditRoute extends Component {
     model: PropTypes.object.isRequired,
     provider: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
+    removeUpdateRequests: PropTypes.func.isRequired,
     unloadResources: PropTypes.func.isRequired,
     updatePackage: PropTypes.func.isRequired,
     updateProvider: PropTypes.func.isRequired
@@ -89,6 +90,10 @@ class PackageEditRoute extends Component {
         state: { eholdings: true, isFreshlySaved: true }
       });
     }
+  }
+
+  componentWillUnmount() {
+    this.props.removeUpdateRequests();
   }
 
   providerEditSubmitted = (values) => {
@@ -262,6 +267,7 @@ export default connect(
     unloadResources: collection => Resource.unload(collection),
     updateProvider: provider => Provider.save(provider),
     updatePackage: model => Package.save(model),
-    destroyPackage: model => Package.destroy(model)
+    destroyPackage: model => Package.destroy(model),
+    removeUpdateRequests: () => Package.removeRequests('update'),
   }
 )(PackageEditRoute);

--- a/src/routes/provider-edit.js
+++ b/src/routes/provider-edit.js
@@ -22,8 +22,9 @@ class ProviderEditRoute extends Component {
     match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
+    removeUpdateRequests: PropTypes.func.isRequired,
     rootProxy: PropTypes.object.isRequired,
-    updateProvider: PropTypes.func.isRequired
+    updateProvider: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -55,6 +56,10 @@ class ProviderEditRoute extends Component {
         state: { eholdings: true, isFreshlySaved: true }
       });
     }
+  }
+
+  componentWillUnmount() {
+    this.props.removeUpdateRequests();
   }
 
   providerEditSubmitted = (values) => {
@@ -136,6 +141,7 @@ export default connect(
     getProvider: id => Provider.find(id),
     updateProvider: model => Provider.save(model),
     getProxyTypes: () => ProxyType.query(),
-    getRootProxy: () => RootProxy.find('root-proxy')
+    getRootProxy: () => RootProxy.find('root-proxy'),
+    removeUpdateRequests: () => Provider.removeRequests('update'),
   }
 )(ProviderEditRoute);

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -101,7 +101,7 @@ export default connect(
     };
   }, {
     createTitle: attrs => Title.create(attrs),
-    removeCreateRequests: () => Title.removeCreateRequests(),
+    removeCreateRequests: () => Title.removeRequests('create'),
     getCustomPackages: () => Package.query({
       filter: { custom: true },
       count: 100,

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -20,6 +20,7 @@ class TitleEditRoute extends Component {
     location: ReactRouterPropTypes.location.isRequired,
     match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired,
+    removeUpdateRequests: PropTypes.func.isRequired,
     updateRequest: PropTypes.object,
     updateTitle: PropTypes.func.isRequired
   };
@@ -65,6 +66,10 @@ class TitleEditRoute extends Component {
         state: { eholdings: true, isFreshlySaved: true }
       });
     }
+  }
+
+  componentWillUnmount() {
+    this.props.removeUpdateRequests();
   }
 
   flattenedIdentifiers = [
@@ -222,6 +227,7 @@ export default connect(
     updateRequest: createResolver(data).getRequest('update', { type: 'titles' })
   }), {
     getTitle: id => Title.find(id, { include: 'resources' }),
-    updateTitle: model => Title.save(model)
+    updateTitle: model => Title.save(model),
+    removeUpdateRequests: () => Title.removeRequests('update'),
   }
 )(TitleEditRoute);


### PR DESCRIPTION
## Purpose
Currently, we have a bug on closing unsaved form, which is described below:
1. Search for a package
2. Edit it and save (if you clicked close button after changing some form fields, a modal notifying about unsaved changes would appear)
3. Start editing this package again, change some fields of the form, but this time, instead of saving the changes, click close button
4. See that no confirmation modal appeared, even though we have unsaved changes

Same issue can be reproduced for titles and providers. 
The problem was caused by the update request object, which contained not relevant information

## Approach

1. Create `REMOVE_REQUEST` action which takes the type of request and then is used to remove requests of that type 
2. Use this action in title/package/provider edit components to delete the update requests after the title/package/provider is updated