### PR TITLE
UIEH-586: Assign tags to package record

### DIFF
--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -105,6 +105,15 @@ class ProviderShow extends Component {
     );
   }
 
+  getEntityTags = () => {
+    return get(this.props.model, ['tags', 'tagList'], []);
+  };
+
+  getTagLabelsArr = () => {
+    const tagRecords = get(this.props.tagsModel, ['resolver', 'state', 'tags', 'records'], {});
+    return Object.values(tagRecords).map((tag) => tag.attributes);
+  };
+
   render() {
     let {
       fetchPackages,
@@ -123,10 +132,7 @@ class ProviderShow extends Component {
     let hasProxy = model.proxy && model.proxy.id;
     let hasToken = model.providerToken && model.providerToken.prompt;
     const hasProviderSettings = hasProxy || hasToken;
-    const tagRecords = get(tagsModel, ['resolver', 'state', 'tags', 'records'], {});
-    const tagLabelsArr = Object.values(tagRecords).map((tag) => tag.attributes);
     const hasSelectedPackages = model.packagesSelected > 0;
-    const entityTags = get(model, ['tags', 'tagList'], []);
 
     return (
       <div>
@@ -168,7 +174,7 @@ class ProviderShow extends Component {
                   displayWhenClosed={
                     <Badge sixe='small'>
                       <span data-test-eholdings-provider-tags-bage>
-                        <FormattedNumber value={entityTags.length} />
+                        <FormattedNumber value={this.getEntityTags().length} />
                       </span>
                     </Badge>
                   }
@@ -180,7 +186,7 @@ class ProviderShow extends Component {
                         updateEntityTags={updateEntityTags}
                         updateFolioTags={updateFolioTags}
                         model={model}
-                        tags={tagLabelsArr}
+                        tags={this.getTagLabelsArr()}
                       />
                     )
                   }

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -16,6 +16,9 @@ class Package {
   packageType = '';
   proxy = {};
   packageToken = {};
+  tags = {
+    tagList: []
+  };
 
   get isPartiallySelected() {
     return this.selectedCount > 0 && this.selectedCount !== this.titleCount;

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -10,6 +10,7 @@ import { ProxyType } from '../redux/application';
 import Package from '../redux/package';
 import Provider from '../redux/provider';
 import Resource from '../redux/resource';
+import Tag from '../redux/tag';
 import { transformQueryParams } from '../components/utilities';
 
 import View from '../components/package/show';
@@ -22,13 +23,17 @@ class PackageShowRoute extends Component {
     getPackageTitles: PropTypes.func.isRequired,
     getProvider: PropTypes.func.isRequired,
     getProxyTypes: PropTypes.func.isRequired,
+    getTags: PropTypes.func.isRequired,
     history: ReactRouterPropTypes.history.isRequired,
     location: ReactRouterPropTypes.location.isRequired,
     match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired,
     provider: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
+    tagsModel: PropTypes.object.isRequired,
     unloadResources: PropTypes.func.isRequired,
+    updateEntityTags: PropTypes.func.isRequired,
+    updateFolioTags: PropTypes.func.isRequired,
     updatePackage: PropTypes.func.isRequired,
   };
 
@@ -39,6 +44,7 @@ class PackageShowRoute extends Component {
     props.getPackage(packageId);
     props.getProxyTypes();
     props.getProvider(providerId);
+    props.getTags();
   }
 
   state = {
@@ -183,8 +189,11 @@ class PackageShowRoute extends Component {
     const {
       history,
       model,
+      tagsModel,
       provider,
       proxyTypes,
+      updateEntityTags,
+      updateFolioTags,
     } = this.props;
     const {
       pkgSearchParams,
@@ -195,6 +204,9 @@ class PackageShowRoute extends Component {
       <TitleManager record={model.name}>
         <View
           model={model}
+          tagsModel={tagsModel}
+          updateEntityTags={updateEntityTags}
+          updateFolioTags={updateFolioTags}
           proxyTypes={proxyTypes}
           provider={provider}
           fetchPackageTitles={this.setPage}
@@ -243,15 +255,19 @@ export default connect(
       model,
       proxyTypes: resolver.query('proxyTypes'),
       provider: resolver.find('providers', model.providerId),
+      tagsModel: resolver.query('tags'),
       resolver
     };
   }, {
     getPackage: id => Package.find(id),
     getPackageTitles: (id, params) => Package.queryRelated(id, 'resources', params),
     getProxyTypes: () => ProxyType.query(),
+    getTags: () => Tag.query(),
     getProvider: id => Provider.find(id),
     unloadResources: collection => Resource.unload(collection),
     updatePackage: model => Package.save(model),
+    updateEntityTags: (model) => Package.save(model),
+    updateFolioTags: (model) => Tag.create(model),
     destroyPackage: model => Package.destroy(model)
   }
 )(PackageShowRoute);

--- a/test/bigtest/interactors/package-show.js
+++ b/test/bigtest/interactors/package-show.js
@@ -64,6 +64,7 @@ import PackageSelectionStatus from './selection-status';
   providerToken = text('[data-test-eholdings-details-token="provider"]');
   providerTokenMessage = text('[data-test-eholdings-details-token-message="provider"]');
   isProviderTokenPresent = isPresent('[data-test-eholdings-details-token="provider"]');
+  isTagsPresent = isPresent('[data-test-eholdings-details-tags]');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="package"]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button]');
   hasCollapseAllButton = isPresent('[data-test-eholdings-details-view-collapse-all-button]');

--- a/test/bigtest/network/factories/package.js
+++ b/test/bigtest/network/factories/package.js
@@ -25,7 +25,9 @@ export default Factory.extend({
     'Partial',
     'Variable'
   ]),
-
+  tags: {
+    tagList: [],
+  },
   withTitles: trait({
     afterCreate(packageObj, server) {
       // If titleCount is greater than zero, we'll auto-create the package titles

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -36,6 +36,10 @@ describe('PackageShow', () => {
       expect(PackageShowPage.paneTitle).to.equal('Cool Package');
     });
 
+    it('does not display tags accordion', () => {
+      expect(PackageShowPage.isTagsPresent).to.equal(false);
+    });
+
     it('displays and focuses on the package name', () => {
       expect(PackageShowPage.name).to.equal('Cool Package');
       expect(PackageShowPage.nameHasFocus).to.be.true;
@@ -115,6 +119,7 @@ describe('PackageShow', () => {
 
   describe('viewing a partially selected package', () => {
     let pkg;
+
     beforeEach(function () {
       pkg = this.server.create('package', {
         provider,
@@ -132,12 +137,19 @@ describe('PackageShow', () => {
       });
       this.visit(`/eholdings/packages/${pkg.id}`);
     });
+
     it('shows the selected # of titles and the total # of titles in the package', () => {
       expect(PackageShowPage.selectionStatus.text).to.equal('5 of 10 titles selected');
     });
+
     it('has a button to add all of the remaining titles by selecting the entire package directly in the detail record', () => {
       expect(PackageShowPage.selectionStatus.buttonText).to.equal('Add all to holdings');
     });
+
+    it('does not display tags accordion', () => {
+      expect(PackageShowPage.isTagsPresent).to.equal(false);
+    });
+
     describe('inspecting the menu', () => {
       beforeEach(() => {
         return PackageShowPage.dropDown.clickDropDownButton();
@@ -159,6 +171,10 @@ describe('PackageShow', () => {
       this.visit(`/eholdings/packages/${providerPackage.id}`);
     });
 
+    it('display tags accordion', () => {
+      expect(PackageShowPage.isTagsPresent).to.equal(true);
+    });
+
     it('displays the package type as complete', () => {
       expect(PackageShowPage.packageType).to.equal('Complete');
     });
@@ -178,6 +194,10 @@ describe('PackageShow', () => {
       providerPackage.packageType = 'Custom';
       providerPackage.isSelected = true;
       this.visit(`/eholdings/packages/${providerPackage.id}`);
+    });
+
+    it('display tags accordion', () => {
+      expect(PackageShowPage.isTagsPresent).to.equal(true);
     });
 
     it('displays the package type as custom', () => {


### PR DESCRIPTION
## Purpose
Purpose: To display, assign, unassign, and output tags associated with individual Package records within the FOLIO eholdings app.

As a staff person
I want to be able to assign, unassign, view, and output tags in a FOLIO eholdings app's package record
So that I can categorize records for filtering and reporting purposes.

Background
Tags are meant to be labels that can be assigned to individual data records in various FOLIO apps. Tags will be used as a visual indicator in the record, to gather records in some way, and to facilitate reporting. This is a cross-app “helper app.” Github repo: https://github.com/folio-org/ui-tags

## Approach
tags functionality in the eholdings app was developed separately from the tags implemented in the stripes-smart-components as in eholdings we not used the search and sort component that integrates the tags.

In order to add the tags the tags the new Tags model was added.
Tags to populate the multi-select dropdown we receive from the direct api call to the mod-tags.

In case the new custom tag is added the tag is also added to the mod-tags.

