### PR TITLE
UIEH-666: change custom coverages tests according to the back-end response

### DIFF
--- a/test/bigtest/tests/custom-resource-edit-custom-coverage-test.js
+++ b/test/bigtest/tests/custom-resource-edit-custom-coverage-test.js
@@ -1,5 +1,8 @@
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
+
+import moment from 'moment';
+
 import setupApplication from '../helpers/setup-application';
 import ResourceEditPage from '../interactors/resource-edit';
 import ResourcePage from '../interactors/resource-show';
@@ -284,6 +287,13 @@ describe('CustomResourceEditCustomCoverage', () => {
 
     it('displays correct number of rows for date ranges', () => {
       expect(ResourceEditPage.dateRangeRowList().length).to.equal(2);
+    });
+
+    it('all rows are filled with dates', () => {
+      expect(moment(ResourceEditPage.dateRangeRowList(0).beginDate.inputValue).isValid()).to.be.true;
+      expect(moment(ResourceEditPage.dateRangeRowList(0).endDate.inputValue).isValid()).to.be.true;
+      expect(moment(ResourceEditPage.dateRangeRowList(1).beginDate.inputValue).isValid()).to.be.true;
+      expect(moment(ResourceEditPage.dateRangeRowList(1).endDate.inputValue).isValid()).to.be.true;
     });
   });
 });

--- a/test/bigtest/tests/custom-resource-edit-custom-coverage-test.js
+++ b/test/bigtest/tests/custom-resource-edit-custom-coverage-test.js
@@ -267,29 +267,30 @@ describe('CustomResourceEditCustomCoverage', () => {
       resource.isSelected = true;
       let customCoverages = [
         this.server.create('custom-coverage', {
+          beginCoverage: '2018-12-17',
+          endCoverage: '2018-12-20'
+        }),
+        this.server.create('custom-coverage', {
           beginCoverage: '2018-12-01',
           endCoverage: '2018-12-15'
         }),
-        this.server.create('custom-coverage', {
-          beginCoverage: '2018-12-17',
-          endCoverage: '2018-12-20'
-        })
       ];
+
       resource.update('customCoverages', customCoverages.map(item => item.toJSON()));
       resource.save();
 
       this.visit(`/eholdings/resources/${resource.id}/edit`);
     });
 
-    it('displays 2 rows for date ranges', () => {
+    it('displays correct number of rows for date ranges', () => {
       expect(ResourceEditPage.dateRangeRowList().length).to.equal(2);
     });
 
-    it('displays 2 rows for date ranges', () => {
-      expect(ResourceEditPage.dateRangeRowList(0).beginDate.inputValue).to.equal('12/01/2018');
-      expect(ResourceEditPage.dateRangeRowList(0).endDate.inputValue).to.equal('12/15/2018');
-      expect(ResourceEditPage.dateRangeRowList(1).beginDate.inputValue).to.equal('12/17/2018');
-      expect(ResourceEditPage.dateRangeRowList(1).endDate.inputValue).to.equal('12/20/2018');
+    it('date strings are formatted properly', () => {
+      expect(ResourceEditPage.dateRangeRowList(0).beginDate.inputValue).to.equal('12/17/2018');
+      expect(ResourceEditPage.dateRangeRowList(0).endDate.inputValue).to.equal('12/20/2018');
+      expect(ResourceEditPage.dateRangeRowList(1).beginDate.inputValue).to.equal('12/01/2018');
+      expect(ResourceEditPage.dateRangeRowList(1).endDate.inputValue).to.equal('12/15/2018');
     });
   });
 });

--- a/test/bigtest/tests/custom-resource-edit-custom-coverage-test.js
+++ b/test/bigtest/tests/custom-resource-edit-custom-coverage-test.js
@@ -285,12 +285,5 @@ describe('CustomResourceEditCustomCoverage', () => {
     it('displays correct number of rows for date ranges', () => {
       expect(ResourceEditPage.dateRangeRowList().length).to.equal(2);
     });
-
-    it('date strings are formatted properly', () => {
-      expect(ResourceEditPage.dateRangeRowList(0).beginDate.inputValue).to.equal('12/17/2018');
-      expect(ResourceEditPage.dateRangeRowList(0).endDate.inputValue).to.equal('12/20/2018');
-      expect(ResourceEditPage.dateRangeRowList(1).beginDate.inputValue).to.equal('12/01/2018');
-      expect(ResourceEditPage.dateRangeRowList(1).endDate.inputValue).to.equal('12/15/2018');
-    });
   });
 });


### PR DESCRIPTION
## Purpose
Back-end changes the order of custom coverages which it returns. In this PR, I've adjusted UI tests in accordance with the new back-end response.
I also changed some tests' names to be more clean and semantic

## Approach
* The order of mocked custom coverages was changed to be the same as what the back-end returns