### PR TITLE
UIEH-669: Make UI permissions effective 

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
       {
         "permissionName": "module.eholdings.enabled",
         "displayName": "UI: eHoldings module is enabled",
-        "visible": true
+        "visible": true,
+        "subPermissions": ["kb-ebsco.all"]
       },
       {
         "permissionName": "settings.eholdings.enabled",
@@ -93,28 +94,12 @@
         "visible": true
       },
       {
-        "permissionName": "ui-eholdings.records.view",
-        "displayName": "eHoldings: Can view providers, packages, titles",
-        "visible": true,
-        "subPermissions": [
-          "module.eholdings.enabled",
-          "ui-eholdings.packages.collection.get",
-          "ui-eholdings.packages.item.get",
-          "ui-eholdings.providers.collection.get",
-          "ui-eholdings.providers.item.get",
-          "ui-eholdings.resources.item.get",
-          "ui-eholdings.titles.collection.get",
-          "ui-eholdings.titles.item.get"
-        ]
-      },
-      {
         "permissionName": "ui-eholdings.package-title.select-unselect",
         "displayName": "eHoldings: Can select/unselect packages and titles to/from your holdings",
         "visible": true,
         "subPermissions": [
-          "ui-eholdings.records.view",
-          "ui-eholdings.packages.item.put",
-          "ui-eholdings.resources.item.put"
+          "kb-ebsco.packages.item.put",
+          "kb-ebsco.resources.item.put"
         ]
       },
       {
@@ -122,8 +107,9 @@
         "displayName": "eHoldings: Can edit providers, packages, titles detail records",
         "visible": true,
         "subPermissions": [
-          "ui-eholdings.package-title.select-unselect",
-          "ui-eholdings.providers.item.put"
+          "kb-ebsco.packages.item.put",
+          "kb-ebsco.resources.item.put",
+          "kb-ebsco.providers.item.put"
         ]
       },
       {
@@ -132,11 +118,11 @@
         "visible": true,
         "subPermissions": [
           "ui-eholdings.records.edit",
-          "ui-eholdings.packages.collection.post",
-          "ui-eholdings.resources.collection.post",
-          "ui-eholdings.titles.collection.post",
-          "ui-eholdings.packages.item.delete",
-          "ui-eholdings.resources.item.delete"
+          "kb-ebsco.packages.collection.post",
+          "kb-ebsco.resources.collection.post",
+          "kb-ebsco.titles.collection.post",
+          "kb-ebsco.packages.item.delete",
+          "kb-ebsco.resources.item.delete"
         ]
       }
     ]

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -8,6 +8,7 @@ import arrayMutators from 'final-form-arrays';
 import createFocusDecorator from 'final-form-focus';
 import { FormattedMessage } from 'react-intl';
 
+import { IfPermission } from '@folio/stripes-core';
 import {
   Accordion,
   Button,
@@ -206,16 +207,18 @@ export default class CustomPackageEdit extends Component {
         )}
 
         {packageSelected && (
-          <Button
-            data-test-eholdings-package-remove-from-holdings-action
-            buttonStyle="dropdownItem fullWidth"
-            onClick={() => {
-              onToggle();
-              this.handleDeleteAction();
-            }}
-          >
-            <FormattedMessage id="ui-eholdings.package.deletePackage" />
-          </Button>
+          <IfPermission perm="ui-eholdings.titles-packages.create-delete">
+            <Button
+              data-test-eholdings-package-remove-from-holdings-action
+              buttonStyle="dropdownItem fullWidth"
+              onClick={() => {
+                onToggle();
+                this.handleDeleteAction();
+              }}
+            >
+              <FormattedMessage id="ui-eholdings.package.deletePackage" />
+            </Button>
+          </IfPermission>
         )}
       </Fragment>
     );

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -8,6 +8,7 @@ import arrayMutators from 'final-form-arrays';
 import createFocusDecorator from 'final-form-focus';
 import { FormattedMessage } from 'react-intl';
 
+import { IfPermission } from '@folio/stripes-core';
 import {
   Accordion,
   Button,
@@ -187,13 +188,14 @@ export default class ManagedPackageEdit extends Component {
 
   getActionMenu = ({ onToggle }) => {
     const {
-      addPackageToHoldings,
       onFullView,
       model,
       onCancel
     } = this.props;
 
     const { packageSelected } = this.state;
+
+    const isAddButtonNeeded = !packageSelected || model.isPartiallySelected;
 
     return (
       <Fragment>
@@ -221,34 +223,52 @@ export default class ManagedPackageEdit extends Component {
           </Button>
         )}
 
-        {packageSelected && (
-          <Button
-            data-test-eholdings-package-remove-from-holdings-action
-            buttonStyle="dropdownItem fullWidth"
-            onClick={() => {
-              onToggle();
-              this.handleDeselectionAction();
-            }}
-          >
-            <FormattedMessage id="ui-eholdings.package.removeFromHoldings" />
-          </Button>
-        )}
-
-        {(!packageSelected || model.isPartiallySelected) && (
-          <Button
-            data-test-eholdings-package-add-to-holdings-action
-            buttonStyle="dropdownItem fullWidth"
-            onClick={() => {
-              onToggle();
-              addPackageToHoldings();
-            }}
-          >
-            <FormattedMessage
-              id={`ui-eholdings.${(model.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings')}`}
-            />
-          </Button>
-        )}
+        <IfPermission perm="ui-eholdings.package-title.select-unselect">
+          {packageSelected && this.renderRemoveFromHoldingsButton(onToggle)}
+          {isAddButtonNeeded && this.renderAddToHoldingsButton(onToggle)}
+        </IfPermission>
       </Fragment>
+    );
+  }
+
+  renderRemoveFromHoldingsButton(onToggle) {
+    return (
+      <Button
+        data-test-eholdings-package-remove-from-holdings-action
+        buttonStyle="dropdownItem fullWidth"
+        onClick={() => {
+          onToggle();
+          this.handleDeselectionAction();
+        }}
+      >
+        <FormattedMessage id="ui-eholdings.package.removeFromHoldings" />
+      </Button>
+    );
+  }
+
+  renderAddToHoldingsButton(onToggle) {
+    const {
+      model: { isPartiallySelected },
+      addPackageToHoldings,
+    } = this.props;
+
+    const translationIdEnding = isPartiallySelected
+      ? 'addAllToHoldings'
+      : 'addToHoldings';
+
+    return (
+      <Button
+        data-test-eholdings-package-add-to-holdings-action
+        buttonStyle="dropdownItem fullWidth"
+        onClick={() => {
+          onToggle();
+          addPackageToHoldings();
+        }}
+      >
+        <FormattedMessage
+          id={`ui-eholdings.${translationIdEnding}`}
+        />
+      </Button>
     );
   }
 

--- a/src/components/package/selection-status.js
+++ b/src/components/package/selection-status.js
@@ -1,18 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { Headline, Icon, Button } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
+
+import { IfPermission } from '@folio/stripes-core';
+import {
+  Headline,
+  Icon,
+  Button,
+} from '@folio/stripes/components';
 
 export default function SelectionStatus({ model, onAddToHoldings }) {
   return (
     <div data-test-eholdings-package-details-selected>
       <SelectionStatusMessage model={model} />
       <br />
-      <SelectionStatusButton
-        model={model}
-        onAddToHoldings={onAddToHoldings}
-      />
+      <IfPermission perm="ui-eholdings.package-title.select-unselect">
+        <SelectionStatusButton
+          model={model}
+          onAddToHoldings={onAddToHoldings}
+        />
+      </IfPermission>
     </div>
   );
 }

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -11,6 +11,7 @@ import set from 'lodash/fp/set';
 import hasIn from 'lodash/fp/hasIn';
 
 import {
+  withStripes,
   Pluggable,
   IfPermission,
 } from '@folio/stripes-core';
@@ -63,6 +64,9 @@ class PackageShow extends Component {
     provider: PropTypes.object.isRequired,
     proxyTypes: PropTypes.object.isRequired,
     searchModal: PropTypes.node,
+    stripes: PropTypes.shape({
+      hasPerm: PropTypes.func.isRequired,
+    }).isRequired,
     tagsModel: PropTypes.object,
     toggleSelected: PropTypes.func.isRequired,
     updateEntityTags: PropTypes.func.isRequired,
@@ -134,6 +138,7 @@ class PackageShow extends Component {
 
   getActionMenu = ({ onToggle }) => {
     const {
+      stripes,
       onEdit,
       onFullView,
       model
@@ -141,18 +146,21 @@ class PackageShow extends Component {
 
     const { packageSelected } = this.state;
 
+    const hasEditPermission = stripes.hasPerm('ui-eholdings.records.edit');
+    const hasSelectionPermission = stripes.hasPerm('ui-eholdings.package-title.select-unselect');
     const isAddButtonNeeded = !packageSelected || model.isPartiallySelected;
+    const isMenuNeeded = hasEditPermission || hasSelectionPermission || onFullView;
 
-    return (
+    return isMenuNeeded && (
       <Fragment>
-        <IfPermission perm="ui-eholdings.records.edit">
+        {hasEditPermission &&
           <Button
             buttonStyle="dropdownItem fullWidth"
             onClick={onEdit}
           >
             <FormattedMessage id="ui-eholdings.actionMenu.edit" />
           </Button>
-        </IfPermission>
+        }
         {onFullView && (
           <Button
             buttonStyle="dropdownItem fullWidth"
@@ -748,4 +756,4 @@ class PackageShow extends Component {
   }
 }
 
-export default PackageShow;
+export default withStripes(PackageShow);

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -320,8 +320,7 @@ class PackageShow extends Component {
                 >
                   <FormattedMessage id="ui-eholdings.tags" />
                 </Headline>
-              )
-              }
+              )}
               open={sections.providerShowTags}
               id="providerShowTags"
               onToggle={this.handleSectionToggle}

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -1,8 +1,16 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import {
+  FormattedNumber,
+  FormattedMessage,
+} from 'react-intl';
+
 import update from 'lodash/fp/update';
 import set from 'lodash/fp/set';
 import hasIn from 'lodash/fp/hasIn';
+import capitalize from 'lodash/capitalize';
+
+import { IfPermission } from '@folio/stripes-core';
 import {
   Accordion,
   Button,
@@ -12,14 +20,13 @@ import {
   KeyValue,
   Badge,
 } from '@folio/stripes/components';
-import { FormattedNumber, FormattedMessage } from 'react-intl';
-import capitalize from 'lodash/capitalize';
 
 import {
   processErrors,
   getEntityTags,
   getTagLabelsArr,
 } from '../../utilities';
+
 import DetailsView from '../../details-view';
 import QueryList from '../../query-list';
 import PackageListItem from '../../package-list-item';
@@ -90,12 +97,14 @@ class ProviderShow extends Component {
 
     return (
       <Fragment>
-        <Button
-          buttonStyle="dropdownItem fullWidth"
-          onClick={onEdit}
-        >
-          <FormattedMessage id="ui-eholdings.actionMenu.edit" />
-        </Button>
+        <IfPermission perm="ui-eholdings.records.edit">
+          <Button
+            buttonStyle="dropdownItem fullWidth"
+            onClick={onEdit}
+          >
+            <FormattedMessage id="ui-eholdings.actionMenu.edit" />
+          </Button>
+        </IfPermission>
 
         {onFullView && (
           <Button
@@ -106,6 +115,33 @@ class ProviderShow extends Component {
           </Button>
         )}
       </Fragment>
+    );
+  }
+
+  renderLastMenu() {
+    let {
+      model: { name },
+      onEdit,
+    } = this.props;
+  
+    return (
+      <IfPermission perm="ui-eholdings.records.edit">
+        <FormattedMessage
+          id="ui-eholdings.label.editLink"
+          values={{
+            name,
+          }}
+        >
+          {ariaLabel => (
+            <IconButton
+              data-test-eholdings-provider-edit-link
+              icon="edit"
+              ariaLabel={ariaLabel}
+              onClick={onEdit}
+            />
+          )}
+        </FormattedMessage>
+      </IfPermission>
     );
   }
 
@@ -291,31 +327,6 @@ class ProviderShow extends Component {
     );
   }
 
-  getLastMenu() {
-    const {
-      model,
-      onEdit,
-    } = this.props;
-
-    return (
-      <FormattedMessage
-        id="ui-eholdings.label.editLink"
-        values={{
-          name: model.name
-        }}
-      >
-        {ariaLabel => (
-          <IconButton
-            data-test-eholdings-provider-edit-link
-            icon="edit"
-            ariaLabel={ariaLabel}
-            onClick={onEdit}
-          />
-        )}
-      </FormattedMessage>
-    );
-  }
-
   render() {
     const {
       listType,
@@ -341,8 +352,8 @@ class ProviderShow extends Component {
           actionMenu={this.getActionMenu}
           sections={sections}
           handleExpandAll={this.handleExpandAll}
-          lastMenu={this.getLastMenu()}
           bodyContent={this.getBodyContent()}
+          lastMenu={this.renderLastMenu()}
           searchModal={searchModal}
           listType={capitalize(listType)}
           listSectionId="providerShowProviderList"

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -10,7 +10,11 @@ import set from 'lodash/fp/set';
 import hasIn from 'lodash/fp/hasIn';
 import capitalize from 'lodash/capitalize';
 
-import { IfPermission } from '@folio/stripes-core';
+import {
+  withStripes,
+  IfPermission,
+} from '@folio/stripes-core';
+
 import {
   Accordion,
   Button,
@@ -49,6 +53,9 @@ class ProviderShow extends Component {
     proxyTypes: PropTypes.object.isRequired,
     rootProxy: PropTypes.object.isRequired,
     searchModal: PropTypes.node,
+    stripes: PropTypes.shape({
+      hasPerm: PropTypes.func.isRequired,
+    }).isRequired,
     tagsModel: PropTypes.object,
     updateEntityTags: PropTypes.func.isRequired,
     updateFolioTags: PropTypes.func.isRequired,
@@ -91,20 +98,24 @@ class ProviderShow extends Component {
 
   getActionMenu = () => {
     const {
+      stripes,
       onEdit,
       onFullView,
     } = this.props;
 
-    return (
+    const hasEditPermission = stripes.hasPerm('ui-eholdings.records.edit');
+    const isMenuNeeded = onFullView || hasEditPermission;
+
+    return isMenuNeeded && (
       <Fragment>
-        <IfPermission perm="ui-eholdings.records.edit">
+        {hasEditPermission && (
           <Button
             buttonStyle="dropdownItem fullWidth"
             onClick={onEdit}
           >
             <FormattedMessage id="ui-eholdings.actionMenu.edit" />
           </Button>
-        </IfPermission>
+        )}
 
         {onFullView && (
           <Button
@@ -366,4 +377,4 @@ class ProviderShow extends Component {
   }
 }
 
-export default ProviderShow;
+export default withStripes(ProviderShow);

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -123,7 +123,7 @@ class ProviderShow extends Component {
       model: { name },
       onEdit,
     } = this.props;
-  
+
     return (
       <IfPermission perm="ui-eholdings.records.edit">
         <FormattedMessage

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -7,6 +7,7 @@ import createFocusDecorator from 'final-form-focus';
 import { FormattedMessage } from 'react-intl';
 import update from 'lodash/fp/update';
 
+import { IfPermission } from '@folio/stripes-core';
 import {
   Accordion,
   Button,
@@ -206,16 +207,18 @@ export default class ResourceEditCustomTitle extends Component {
         </Button>
 
         {resourceSelected && (
-          <Button
-            data-test-eholdings-remove-resource-from-holdings
-            buttonStyle="dropdownItem fullWidth"
-            onClick={() => {
-              onToggle();
-              this.handleRemoveResourceFromHoldings();
-            }}
-          >
-            <FormattedMessage id="ui-eholdings.resource.actionMenu.removeHolding" />
-          </Button>
+          <IfPermission perm="ui-eholdings.package-title.select-unselect">
+            <Button
+              data-test-eholdings-remove-resource-from-holdings
+              buttonStyle="dropdownItem fullWidth"
+              onClick={() => {
+                onToggle();
+                this.handleRemoveResourceFromHoldings();
+              }}
+            >
+              <FormattedMessage id="ui-eholdings.resource.actionMenu.removeHolding" />
+            </Button>
+          </IfPermission>
         )}
       </Fragment>
     );

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -16,6 +16,8 @@ import {
   ModalFooter
 } from '@folio/stripes/components';
 
+import { IfPermission } from '@folio/stripes-core';
+
 import { processErrors, isBookPublicationType } from '../../utilities';
 
 import DetailsView from '../../details-view';
@@ -195,7 +197,6 @@ export default class ResourceEditManagedTitle extends Component {
 
   getActionMenu = ({ onToggle }) => {
     const { onCancel } = this.props;
-    const { managedResourceSelected } = this.state;
 
     return (
       <Fragment>
@@ -209,32 +210,39 @@ export default class ResourceEditManagedTitle extends Component {
         >
           <FormattedMessage id="ui-eholdings.actionMenu.cancelEditing" />
         </Button>
-
-        {managedResourceSelected ? (
-          <Button
-            data-test-eholdings-remove-resource-from-holdings
-            buttonStyle="dropdownItem fullWidth"
-            onClick={() => {
-              onToggle();
-              this.handleRemoveResourceFromHoldings();
-            }}
-          >
-            <FormattedMessage id="ui-eholdings.resource.actionMenu.removeHolding" />
-          </Button>
-        ) : (
-          <Button
-            data-test-eholdings-add-resource-to-holdings
-            buttonStyle="dropdownItem fullWidth"
-            onClick={() => {
-              onToggle();
-              this.handleAddResourceToHoldings();
-            }}
-          >
-            <FormattedMessage id="ui-eholdings.resource.actionMenu.addHolding" />
-          </Button>
-        )}
+        <IfPermission perm="ui-eholdings.package-title.select-unselect">
+          {this.renderSelectionButton(onToggle)}
+        </IfPermission>
       </Fragment>
     );
+  }
+
+  renderSelectionButton(onToggle) {
+    return this.state.managedResourceSelected
+      ? (
+        <Button
+          data-test-eholdings-remove-resource-from-holdings
+          buttonStyle="dropdownItem fullWidth"
+          onClick={() => {
+            onToggle();
+            this.handleRemoveResourceFromHoldings();
+          }}
+        >
+          <FormattedMessage id="ui-eholdings.resource.actionMenu.removeHolding" />
+        </Button>
+      )
+      : (
+        <Button
+          data-test-eholdings-add-resource-to-holdings
+          buttonStyle="dropdownItem fullWidth"
+          onClick={() => {
+            onToggle();
+            this.handleAddResourceToHoldings();
+          }}
+        >
+          <FormattedMessage id="ui-eholdings.resource.actionMenu.addHolding" />
+        </Button>
+      );
   }
 
   render() {
@@ -323,14 +331,17 @@ export default class ResourceEditManagedTitle extends Component {
                         }
                         <br />
                         {((!managedResourceSelected && !isSelectInFlight) || (!this.props.model.isSelected && isSelectInFlight)) && (
-                          <Button
-                            buttonStyle="primary"
-                            onClick={this.handleAddResourceToHoldings}
-                            disabled={isSelectInFlight}
-                            data-test-eholdings-resource-add-to-holdings-button
-                          >
-                            <FormattedMessage id="ui-eholdings.addToHoldings" />
-                          </Button>)}
+                          <IfPermission perm="ui-eholdings.package-title.select-unselect">
+                            <Button
+                              buttonStyle="primary"
+                              onClick={this.handleAddResourceToHoldings}
+                              disabled={isSelectInFlight}
+                              data-test-eholdings-resource-add-to-holdings-button
+                            >
+                              <FormattedMessage id="ui-eholdings.addToHoldings" />
+                            </Button>
+                          </IfPermission>
+                        )}
                       </label>
                     </Accordion>
 

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -1,7 +1,12 @@
 import React, { Component, cloneElement } from 'react';
 import PropTypes from 'prop-types';
-import { Button, PaneMenu } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
+
+import { IfPermission } from '@folio/stripes-core';
+import {
+  Button,
+  PaneMenu,
+} from '@folio/stripes/components';
 
 import Paneset, { Pane } from '../paneset';
 
@@ -76,17 +81,19 @@ export default class SearchPaneset extends Component {
 
   renderNewButton = () => {
     return (
-      <Button
-        data-test-eholdings-search-new-button
-        buttonStyle="primary"
-        marginBottom0
-        to={{
-          pathname: `/eholdings/${this.props.resultsType}/new`,
-          state: { eholdings: true }
-        }}
-      >
-        <FormattedMessage id="ui-eholdings.search.addNew" />
-      </Button>
+      <IfPermission perm="ui-eholdings.titles-packages.create-delete">
+        <Button
+          data-test-eholdings-search-new-button
+          buttonStyle="primary"
+          marginBottom0
+          to={{
+            pathname: `/eholdings/${this.props.resultsType}/new`,
+            state: { eholdings: true }
+          }}
+        >
+          <FormattedMessage id="ui-eholdings.search.addNew" />
+        </Button>
+      </IfPermission>
     );
   };
 


### PR DESCRIPTION
## Purpose
We want to not let a user do an action if they don't have the permission to do the action.
## Approach
`IfPermission` component from `stripes-core` was used to render content depending on current user's permissions. I also had to inject stripes into `ResourceShow` component to use stripes's `hasPerm` function. This is needed for conditional rendering.

View permission was deleted from `package.json`, as it was decided to not use it at all. 

One more thing which I've done is removing the selection permission from the edit's sub-permissions (it's not needed there)   