### PR TITLE
UIEH-656: fix bug on adding a contributor with default type

### DIFF
--- a/src/components/title/_fields/contributor/contributor-field.js
+++ b/src/components/title/_fields/contributor/contributor-field.js
@@ -71,7 +71,7 @@ export default class ContributorField extends Component {
   renderContributorTypeOptions() {
     return contributorTypeOptions.map(({ value, translationIdEnding }) => (
       <FormattedMessage id={`ui-eholdings.label.${translationIdEnding}`}>
-        {(message) => <option value={value}>{message}</option>}
+        {message => <option value={value}>{message}</option>}
       </FormattedMessage>
     ));
   }
@@ -120,7 +120,8 @@ export default class ContributorField extends Component {
       <div data-test-eholdings-contributors-fields>
         <FieldArray name="contributors">
           {({ fields, meta: { initial } }) => {
-            const emptyMessage = initial && initial.length > 0 && initial[0].contributor
+            const areInitialValuesPassed = initial && initial.length;
+            const emptyMessage = areInitialValuesPassed
               ? <FormattedMessage id="ui-eholdings.title.contributor.notSet" />
               : '';
 
@@ -131,7 +132,7 @@ export default class ContributorField extends Component {
                 fields={fields}
                 legend={legend}
                 onAdd={() => this.addNewField(fields)}
-                onRemove={index => fields.remove(index)}
+                onRemove={fields.remove}
                 renderField={this.renderFields}
               />
             );

--- a/src/components/title/_fields/contributor/contributor-field.js
+++ b/src/components/title/_fields/contributor/contributor-field.js
@@ -57,7 +57,7 @@ export default class ContributorField extends Component {
         <Field
           name={`${contributor}.type`}
           component={Select}
-          autoFocus={Object.keys(contributor).length === 0}
+          autoFocus
           label={<FormattedMessage id="ui-eholdings.type" />}
           id={`${contributor}-type`}
           validate={this.validateContributorType}

--- a/src/components/title/_fields/contributor/contributor-field.js
+++ b/src/components/title/_fields/contributor/contributor-field.js
@@ -12,6 +12,21 @@ import {
 import { FormattedMessage } from 'react-intl';
 import styles from './contributor-field.css';
 
+const contributorTypeOptions = [
+  {
+    value: 'Author',
+    translationIdEnding: 'author'
+  },
+  {
+    value: 'Editor',
+    translationIdEnding: 'editor'
+  },
+  {
+    value: 'Illustrator',
+    translationIdEnding: 'illustrator'
+  },
+];
+
 export default class ContributorField extends Component {
   validateName(value) {
     let errors;
@@ -27,74 +42,100 @@ export default class ContributorField extends Component {
     return errors;
   }
 
-  renderField = (contributor) => {
+  addNewField(fields) {
+    const defaultContributorTypeOption = contributorTypeOptions[0].value;
+
+    fields.push({ type: defaultContributorTypeOption });
+  }
+
+  renderContributorTypeField(contributor) {
+    return (
+      <div
+        data-test-eholdings-contributor-type
+        className={styles['contributor-fields-contributor']}
+      >
+        <Field
+          name={`${contributor}.type`}
+          component={Select}
+          autoFocus={Object.keys(contributor).length === 0}
+          label={<FormattedMessage id="ui-eholdings.type" />}
+          id={`${contributor}-type`}
+          validate={this.validateContributorType}
+        >
+          {this.renderContributorTypeOptions()}
+        </Field>
+      </div>
+    );
+  }
+
+  renderContributorTypeOptions() {
+    return contributorTypeOptions.map(({ value, translationIdEnding }) => (
+      <FormattedMessage id={`ui-eholdings.label.${translationIdEnding}`}>
+        {(message) => <option value={value}>{message}</option>}
+      </FormattedMessage>
+    ));
+  }
+
+  renderContributorNameField(contributor) {
+    return (
+      <div
+        data-test-eholdings-contributor-contributor
+        className={styles['contributor-fields-contributor']}
+      >
+        <Field
+          name={`${contributor}.contributor`}
+          type="text"
+          id={`${contributor}-input`}
+          component={TextField}
+          label={<FormattedMessage id="ui-eholdings.name" />}
+          validate={this.validateName}
+        />
+      </div>
+    );
+  }
+
+  renderFields = (contributor) => {
     return (
       <Fragment>
-        <div
-          data-test-eholdings-contributor-type
-          className={styles['contributor-fields-contributor']}
-        >
-          <Field
-            name={`${contributor}.type`}
-            component={Select}
-            autoFocus={Object.keys(contributor).length === 0}
-            label={<FormattedMessage id="ui-eholdings.type" />}
-            id={`${contributor}-type`}
-          >
-            <FormattedMessage id="ui-eholdings.label.author">
-              {(message) => <option value="author">{message}</option>}
-            </FormattedMessage>
-            <FormattedMessage id="ui-eholdings.label.editor">
-              {(message) => <option value="editor">{message}</option>}
-            </FormattedMessage>
-            <FormattedMessage id="ui-eholdings.label.illustrator">
-              {(message) => <option value="illustrator">{message}</option>}
-            </FormattedMessage>
-          </Field>
-        </div>
-        <div
-          data-test-eholdings-contributor-contributor
-          className={styles['contributor-fields-contributor']}
-        >
-          <Field
-            name={`${contributor}.contributor`}
-            type="text"
-            id={`${contributor}-input`}
-            component={TextField}
-            label={<FormattedMessage id="ui-eholdings.name" />}
-            validate={this.validateName}
-          />
-        </div>
+        {this.renderContributorTypeField(contributor)}
+        {this.renderContributorNameField(contributor)}
       </Fragment>
     );
   }
 
   render() {
+    const addLabel = (
+      <Icon icon="plus-sign">
+        <FormattedMessage id="ui-eholdings.title.contributor.addContributor" />
+      </Icon>
+    );
+
+    const legend = (
+      <Headline tag="h4">
+        <FormattedMessage id="ui-eholdings.label.contributors" />
+      </Headline>
+    );
+
     return (
       <div data-test-eholdings-contributors-fields>
         <FieldArray name="contributors">
-          {({ fields, meta: { initial } }) => (
-            <RepeatableField
-              addLabel={
-                <Icon icon="plus-sign">
-                  <FormattedMessage id="ui-eholdings.title.contributor.addContributor" />
-                </Icon>
-              }
-              emptyMessage={
-                initial && initial.length > 0 && initial[0].contributor ?
-                  <FormattedMessage id="ui-eholdings.title.contributor.notSet" /> : ''
-              }
-              fields={fields}
-              legend={
-                <Headline tag="h4">
-                  <FormattedMessage id="ui-eholdings.label.contributors" />
-                </Headline>
-              }
-              onAdd={() => fields.push({})}
-              onRemove={index => fields.remove(index)}
-              renderField={this.renderField}
-            />
-          )}
+          {({ fields, meta: { initial } }) => {
+            const emptyMessage = initial && initial.length > 0 && initial[0].contributor
+              ? <FormattedMessage id="ui-eholdings.title.contributor.notSet" />
+              : '';
+
+            return (
+              <RepeatableField
+                addLabel={addLabel}
+                emptyMessage={emptyMessage}
+                fields={fields}
+                legend={legend}
+                onAdd={() => this.addNewField(fields)}
+                onRemove={index => fields.remove(index)}
+                renderField={this.renderFields}
+              />
+            );
+          }}
         </FieldArray>
       </div>
     );

--- a/test/bigtest/tests/custom-title-edit-test.js
+++ b/test/bigtest/tests/custom-title-edit-test.js
@@ -80,7 +80,7 @@ describe('CustomTitleEdit', () => {
 
     it('shows a contributor field', () => {
       expect(TitleEditPage.contributorValue).to.equal('Foo');
-      expect(TitleEditPage.contributorType).to.equal('author');
+      expect(TitleEditPage.contributorType).to.equal('Author');
     });
 
     it('shows add contributor button', () => {
@@ -112,7 +112,7 @@ describe('CustomTitleEdit', () => {
     describe('adding a second contributor', () => {
       beforeEach(() => {
         return TitleEditPage.clickAddContributor()
-          .contributorsRowList(1).type('editor')
+          .contributorsRowList(1).type('Editor')
           .contributorsRowList(1).contributor('Ron'); // eslint-disable-line newline-per-chained-call
       });
 

--- a/test/bigtest/tests/title-create-test.js
+++ b/test/bigtest/tests/title-create-test.js
@@ -96,7 +96,7 @@ describe('TitleCreate', () => {
       beforeEach(() => {
         return TitleCreatePage
           .fillName('My Title')
-          .addContributor('author', 'Me')
+          .addContributor('Author', 'Me')
           .selectPackage(packages[0].name)
           .save();
       });


### PR DESCRIPTION
## Purpose
Currently, when we edit a title, click `Add new contributor` and don't change the type of the contributor, the default displayed type (which is `Author`) won't be sent to the back-end. The `Author` value is displayed in the select, but it isn't actually a part of the form's state.

## Approach
I added `addNewField` method to `contributor-field` component, which is responsible for setting the value of a just created select to the form's state. I also adjusted related tests and tests related to the bug described below.

This PR also fixes another bug which I found. It can be reproduced as follows: 
1. Go to title edit
2. Add some contributors of different type to the title. Save edited title
3. Go to editing the title again
4. Notice that all contributor type selects display 'Author' option, even though you set the them to some other types

The reason for the bug was just a misspelling