### PR TITLE
UIEH-587: Assign tags to title+package (aka resource) records

### DIFF
--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -2,7 +2,6 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import update from 'lodash/fp/update';
 import set from 'lodash/fp/set';
-import get from 'lodash/get';
 
 import {
   Accordion,
@@ -16,7 +15,11 @@ import {
   Badge,
 } from '@folio/stripes/components';
 import { FormattedDate, FormattedNumber, FormattedMessage } from 'react-intl';
-import { processErrors } from '../../utilities';
+import {
+  processErrors,
+  getEntityTags,
+  getTagLabelsArr,
+} from '../../utilities';
 
 import DetailsView from '../../details-view';
 import QueryList from '../../query-list';
@@ -174,15 +177,6 @@ class PackageShow extends Component {
     );
   };
 
-  getEntityTags = () => {
-    return get(this.props.model, ['tags', 'tagList'], []);
-  };
-
-  getTagLabelsArr = () => {
-    const tagRecords = get(this.props.tagsModel, ['resolver', 'state', 'tags', 'records'], {});
-    return Object.values(tagRecords).map((tag) => tag.attributes);
-  };
-
   render() {
     let {
       model,
@@ -288,14 +282,14 @@ class PackageShow extends Component {
             <div>
               {packageSelected && (
                 <Accordion
-                  label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.provider.providerTags" /></Headline>}
+                  label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.tags" /></Headline>}
                   open={sections.providerShowTags}
                   id="providerShowTags"
                   onToggle={this.handleSectionToggle}
                   displayWhenClosed={
                     <Badge sixe='small'>
                       <span data-test-eholdings-provider-tags-bage>
-                        <FormattedNumber value={this.getEntityTags().length} />
+                        <FormattedNumber value={getEntityTags(model).length} />
                       </span>
                     </Badge>
                   }
@@ -307,7 +301,7 @@ class PackageShow extends Component {
                         updateEntityTags={updateEntityTags}
                         updateFolioTags={updateFolioTags}
                         model={model}
-                        tags={this.getTagLabelsArr()}
+                        tags={getTagLabelsArr(tagsModel)}
                       />
                     )
                   }

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -2,7 +2,6 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import update from 'lodash/fp/update';
 import set from 'lodash/fp/set';
-import get from 'lodash/get';
 import {
   Accordion,
   Button,
@@ -15,7 +14,11 @@ import {
 import { FormattedNumber, FormattedMessage } from 'react-intl';
 import capitalize from 'lodash/capitalize';
 
-import { processErrors } from '../../utilities';
+import {
+  processErrors,
+  getEntityTags,
+  getTagLabelsArr,
+} from '../../utilities';
 import DetailsView from '../../details-view';
 import QueryList from '../../query-list';
 import PackageListItem from '../../package-list-item';
@@ -105,15 +108,6 @@ class ProviderShow extends Component {
     );
   }
 
-  getEntityTags = () => {
-    return get(this.props.model, ['tags', 'tagList'], []);
-  };
-
-  getTagLabelsArr = () => {
-    const tagRecords = get(this.props.tagsModel, ['resolver', 'state', 'tags', 'records'], {});
-    return Object.values(tagRecords).map((tag) => tag.attributes);
-  };
-
   render() {
     let {
       fetchPackages,
@@ -167,14 +161,14 @@ class ProviderShow extends Component {
             <div>
               {hasSelectedPackages && (
                 <Accordion
-                  label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.provider.providerTags" /></Headline>}
+                  label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.tags" /></Headline>}
                   open={sections.providerShowTags}
                   id="providerShowTags"
                   onToggle={this.handleSectionToggle}
                   displayWhenClosed={
                     <Badge sixe='small'>
                       <span data-test-eholdings-provider-tags-bage>
-                        <FormattedNumber value={this.getEntityTags().length} />
+                        <FormattedNumber value={getEntityTags(model).length} />
                       </span>
                     </Badge>
                   }
@@ -186,7 +180,7 @@ class ProviderShow extends Component {
                         updateEntityTags={updateEntityTags}
                         updateFolioTags={updateFolioTags}
                         model={model}
-                        tags={this.getTagLabelsArr()}
+                        tags={getTagLabelsArr(tagsModel)}
                       />
                     )
                   }

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -1,12 +1,16 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  FormattedNumber,
+} from 'react-intl';
 import update from 'lodash/fp/update';
 import set from 'lodash/fp/set';
 
 import {
   Accordion,
   Button,
+  Badge,
   Headline,
   IconButton,
   Icon,
@@ -21,8 +25,15 @@ import ExternalLink from '../external-link/external-link';
 import IdentifiersList from '../identifiers-list';
 import ContributorsList from '../contributors-list';
 import CoverageDateList from '../coverage-date-list';
-import { isBookPublicationType, isValidCoverageList, processErrors } from '../utilities';
+import {
+  isBookPublicationType,
+  isValidCoverageList,
+  processErrors,
+  getEntityTags,
+  getTagLabelsArr,
+} from '../utilities';
 import Toaster from '../toaster';
+import Tags from '../tags';
 import KeyValueColumns from '../key-value-columns';
 import ProxyDisplay from '../proxy-display';
 
@@ -32,13 +43,17 @@ class ResourceShow extends Component {
     model: PropTypes.object.isRequired,
     onEdit: PropTypes.func.isRequired,
     proxyTypes: PropTypes.object.isRequired,
-    toggleSelected: PropTypes.func.isRequired
+    tagsModel: PropTypes.object,
+    toggleSelected: PropTypes.func.isRequired,
+    updateEntityTags: PropTypes.func.isRequired,
+    updateFolioTags: PropTypes.func.isRequired,
   };
 
   state = {
     showSelectionModal: false,
     resourceSelected: this.props.model.isSelected,
     sections: {
+      resourceShowTags: true,
       resourceShowHoldingStatus: true,
       resourceShowInformation: true,
       resourceShowSettings: true,
@@ -130,7 +145,10 @@ class ResourceShow extends Component {
       model,
       proxyTypes,
       onEdit,
-      isFreshlySaved
+      isFreshlySaved,
+      tagsModel,
+      updateEntityTags,
+      updateFolioTags,
     } = this.props;
 
     let {
@@ -202,6 +220,33 @@ class ResourceShow extends Component {
           )}
           bodyContent={(
             <div>
+              {resourceSelected &&
+                <Accordion
+                  label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.tags" /></Headline>}
+                  open={sections.providerShowTags}
+                  id="resourceShowTags"
+                  onToggle={this.handleSectionToggle}
+                  displayWhenClosed={
+                    <Badge sixe='small'>
+                      <span data-test-eholdings-resource-tags-bage>
+                        <FormattedNumber value={getEntityTags(model).length} />
+                      </span>
+                    </Badge>
+                  }
+                >
+                  {(!tagsModel.request.isResolved || model.isLoading)
+                    ? <Icon icon="spinner-ellipsis" />
+                    : (
+                      <Tags
+                        updateEntityTags={updateEntityTags}
+                        updateFolioTags={updateFolioTags}
+                        model={model}
+                        tags={getTagLabelsArr(tagsModel)}
+                      />
+                    )
+                  }
+                </Accordion>
+              }
               <Accordion
                 label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.label.holdingStatus" /></Headline>}
                 open={sections.resourceShowHoldingStatus}

--- a/src/components/tags/tags.js
+++ b/src/components/tags/tags.js
@@ -46,7 +46,6 @@ export default class Tags extends React.Component {
       model,
       updateEntityTags,
     } = this.props;
-
     model.tags = { tagList: sortBy(uniq([...tags, ...this.getTagsList()])) };
     updateEntityTags(model);
   }

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import queryString from 'qs';
+import get from 'lodash/get';
 
 export function isBookPublicationType(publicationType) {
   let publicationTypeIsBook = {
@@ -74,3 +75,19 @@ export function transformQueryParams(searchType, params) {
     return { ...searchParams, filter: searchfilter };
   } else { return params; }
 }
+/**
+ *  Getter helper for the entity tags
+ * @param {Object} entityModel - entity model that has tags attibute as tags:{taglist:[]}
+ */
+export const getEntityTags = (entityModel) => {
+  return get(entityModel, ['tags', 'tagList'], []);
+};
+
+/**
+ *
+ * @param {Object} entityModel - entity model that has tags attibute as tags:{taglist:[]}
+ */
+export const getTagLabelsArr = (tagsModel) => {
+  const tagRecords = get(tagsModel, ['resolver', 'state', 'tags', 'records'], {});
+  return Object.values(tagRecords).map((tag) => tag.attributes);
+};

--- a/src/redux/resource.js
+++ b/src/redux/resource.js
@@ -18,6 +18,9 @@ class Resource {
   visibilityData = {};
   coverageStatement = '';
   proxy = {};
+  tags = {
+    tagList: [],
+  };
 
   // these are really title attributes, but have to stick around
   // until /PUT titles is available in mod-kb-ebsco
@@ -67,6 +70,7 @@ class Resource {
         isTitleCustom: this.isTitleCustom,
         isPeerReviewed: this.isPeerReviewed,
         description: this.description,
+        tags: this.tags,
       };
     }
 

--- a/src/redux/title.js
+++ b/src/redux/title.js
@@ -23,11 +23,12 @@ class Title {
     let data = { id: this.id, type: this.type };
     let { resources, ...attributes } = this.data.attributes;
     let payload = { data };
+    const readOnlyAttributes = ['isTitleCustom', 'subjects'];
 
     data.attributes = Object.keys(attributes).reduce((attrs, attr) => {
-      const isAttributeExcluded = this[attr] === null;
+      const isReadOnly = readOnlyAttributes.includes(attr);
 
-      if (isAttributeExcluded) return attrs;
+      if (isReadOnly) return attrs;
 
       return Object.assign(attrs, { [attr]: this[attr] });
     }, {});
@@ -41,7 +42,6 @@ class Title {
         attributes: resource
       }));
     }
-
     return payload;
   }
 }

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -9,26 +9,37 @@ import { createResolver } from '../redux';
 import Resource from '../redux/resource';
 import View from '../components/resource/resource-show';
 import { ProxyType } from '../redux/application';
+import Tag from '../redux/tag';
 
 class ResourceShowRoute extends Component {
   static propTypes = {
     destroyResource: PropTypes.func.isRequired,
     getProxyTypes: PropTypes.func.isRequired,
     getResource: PropTypes.func.isRequired,
+    getTags: PropTypes.func.isRequired,
     history: ReactRouterPropTypes.history.isRequired,
     location: ReactRouterPropTypes.location.isRequired,
     match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
-    updateResource: PropTypes.func.isRequired
+    tagsModel: PropTypes.object.isRequired,
+    updateEntityTags: PropTypes.func.isRequired,
+    updateFolioTags: PropTypes.func.isRequired,
+    updateResource: PropTypes.func.isRequired,
   };
 
   constructor(props) {
     super(props);
-    let { match, getResource, getProxyTypes } = props;
-    let { id } = match.params;
+    const {
+      match,
+      getResource,
+      getProxyTypes,
+      getTags,
+    } = props;
+    const { id } = match.params;
     getResource(id);
     getProxyTypes();
+    getTags();
   }
 
   componentDidUpdate(prevProps) {
@@ -94,7 +105,14 @@ class ResourceShowRoute extends Component {
   }
 
   render() {
-    const { model, proxyTypes, history } = this.props;
+    const {
+      model,
+      proxyTypes,
+      history,
+      tagsModel,
+      updateEntityTags,
+      updateFolioTags,
+    } = this.props;
 
     if (model.isLoading) {
       return <Icon icon='spinner-ellipsis' />;
@@ -104,6 +122,9 @@ class ResourceShowRoute extends Component {
       <TitleManager record={model.name}>
         <View
           model={model}
+          tagsModel={tagsModel}
+          updateEntityTags={updateEntityTags}
+          updateFolioTags={updateFolioTags}
           proxyTypes={proxyTypes}
           toggleSelected={this.toggleSelected}
           onEdit={this.handleEdit}
@@ -124,6 +145,7 @@ export default connect(
 
     return {
       model: resolver.find('resources', match.params.id),
+      tagsModel: resolver.query('tags'),
       proxyTypes: resolver.query('proxyTypes'),
       resolver
     };
@@ -131,6 +153,9 @@ export default connect(
     getResource: id => Resource.find(id, { include: ['package', 'title'] }),
     getProxyTypes: () => ProxyType.query(),
     updateResource: model => Resource.save(model),
+    updateEntityTags: model => Resource.save(model),
+    updateFolioTags: model => Tag.create(model),
+    getTags: () => Tag.query(),
     destroyResource: model => Resource.destroy(model)
   }
 )(ResourceShowRoute);

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -146,15 +146,9 @@ class TitleEditRoute extends Component {
       updateTitle,
     } = this.props;
 
-    const excludedAttrs = {
-      subjects: null,
-      isTitleCustom: null,
-    };
-
     const newValues = {
       ...values,
       identifiers: this.expandIdentifiers(values.identifiers),
-      ...excludedAttrs,
     };
 
     updateTitle(Object.assign(model, newValues));

--- a/src/routes/title-show.js
+++ b/src/routes/title-show.js
@@ -9,6 +9,7 @@ import { createResolver } from '../redux';
 import Title from '../redux/title';
 import Package from '../redux/package';
 import Resource from '../redux/resource';
+import Tag from '../redux/tag';
 import View from '../components/title/show';
 
 class TitleShowRoute extends Component {
@@ -17,19 +18,30 @@ class TitleShowRoute extends Component {
     createResource: PropTypes.func.isRequired,
     customPackages: PropTypes.object.isRequired,
     getCustomPackages: PropTypes.func.isRequired,
+    getTags: PropTypes.func.isRequired,
     getTitle: PropTypes.func.isRequired,
     history: ReactRouterPropTypes.history.isRequired,
     location: ReactRouterPropTypes.location.isRequired,
     match: ReactRouterPropTypes.match.isRequired,
-    model: PropTypes.object.isRequired
+    model: PropTypes.object.isRequired,
+    tagsModel: PropTypes.object.isRequired,
+    updateEntityTags: PropTypes.func.isRequired,
+    updateFolioTags: PropTypes.func.isRequired,
   };
 
   componentDidMount() {
-    let { match, getTitle, getCustomPackages } = this.props;
-    let { titleId } = match.params;
+    const {
+      match,
+      getTitle,
+      getCustomPackages,
+      getTags,
+    } = this.props;
+
+    const { titleId } = match.params;
 
     getTitle(titleId);
     getCustomPackages();
+    getTags();
   }
 
   componentDidUpdate(prevProps) {
@@ -99,16 +111,22 @@ class TitleShowRoute extends Component {
   }
 
   render() {
-    let {
+    const {
       model,
       customPackages,
       createRequest,
       history,
+      tagsModel,
+      updateEntityTags,
+      updateFolioTags,
     } = this.props;
 
     return (
       <TitleManager record={this.props.model.name}>
         <View
+          tagsModel={tagsModel}
+          updateEntityTags={updateEntityTags}
+          updateFolioTags={updateFolioTags}
           request={createRequest}
           model={model}
           customPackages={customPackages}
@@ -138,6 +156,7 @@ export default connect(
     return {
       model: resolver.find('titles', match.params.titleId),
       createRequest: resolver.getRequest('create', { type: 'resources' }),
+      tagsModel: resolver.query('tags'),
       customPackages: resolver.query('packages', {
         filter: { custom: true },
         count: 100
@@ -145,6 +164,9 @@ export default connect(
     };
   }, {
     getTitle: id => Title.find(id, { include: 'resources' }),
+    getTags: () => Tag.query(),
+    updateEntityTags: (model) => Title.save(model),
+    updateFolioTags: (model) => Tag.create(model),
     createResource: attrs => Resource.create(attrs),
     getCustomPackages: () => Package.query({
       filter: { custom: true },

--- a/test/bigtest/interactors/resource-show.js
+++ b/test/bigtest/interactors/resource-show.js
@@ -63,6 +63,7 @@ import Toast from './toast';
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button]');
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   paneSub = text('[data-test-eholdings-details-view-pane-sub]');
+  isTagsPresent = isPresent('[data-test-eholdings-details-tags]');
   isSelectedToggleDisabled = property('[data-test-eholdings-resource-show-selected] input[type=checkbox]', 'disabled');
   toggleIsSelected = clickable('[data-test-eholdings-resource-show-holding-status] input');
   isEditingCustomEmbargo = isPresent('[data-test-eholdings-embargo-form] form');

--- a/test/bigtest/interactors/title-show.js
+++ b/test/bigtest/interactors/title-show.js
@@ -67,6 +67,7 @@ import Toast from './toast';
   descriptionText = text('[data-test-eholdings-description-field]');
   clickEditButton = clickable('[data-test-eholdings-title-edit-link]');
   hasEditButton = isPresent('[data-test-eholdings-title-edit-link]');
+  isTagsPresent = isPresent('[data-test-eholdings-details-tags]');
 
   toast = Toast
 

--- a/test/bigtest/network/factories/resource.js
+++ b/test/bigtest/network/factories/resource.js
@@ -6,6 +6,9 @@ export default Factory.extend({
   customCoverages: [],
   coverageStatement: '',
   managedCoverages: [],
+  tags: {
+    tagList: [],
+  },
 
   withTitle: trait({
     afterCreate(resource, server) {

--- a/test/bigtest/network/factories/title.js
+++ b/test/bigtest/network/factories/title.js
@@ -26,6 +26,9 @@ export default Factory.extend({
   isPeerReviewed: false,
   edition: '',
   description: '',
+  tags: {
+    tagList: [],
+  },
 
   withPackages: trait({
     afterCreate(title, server) {

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -143,6 +143,22 @@ describe('ResourceShow', () => {
       });
     });
 
+    describe('when resource is not selected', () => {
+      it('should not display tags accordion', () => {
+        expect(ResourcePage.isTagsPresent).to.be.false;
+      });
+    });
+
+    describe('when resource is selected', () => {
+      beforeEach(() => {
+        resource.update('isSelected', true);
+      });
+
+      it('should display tags accordion', () => {
+        expect(ResourcePage.isTagsPresent).to.be.true;
+      });
+    });
+
     describe('when token is needed', () => {
       beforeEach(() => {
         resource.update('isTokenNeeded', true);

--- a/test/bigtest/tests/title-show-test.js
+++ b/test/bigtest/tests/title-show-test.js
@@ -295,6 +295,10 @@ describe('TitleShow', () => {
     it('displays the edit button for a custom title', () => {
       expect(TitleShowPage.hasEditButton).to.be.true;
     });
+
+    it('displays tags accordion for a custom title', () => {
+      expect(TitleShowPage.isTagsPresent).to.be.true;
+    });
   });
 
   describe('encountering a server error', () => {

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -56,7 +56,6 @@
     "package.toast.isNewRecord": "Custom package created.",
     "package.toast.isDestroyed": "Title removed from package.",
 
-    "provider.providerTags": "Tags",
     "provider.labels": "Labels",
     "provider.providerInformation": "Provider information",
     "provider.providerSettings": "Provider settings",
@@ -129,6 +128,7 @@
     "title.editCustomTitle": "Edit {name}",
     "title.chooseAPackage": "Choose a package",
     
+    "tags": "Tags",
     "tags.addTagFor": "Add tag for: <strong>{filter}</strong>",
 
     "settings.goBackToEholdings": "Go back to eHoldings settings",


### PR DESCRIPTION
## Purpose
To display, assign, unassign, and output tags associated with individual title+package (aka resource) records within the FOLIO eholdings app.

As a staff person
I want to be able to assign, unassign, view, and output tags on a FOLIO eholdings app's title+package (aka resource) record
So that I can categorize records for filtering and reporting purposes.

Background
Tags are meant to be labels that can be assigned to individual data records in various FOLIO apps. Tags will be used as a visual indicator in the record, to gather records in some way, and to facilitate reporting. This is a cross-app “helper app.” Github repo: https://github.com/folio-org/ui-tags

Screenshot - Same implementation as Provider
https://drive.google.com/drive/folders/1srda9mL1jeP09lKislIkxMuaG5C2a3Ap

## Approach
tags functionality in the eholdings app was developed separately from the tags implemented in the stripes-smart-components as in eholdings we not used the search and sort component that integrates the tags.

In order to add the tags the tags the new Tags model was added.
Tags to populate the multi-select dropdown we receive from the direct api call to the mod-tags.

In case the new custom tag is added the tag is also added to the mod-tags.
