### PR TITLE
UIEH-665: fix bug on removing custom coverage from package or resource

### DIFF
--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -1,12 +1,14 @@
 import React, { Component, Fragment } from 'react';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
-import moment from 'moment';
 import {
   FormattedMessage,
   injectIntl,
   intlShape,
 } from 'react-intl';
+
+import moment from 'moment';
+import isEqual from 'lodash/isEqual';
 
 import {
   Datepicker,
@@ -119,6 +121,7 @@ class PackageCoverageFields extends Component {
       <div data-test-eholdings-package-coverage-fields>
         <FieldArray
           component={this.renderRepeatableField}
+          isEqual={isEqual}
           name="customCoverages"
           validate={this.validateDateRange}
         />

--- a/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
+++ b/src/components/resource/_fields/custom-coverage/custom-coverage-fields.js
@@ -2,8 +2,15 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
+import {
+  FormattedDate,
+  FormattedMessage,
+  injectIntl,
+  intlShape,
+} from 'react-intl';
+
 import moment from 'moment';
-import { FormattedDate, FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import isEqual from 'lodash/isEqual';
 
 import {
   Datepicker,
@@ -243,6 +250,7 @@ class ResourceCoverageFields extends Component {
       <div data-test-eholdings-resource-coverage-fields>
         <FieldArray
           component={this.renderCoverageFields}
+          isEqual={isEqual}
           name="customCoverages"
           validate={this.validateDateRange}
         />

--- a/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
+++ b/src/components/resource/_fields/managed-coverage/managed-coverage-fields.js
@@ -1,9 +1,17 @@
 import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import {
+  FormattedDate,
+  FormattedMessage,
+  injectIntl,
+  intlShape,
+} from 'react-intl';
+
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
-import PropTypes from 'prop-types';
+
 import moment from 'moment';
-import { FormattedDate, FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import isEqual from 'lodash/isEqual';
 
 import {
   Datepicker,
@@ -14,6 +22,7 @@ import {
 
 import CoverageDateList from '../../../coverage-date-list';
 import { isBookPublicationType } from '../../../utilities';
+
 import styles from './managed-coverage-fields.css';
 
 class ResourceCoverageFields extends Component {
@@ -285,6 +294,7 @@ class ResourceCoverageFields extends Component {
       <div data-test-eholdings-resource-coverage-fields>
         <FieldArray
           component={this.renderCoverageFields}
+          isEqual={isEqual}
           name="customCoverages"
           validate={this.validateDateRange}
         />


### PR DESCRIPTION
## Purpose
The bug is that when we go to resource/package edit and try to remove a custom coverage from a resource/package, the save button is not enabled.

## Approach
`FieldArray` component from `react-final-form-arrays` is used to render coverage date fields. It has a prop `isEqual`, which is a function whose role is to check if the values of fields inside of the `FieldArray` was changed. If `isEqual` function is not provided, it will return `true` by default:
![52351620-2ba2ba80-2a3c-11e9-891c-095334a4e9a5](https://user-images.githubusercontent.com/43514877/54531686-94ac1500-498e-11e9-847d-2d54f6af342c.png)

To fix the bug I just passed lodash's `isEqual` as a prop to `FieldArray`