### PR TITLE
Add agreements section to package show details page

### DIFF
--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -76,13 +76,14 @@ export default class AgreementsList extends React.Component {
 
         return {
           id,
-          startDate: <FormattedDate
-            value={startDate}
-            timeZone="UTC"
-            year="numeric"
-            month="numeric"
-            day="numeric"
-          />,
+          startDate: (
+            <FormattedDate
+              value={startDate}
+              year="numeric"
+              month="numeric"
+              day="numeric"
+            />
+          ),
           status: agreementStatus.label,
           name,
         };

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -21,10 +21,15 @@ const COLUMN_WIDTHS = {
 export default class AgreementsList extends React.Component {
   static propTypes = {
     agreements: PropTypes.object,
+    getAgreements: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
     agreements: {},
+  }
+
+  componentDidMount() {
+    this.props.getAgreements();
   }
 
   rowFormatter = (row) => {
@@ -93,25 +98,17 @@ export default class AgreementsList extends React.Component {
   }
 
   renderMultiColumnList = (ariaLabel) => {
-    const {
-      agreements: {
-        total,
-      },
-    } = this.props;
-
     return (
       <MultiColumnList
         id="agreements-list"
         interactive
         ariaLabel={ariaLabel}
-        totalCount={total}
         contentData={this.getResults()}
         visibleColumns={COLUMN_NAMES}
         columnMapping={this.getColumnsMap()}
         columnWidths={COLUMN_WIDTHS}
         isEmptyMessage={<FormattedMessage id="ui-eholdings.agreements.notFound" />}
         rowFormatter={this.rowFormatter}
-        onHeaderClick={this.onHeaderClickHandler}
       />
     );
   }

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -96,26 +96,24 @@ export default class AgreementsList extends React.Component {
       });
   }
 
-  renderMultiColumnList = (ariaLabel) => {
-    return (
-      <MultiColumnList
-        id="agreements-list"
-        interactive
-        ariaLabel={ariaLabel}
-        contentData={this.getResults()}
-        visibleColumns={COLUMN_NAMES}
-        columnMapping={columnsMap}
-        columnWidths={COLUMN_WIDTHS}
-        isEmptyMessage={<FormattedMessage id="ui-eholdings.agreements.notFound" />}
-        rowFormatter={this.rowFormatter}
-      />
-    );
-  }
-
   render() {
     return (
       <FormattedMessage id="ui-eholdings.agreements">
-        {(ariaLabel) => this.renderMultiColumnList(ariaLabel)}
+        {
+          (ariaLabel) => (
+            <MultiColumnList
+              id="agreements-list"
+              interactive
+              ariaLabel={ariaLabel}
+              contentData={this.getResults()}
+              visibleColumns={COLUMN_NAMES}
+              columnMapping={columnsMap}
+              columnWidths={COLUMN_WIDTHS}
+              isEmptyMessage={<FormattedMessage id="ui-eholdings.agreements.notFound" />}
+              rowFormatter={this.rowFormatter}
+            />
+          )
+        }
       </FormattedMessage>
     );
   }

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -18,6 +18,12 @@ const COLUMN_WIDTHS = {
   status: '30%',
 };
 
+const columnsMap = {
+  startDate: <FormattedMessage id="ui-eholdings.startDate" />,
+  name: <FormattedMessage id="ui-eholdings.name" />,
+  status: <FormattedMessage id="ui-eholdings.status" />,
+};
+
 export default class AgreementsList extends React.Component {
   static propTypes = {
     agreements: PropTypes.object,
@@ -90,14 +96,6 @@ export default class AgreementsList extends React.Component {
       });
   }
 
-  getColumnsMap = () => {
-    return {
-      startDate: <FormattedMessage id="ui-eholdings.startDate" />,
-      name: <FormattedMessage id="ui-eholdings.name" />,
-      status: <FormattedMessage id="ui-eholdings.status" />,
-    };
-  }
-
   renderMultiColumnList = (ariaLabel) => {
     return (
       <MultiColumnList
@@ -106,7 +104,7 @@ export default class AgreementsList extends React.Component {
         ariaLabel={ariaLabel}
         contentData={this.getResults()}
         visibleColumns={COLUMN_NAMES}
-        columnMapping={this.getColumnsMap()}
+        columnMapping={columnsMap}
         columnWidths={COLUMN_WIDTHS}
         isEmptyMessage={<FormattedMessage id="ui-eholdings.agreements.notFound" />}
         rowFormatter={this.rowFormatter}

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  FormattedMessage,
+  FormattedDate,
+} from 'react-intl';
+import { Link } from 'react-router-dom';
+
+import {
+  MultiColumnList,
+} from '@folio/stripes/components';
+
+
+const COLUMN_NAMES = ['startDate', 'status', 'name'];
+const COLUMN_WIDTHS = {
+  startDate: '30%',
+  name: '40%',
+  status: '30%',
+};
+
+export default class AgreementsList extends React.Component {
+  static propTypes = {
+    agreements: PropTypes.object,
+  }
+
+  static defaultProps = {
+    agreements: {},
+  }
+
+  rowFormatter = (row) => {
+    const {
+      rowClass,
+      rowData: { id },
+      rowProps,
+      cells,
+      labelStrings,
+    } = row;
+
+    const ermAgreementUrl = `/erm/agreements/view/${id}`;
+    const ariaLabel = labelStrings && labelStrings.join('...');
+
+    return (
+      <div
+        role="listitem"
+        key={id}
+      >
+        <Link
+          data-test-package-show-agreements-list-item
+          to={ermAgreementUrl}
+          aria-label={ariaLabel}
+          className={rowClass}
+          {...rowProps}
+        >
+          {cells}
+        </Link>
+      </div>
+    );
+  };
+
+  getResults() {
+    const results = this.props.agreements.results || [];
+
+    return results
+      .map(result => {
+        const {
+          id,
+          name,
+          startDate,
+          agreementStatus,
+        } = result;
+
+        return {
+          id,
+          startDate: <FormattedDate
+            value={startDate}
+            timeZone="UTC"
+            year="numeric"
+            month="numeric"
+            day="numeric"
+          />,
+          status: agreementStatus.label,
+          name,
+        };
+      });
+  }
+
+  getColumnsMap = () => {
+    return {
+      startDate: <FormattedMessage id="ui-eholdings.startDate" />,
+      name: <FormattedMessage id="ui-eholdings.name" />,
+      status: <FormattedMessage id="ui-eholdings.status" />,
+    };
+  }
+
+  renderMultiColumnList = (ariaLabel) => {
+    const {
+      agreements: {
+        total,
+      },
+    } = this.props;
+
+    return (
+      <MultiColumnList
+        id="agreements-list"
+        interactive
+        ariaLabel={ariaLabel}
+        totalCount={total}
+        contentData={this.getResults()}
+        visibleColumns={COLUMN_NAMES}
+        columnMapping={this.getColumnsMap()}
+        columnWidths={COLUMN_WIDTHS}
+        isEmptyMessage={<FormattedMessage id="ui-eholdings.agreements.notFound" />}
+        rowFormatter={this.rowFormatter}
+        onHeaderClick={this.onHeaderClickHandler}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <FormattedMessage id="ui-eholdings.agreements">
+        {(ariaLabel) => this.renderMultiColumnList(ariaLabel)}
+      </FormattedMessage>
+    );
+  }
+}

--- a/src/components/agreements-list/index.js
+++ b/src/components/agreements-list/index.js
@@ -1,0 +1,1 @@
+export { default } from './agreements-list';

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -1,10 +1,8 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import {
-  update,
-  set,
-  hasIn,
-} from 'lodash/fp';
+import update from 'lodash/fp/update';
+import set from 'lodash/fp/set';
+import hasIn from 'lodash/fp/hasIn';
 import {
   FormattedDate,
   FormattedNumber,
@@ -240,6 +238,7 @@ class PackageShow extends Component {
     const hasProxy = hasIn('proxy.id', model);
     const hasProviderToken = hasIn('providerToken.prompt', provider);
     const hasPackageToken = hasIn('packageToken.prompt', model);
+    const isProxyAvailable = hasProxy && proxyTypes.request.isResolved && model.isLoaded && provider.isLoaded;
 
     return (
       <div>
@@ -278,7 +277,7 @@ class PackageShow extends Component {
           )
         }
         {
-          hasProxy && proxyTypes.request.isResolved && model.isLoaded && provider.isLoaded
+          isProxyAvailable
             ? (
               <ProxyDisplay
                 model={model}
@@ -340,7 +339,15 @@ class PackageShow extends Component {
         {
           packageSelected && (
             <Accordion
-              label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.tags" /></Headline>}
+              label={(
+                <Headline
+                  size="large"
+                  tag="h3"
+                >
+                  <FormattedMessage id="ui-eholdings.tags" />
+                </Headline>
+                )
+              }
               open={sections.providerShowTags}
               id="providerShowTags"
               onToggle={this.handleSectionToggle}
@@ -367,7 +374,14 @@ class PackageShow extends Component {
           )
         }
         <Accordion
-          label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.label.holdingStatus" /></Headline>}
+          label={(
+            <Headline
+              size="large"
+              tag="h3"
+            >
+              <FormattedMessage id="ui-eholdings.label.holdingStatus" />
+            </Headline>
+          )}
           open={sections.packageShowHoldingStatus}
           id="packageShowHoldingStatus"
           onToggle={this.handleSectionToggle}
@@ -379,7 +393,14 @@ class PackageShow extends Component {
         </Accordion>
 
         <Accordion
-          label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.label.packageInformation" /></Headline>}
+          label={(
+            <Headline
+              size="large"
+              tag="h3"
+            >
+              <FormattedMessage id="ui-eholdings.label.packageInformation" />
+            </Headline>
+          )}
           open={sections.packageShowInformation}
           id="packageShowInformation"
           onToggle={this.handleSectionToggle}
@@ -388,7 +409,9 @@ class PackageShow extends Component {
             <div>
               <KeyValue label={<FormattedMessage id="ui-eholdings.package.provider" />}>
                 <div data-test-eholdings-package-details-provider>
-                  <InternalLink to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</InternalLink>
+                  <InternalLink to={`/eholdings/providers/${model.providerId}`}>
+                    {model.providerName}
+                  </InternalLink>
                 </div>
               </KeyValue>
 
@@ -430,7 +453,14 @@ class PackageShow extends Component {
         </Accordion>
 
         <Accordion
-          label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.package.packageSettings" /></Headline>}
+          label={(
+            <Headline
+              size="large"
+              tag="h3"
+            >
+              <FormattedMessage id="ui-eholdings.package.packageSettings" />
+            </Headline>
+          )}
           open={sections.packageShowSettings}
           id="packageShowSettings"
           onToggle={this.handleSectionToggle}
@@ -443,7 +473,14 @@ class PackageShow extends Component {
         </Accordion>
 
         <Accordion
-          label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.package.coverageSettings" /></Headline>}
+          label={(
+            <Headline
+              size="large"
+              tag="h3"
+            >
+              <FormattedMessage id="ui-eholdings.package.coverageSettings" />
+            </Headline>
+          )}
           closedByDefault={!packageSelected}
           open={sections.packageShowCoverageSettings}
           id="packageShowCoverageSettings"

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -515,23 +515,21 @@ class PackageShow extends Component {
     } = this.props;
 
     return (
-      (
-        <FormattedMessage
-          id="ui-eholdings.label.editLink"
-          values={{
-            name: model.name
-          }}
-        >
-          {ariaLabel => (
-            <IconButton
-              data-test-eholdings-package-edit-link
-              icon="edit"
-              ariaLabel={ariaLabel}
-              onClick={onEdit}
-            />
-          )}
-        </FormattedMessage>
-      )
+      <FormattedMessage
+        id="ui-eholdings.label.editLink"
+        values={{
+          name: model.name
+        }}
+      >
+        {ariaLabel => (
+          <IconButton
+            data-test-eholdings-package-edit-link
+            icon="edit"
+            ariaLabel={ariaLabel}
+            onClick={onEdit}
+          />
+        )}
+      </FormattedMessage>
     );
   }
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -1,8 +1,17 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import update from 'lodash/fp/update';
-import set from 'lodash/fp/set';
+import {
+  update,
+  set,
+  get,
+} from 'lodash/fp';
+import {
+  FormattedDate,
+  FormattedNumber,
+  FormattedMessage,
+} from 'react-intl';
 
+import { Pluggable } from '@folio/stripes-core';
 import {
   Accordion,
   Button,
@@ -14,20 +23,19 @@ import {
   ModalFooter,
   Badge,
 } from '@folio/stripes/components';
-import { FormattedDate, FormattedNumber, FormattedMessage } from 'react-intl';
+
 import {
   processErrors,
   getEntityTags,
   getTagLabelsArr,
 } from '../../utilities';
-
 import DetailsView from '../../details-view';
 import QueryList from '../../query-list';
 import InternalLink from '../../internal-link';
+import AgreementsList from '../../agreements-list';
 import TitleListItem from '../../title-list-item';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
-
 import SelectionStatus from '../selection-status';
 import KeyValueColumns from '../../key-value-columns';
 import ProxyDisplay from '../../proxy-display';
@@ -39,11 +47,14 @@ const ITEM_HEIGHT = 53;
 class PackageShow extends Component {
   static propTypes = {
     addPackageToHoldings: PropTypes.func.isRequired,
+    agreements: PropTypes.object,
     fetchPackageTitles: PropTypes.func.isRequired,
+    getAgreements: PropTypes.func.isRequired,
     isDestroyed: PropTypes.bool,
     isFreshlySaved: PropTypes.bool,
     isNewRecord: PropTypes.bool,
     model: PropTypes.object.isRequired,
+    onAddAgreement: PropTypes.func.isRequired,
     onEdit: PropTypes.func.isRequired,
     onFullView: PropTypes.func,
     provider: PropTypes.object.isRequired,
@@ -66,8 +77,9 @@ class PackageShow extends Component {
       packageShowInformation: true,
       packageShowSettings: true,
       packageShowCoverageSettings: true,
+      packageShowAgreements: true,
       packageShowTitles: true
-    }
+    },
   };
 
   static getDerivedStateFromProps(nextProps) {
@@ -135,76 +147,453 @@ class PackageShow extends Component {
           <FormattedMessage id="ui-eholdings.actionMenu.edit" />
         </Button>
 
-        {onFullView && (
-          <Button
-            buttonStyle="dropdownItem fullWidth"
-            onClick={onFullView}
-          >
-            <FormattedMessage id="ui-eholdings.actionMenu.fullView" />
-          </Button>
-        )}
+        {
+          onFullView && (
+            <Button
+              buttonStyle="dropdownItem fullWidth"
+              onClick={onFullView}
+            >
+              <FormattedMessage id="ui-eholdings.actionMenu.fullView" />
+            </Button>
+          )
+        }
 
-        {packageSelected && (
-          <Button
-            data-test-eholdings-package-remove-from-holdings-action
-            buttonStyle="dropdownItem fullWidth"
-            onClick={() => {
-              onToggle();
-              this.handleSelectionToggle();
-            }}
-          >
-            <FormattedMessage
-              id={`ui-eholdings.package.${(model.isCustom ? 'deletePackage' : 'removeFromHoldings')}`}
-            />
-          </Button>
-        )}
+        {
+          packageSelected && (
+            <Button
+              data-test-eholdings-package-remove-from-holdings-action
+              buttonStyle="dropdownItem fullWidth"
+              onClick={() => {
+                onToggle();
+                this.handleSelectionToggle();
+              }}
+            >
+              <FormattedMessage
+                id={`ui-eholdings.package.${(model.isCustom ? 'deletePackage' : 'removeFromHoldings')}`}
+              />
+            </Button>
+          )
+        }
 
-        {(!packageSelected || model.isPartiallySelected) && (
-          <Button
-            data-test-eholdings-package-add-to-holdings-action
-            buttonStyle="dropdownItem fullWidth"
-            onClick={() => {
-              onToggle();
-              this.props.addPackageToHoldings();
-            }}
-          >
-            <FormattedMessage
-              id={`ui-eholdings.${(model.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings')}`}
-            />
-          </Button>
-        )}
+        {
+          (!packageSelected || model.isPartiallySelected) && (
+            <Button
+              data-test-eholdings-package-add-to-holdings-action
+              buttonStyle="dropdownItem fullWidth"
+              onClick={() => {
+                onToggle();
+                this.props.addPackageToHoldings();
+              }}
+            >
+              <FormattedMessage
+                id={`ui-eholdings.${(model.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings')}`}
+              />
+            </Button>
+          )
+        }
       </Fragment>
     );
   };
 
-  render() {
-    let {
+  getAgreementsSectionHeader = () => {
+    return (
+      <Headline
+        size="large"
+        tag="h3"
+      >
+        <FormattedMessage id="ui-eholdings.agreements" />
+      </Headline>
+    );
+  }
+
+  renderFindAgreementTrigger = (props) => {
+    return (
+      <Button {...props}>
+        <FormattedMessage id="ui-eholdings.add" />
+      </Button>
+    );
+  }
+
+  getAgreementsSectionButtons() {
+    return (
+      <Pluggable
+        dataKey="package-show-find-agreement"
+        type="find-agreement"
+        renderTrigger={this.renderFindAgreementTrigger}
+        onAgreementSelected={this.onSelectAgreementHandler}
+      />
+    );
+  }
+
+  renderPackageSettings() {
+    const {
       model,
-      fetchPackageTitles,
       proxyTypes,
       provider,
-      searchModal,
-      isFreshlySaved,
-      isNewRecord,
-      isDestroyed,
+    } = this.props;
+
+    const {
+      packageAllowedToAddTitles,
+    } = this.state;
+
+    const visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
+    const hasProxy = !!get(model, 'proxy.id');
+    const hasProviderToken = !!get(provider, 'provider.providerToken.prompt');
+    const hasPackageToken = !!get(model, 'packageToken.prompt');
+
+    return (
+      <div>
+        <KeyValue label={<FormattedMessage id="ui-eholdings.package.visibility" />}>
+          <div data-test-eholdings-package-details-visibility-status>
+            {
+              !model.visibilityData.isHidden
+                ? <FormattedMessage id="ui-eholdings.yes" />
+                : <FormattedMessage id="ui-eholdings.package.visibility.no" values={{ visibilityMessage }} />
+            }
+          </div>
+        </KeyValue>
+        {
+          !model.isCustom && (
+            <KeyValue label={<FormattedMessage id="ui-eholdings.package.packageAllowToAddTitles" />}>
+              <div>
+                {
+                  packageAllowedToAddTitles !== null
+                    ? (
+                      <div data-test-eholdings-package-details-allow-add-new-titles>
+                        {packageAllowedToAddTitles ?
+                          (<FormattedMessage id="ui-eholdings.yes" />)
+                          :
+                          (<FormattedMessage id="ui-eholdings.no" />)
+                        }
+                      </div>
+                    )
+                    : (
+                      <div>
+                        <Icon icon="spinner-ellipsis" />
+                      </div>
+                    )
+                }
+              </div>
+            </KeyValue>
+          )
+        }
+        {
+          hasProxy && proxyTypes.request.isResolved && model.isLoaded && provider.isLoaded
+            ? (
+              <ProxyDisplay
+                model={model}
+                proxyTypes={proxyTypes}
+                inheritedProxyId={provider.proxy && provider.proxy.id}
+              />
+            )
+            : <Icon icon="spinner-ellipsis" />
+        }
+        {
+          hasProviderToken && (
+            provider.isLoading
+              ? <Icon icon="spinner-ellipsis" />
+              : (
+                <KeyValue label={<FormattedMessage id="ui-eholdings.provider.token" />}>
+                  <TokenDisplay
+                    token={provider.providerToken}
+                    type="provider"
+                  />
+                </KeyValue>
+              )
+          )
+        }
+        {
+          hasPackageToken && (
+            model.isLoading
+              ? <Icon icon="spinner-ellipsis" />
+              : (
+                <KeyValue label={<FormattedMessage id="ui-eholdings.package.token" />}>
+                  <TokenDisplay
+                    token={model.packageToken}
+                    type="package"
+                  />
+                </KeyValue>
+              )
+          )
+        }
+      </div>
+    );
+  }
+
+  getBodyContent() {
+    const {
+      model,
+      agreements,
       onEdit,
       tagsModel,
       updateEntityTags,
       updateFolioTags,
     } = this.props;
 
+    const {
+      sections,
+      packageSelected,
+    } = this.state;
+
+    return (
+      <div>
+        {
+          packageSelected && (
+            <Accordion
+              label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.tags" /></Headline>}
+              open={sections.providerShowTags}
+              id="providerShowTags"
+              onToggle={this.handleSectionToggle}
+              displayWhenClosed={
+                <Badge sixe='small'>
+                  <span data-test-eholdings-provider-tags-bage>
+                    <FormattedNumber value={getEntityTags(model).length} />
+                  </span>
+                </Badge>
+              }
+            >
+              {(!tagsModel.request.isResolved || model.isLoading)
+                ? <Icon icon="spinner-ellipsis" />
+                : (
+                  <Tags
+                    updateEntityTags={updateEntityTags}
+                    updateFolioTags={updateFolioTags}
+                    model={model}
+                    tags={getTagLabelsArr(tagsModel)}
+                  />
+                )
+              }
+            </Accordion>
+          )
+        }
+        <Accordion
+          label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.label.holdingStatus" /></Headline>}
+          open={sections.packageShowHoldingStatus}
+          id="packageShowHoldingStatus"
+          onToggle={this.handleSectionToggle}
+        >
+          <SelectionStatus
+            model={model}
+            onAddToHoldings={this.props.addPackageToHoldings}
+          />
+        </Accordion>
+
+        <Accordion
+          label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.label.packageInformation" /></Headline>}
+          open={sections.packageShowInformation}
+          id="packageShowInformation"
+          onToggle={this.handleSectionToggle}
+        >
+          <KeyValueColumns>
+            <div>
+              <KeyValue label={<FormattedMessage id="ui-eholdings.package.provider" />}>
+                <div data-test-eholdings-package-details-provider>
+                  <InternalLink to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</InternalLink>
+                </div>
+              </KeyValue>
+
+              {
+                model.contentType && (
+                  <KeyValue label={<FormattedMessage id="ui-eholdings.package.contentType" />}>
+                    <div data-test-eholdings-package-details-content-type>
+                      {model.contentType}
+                    </div>
+                  </KeyValue>
+                )
+              }
+
+              {
+                model.packageType && (
+                  <KeyValue label={<FormattedMessage id="ui-eholdings.package.packageType" />}>
+                    <div data-test-eholdings-package-details-type>
+                      {model.packageType}
+                    </div>
+                  </KeyValue>
+                )
+              }
+            </div>
+
+            <div>
+              <KeyValue label={<FormattedMessage id="ui-eholdings.package.titlesSelected" />}>
+                <div data-test-eholdings-package-details-titles-selected>
+                  <FormattedNumber value={model.selectedCount} />
+                </div>
+              </KeyValue>
+
+              <KeyValue label={<FormattedMessage id="ui-eholdings.package.totalTitles" />}>
+                <div data-test-eholdings-package-details-titles-total>
+                  <FormattedNumber value={model.titleCount} />
+                </div>
+              </KeyValue>
+            </div>
+          </KeyValueColumns>
+        </Accordion>
+
+        <Accordion
+          label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.package.packageSettings" /></Headline>}
+          open={sections.packageShowSettings}
+          id="packageShowSettings"
+          onToggle={this.handleSectionToggle}
+        >
+          {
+            packageSelected
+              ? this.renderPackageSettings()
+              : <p><FormattedMessage id="ui-eholdings.package.visibility.notSelected" /></p>
+          }
+        </Accordion>
+
+        <Accordion
+          label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.package.coverageSettings" /></Headline>}
+          closedByDefault={!packageSelected}
+          open={sections.packageShowCoverageSettings}
+          id="packageShowCoverageSettings"
+          onToggle={this.handleSectionToggle}
+        >
+          {
+            packageSelected
+              ? (
+                <div>
+                  {
+                    model.customCoverage.beginCoverage
+                      ? (
+                        <div>
+                          <KeyValue label={<FormattedMessage id="ui-eholdings.package.customCoverageDates" />}>
+                            <div data-test-eholdings-package-details-custom-coverage-display>
+                              <FormattedDate
+                                value={model.customCoverage.beginCoverage}
+                                timeZone="UTC"
+                                year="numeric"
+                                month="numeric"
+                                day="numeric"
+                              />
+                              &nbsp;-&nbsp;
+                              {
+                                (model.customCoverage.endCoverage)
+                                  ? (
+                                    <FormattedDate
+                                      value={model.customCoverage.endCoverage}
+                                      timeZone="UTC"
+                                      year="numeric"
+                                      month="numeric"
+                                      day="numeric"
+                                    />
+                                  )
+                                  : <FormattedMessage id="ui-eholdings.date.present" />
+                              }
+                            </div>
+                          </KeyValue>
+                        </div>
+                      )
+                      : <p><FormattedMessage id="ui-eholdings.package.customCoverage.notSet" /></p>
+                  }
+                </div>
+              )
+              : <p><FormattedMessage id="ui-eholdings.package.customCoverage.notSelected" /></p>
+          }
+        </Accordion>
+
+        <Accordion
+          id="packageShowAgreements"
+          label={this.getAgreementsSectionHeader()}
+          open={sections.packageShowAgreements}
+          displayWhenOpen={this.getAgreementsSectionButtons()}
+          onToggle={this.handleSectionToggle}
+        >
+          <AgreementsList agreements={agreements} />
+        </Accordion>
+      </div>
+    );
+  }
+
+  getLastMenu() {
+    const {
+      model,
+      onEdit,
+    } = this.props;
+
+    return (
+      (
+        <FormattedMessage
+          id="ui-eholdings.label.editLink"
+          values={{
+            name: model.name
+          }}
+        >
+          {ariaLabel => (
+            <IconButton
+              data-test-eholdings-package-edit-link
+              icon="edit"
+              ariaLabel={ariaLabel}
+              onClick={onEdit}
+            />
+          )}
+        </FormattedMessage>
+      )
+    );
+  }
+
+  renderTitlesListItem = (item) => {
+    return (
+      <TitleListItem
+        item={item.content}
+        link={item.content && `/eholdings/resources/${item.content.id}`}
+        showSelected
+        headingLevel='h4'
+      />
+    );
+  }
+
+  renderTitlesList = (scrollable) => {
+    const {
+      model,
+      fetchPackageTitles,
+    } = this.props;
+
+    return (
+      <QueryList
+        type="package-titles"
+        fetch={fetchPackageTitles}
+        collection={model.resources}
+        length={model.titleCount}
+        scrollable={scrollable}
+        itemHeight={ITEM_HEIGHT}
+        notFoundMessage={<FormattedMessage id="ui-eholdings.notFound" />}
+        renderItem={this.renderTitlesListItem}
+      />
+    );
+  }
+
+  renderAgreementsListItem(item) {
+    return (
+      <TitleListItem
+        item={item.content}
+        link={item.content && `/erm/sas/${item.content.id}`}
+        showSelected
+        headingLevel='h4'
+      />
+    );
+  }
+
+  onSelectAgreementHandler = (agreement) => {
+    this.props.onAddAgreement(agreement);
+  }
+
+  render() {
+    let {
+      model,
+      searchModal,
+      isFreshlySaved,
+      isNewRecord,
+      isDestroyed,
+      agreements,
+    } = this.props;
+
     let {
       showSelectionModal,
-      packageSelected,
-      packageAllowedToAddTitles,
       isCoverageEditable,
       sections
     } = this.state;
 
-    let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
-    let hasProxy = model.proxy && model.proxy.id;
-    let hasProviderToken = provider.providerToken && provider.providerToken.prompt;
-    let hasPackageToken = model.packageToken && model.packageToken.prompt;
     let modalMessage = model.isCustom ?
       {
         header: <FormattedMessage id="ui-eholdings.package.modal.header.isCustom" />,
@@ -219,7 +608,17 @@ class PackageShow extends Component {
         buttonCancel: <FormattedMessage id="ui-eholdings.package.modal.buttonCancel" />
       };
 
-    let toasts = processErrors(model);
+    let toasts = [
+      ...processErrors(model),
+    ];
+
+    if (get(agreements, 'error')) {
+      toasts.push({
+        type: 'error',
+        id: 'agreements-error',
+        message: agreements.error,
+      });
+    }
 
     // if coming from creating a new custom package, show a success toast
     if (isNewRecord) {
@@ -251,7 +650,11 @@ class PackageShow extends Component {
 
     return (
       <div>
-        <Toaster toasts={toasts} position="bottom" />
+        <Toaster
+          toasts={toasts}
+          position="bottom"
+        />
+
         <DetailsView
           type="package"
           model={model}
@@ -261,246 +664,13 @@ class PackageShow extends Component {
           sections={sections}
           handleExpandAll={this.handleExpandAll}
           searchModal={searchModal}
-          lastMenu={(
-            <FormattedMessage
-              id="ui-eholdings.label.editLink"
-              values={{
-                name: model.name
-              }}
-            >
-              {ariaLabel => (
-                <IconButton
-                  data-test-eholdings-package-edit-link
-                  icon="edit"
-                  ariaLabel={ariaLabel}
-                  onClick={onEdit}
-                />
-              )}
-            </FormattedMessage>
-          )}
-          bodyContent={(
-            <div>
-              {packageSelected && (
-                <Accordion
-                  label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.tags" /></Headline>}
-                  open={sections.providerShowTags}
-                  id="providerShowTags"
-                  onToggle={this.handleSectionToggle}
-                  displayWhenClosed={
-                    <Badge sixe='small'>
-                      <span data-test-eholdings-provider-tags-bage>
-                        <FormattedNumber value={getEntityTags(model).length} />
-                      </span>
-                    </Badge>
-                  }
-                >
-                  {(!tagsModel.request.isResolved || model.isLoading)
-                    ? <Icon icon="spinner-ellipsis" />
-                    : (
-                      <Tags
-                        updateEntityTags={updateEntityTags}
-                        updateFolioTags={updateFolioTags}
-                        model={model}
-                        tags={getTagLabelsArr(tagsModel)}
-                      />
-                    )
-                  }
-                </Accordion>
-              )}
-              <Accordion
-                label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.label.holdingStatus" /></Headline>}
-                open={sections.packageShowHoldingStatus}
-                id="packageShowHoldingStatus"
-                onToggle={this.handleSectionToggle}
-              >
-                <SelectionStatus
-                  model={model}
-                  onAddToHoldings={this.props.addPackageToHoldings}
-                />
-              </Accordion>
-              <Accordion
-                label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.label.packageInformation" /></Headline>}
-                open={sections.packageShowInformation}
-                id="packageShowInformation"
-                onToggle={this.handleSectionToggle}
-              >
-                <KeyValueColumns>
-                  <div>
-                    <KeyValue label={<FormattedMessage id="ui-eholdings.package.provider" />}>
-                      <div data-test-eholdings-package-details-provider>
-                        <InternalLink to={`/eholdings/providers/${model.providerId}`}>{model.providerName}</InternalLink>
-                      </div>
-                    </KeyValue>
-
-                    {model.contentType && (
-                      <KeyValue label={<FormattedMessage id="ui-eholdings.package.contentType" />}>
-                        <div data-test-eholdings-package-details-content-type>
-                          {model.contentType}
-                        </div>
-                      </KeyValue>
-                    )}
-
-                    {model.packageType && (
-                      <KeyValue label={<FormattedMessage id="ui-eholdings.package.packageType" />}>
-                        <div data-test-eholdings-package-details-type>
-                          {model.packageType}
-                        </div>
-                      </KeyValue>
-                    )}
-                  </div>
-
-                  <div>
-                    <KeyValue label={<FormattedMessage id="ui-eholdings.package.titlesSelected" />}>
-                      <div data-test-eholdings-package-details-titles-selected>
-                        <FormattedNumber value={model.selectedCount} />
-                      </div>
-                    </KeyValue>
-
-                    <KeyValue label={<FormattedMessage id="ui-eholdings.package.totalTitles" />}>
-                      <div data-test-eholdings-package-details-titles-total>
-                        <FormattedNumber value={model.titleCount} />
-                      </div>
-                    </KeyValue>
-                  </div>
-                </KeyValueColumns>
-              </Accordion>
-              <Accordion
-                label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.package.packageSettings" /></Headline>}
-                open={sections.packageShowSettings}
-                id="packageShowSettings"
-                onToggle={this.handleSectionToggle}
-              >
-                {packageSelected ? (
-                  <div>
-                    <KeyValue label={<FormattedMessage id="ui-eholdings.package.visibility" />}>
-                      <div data-test-eholdings-package-details-visibility-status>
-                        {!model.visibilityData.isHidden ?
-                          (<FormattedMessage id="ui-eholdings.yes" />)
-                          :
-                          (<FormattedMessage id="ui-eholdings.package.visibility.no" values={{ visibilityMessage }} />)}
-                      </div>
-                    </KeyValue>
-                    {!model.isCustom && (
-                      <KeyValue label={<FormattedMessage id="ui-eholdings.package.packageAllowToAddTitles" />}>
-                        <div>
-                          {packageAllowedToAddTitles != null ? (
-                            <div data-test-eholdings-package-details-allow-add-new-titles>
-                              {packageAllowedToAddTitles ?
-                                (<FormattedMessage id="ui-eholdings.yes" />)
-                                :
-                                (<FormattedMessage id="ui-eholdings.no" />)
-                              }
-                            </div>
-                          ) : (
-                            <div>
-                              <Icon icon="spinner-ellipsis" />
-                            </div>
-                          )}
-                        </div>
-                      </KeyValue>
-                    )}
-                    {hasProxy && (proxyTypes.request.isResolved && model.isLoaded && provider.isLoaded) ? (
-                      <ProxyDisplay
-                        model={model}
-                        proxyTypes={proxyTypes}
-                        inheritedProxyId={provider.proxy && provider.proxy.id}
-                      />
-                    ) : (
-                      <Icon icon="spinner-ellipsis" />
-                    )}
-                    {hasProviderToken && (
-                      (provider.isLoading) ? (
-                        <Icon icon="spinner-ellipsis" />
-                      ) : (
-                        <KeyValue label={<FormattedMessage id="ui-eholdings.provider.token" />}>
-                          <TokenDisplay
-                            token={provider.providerToken}
-                            type="provider"
-                          />
-                        </KeyValue>
-                      ))}
-                    {hasPackageToken && (
-                      (model.isLoading) ? (
-                        <Icon icon="spinner-ellipsis" />
-                      ) : (
-                        <KeyValue label={<FormattedMessage id="ui-eholdings.package.token" />}>
-                          <TokenDisplay
-                            token={model.packageToken}
-                            type="package"
-                          />
-                        </KeyValue>
-                      ))}
-                  </div>
-                ) : (
-                  <p><FormattedMessage id="ui-eholdings.package.visibility.notSelected" /></p>
-                )}
-              </Accordion>
-              <Accordion
-                label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.package.coverageSettings" /></Headline>}
-                closedByDefault={!packageSelected}
-                open={sections.packageShowCoverageSettings}
-                id="packageShowCoverageSettings"
-                onToggle={this.handleSectionToggle}
-              >
-                {packageSelected ? (
-                  <div>
-                    {model.customCoverage.beginCoverage ? (
-                      <div>
-                        <KeyValue label={<FormattedMessage id="ui-eholdings.package.customCoverageDates" />}>
-                          <div data-test-eholdings-package-details-custom-coverage-display>
-                            <FormattedDate
-                              value={model.customCoverage.beginCoverage}
-                              timeZone="UTC"
-                              year="numeric"
-                              month="numeric"
-                              day="numeric"
-                            />
-                              &nbsp;-&nbsp;
-                            {(model.customCoverage.endCoverage) ? (
-                              <FormattedDate
-                                value={model.customCoverage.endCoverage}
-                                timeZone="UTC"
-                                year="numeric"
-                                month="numeric"
-                                day="numeric"
-                              />
-                            ) : (<FormattedMessage id="ui-eholdings.date.present" />)}
-                          </div>
-                        </KeyValue>
-                      </div>
-                    ) : (
-                      <p><FormattedMessage id="ui-eholdings.package.customCoverage.notSet" /></p>
-                    )}
-                  </div>
-                ) : (
-                  <p><FormattedMessage id="ui-eholdings.package.customCoverage.notSelected" /></p>
-                )}
-              </Accordion>
-            </div>
-          )}
+          lastMenu={this.getLastMenu()}
+          bodyContent={this.getBodyContent()}
           listType="titles"
           listSectionId="packageShowTitles"
           onListToggle={this.handleSectionToggle}
           resultsLength={model.resources.length}
-          renderList={scrollable => (
-            <QueryList
-              type="package-titles"
-              fetch={fetchPackageTitles}
-              collection={model.resources}
-              length={model.titleCount}
-              scrollable={scrollable}
-              itemHeight={ITEM_HEIGHT}
-              notFoundMessage={<FormattedMessage id="ui-eholdings.notFound" />}
-              renderItem={item => (
-                <TitleListItem
-                  item={item.content}
-                  link={item.content && `/eholdings/resources/${item.content.id}`}
-                  showSelected
-                  headingLevel='h4'
-                />
-              )}
-            />
-          )}
+          renderList={this.renderTitlesList}
         />
 
         <Modal

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -220,7 +220,7 @@ class PackageShow extends Component {
         dataKey="package-show-find-agreement"
         type="find-agreement"
         renderTrigger={this.renderFindAgreementTrigger}
-        onAgreementSelected={this.onSelectAgreementHandler}
+        onAgreementSelected={this.props.onAddAgreement}
       />
     );
   }
@@ -562,21 +562,6 @@ class PackageShow extends Component {
         renderItem={this.renderTitlesListItem}
       />
     );
-  }
-
-  renderAgreementsListItem(item) {
-    return (
-      <TitleListItem
-        item={item.content}
-        link={item.content && `/erm/sas/${item.content.id}`}
-        showSelected
-        headingLevel='h4'
-      />
-    );
-  }
-
-  onSelectAgreementHandler = (agreement) => {
-    this.props.onAddAgreement(agreement);
   }
 
   render() {

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   update,
   set,
-  get,
+  hasIn,
 } from 'lodash/fp';
 import {
   FormattedDate,
@@ -237,9 +237,9 @@ class PackageShow extends Component {
     } = this.state;
 
     const visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
-    const hasProxy = !!get(model, 'proxy.id');
-    const hasProviderToken = !!get(provider, 'provider.providerToken.prompt');
-    const hasPackageToken = !!get(model, 'packageToken.prompt');
+    const hasProxy = hasIn('proxy.id', model);
+    const hasProviderToken = hasIn('providerToken.prompt', provider);
+    const hasPackageToken = hasIn('packageToken.prompt', model);
 
     return (
       <div>
@@ -323,8 +323,8 @@ class PackageShow extends Component {
   getBodyContent() {
     const {
       model,
+      getAgreements,
       agreements,
-      onEdit,
       tagsModel,
       updateEntityTags,
       updateFolioTags,
@@ -499,7 +499,10 @@ class PackageShow extends Component {
           displayWhenOpen={this.getAgreementsSectionButtons()}
           onToggle={this.handleSectionToggle}
         >
-          <AgreementsList agreements={agreements} />
+          <AgreementsList
+            getAgreements={getAgreements}
+            agreements={agreements}
+          />
         </Accordion>
       </div>
     );
@@ -585,7 +588,6 @@ class PackageShow extends Component {
       isFreshlySaved,
       isNewRecord,
       isDestroyed,
-      agreements,
     } = this.props;
 
     let {
@@ -611,14 +613,6 @@ class PackageShow extends Component {
     let toasts = [
       ...processErrors(model),
     ];
-
-    if (get(agreements, 'error')) {
-      toasts.push({
-        type: 'error',
-        id: 'agreements-error',
-        message: agreements.error,
-      });
-    }
 
     // if coming from creating a new custom package, show a success toast
     if (isNewRecord) {

--- a/src/redux/actions/attach-agreement-failure.js
+++ b/src/redux/actions/attach-agreement-failure.js
@@ -3,9 +3,6 @@ export const ATTACH_AGREEMENT_FAILURE = 'ATTACH_AGREEMENT_FAILURE';
 export function attachAgreementFailure(payload) {
   return {
     type: 'ATTACH_AGREEMENT_FAILURE',
-    payload: {
-      ...payload,
-      isLoading: false,
-    },
+    payload,
   };
-};
+}

--- a/src/redux/actions/attach-agreement-failure.js
+++ b/src/redux/actions/attach-agreement-failure.js
@@ -1,0 +1,11 @@
+export const ATTACH_AGREEMENT_FAILURE = 'ATTACH_AGREEMENT_FAILURE';
+
+export function attachAgreementFailure(payload) {
+  return {
+    type: 'ATTACH_AGREEMENT_FAILURE',
+    payload: {
+      ...payload,
+      isLoading: false,
+    },
+  };
+};

--- a/src/redux/actions/attach-agreement-success.js
+++ b/src/redux/actions/attach-agreement-success.js
@@ -1,11 +1,7 @@
 export const ATTACH_AGREEMENT_SUCCESS = 'ATTACH_AGREEMENT_SUCCESS';
 
-export function attachAgreementSuccess(payload) {
+export function attachAgreementSuccess() {
   return {
     type: 'ATTACH_AGREEMENT_SUCCESS',
-    payload: {
-      ...payload,
-      isLoading: false,
-    },
   };
-};
+}

--- a/src/redux/actions/attach-agreement-success.js
+++ b/src/redux/actions/attach-agreement-success.js
@@ -1,0 +1,11 @@
+export const ATTACH_AGREEMENT_SUCCESS = 'ATTACH_AGREEMENT_SUCCESS';
+
+export function attachAgreementSuccess(payload) {
+  return {
+    type: 'ATTACH_AGREEMENT_SUCCESS',
+    payload: {
+      ...payload,
+      isLoading: false,
+    },
+  };
+};

--- a/src/redux/actions/attach-agreement.js
+++ b/src/redux/actions/attach-agreement.js
@@ -3,9 +3,6 @@ export const ATTACH_AGREEMENT = 'ATTACH_AGREEMENT';
 export function attachAgreement(payload) {
   return {
     type: ATTACH_AGREEMENT,
-    payload: {
-      ...payload,
-      isLoading: true,
-    },
+    payload,
   };
 }

--- a/src/redux/actions/attach-agreement.js
+++ b/src/redux/actions/attach-agreement.js
@@ -1,0 +1,11 @@
+export const ATTACH_AGREEMENT = 'ATTACH_AGREEMENT';
+
+export function attachAgreement(payload) {
+  return {
+    type: ATTACH_AGREEMENT,
+    payload: {
+      ...payload,
+      isLoading: true,
+    },
+  };
+}

--- a/src/redux/actions/get-agreements-failure.js
+++ b/src/redux/actions/get-agreements-failure.js
@@ -8,4 +8,4 @@ export function getAgreementsFailure(payload) {
       isLoading: false,
     },
   };
-};
+}

--- a/src/redux/actions/get-agreements-failure.js
+++ b/src/redux/actions/get-agreements-failure.js
@@ -1,0 +1,11 @@
+export const GET_AGREEMENTS_FAILURE = 'GET_AGREEMENTS_FAILURE';
+
+export function getAgreementsFailure(payload) {
+  return {
+    type: GET_AGREEMENTS_FAILURE,
+    payload: {
+      ...payload,
+      isLoading: false,
+    },
+  };
+};

--- a/src/redux/actions/get-agreements-success.js
+++ b/src/redux/actions/get-agreements-success.js
@@ -1,0 +1,11 @@
+export const GET_AGREEMENTS_SUCCESS = 'GET_AGREEMENTS_SUCCESS';
+
+export function getAgreementsSuccess(payload) {
+  return {
+    type: GET_AGREEMENTS_SUCCESS,
+    payload: {
+      ...payload,
+      isLoading: false,
+    },
+  };
+};

--- a/src/redux/actions/get-agreements-success.js
+++ b/src/redux/actions/get-agreements-success.js
@@ -8,4 +8,4 @@ export function getAgreementsSuccess(payload) {
       isLoading: false,
     },
   };
-};
+}

--- a/src/redux/actions/get-agreements.js
+++ b/src/redux/actions/get-agreements.js
@@ -1,0 +1,11 @@
+export const GET_AGREEMENTS = 'GET_AGREEMENTS';
+
+export function getAgreements(payload) {
+  return {
+    type: GET_AGREEMENTS,
+    payload: {
+      ...payload,
+      isLoading: true,
+    },
+  };
+}

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -1,0 +1,6 @@
+export * from './attach-agreement';
+export * from './attach-agreement-success';
+export * from './attach-agreement-failure';
+export * from './get-agreements';
+export * from './get-agreements-success';
+export * from './get-agreements-failure';

--- a/src/redux/epics/attach-agreement.js
+++ b/src/redux/epics/attach-agreement.js
@@ -16,7 +16,7 @@ import {
   parseResponseBody,
 } from './common';
 
-export default function attachAgreementEpic(action$, store) {
+export default function attachAgreement(action$, store) {
   const {
     getState,
   } = store;

--- a/src/redux/epics/attachAgreement.js
+++ b/src/redux/epics/attachAgreement.js
@@ -1,0 +1,61 @@
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/from';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/catch';
+
+import {
+  ATTACH_AGREEMENT,
+  getAgreements,
+  attachAgreementFailure,
+} from '../actions';
+
+import { getHeaders } from './common';
+
+const parseResponseBody = (response) => {
+  return response.text().then((text) => {
+    try { return JSON.parse(text); } catch (e) { return text; }
+  });
+};
+
+export default function attachAgreementEpic(action$, store) {
+  const {
+    getState,
+  } = store;
+
+  return action$
+    .ofType(ATTACH_AGREEMENT)
+    .mergeMap((action) => {
+      const {
+        payload,
+      } = action;
+
+      const state = getState();
+      const PUT = 'PUT';
+
+      const url = `${state.okapi.url}/erm/sas/${payload.id}`;
+
+      const requestOptions = {
+        headers: getHeaders(state),
+        method: PUT,
+        body: {
+          items:[
+            {
+              type: 'external',
+              authority: 'EKB',
+              reference: payload.referenceId,
+              label: payload.name,
+            }
+          ],
+        },
+      };
+
+      const promise = fetch(url, requestOptions)
+        .then(response => Promise.all([response.ok, parseResponseBody(response)]))
+        .then(([ok, body]) => (ok ? body : Promise.reject(body)));
+
+      return Observable.from(promise)
+        .map(() => getAgreements({ referenceId: payload.referenceId }))
+        .catch(error => Observable.of(attachAgreementFailure(error)));
+    });
+}

--- a/src/redux/epics/attachAgreement.js
+++ b/src/redux/epics/attachAgreement.js
@@ -7,16 +7,14 @@ import 'rxjs/add/operator/catch';
 import {
   ATTACH_AGREEMENT,
   getAgreements,
+  attachAgreementSuccess,
   attachAgreementFailure,
 } from '../actions';
 
-import { getHeaders } from './common';
-
-const parseResponseBody = (response) => {
-  return response.text().then((text) => {
-    try { return JSON.parse(text); } catch (e) { return text; }
-  });
-};
+import {
+  getHeaders,
+  parseResponseBody,
+} from './common';
 
 export default function attachAgreementEpic(action$, store) {
   const {
@@ -55,7 +53,10 @@ export default function attachAgreementEpic(action$, store) {
         .then(([ok, body]) => (ok ? body : Promise.reject(body)));
 
       return Observable.from(promise)
-        .map(() => getAgreements({ referenceId: payload.referenceId }))
-        .catch(error => Observable.of(attachAgreementFailure(error)));
+        .map(() => {
+          attachAgreementSuccess();
+          return getAgreements({ referenceId: payload.referenceId });
+        })
+        .catch(error => Observable.of(attachAgreementFailure({ error })));
     });
 }

--- a/src/redux/epics/common/get-headers.js
+++ b/src/redux/epics/common/get-headers.js
@@ -1,0 +1,7 @@
+export default function getHeaders(state) {
+  return {
+    'X-Okapi-Tenant': state.okapi.tenant,
+    'X-Okapi-Token': state.okapi.token,
+    'Content-Type': 'application/json',
+  };
+}

--- a/src/redux/epics/common/index.js
+++ b/src/redux/epics/common/index.js
@@ -1,0 +1,1 @@
+export * from './get-headers';

--- a/src/redux/epics/common/index.js
+++ b/src/redux/epics/common/index.js
@@ -1,1 +1,2 @@
-export * from './get-headers';
+export { default as getHeaders } from './get-headers';
+export { default as parseResponseBody } from './parse-response-body';

--- a/src/redux/epics/common/parse-response-body.js
+++ b/src/redux/epics/common/parse-response-body.js
@@ -1,0 +1,5 @@
+export default function parseResponseBody(response) {
+  return response.text().then((text) => {
+    try { return JSON.parse(text); } catch (e) { return text; }
+  });
+}

--- a/src/redux/epics/get-agreements.js
+++ b/src/redux/epics/get-agreements.js
@@ -15,7 +15,7 @@ import {
   parseResponseBody,
 } from './common';
 
-export default function getAgreementsEpic(action$, store) {
+export default function getAgreements(action$, store) {
   const {
     getState,
   } = store;

--- a/src/redux/epics/getAgreements.js
+++ b/src/redux/epics/getAgreements.js
@@ -1,0 +1,58 @@
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/from';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/catch';
+
+import {
+  GET_AGREEMENTS,
+  getAgreementsSuccess,
+  getAgreementsFailure,
+} from '../actions';
+
+import { getHeaders } from './common';
+
+const parseResponseBody = (response) => {
+  return response.text().then((text) => {
+    try { return JSON.parse(text); } catch (e) { return text; }
+  });
+};
+
+export default function getAgreementsEpic(action$, store) {
+  const {
+    getState,
+  } = store;
+
+  return action$
+    .ofType(GET_AGREEMENTS)
+    .mergeMap((action) => {
+      const {
+        payload,
+        payload: {
+          referenceId,
+        },
+      } = action;
+
+      const state = getState();
+      const method = 'GET';
+
+      const url = `${state.okapi.url}/erm/sas?filters=items.reference=${referenceId}&sort=startDate=desc&stats=true`;
+
+      const requestOptions = {
+        headers: getHeaders(state),
+        method,
+      };
+
+      const promise = fetch(url, requestOptions)
+        .then(response => Promise.all([response.ok, parseResponseBody(response)]))
+        .then(([ok, body]) => (ok ? body : Promise.reject(body)));
+
+      return Observable
+        .from(promise)
+        .map(responseBody => getAgreementsSuccess({
+          agreements: responseBody,
+          ...payload,
+        }))
+        .catch(error => Observable.of(getAgreementsFailure({ referenceId, error })));
+    });
+}

--- a/src/redux/epics/getAgreements.js
+++ b/src/redux/epics/getAgreements.js
@@ -10,13 +10,10 @@ import {
   getAgreementsFailure,
 } from '../actions';
 
-import { getHeaders } from './common';
-
-const parseResponseBody = (response) => {
-  return response.text().then((text) => {
-    try { return JSON.parse(text); } catch (e) { return text; }
-  });
-};
+import {
+  getHeaders,
+  parseResponseBody,
+} from './common';
 
 export default function getAgreementsEpic(action$, store) {
   const {

--- a/src/redux/epics/index.js
+++ b/src/redux/epics/index.js
@@ -1,0 +1,2 @@
+export { default as getAgreementsEpic } from './getAgreements';
+export { default as attachAgreementEpic } from './attachAgreement';

--- a/src/redux/epics/index.js
+++ b/src/redux/epics/index.js
@@ -1,2 +1,2 @@
-export { default as getAgreementsEpic } from './getAgreements';
-export { default as attachAgreementEpic } from './attachAgreement';
+export { default as getAgreements } from './get-agreements';
+export { default as attachAgreement } from './attach-agreement';

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -20,11 +20,11 @@ import {
   epic as dataEpic,
 } from './data';
 
-import agreementsReducer from './reducers';
+import agreements from './reducers';
 
 import {
-  getAgreementsEpic,
-  attachAgreementEpic,
+  getAgreements,
+  attachAgreement,
 } from './epics';
 
 export const createResolver = (state) => {
@@ -42,16 +42,18 @@ export const createResolver = (state) => {
 };
 
 export const reducer = combineReducers({
-  data: (state = {}, action) => {
+  data: (state, action) => {
+    const currentState = state || {};
+
     return {
-      ...dataReducer(state, action),
-      agreements: agreementsReducer(state.agreements, action),
+      ...dataReducer(currentState, action),
+      agreements: agreements(currentState.agreements, action),
     };
   }
 });
 
 export const epics = combineEpics(
   dataEpic,
-  getAgreementsEpic,
-  attachAgreementEpic,
+  getAgreements,
+  attachAgreement,
 );

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -17,8 +17,15 @@ import {
 
 import {
   reducer as dataReducer,
-  epic as dataEpic
+  epic as dataEpic,
 } from './data';
+
+import agreementsReducer from './reducers';
+
+import {
+  getAgreementsEpic,
+  attachAgreementEpic,
+} from './epics';
 
 export const createResolver = (state) => {
   return new Resolver(state, [
@@ -35,9 +42,16 @@ export const createResolver = (state) => {
 };
 
 export const reducer = combineReducers({
-  data: dataReducer
+  data: (state = {}, action) => {
+    return {
+      ...dataReducer(state, action),
+      agreements: agreementsReducer(state.agreements, action),
+    };
+  }
 });
 
 export const epics = combineEpics(
-  dataEpic
+  dataEpic,
+  getAgreementsEpic,
+  attachAgreementEpic,
 );

--- a/src/redux/reducers/agreements.js
+++ b/src/redux/reducers/agreements.js
@@ -25,13 +25,13 @@ const handlers = {
     const {
       payload: {
         referenceId,
-        agreements,
+        agreements: agreementsItems,
       },
     } = action;
 
     return {
       ...state,
-      [referenceId]: { ...agreements },
+      [referenceId]: { ...agreementsItems },
     };
   },
   [GET_AGREEMENTS_FAILURE]: (state, action) => {
@@ -54,10 +54,12 @@ const handlers = {
   },
 };
 
-export default function agreementsReducer(state = {}, action) {
+export default function agreements(state, action) {
+  const currentState = state || {};
+
   if (handlers[action.type]) {
-    return handlers[action.type](state, action);
+    return handlers[action.type](currentState, action);
   } else {
-    return state;
+    return currentState;
   }
 }

--- a/src/redux/reducers/agreements.js
+++ b/src/redux/reducers/agreements.js
@@ -2,9 +2,6 @@ import {
   GET_AGREEMENTS,
   GET_AGREEMENTS_SUCCESS,
   GET_AGREEMENTS_FAILURE,
-  ATTACH_AGREEMENT,
-  ATTACH_AGREEMENT_SUCCESS,
-  ATTACH_AGREEMENT_FAILURE,
 } from '../actions';
 
 const handlers = {
@@ -22,7 +19,7 @@ const handlers = {
         ...state[referenceId],
         isLoading,
       },
-    }
+    };
   },
   [GET_AGREEMENTS_SUCCESS]: (state, action) => {
     const {
@@ -54,15 +51,6 @@ const handlers = {
         error,
       }
     };
-  },
-  [ATTACH_AGREEMENT]: (state, action) => {
-    return state;
-  },
-  [ATTACH_AGREEMENT_SUCCESS]: (state, action) => {
-    return state;
-  },
-  [ATTACH_AGREEMENT_FAILURE]: (state, action) => {
-    return state;
   },
 };
 

--- a/src/redux/reducers/agreements.js
+++ b/src/redux/reducers/agreements.js
@@ -1,0 +1,75 @@
+import {
+  GET_AGREEMENTS,
+  GET_AGREEMENTS_SUCCESS,
+  GET_AGREEMENTS_FAILURE,
+  ATTACH_AGREEMENT,
+  ATTACH_AGREEMENT_SUCCESS,
+  ATTACH_AGREEMENT_FAILURE,
+} from '../actions';
+
+const handlers = {
+  [GET_AGREEMENTS]: (state, action) => {
+    const {
+      payload: {
+        referenceId,
+        isLoading,
+      },
+    } = action;
+
+    return {
+      ...state,
+      [referenceId]: {
+        ...state[referenceId],
+        isLoading,
+      },
+    }
+  },
+  [GET_AGREEMENTS_SUCCESS]: (state, action) => {
+    const {
+      payload: {
+        referenceId,
+        agreements,
+      },
+    } = action;
+
+    return {
+      ...state,
+      [referenceId]: { ...agreements },
+    };
+  },
+  [GET_AGREEMENTS_FAILURE]: (state, action) => {
+    const {
+      payload: {
+        referenceId,
+        isLoading,
+        error,
+      },
+    } = action;
+
+    return {
+      ...state,
+      [referenceId]: {
+        ...state[referenceId],
+        isLoading,
+        error,
+      }
+    };
+  },
+  [ATTACH_AGREEMENT]: (state, action) => {
+    return state;
+  },
+  [ATTACH_AGREEMENT_SUCCESS]: (state, action) => {
+    return state;
+  },
+  [ATTACH_AGREEMENT_FAILURE]: (state, action) => {
+    return state;
+  },
+};
+
+export default function agreementsReducer(state = {}, action) {
+  if (handlers[action.type]) {
+    return handlers[action.type](state, action);
+  } else {
+    return state;
+  }
+}

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -1,0 +1,1 @@
+export { default } from './agreements';

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -1,0 +1,1 @@
+export * from './select-agreements';

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -1,1 +1,1 @@
-export * from './select-agreements';
+export { default } from './select-agreements';

--- a/src/redux/selectors/select-agreements.js
+++ b/src/redux/selectors/select-agreements.js
@@ -1,0 +1,3 @@
+export function selectAgreements(store, id) {
+  return store.eholdings.data.agreements[id];
+} 

--- a/src/redux/selectors/select-agreements.js
+++ b/src/redux/selectors/select-agreements.js
@@ -1,3 +1,3 @@
-export function selectAgreements(store, id) {
+export default function selectAgreements(store, id) {
   return store.eholdings.data.agreements[id];
-} 
+}

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -18,9 +18,7 @@ import {
   getAgreements,
   attachAgreement,
 } from '../redux/actions';
-import {
-  selectAgreements,
-} from '../redux/selectors';
+import selectAgreements from '../redux/selectors';
 import { transformQueryParams } from '../components/utilities';
 
 import View from '../components/package/show';
@@ -115,7 +113,7 @@ class PackageShowRoute extends Component {
       label: name,
     };
 
-    this.props.attachAgreement({ id: match.params.packageId, agreement });
+    this.props.attachAgreement({ id, referenceId: match.params.packageId, agreement });
   };
 
   toggleSelected = () => {
@@ -158,7 +156,7 @@ class PackageShowRoute extends Component {
     } = this.props;
 
     this.props.getAgreements({
-      referenceId:  match.params.packageId,
+      referenceId: match.params.packageId,
     });
   }
 

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -2,15 +2,25 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { connect } from 'react-redux';
+import queryString from 'qs';
+
 import { TitleManager } from '@folio/stripes/core';
 
-import queryString from 'qs';
-import { createResolver } from '../redux';
+import {
+  createResolver,
+} from '../redux';
 import { ProxyType } from '../redux/application';
 import Package from '../redux/package';
 import Provider from '../redux/provider';
 import Resource from '../redux/resource';
 import Tag from '../redux/tag';
+import {
+  getAgreements,
+  attachAgreement,
+} from '../redux/actions';
+import {
+  selectAgreements,
+} from '../redux/selectors';
 import { transformQueryParams } from '../components/utilities';
 
 import View from '../components/package/show';
@@ -18,7 +28,10 @@ import SearchModal from '../components/search-modal';
 
 class PackageShowRoute extends Component {
   static propTypes = {
+    agreements: PropTypes.object,
+    attachAgreement: PropTypes.func.isRequired,
     destroyPackage: PropTypes.func.isRequired,
+    getAgreements: PropTypes.func.isRequired,
     getPackage: PropTypes.func.isRequired,
     getPackageTitles: PropTypes.func.isRequired,
     getProvider: PropTypes.func.isRequired,
@@ -90,6 +103,21 @@ class PackageShowRoute extends Component {
     updatePackage(model);
   };
 
+  attachAgreementToPackage = ({ name, id }) => {
+    const {
+      match,
+    } = this.props;
+
+    const agreement = {
+      type: 'external',
+      authority: 'EKB',
+      reference: match.params.packageId,
+      label: name,
+    };
+
+    this.props.attachAgreement({ id: match.params.packageId, agreement });
+  };
+
   toggleSelected = () => {
     let { model, updatePackage, destroyPackage } = this.props;
     // if the package is custom setting the holding status to false
@@ -122,6 +150,16 @@ class PackageShowRoute extends Component {
     let params = transformQueryParams('titles', { ...pkgSearchParams });
 
     getPackageTitles(packageId, { ...params, page });
+  }
+
+  getAgreementsHandler = () => {
+    const {
+      match,
+    } = this.props;
+
+    this.props.getAgreements({
+      referenceId:  match.params.packageId,
+    });
   }
 
   setPage = (page) => {
@@ -194,6 +232,7 @@ class PackageShowRoute extends Component {
       proxyTypes,
       updateEntityTags,
       updateFolioTags,
+      agreements,
     } = this.props;
     const {
       pkgSearchParams,
@@ -207,14 +246,17 @@ class PackageShowRoute extends Component {
           tagsModel={tagsModel}
           updateEntityTags={updateEntityTags}
           updateFolioTags={updateFolioTags}
+          agreements={agreements}
           proxyTypes={proxyTypes}
           provider={provider}
+          getAgreements={this.getAgreementsHandler}
           fetchPackageTitles={this.setPage}
           toggleSelected={this.toggleSelected}
           addPackageToHoldings={this.addPackageToHoldings}
           toggleHidden={this.toggleHidden}
           customCoverageSubmitted={this.customCoverageSubmitted}
           toggleAllowKbToAddTitles={this.toggleAllowKbToAddTitles}
+          onAddAgreement={this.attachAgreementToPackage}
           onEdit={this.handleEdit}
           onFullView={this.getSearchType() && this.handleFullView}
           isFreshlySaved={
@@ -248,26 +290,37 @@ class PackageShowRoute extends Component {
 }
 
 export default connect(
-  ({ eholdings: { data } }, { match }) => {
-    let resolver = createResolver(data);
-    let model = resolver.find('packages', match.params.packageId);
+  (store, ownProps) => {
+    const {
+      eholdings: { data },
+    } = store;
+
+    const { match } = ownProps;
+
+    const resolver = createResolver(data);
+    const model = resolver.find('packages', match.params.packageId);
+
     return {
       model,
       proxyTypes: resolver.query('proxyTypes'),
       provider: resolver.find('providers', model.providerId),
       tagsModel: resolver.query('tags'),
-      resolver
+      resolver,
+      agreements: selectAgreements(store, match.params.packageId),
     };
-  }, {
+  },
+  {
     getPackage: id => Package.find(id),
     getPackageTitles: (id, params) => Package.queryRelated(id, 'resources', params),
     getProxyTypes: () => ProxyType.query(),
     getTags: () => Tag.query(),
     getProvider: id => Provider.find(id),
+    getAgreements: (data) => getAgreements(data),
     unloadResources: collection => Resource.unload(collection),
     updatePackage: model => Package.save(model),
     updateEntityTags: (model) => Package.save(model),
     updateFolioTags: (model) => Tag.create(model),
-    destroyPackage: model => Package.destroy(model)
+    destroyPackage: model => Package.destroy(model),
+    attachAgreement: (data) => attachAgreement(data),
   }
 )(PackageShowRoute);

--- a/test/bigtest/interactors/package-show.js
+++ b/test/bigtest/interactors/package-show.js
@@ -11,7 +11,7 @@ import {
   text,
   triggerable,
   is,
-  attribute
+  attribute,
 } from '@bigtest/interactor';
 import { getComputedStyle, hasClassBeginningWith } from './helpers';
 import Datepicker from './datepicker';
@@ -35,8 +35,16 @@ import PackageSelectionStatus from './selection-status';
   removeFromHoldings = new Interactor('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
 }
 
+@interactor class AgreementsSection {
+  isExpanded = !!attribute('#accordion-toggle-button-packageShowAgreements', 'aria-expanded');
+  agreements = collection('[data-test-package-show-agreements-list-item]');
+  clickStartDateColumnHeader = clickable('#clickable-list-column-startdate');
+  startDateColumnSortDirection = attribute('#list-column-startdate', 'aria-sort');
+}
+
 @interactor class PackageShowPage {
   isLoaded = isPresent('[data-test-eholdings-details-view-name="package"]');
+
   whenLoaded() {
     return this.when(() => this.isLoaded);
   }
@@ -132,6 +140,9 @@ import PackageSelectionStatus from './selection-status';
   endDate = scoped('[data-test-eholdings-coverage-fields-date-range-end]', Datepicker);
 
   toast = Toast;
+
+  agreementsSection = new AgreementsSection('#packageShowAgreements');
+  findAgreementsModalIsVisible = isPresent('[class^="modal"] #list-agreements');
 
   selectPackage() {
     return this

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -27,6 +27,54 @@ export default function config() {
     ]
   });
 
+  this.get('/erm/sas', {
+    results: [
+      { "id": "2c918098689ba8f70168a349f1160027", "contacts": [], "tags": [], "startDate": "2019-01-01T00:01:00Z", "items": [], "historyLines": [], "name": "Test", "orgs": [], "agreementStatus": { "id": "2c918098689ba8f701689baa48e40011", "value": "active", "label": "Active" }, "description": "Test description" },
+      { "id": "2c918098689ba8f70168a36a44220028", "contacts": [], "tags": [], "startDate": "2019-01-01T00:01:00Z", "items": [], "historyLines": [], "name": "test 1", "orgs": [{ "id": "2c918098689ba8f70168a36dc97a002b", "org": { "id": "2c918098689ba8f70168a36da25a0029", "name": "EBSCO" }, "role": { "id": "2c918098689ba8f701689baa492d001f", "value": "subscriber", "label": "Subscriber" }, "owner": { "id": "2c918098689ba8f70168a36a44220028" } }, { "id": "2c918098689ba8f70168a36dc97a002a", "owner": { "id": "2c918098689ba8f70168a36a44220028" } }], "agreementStatus": { "id": "2c918098689ba8f701689baa48e40011", "value": "active", "label": "Active" } },
+      { "id": "2c918098689ba8f70168a45f3142002c", "contacts": [], "tags": [], "startDate": "2019-01-01T00:01:00Z", "items": [], "historyLines": [], "name": "test", "orgs": [], "agreementStatus": { "id": "2c918098689ba8f701689baa48e40011", "value": "active", "label": "Active" } },
+    ],
+    pageSize: 10,
+    page: 1,
+    totalPages: 1,
+    meta: {},
+    totalRecords: 7,
+    total: 7,
+  });
+
+  this.put('/erm/sas/:id', (data, request) => {
+    return {
+      "id": request.id,
+      "contacts": [],
+      "tags": [],
+      "startDate": "2019-01-01T00:01:00Z",
+      "items": [],
+      "historyLines": [],
+      "name": "Kingston Package",
+      "orgs": [
+        {
+          "id": "2c918098689ba8f70168cd490ca60032",
+          "org": {
+            "id": "2c918098689ba8f70168cd48eed70031",
+            "name": "Kingston"
+          },
+          "role": {
+            "id": "2c918098689ba8f701689baa49360021",
+            "value": "subscription_agent",
+            "label": "Subscription Agent"
+          },
+          "owner": {
+            "id": "2c918098689ba8f70168a46055f9002d"
+          }
+        }
+      ],
+      "agreementStatus": {
+        "id": "2c918098689ba8f701689baa48e40011",
+        "value": "active",
+        "label": "Active",
+      },
+    }
+  });
+
   // e-holdings endpoints
   this.namespace = 'eholdings';
 
@@ -61,14 +109,14 @@ export default function config() {
   // Current root proxy
   this.get('/root-proxy', {
     data:
-      {
+    {
+      id: 'root-proxy',
+      type: 'rootProxies',
+      attributes: {
         id: 'root-proxy',
-        type: 'rootProxies',
-        attributes: {
-          id: 'root-proxy',
-          proxyTypeId: 'bigTestJS'
-        }
+        proxyTypeId: 'bigTestJS'
       }
+    }
   });
 
   // update root proxy

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -29,9 +29,74 @@ export default function config() {
 
   this.get('/erm/sas', {
     results: [
-      { "id": "2c918098689ba8f70168a349f1160027", "contacts": [], "tags": [], "startDate": "2019-01-01T00:01:00Z", "items": [], "historyLines": [], "name": "Test", "orgs": [], "agreementStatus": { "id": "2c918098689ba8f701689baa48e40011", "value": "active", "label": "Active" }, "description": "Test description" },
-      { "id": "2c918098689ba8f70168a36a44220028", "contacts": [], "tags": [], "startDate": "2019-01-01T00:01:00Z", "items": [], "historyLines": [], "name": "test 1", "orgs": [{ "id": "2c918098689ba8f70168a36dc97a002b", "org": { "id": "2c918098689ba8f70168a36da25a0029", "name": "EBSCO" }, "role": { "id": "2c918098689ba8f701689baa492d001f", "value": "subscriber", "label": "Subscriber" }, "owner": { "id": "2c918098689ba8f70168a36a44220028" } }, { "id": "2c918098689ba8f70168a36dc97a002a", "owner": { "id": "2c918098689ba8f70168a36a44220028" } }], "agreementStatus": { "id": "2c918098689ba8f701689baa48e40011", "value": "active", "label": "Active" } },
-      { "id": "2c918098689ba8f70168a45f3142002c", "contacts": [], "tags": [], "startDate": "2019-01-01T00:01:00Z", "items": [], "historyLines": [], "name": "test", "orgs": [], "agreementStatus": { "id": "2c918098689ba8f701689baa48e40011", "value": "active", "label": "Active" } },
+      {
+        id: '2c918098689ba8f70168a349f1160027',
+        contacts: [],
+        tags: [],
+        startDate: '2019-01-01T00:01:00Z',
+        items: [],
+        historyLines: [],
+        name: 'Test',
+        orgs: [],
+        agreementStatus: {
+          id: '2c918098689ba8f701689baa48e40011',
+          value: 'active',
+          label: 'Active',
+        },
+        description: 'Test description',
+      },
+      {
+        id: '2c918098689ba8f70168a36a44220028',
+        contacts: [],
+        tags: [],
+        startDate: '2019-01-01T00:01:00Z',
+        items: [],
+        historyLines: [],
+        name: 'test 1',
+        orgs: [
+          {
+            id: '2c918098689ba8f70168a36dc97a002b',
+            org: {
+              id: '2c918098689ba8f70168a36da25a0029',
+              name: 'EBSCO'
+            },
+            role: {
+              id: '2c918098689ba8f701689baa492d001f',
+              value: 'subscriber',
+              label: 'Subscriber',
+            },
+            owner: {
+              id: '2c918098689ba8f70168a36a44220028'
+            }
+          },
+          {
+            id: '2c918098689ba8f70168a36dc97a002a',
+            owner: {
+              id: '2c918098689ba8f70168a36a44220028'
+            }
+          }
+        ],
+        agreementStatus: {
+          id: '2c918098689ba8f701689baa48e40011',
+          value: 'active',
+          label: 'Active',
+        }
+      },
+      {
+        id: '2c918098689ba8f70168a45f3142002c',
+        contacts: [],
+        tags: [],
+        startDate: '2019-01-01T00:01:00Z',
+        items: [],
+        historyLines: [],
+        name: 'test',
+        orgs: [],
+        agreementStatus: {
+          id: '2c918098689ba8f701689baa48e40011',
+          value: 'active',
+          label: 'Active',
+        },
+      },
     ],
     pageSize: 10,
     page: 1,
@@ -43,36 +108,36 @@ export default function config() {
 
   this.put('/erm/sas/:id', (data, request) => {
     return {
-      "id": request.id,
-      "contacts": [],
-      "tags": [],
-      "startDate": "2019-01-01T00:01:00Z",
-      "items": [],
-      "historyLines": [],
-      "name": "Kingston Package",
-      "orgs": [
+      'id': request.id,
+      'contacts': [],
+      'tags': [],
+      'startDate': '2019-01-01T00:01:00Z',
+      'items': [],
+      'historyLines': [],
+      'name': 'Kingston Package',
+      'orgs': [
         {
-          "id": "2c918098689ba8f70168cd490ca60032",
-          "org": {
-            "id": "2c918098689ba8f70168cd48eed70031",
-            "name": "Kingston"
+          'id': '2c918098689ba8f70168cd490ca60032',
+          'org': {
+            'id': '2c918098689ba8f70168cd48eed70031',
+            'name': 'Kingston'
           },
-          "role": {
-            "id": "2c918098689ba8f701689baa49360021",
-            "value": "subscription_agent",
-            "label": "Subscription Agent"
+          'role': {
+            'id': '2c918098689ba8f701689baa49360021',
+            'value': 'subscription_agent',
+            'label': 'Subscription Agent'
           },
-          "owner": {
-            "id": "2c918098689ba8f70168a46055f9002d"
+          'owner': {
+            'id': '2c918098689ba8f70168a46055f9002d'
           }
         }
       ],
-      "agreementStatus": {
-        "id": "2c918098689ba8f701689baa48e40011",
-        "value": "active",
-        "label": "Active",
+      'agreementStatus': {
+        'id': '2c918098689ba8f701689baa48e40011',
+        'value': 'active',
+        'label': 'Active',
       },
-    }
+    };
   });
 
   // e-holdings endpoints

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -94,37 +94,13 @@ describe('PackageShow', () => {
         expect(PackageShowPage.agreementsSection.agreements().length).to.equal(3);
       });
 
-      it('should display agreements sorted by start date in descending order by default', () => {
-        expect(PackageShowPage.agreementsSection.startDateColumnSortDirection).to.equal('descending');
-      });
-
-      describe('after first click on start date column header', () => {
-        beforeEach(async () => {
-          await PackageShowPage.agreementsSection.clickStartDateColumnHeader();
-        });
-
-        it('should change agreements start date sorting order to ascending', () => {
-          expect(PackageShowPage.agreementsSection.startDateColumnSortDirection).to.equal('ascending');
-        });
-
-        describe('after second click on start date column header', () => {
-          beforeEach(async () => {
-            await PackageShowPage.agreementsSection.clickStartDateColumnHeader()
-          });
-
-          it('should change agreements start date sorting order to descending', () => {
-            expect(PackageShowPage.agreementsSection.startDateColumnSortDirection).to.equal('descending');
-          });
-        });
-      });
-
       describe('after click on first agreement', () => {
         beforeEach(async () => {
           await PackageShowPage.agreementsSection.agreements(0).click();
         });
 
         it('should redirect to agreement details page', function () {
-          const itemDetailsUrl = '/erm/view/2c918098689ba8f70168a349f1160027';
+          const itemDetailsUrl = '/erm/agreements/view/2c918098689ba8f70168a349f1160027';
 
           expect(this.location.pathname).to.contain(itemDetailsUrl);
         });

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -85,6 +85,52 @@ describe('PackageShow', () => {
       expect(PackageShowPage.hasBackButton).to.be.true;
     });
 
+    describe('agreements section', () => {
+      it('should display open accordion by default', () => {
+        expect(PackageShowPage.agreementsSection.isExpanded).to.be.true;
+      });
+
+      it('should display a 3 items in the list of agreements', () => {
+        expect(PackageShowPage.agreementsSection.agreements().length).to.equal(3);
+      });
+
+      it('should display agreements sorted by start date in descending order by default', () => {
+        expect(PackageShowPage.agreementsSection.startDateColumnSortDirection).to.equal('descending');
+      });
+
+      describe('after first click on start date column header', () => {
+        beforeEach(async () => {
+          await PackageShowPage.agreementsSection.clickStartDateColumnHeader();
+        });
+
+        it('should change agreements start date sorting order to ascending', () => {
+          expect(PackageShowPage.agreementsSection.startDateColumnSortDirection).to.equal('ascending');
+        });
+
+        describe('after second click on start date column header', () => {
+          beforeEach(async () => {
+            await PackageShowPage.agreementsSection.clickStartDateColumnHeader()
+          });
+  
+          it('should change agreements start date sorting order to descending', () => {
+            expect(PackageShowPage.agreementsSection.startDateColumnSortDirection).to.equal('descending');
+          });
+        });
+      });
+
+      describe('after click on first agreement', () => {
+        beforeEach(async () => {
+          await PackageShowPage.agreementsSection.agreements(0).click();
+        });
+
+        it('should redirect to agreement details page', function () {
+          const itemDetailsUrl = '/erm/view/2c918098689ba8f70168a349f1160027';
+
+          expect(this.location.pathname).to.contain(itemDetailsUrl);
+        });
+      });
+    });
+
     describe('clicking the collapse all button', () => {
       beforeEach(() => {
         return PackageShowPage.clickCollapseAllButton();

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -111,7 +111,7 @@ describe('PackageShow', () => {
           beforeEach(async () => {
             await PackageShowPage.agreementsSection.clickStartDateColumnHeader()
           });
-  
+
           it('should change agreements start date sorting order to descending', () => {
             expect(PackageShowPage.agreementsSection.startDateColumnSortDirection).to.equal('descending');
           });

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -1,5 +1,11 @@
 {
     "meta.title": "eHoldings",
+    "add": "Add",
+    "startDate": "Start Date",
+    "name": "Name",
+    "status": "Status",
+    "agreements": "Agreements",
+    "agreements.notFound": "No agreements found",
     "package.actionMenu.edit": "Edit",
     "package.addToHoldings": "Add to holdings",
     "package.addToken": "Add token",


### PR DESCRIPTION
https://issues.folio.org/browse/UIEH-628

## Purpose
Add new feature for attaching agreements to the package. Apply a new approach of managing data in eholdings app.

## Approach
- Add an accordion for with a list of agreements
- Add actions, reducers, epics for fetching and updating agreements
- Add a "ui-find-agreements" plugin for attaching an agreement to the package
- Add tests

#### TODOS
Full agreements functionality should be tested after an ERM with agreements has been added to the FOLIO snapshot build.
Unit tests for new redux stuff will be added during work on https://issues.folio.org/browse/UIEH-630

## Screenshots
<img width="920" alt="Снимок экрана 2019-03-11 в 12 10 18" src="https://user-images.githubusercontent.com/43621626/54116096-b0e00d00-43f6-11e9-9cae-ee3060ada966.png">
<img width="1460" alt="Снимок экрана 2019-03-11 в 12 09 57" src="https://user-images.githubusercontent.com/43621626/54116095-b0477680-43f6-11e9-9403-914e7a97c11b.png">

