### PR TITLE
UIEH-668: fix bug on removing custom embargo

### DIFF
--- a/src/components/resource/_fields/coverage-statement/coverageStatementDecorator.js
+++ b/src/components/resource/_fields/coverage-statement/coverageStatementDecorator.js
@@ -1,19 +1,30 @@
 import createCalculateDecorator from 'final-form-calculate';
 
+import { coverageStatementStatuses } from '../../../../constants';
+
+const {
+  YES,
+  NO,
+} = coverageStatementStatuses;
+
 export default createCalculateDecorator(
   {
     field: 'hasCoverageStatement',
     updates: {
-      coverageStatement: (hasCoverageStatement, { coverageStatement }) => {
-        return (hasCoverageStatement === 'no') ? '' : coverageStatement;
+      coverageStatement: (hasCoverageStatementValue, formValues) => {
+        return hasCoverageStatementValue === NO
+          ? ''
+          : formValues.coverageStatement;
       }
     }
   },
   {
     field: 'coverageStatement',
     updates: {
-      hasCoverageStatement: (coverageStatement) => {
-        return (coverageStatement && coverageStatement.length) > 0 ? 'yes' : 'no';
+      hasCoverageStatement: (coverageStatementValue) => {
+        return coverageStatementValue && coverageStatementValue.length
+          ? YES
+          : NO;
       }
     }
   }

--- a/src/components/resource/_fields/coverage-statement/coverageStatementDecorator.js
+++ b/src/components/resource/_fields/coverage-statement/coverageStatementDecorator.js
@@ -2,17 +2,12 @@ import createCalculateDecorator from 'final-form-calculate';
 
 import { coverageStatementStatuses } from '../../../../constants';
 
-const {
-  YES,
-  NO,
-} = coverageStatementStatuses;
-
 export default createCalculateDecorator(
   {
     field: 'hasCoverageStatement',
     updates: {
       coverageStatement: (hasCoverageStatementValue, formValues) => {
-        return hasCoverageStatementValue === NO
+        return hasCoverageStatementValue === coverageStatementStatuses.NO_STATUS
           ? ''
           : formValues.coverageStatement;
       }
@@ -23,8 +18,8 @@ export default createCalculateDecorator(
     updates: {
       hasCoverageStatement: (coverageStatementValue) => {
         return coverageStatementValue && coverageStatementValue.length
-          ? YES
-          : NO;
+          ? coverageStatementStatuses.YES_STATUS
+          : coverageStatementStatuses.NO_STATUS;
       }
     }
   }

--- a/src/components/resource/_fields/coverage-statement/coverageStatementDecorator.js
+++ b/src/components/resource/_fields/coverage-statement/coverageStatementDecorator.js
@@ -1,0 +1,20 @@
+import createCalculateDecorator from 'final-form-calculate';
+
+export default createCalculateDecorator(
+  {
+    field: 'hasCoverageStatement',
+    updates: {
+      coverageStatement: (hasCoverageStatement, { coverageStatement }) => {
+        return (hasCoverageStatement === 'no') ? '' : coverageStatement;
+      }
+    }
+  },
+  {
+    field: 'coverageStatement',
+    updates: {
+      hasCoverageStatement: (coverageStatement) => {
+        return (coverageStatement && coverageStatement.length) > 0 ? 'yes' : 'no';
+      }
+    }
+  }
+);

--- a/src/components/resource/_fields/coverage-statement/coverageStatementDecorator.js
+++ b/src/components/resource/_fields/coverage-statement/coverageStatementDecorator.js
@@ -1,13 +1,13 @@
 import createCalculateDecorator from 'final-form-calculate';
 
-import { coverageStatementStatuses } from '../../../../constants';
+import { coverageStatementExistenceStatuses } from '../../../../constants';
 
 export default createCalculateDecorator(
   {
     field: 'hasCoverageStatement',
     updates: {
       coverageStatement: (hasCoverageStatementValue, formValues) => {
-        return hasCoverageStatementValue === coverageStatementStatuses.NO_STATUS
+        return hasCoverageStatementValue === coverageStatementExistenceStatuses.NO
           ? ''
           : formValues.coverageStatement;
       }
@@ -18,8 +18,8 @@ export default createCalculateDecorator(
     updates: {
       hasCoverageStatement: (coverageStatementValue) => {
         return coverageStatementValue && coverageStatementValue.length
-          ? coverageStatementStatuses.YES_STATUS
-          : coverageStatementStatuses.NO_STATUS;
+          ? coverageStatementExistenceStatuses.YES
+          : coverageStatementExistenceStatuses.NO;
       }
     }
   }

--- a/src/components/resource/_fields/coverage-statement/index.js
+++ b/src/components/resource/_fields/coverage-statement/index.js
@@ -1,1 +1,2 @@
 export { default } from './coverage-statement-fields';
+export { default as coverageStatementDecorator } from './coverageStatementDecorator';

--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -47,7 +47,7 @@ function validateEmbargoUnit(embargoUnit, { customEmbargoPeriod }) {
 }
 
 export default class CustomEmbargoFields extends Component {
-  renderEmbargoUnitField(fields) {
+  renderEmbargoUnitField({ name: fieldsName }) {
     return (
       <div
         data-test-eholdings-custom-embargo-select
@@ -56,7 +56,7 @@ export default class CustomEmbargoFields extends Component {
         <FormattedMessage id="ui-eholdings.label.selectTimePeriod">
           {placeholder => (
             <Field
-              name={`${fields.name}[0].embargoUnit`}
+              name={`${fieldsName}[0].embargoUnit`}
               component={Select}
               validate={validateEmbargoUnit}
               placeholder={placeholder}

--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -35,10 +35,11 @@ function validateEmbargoValue(value) {
   return error;
 }
 
-function validateEmbargoUnit(embargoUnitValue, { customEmbargoPeriod }) {
+function validateEmbargoUnit(embargoUnit, { customEmbargoPeriod }) {
   let error;
+  const embargoValueIsSet = customEmbargoPeriod.length && customEmbargoPeriod[0].embargoValue > 0;
 
-  if (customEmbargoPeriod.length && customEmbargoPeriod[0].embargoValue > 0 && !embargoUnitValue) {
+  if (embargoValueIsSet && !embargoUnit) {
     error = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.unit" />;
   }
 
@@ -46,34 +47,13 @@ function validateEmbargoUnit(embargoUnitValue, { customEmbargoPeriod }) {
 }
 
 export default class CustomEmbargoFields extends Component {
-  renderInputs(fields, initial) {
-    const embargoValueField = (
-      <div
-        data-test-eholdings-custom-embargo-textfield
-        className={styles['custom-embargo-text-field']}
-      >
-        <FormattedMessage id="ui-eholdings.number">
-          {placeholder => (
-            <Field
-              name={`${fields.name}[0].embargoValue`}
-              component={TextField}
-              placeholder={placeholder}
-              autoFocus={!initial.length}
-              validate={validateEmbargoValue}
-            />
-          )}
-        </FormattedMessage>
-      </div>
-    );
-
-    const embargoUnitField = (
+  renderEmbargoUnitField(fields) {
+    return (
       <div
         data-test-eholdings-custom-embargo-select
         className={styles['custom-embargo-select']}
       >
-        <FormattedMessage
-          id="ui-eholdings.label.selectTimePeriod"
-        >
+        <FormattedMessage id="ui-eholdings.label.selectTimePeriod">
           {placeholder => (
             <Field
               name={`${fields.name}[0].embargoUnit`}
@@ -98,8 +78,31 @@ export default class CustomEmbargoFields extends Component {
         </FormattedMessage>
       </div>
     );
+  }
 
-    const removeButton = (
+  renderEmbargoValueField(fields, initialValues) {
+    return (
+      <div
+        data-test-eholdings-custom-embargo-textfield
+        className={styles['custom-embargo-text-field']}
+      >
+        <FormattedMessage id="ui-eholdings.number">
+          {placeholder => (
+            <Field
+              name={`${fields.name}[0].embargoValue`}
+              component={TextField}
+              placeholder={placeholder}
+              autoFocus={!initialValues.length}
+              validate={validateEmbargoValue}
+            />
+          )}
+        </FormattedMessage>
+      </div>
+    );
+  }
+
+  renderRemoveButton(fields) {
+    return (
       <div
         data-test-eholdings-custom-embargo-remove-row-button
         className={styles['custom-embargo-clear-row']}
@@ -116,17 +119,19 @@ export default class CustomEmbargoFields extends Component {
         </FormattedMessage>
       </div>
     );
+  }
 
+  renderInputs(fields, initialValues) {
     return (
       <div className={styles['custom-embargo-fields']}>
-        {embargoValueField}
-        {embargoUnitField}
-        {removeButton}
+        {this.renderEmbargoValueField(fields, initialValues)}
+        {this.renderEmbargoUnitField(fields)}
+        {this.renderRemoveButton(fields)}
       </div>
     );
   }
 
-  renderAddButton(fields, initial) {
+  renderAddButton(fields, initialValues) {
     const removalWarning = (
       <p data-test-eholdings-embargo-fields-saving-will-remove>
         <FormattedMessage id="ui-eholdings.resource.embargoPeriod.saveWillRemove" />
@@ -135,11 +140,7 @@ export default class CustomEmbargoFields extends Component {
 
     return (
       <div>
-        {initial.length
-          ? removalWarning
-          : null
-        }
-
+        {!!initialValues.length && removalWarning}
         <div
           className={styles['custom-embargo-add-row-button']}
           data-test-eholdings-custom-embargo-add-row-button
@@ -157,10 +158,15 @@ export default class CustomEmbargoFields extends Component {
     );
   }
 
-  renderEmbargoField = ({ fields, meta: { initial } }) => {
+  renderEmbargoField = ({ fields, meta: { initial: initialValues } }) => {
+    const fieldsData = [
+      fields,
+      initialValues,
+    ];
+
     return fields.value.length
-      ? this.renderInputs(fields, initial)
-      : this.renderAddButton(fields, initial);
+      ? this.renderInputs(...fieldsData)
+      : this.renderAddButton(...fieldsData);
   }
 
   render() {

--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -35,10 +35,10 @@ function validateEmbargoValue(value) {
   return error;
 }
 
-function validateEmbargoUnit(value, { customEmbargoValue }) {
+function validateEmbargoUnit(embargoUnitValue, { customEmbargoPeriod }) {
   let error;
 
-  if (customEmbargoValue > 0 && !value) {
+  if (customEmbargoPeriod.length && customEmbargoPeriod[0].embargoValue > 0 && !embargoUnitValue) {
     error = <FormattedMessage id="ui-eholdings.validate.errors.embargoPeriod.unit" />;
   }
 
@@ -71,27 +71,31 @@ export default class CustomEmbargoFields extends Component {
         data-test-eholdings-custom-embargo-select
         className={styles['custom-embargo-select']}
       >
-        <Field
-          name={`${fields.name}[0].embargoUnit`}
-          component={Select}
-          validate={validateEmbargoUnit}
+        <FormattedMessage
+          id="ui-eholdings.label.selectTimePeriod"
         >
-          <FormattedMessage id="ui-eholdings.label.selectTimePeriod">
-            {(message) => <option value="">{message}</option>}
-          </FormattedMessage>
-          <FormattedMessage id="ui-eholdings.label.days">
-            {(message) => <option value="Days">{message}</option>}
-          </FormattedMessage>
-          <FormattedMessage id="ui-eholdings.label.weeks">
-            {(message) => <option value="Weeks">{message}</option>}
-          </FormattedMessage>
-          <FormattedMessage id="ui-eholdings.label.months">
-            {(message) => <option value="Months">{message}</option>}
-          </FormattedMessage>
-          <FormattedMessage id="ui-eholdings.label.years">
-            {(message) => <option value="Years">{message}</option>}
-          </FormattedMessage>
-        </Field>
+          {placeholder => (
+            <Field
+              name={`${fields.name}[0].embargoUnit`}
+              component={Select}
+              validate={validateEmbargoUnit}
+              placeholder={placeholder}
+            >
+              <FormattedMessage id="ui-eholdings.label.days">
+                {(message) => <option value="Days">{message}</option>}
+              </FormattedMessage>
+              <FormattedMessage id="ui-eholdings.label.weeks">
+                {(message) => <option value="Weeks">{message}</option>}
+              </FormattedMessage>
+              <FormattedMessage id="ui-eholdings.label.months">
+                {(message) => <option value="Months">{message}</option>}
+              </FormattedMessage>
+              <FormattedMessage id="ui-eholdings.label.years">
+                {(message) => <option value="Years">{message}</option>}
+              </FormattedMessage>
+            </Field>
+          )}
+        </FormattedMessage>
       </div>
     );
 

--- a/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
+++ b/src/components/resource/_fields/custom-embargo/custom-embargo-fields.js
@@ -1,15 +1,18 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
+import { FieldArray } from 'react-final-form-arrays';
 import { FormattedMessage } from 'react-intl';
+
+import isEqual from 'lodash/isEqual';
 
 import {
   Button,
   Icon,
   IconButton,
   Select,
-  TextField
+  TextField,
 } from '@folio/stripes/components';
+
 import styles from './custom-embargo-fields.css';
 
 function validateEmbargoValue(value) {
@@ -43,105 +46,95 @@ function validateEmbargoUnit(value, { customEmbargoValue }) {
 }
 
 export default class CustomEmbargoFields extends Component {
-  static propTypes = {
-    change: PropTypes.func.isRequired,
-    initial: PropTypes.object,
-    showInputs: PropTypes.bool
-  };
-
-  static defaultProps = {
-    initial: []
-  };
-
-  state = {
-    showInputs: this.props.showInputs
-  };
-
-  clearValues = () => {
-    this.props.change('customEmbargoValue', 0);
-    this.props.change('customEmbargoUnit', '');
-    this.toggleInputs();
-  }
-
-  toggleInputs = () => {
-    this.setState(({ showInputs }) => ({
-      showInputs: !showInputs
-    }));
-  }
-
-  render() {
-    let { initial } = this.props;
-    let { showInputs } = this.state;
-
-    return (showInputs) ? (
-      <div className={styles['custom-embargo-fields']}>
-        <div
-          data-test-eholdings-custom-embargo-textfield
-          className={styles['custom-embargo-text-field']}
-        >
-          <FormattedMessage id="ui-eholdings.number">
-            {placeholder => (
-              <Field
-                name="customEmbargoValue"
-                component={TextField}
-                placeholder={placeholder}
-                autoFocus={initial.customEmbargoValue === 0}
-                validate={validateEmbargoValue}
-              />
-            )}
-          </FormattedMessage>
-        </div>
-
-        <div
-          data-test-eholdings-custom-embargo-select
-          className={styles['custom-embargo-select']}
-        >
-          <Field
-            name="customEmbargoUnit"
-            component={Select}
-            validate={validateEmbargoUnit}
-          >
-            <FormattedMessage id="ui-eholdings.label.selectTimePeriod">
-              {(message) => <option value="">{message}</option>}
-            </FormattedMessage>
-            <FormattedMessage id="ui-eholdings.label.days">
-              {(message) => <option value="Days">{message}</option>}
-            </FormattedMessage>
-            <FormattedMessage id="ui-eholdings.label.weeks">
-              {(message) => <option value="Weeks">{message}</option>}
-            </FormattedMessage>
-            <FormattedMessage id="ui-eholdings.label.months">
-              {(message) => <option value="Months">{message}</option>}
-            </FormattedMessage>
-            <FormattedMessage id="ui-eholdings.label.years">
-              {(message) => <option value="Years">{message}</option>}
-            </FormattedMessage>
-          </Field>
-        </div>
-
-        <div
-          data-test-eholdings-custom-embargo-remove-row-button
-          className={styles['custom-embargo-clear-row']}
-        >
-          <FormattedMessage id="ui-eholdings.resource.embargoPeriod.clear">
-            {ariaLabel => (
-              <IconButton
-                icon="trash"
-                onClick={this.clearValues}
-                size="small"
-                ariaLabel={ariaLabel}
-              />
-            )}
-          </FormattedMessage>
-        </div>
+  renderInputs(fields, initial) {
+    const embargoValueField = (
+      <div
+        data-test-eholdings-custom-embargo-textfield
+        className={styles['custom-embargo-text-field']}
+      >
+        <FormattedMessage id="ui-eholdings.number">
+          {placeholder => (
+            <Field
+              name={`${fields.name}[0].embargoValue`}
+              component={TextField}
+              placeholder={placeholder}
+              autoFocus={!initial.length}
+              validate={validateEmbargoValue}
+            />
+          )}
+        </FormattedMessage>
       </div>
-    ) : (
+    );
+
+    const embargoUnitField = (
+      <div
+        data-test-eholdings-custom-embargo-select
+        className={styles['custom-embargo-select']}
+      >
+        <Field
+          name={`${fields.name}[0].embargoUnit`}
+          component={Select}
+          validate={validateEmbargoUnit}
+        >
+          <FormattedMessage id="ui-eholdings.label.selectTimePeriod">
+            {(message) => <option value="">{message}</option>}
+          </FormattedMessage>
+          <FormattedMessage id="ui-eholdings.label.days">
+            {(message) => <option value="Days">{message}</option>}
+          </FormattedMessage>
+          <FormattedMessage id="ui-eholdings.label.weeks">
+            {(message) => <option value="Weeks">{message}</option>}
+          </FormattedMessage>
+          <FormattedMessage id="ui-eholdings.label.months">
+            {(message) => <option value="Months">{message}</option>}
+          </FormattedMessage>
+          <FormattedMessage id="ui-eholdings.label.years">
+            {(message) => <option value="Years">{message}</option>}
+          </FormattedMessage>
+        </Field>
+      </div>
+    );
+
+    const removeButton = (
+      <div
+        data-test-eholdings-custom-embargo-remove-row-button
+        className={styles['custom-embargo-clear-row']}
+      >
+        <FormattedMessage id="ui-eholdings.resource.embargoPeriod.clear">
+          {ariaLabel => (
+            <IconButton
+              icon="trash"
+              onClick={fields.pop}
+              size="small"
+              ariaLabel={ariaLabel}
+            />
+          )}
+        </FormattedMessage>
+      </div>
+    );
+
+    return (
+      <div className={styles['custom-embargo-fields']}>
+        {embargoValueField}
+        {embargoUnitField}
+        {removeButton}
+      </div>
+    );
+  }
+
+  renderAddButton(fields, initial) {
+    const removalWarning = (
+      <p data-test-eholdings-embargo-fields-saving-will-remove>
+        <FormattedMessage id="ui-eholdings.resource.embargoPeriod.saveWillRemove" />
+      </p>
+    );
+
+    return (
       <div>
-        {initial.customEmbargoValue !== 0 && (
-          <p data-test-eholdings-embargo-fields-saving-will-remove>
-            <FormattedMessage id="ui-eholdings.resource.embargoPeriod.saveWillRemove" />
-          </p>
-        )}
+        {initial.length
+          ? removalWarning
+          : null
+        }
 
         <div
           className={styles['custom-embargo-add-row-button']}
@@ -149,7 +142,7 @@ export default class CustomEmbargoFields extends Component {
         >
           <Button
             type="button"
-            onClick={this.toggleInputs}
+            onClick={() => { fields.push({ embargoValue: 0 }); }}
           >
             <Icon icon="plus-sign">
               <FormattedMessage id="ui-eholdings.resource.embargoPeriod.addCustom" />
@@ -157,6 +150,22 @@ export default class CustomEmbargoFields extends Component {
           </Button>
         </div>
       </div>
+    );
+  }
+
+  renderEmbargoField = ({ fields, meta: { initial } }) => {
+    return fields.value.length
+      ? this.renderInputs(fields, initial)
+      : this.renderAddButton(fields, initial);
+  }
+
+  render() {
+    return (
+      <FieldArray
+        isEqual={isEqual}
+        render={this.renderEmbargoField}
+        name="customEmbargoPeriod"
+      />
     );
   }
 }

--- a/src/components/resource/_fields/custom-embargo/get-custom-embargo-initial.js
+++ b/src/components/resource/_fields/custom-embargo/get-custom-embargo-initial.js
@@ -1,0 +1,10 @@
+const getEmbargoInitial = ({ embargoValue, embargoUnit }) => {
+  return embargoValue
+    ? [{
+      embargoValue,
+      embargoUnit,
+    }]
+    : [];
+};
+
+export default getEmbargoInitial;

--- a/src/components/resource/_fields/custom-embargo/index.js
+++ b/src/components/resource/_fields/custom-embargo/index.js
@@ -1,1 +1,2 @@
 export { default } from './custom-embargo-fields';
+export { default as getEmbargoInitial } from './get-custom-embargo-initial';

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -2,7 +2,6 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Form, FormSpy } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
-import createCalculateDecorator from 'final-form-calculate';
 import createFocusDecorator from 'final-form-focus';
 import { FormattedMessage } from 'react-intl';
 import update from 'lodash/fp/update';
@@ -23,7 +22,7 @@ import DetailsView from '../../details-view';
 import VisibilityField from '../_fields/visibility';
 import CustomCoverageFields from '../_fields/custom-coverage';
 import CustomUrlFields from '../_fields/custom-url';
-import CoverageStatementFields from '../_fields/coverage-statement';
+import CoverageStatementFields, { coverageStatementDecorator } from '../_fields/coverage-statement';
 import CustomEmbargoFields from '../_fields/custom-embargo';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
@@ -32,25 +31,6 @@ import CoverageDateList from '../../coverage-date-list';
 import ProxySelectField from '../../proxy-select';
 
 import historyActions from '../../../constants/historyActions';
-
-const coverageStatementDecorator = createCalculateDecorator(
-  {
-    field: 'hasCoverageStatement',
-    updates: {
-      coverageStatement: (hasCoverageStatement, { coverageStatement }) => {
-        return (hasCoverageStatement === 'no') ? '' : coverageStatement;
-      }
-    }
-  },
-  {
-    field: 'coverageStatement',
-    updates: {
-      hasCoverageStatement: (coverageStatement) => {
-        return (coverageStatement && coverageStatement.length) > 0 ? 'yes' : 'no';
-      }
-    }
-  }
-);
 
 const focusOnErrors = createFocusDecorator();
 

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -4,7 +4,9 @@ import { Form, FormSpy } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
 import createFocusDecorator from 'final-form-focus';
 import { FormattedMessage } from 'react-intl';
+
 import update from 'lodash/fp/update';
+import get from 'lodash/get';
 
 import { IfPermission } from '@folio/stripes-core';
 import {
@@ -89,8 +91,8 @@ export default class ResourceEditCustomTitle extends Component {
     } = this.props.model;
 
     const hasCoverageStatement = coverageStatement.length > 0
-      ? coverageStatementStatuses.YES
-      : coverageStatementStatuses.NO;
+      ? coverageStatementStatuses.YES_STATUS
+      : coverageStatementStatuses.NO_STATUS;
 
     return {
       isSelected,
@@ -246,10 +248,7 @@ export default class ResourceEditCustomTitle extends Component {
       initialValues,
     } = this.state;
 
-    const hasInheritedProxy = model.package &&
-      model.package.proxy &&
-      model.package.proxy.id;
-
+    const hasInheritedProxy = get(model, 'package.proxy.id');
     const visibilityMessage = model.package.visibilityData.isHidden
       ? <FormattedMessage id="ui-eholdings.resource.visibilityData.isHidden" />
       : model.visibilityData.reason && `(${model.visibilityData.reason})`;

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -6,7 +6,7 @@ import createFocusDecorator from 'final-form-focus';
 import { FormattedMessage } from 'react-intl';
 
 import update from 'lodash/fp/update';
-import get from 'lodash/get';
+import hasIn from 'lodash/hasIn';
 
 import { IfPermission } from '@folio/stripes-core';
 import {
@@ -32,9 +32,10 @@ import PaneHeaderButton from '../../pane-header-button';
 import CoverageDateList from '../../coverage-date-list';
 import ProxySelectField from '../../proxy-select';
 
+
 import {
   historyActions,
-  coverageStatementStatuses,
+  coverageStatementExistenceStatuses,
 } from '../../../constants';
 
 const focusOnErrors = createFocusDecorator();
@@ -91,8 +92,8 @@ export default class ResourceEditCustomTitle extends Component {
     } = this.props.model;
 
     const hasCoverageStatement = coverageStatement.length > 0
-      ? coverageStatementStatuses.YES_STATUS
-      : coverageStatementStatuses.NO_STATUS;
+      ? coverageStatementExistenceStatuses.YES
+      : coverageStatementExistenceStatuses.NO;
 
     return {
       isSelected,
@@ -248,7 +249,7 @@ export default class ResourceEditCustomTitle extends Component {
       initialValues,
     } = this.state;
 
-    const hasInheritedProxy = get(model, 'package.proxy.id');
+    const hasInheritedProxy = hasIn(model, 'package.proxy.id');
     const visibilityMessage = model.package.visibilityData.isHidden
       ? <FormattedMessage id="ui-eholdings.resource.visibilityData.isHidden" />
       : model.visibilityData.reason && `(${model.visibilityData.reason})`;

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -23,7 +23,7 @@ import VisibilityField from '../_fields/visibility';
 import CustomCoverageFields from '../_fields/custom-coverage';
 import CustomUrlFields from '../_fields/custom-url';
 import CoverageStatementFields, { coverageStatementDecorator } from '../_fields/coverage-statement';
-import CustomEmbargoFields from '../_fields/custom-embargo';
+import CustomEmbargoFields, { getEmbargoInitial } from '../_fields/custom-embargo';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 import PaneHeaderButton from '../../pane-header-button';
@@ -89,7 +89,7 @@ export default class ResourceEditCustomTitle extends Component {
       ? 'yes'
       : 'no';
 
-    const initialValues = {
+    return {
       isSelected,
       customCoverages,
       coverageStatement,
@@ -97,17 +97,8 @@ export default class ResourceEditCustomTitle extends Component {
       customUrl: url,
       proxyId: proxy.id,
       isVisible: !visibilityData.isHidden,
-      customEmbargoPeriod: []
+      customEmbargoPeriod: getEmbargoInitial(customEmbargoPeriod)
     };
-
-    if (customEmbargoPeriod.embargoValue) {
-      initialValues.customEmbargoPeriod = [{
-        embargoValue: customEmbargoPeriod.embargoValue,
-        embargoUnit: customEmbargoPeriod.embargoUnit,
-      }];
-    }
-
-    return initialValues;
   }
 
   toggleSection = ({ id }) => {

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -30,7 +30,10 @@ import PaneHeaderButton from '../../pane-header-button';
 import CoverageDateList from '../../coverage-date-list';
 import ProxySelectField from '../../proxy-select';
 
-import historyActions from '../../../constants/historyActions';
+import {
+  historyActions,
+  coverageStatementStatuses,
+} from '../../../constants';
 
 const focusOnErrors = createFocusDecorator();
 
@@ -86,8 +89,8 @@ export default class ResourceEditCustomTitle extends Component {
     } = this.props.model;
 
     const hasCoverageStatement = coverageStatement.length > 0
-      ? 'yes'
-      : 'no';
+      ? coverageStatementStatuses.YES
+      : coverageStatementStatuses.NO;
 
     return {
       isSelected,

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -23,7 +23,7 @@ import { processErrors, isBookPublicationType } from '../../utilities';
 import CoverageStatementFields, { coverageStatementDecorator } from '../_fields/coverage-statement';
 import VisibilityField from '../_fields/visibility';
 import Toaster from '../../toaster';
-import CustomEmbargoFields from '../_fields/custom-embargo';
+import CustomEmbargoFields, { getEmbargoInitial } from '../_fields/custom-embargo';
 import NavigationModal from '../../navigation-modal';
 import ProxySelectField from '../../proxy-select';
 import ManagedCoverageFields from '../_fields/managed-coverage';
@@ -89,24 +89,15 @@ export default class ResourceEditManagedTitle extends Component {
       ? 'yes'
       : 'no';
 
-    const initialValues = {
+    return {
       isSelected,
       isVisible: !visibilityData.isHidden,
       customCoverages,
       coverageStatement,
       hasCoverageStatement,
       proxyId: proxy.id,
-      customEmbargoPeriod: []
+      customEmbargoPeriod: getEmbargoInitial(customEmbargoPeriod)
     };
-
-    if (customEmbargoPeriod.embargoValue) {
-      initialValues.customEmbargoPeriod = [{
-        embargoValue: customEmbargoPeriod.embargoValue,
-        embargoUnit: customEmbargoPeriod.embargoUnit,
-      }];
-    }
-
-    return initialValues;
   }
 
   toggleSection = ({ id }) => {

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -7,7 +7,6 @@ import createFocusDecorator from 'final-form-focus';
 import { FormattedMessage } from 'react-intl';
 
 import update from 'lodash/fp/update';
-import isEqual from 'lodash/isEqual';
 
 import {
   Accordion,
@@ -78,7 +77,6 @@ export default class ResourceEditManagedTitle extends Component {
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    // debugger;
     let stateUpdates = {};
 
     if (nextProps.model.update.errors.length) {
@@ -93,7 +91,6 @@ export default class ResourceEditManagedTitle extends Component {
         managedResourceSelected: nextProps.model.isSelected
       });
     }
-    const customEmbargoChanged = !isEqual(nextProps.model.customEmbargoPeriod, prevState.initialValues.customEmbargoPeriod[0]);    
 
     return stateUpdates;
   }

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -91,8 +91,8 @@ export default class ResourceEditManagedTitle extends Component {
     } = this.props.model;
 
     const hasCoverageStatement = coverageStatement.length > 0
-      ? coverageStatementStatuses.YES
-      : coverageStatementStatuses.NO;
+      ? coverageStatementStatuses.YES_STATUS
+      : coverageStatementStatuses.NO_STATUS;
 
     return {
       isSelected,
@@ -269,7 +269,7 @@ export default class ResourceEditManagedTitle extends Component {
     } = this.state;
 
     const isSelectInFlight = model.update.isPending && hasIn(model.update.changedAttributes, 'isSelected');
-    const hasInheritedProxy = get(model, 'package.proxy.id', false);
+    const hasInheritedProxy = get(model, 'package.proxy.id');
     const visibilityMessage = model.package.visibilityData.isHidden
       ? <FormattedMessage id="ui-eholdings.resource.visibilityData.isHidden" />
       : model.visibilityData.reason && `(${model.visibilityData.reason})`;

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -2,7 +2,6 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Form, FormSpy } from 'react-final-form';
 import arrayMutators from 'final-form-arrays';
-import createCalculateDecorator from 'final-form-calculate';
 import createFocusDecorator from 'final-form-focus';
 import { FormattedMessage } from 'react-intl';
 
@@ -21,37 +20,18 @@ import { IfPermission } from '@folio/stripes-core';
 
 import { processErrors, isBookPublicationType } from '../../utilities';
 
-import DetailsView from '../../details-view';
+import CoverageStatementFields, { coverageStatementDecorator } from '../_fields/coverage-statement';
 import VisibilityField from '../_fields/visibility';
-import CoverageStatementFields from '../_fields/coverage-statement';
-import ManagedCoverageFields from '../_fields/managed-coverage';
+import Toaster from '../../toaster';
 import CustomEmbargoFields from '../_fields/custom-embargo';
 import NavigationModal from '../../navigation-modal';
-import Toaster from '../../toaster';
-import PaneHeaderButton from '../../pane-header-button';
-import CoverageDateList from '../../coverage-date-list';
 import ProxySelectField from '../../proxy-select';
+import ManagedCoverageFields from '../_fields/managed-coverage';
+import CoverageDateList from '../../coverage-date-list';
+import PaneHeaderButton from '../../pane-header-button';
+import DetailsView from '../../details-view';
 
 import historyActions from '../../../constants/historyActions';
-
-const coverageStatementDecorator = createCalculateDecorator(
-  {
-    field: 'hasCoverageStatement',
-    updates: {
-      coverageStatement: (hasCoverageStatement, { coverageStatement }) => {
-        return (hasCoverageStatement === 'no') ? '' : coverageStatement;
-      }
-    }
-  },
-  {
-    field: 'coverageStatement',
-    updates: {
-      hasCoverageStatement: (coverageStatement) => {
-        return (coverageStatement && coverageStatement.length) > 0 ? 'yes' : 'no';
-      }
-    }
-  }
-);
 
 const focusOnErrors = createFocusDecorator();
 

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -100,8 +100,8 @@ export default class ResourceEditManagedTitle extends Component {
       customCoverages,
       coverageStatement,
       hasCoverageStatement,
+      customEmbargoPeriod: getEmbargoInitial(customEmbargoPeriod),
       proxyId: proxy.id,
-      customEmbargoPeriod: getEmbargoInitial(customEmbargoPeriod)
     };
   }
 

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -6,6 +6,8 @@ import createFocusDecorator from 'final-form-focus';
 import { FormattedMessage } from 'react-intl';
 
 import update from 'lodash/fp/update';
+import hasIn from 'lodash/hasIn';
+import get from 'lodash/get';
 
 import {
   Accordion,
@@ -31,7 +33,10 @@ import CoverageDateList from '../../coverage-date-list';
 import PaneHeaderButton from '../../pane-header-button';
 import DetailsView from '../../details-view';
 
-import historyActions from '../../../constants/historyActions';
+import {
+  historyActions,
+  coverageStatementStatuses,
+} from '../../../constants';
 
 const focusOnErrors = createFocusDecorator();
 
@@ -86,8 +91,8 @@ export default class ResourceEditManagedTitle extends Component {
     } = this.props.model;
 
     const hasCoverageStatement = coverageStatement.length > 0
-      ? 'yes'
-      : 'no';
+      ? coverageStatementStatuses.YES
+      : coverageStatementStatuses.NO;
 
     return {
       isSelected,
@@ -263,12 +268,8 @@ export default class ResourceEditManagedTitle extends Component {
       initialValues,
     } = this.state;
 
-    const isSelectInFlight = model.update.isPending && 'isSelected' in model.update.changedAttributes;
-
-    const hasInheritedProxy = model.package &&
-      model.package.proxy &&
-      model.package.proxy.id;
-
+    const isSelectInFlight = model.update.isPending && hasIn(model.update.changedAttributes, 'isSelected');
+    const hasInheritedProxy = get(model, 'package.proxy.id', false);
     const visibilityMessage = model.package.visibilityData.isHidden
       ? <FormattedMessage id="ui-eholdings.resource.visibilityData.isHidden" />
       : model.visibilityData.reason && `(${model.visibilityData.reason})`;

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -7,7 +7,6 @@ import { FormattedMessage } from 'react-intl';
 
 import update from 'lodash/fp/update';
 import hasIn from 'lodash/hasIn';
-import get from 'lodash/get';
 
 import {
   Accordion,
@@ -35,7 +34,7 @@ import DetailsView from '../../details-view';
 
 import {
   historyActions,
-  coverageStatementStatuses,
+  coverageStatementExistenceStatuses,
 } from '../../../constants';
 
 const focusOnErrors = createFocusDecorator();
@@ -91,8 +90,8 @@ export default class ResourceEditManagedTitle extends Component {
     } = this.props.model;
 
     const hasCoverageStatement = coverageStatement.length > 0
-      ? coverageStatementStatuses.YES_STATUS
-      : coverageStatementStatuses.NO_STATUS;
+      ? coverageStatementExistenceStatuses.YES
+      : coverageStatementExistenceStatuses.NO;
 
     return {
       isSelected,
@@ -269,7 +268,7 @@ export default class ResourceEditManagedTitle extends Component {
     } = this.state;
 
     const isSelectInFlight = model.update.isPending && hasIn(model.update.changedAttributes, 'isSelected');
-    const hasInheritedProxy = get(model, 'package.proxy.id');
+    const hasInheritedProxy = hasIn(model, 'package.proxy.id');
     const visibilityMessage = model.package.visibilityData.isHidden
       ? <FormattedMessage id="ui-eholdings.resource.visibilityData.isHidden" />
       : model.visibilityData.reason && `(${model.visibilityData.reason})`;

--- a/src/components/resource/resource-edit.js
+++ b/src/components/resource/resource-edit.js
@@ -1,49 +1,47 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+
+import { Icon } from '@folio/stripes-components';
 
 import ManagedResourceEdit from './edit-managed-title';
 import CustomResourceEdit from './edit-custom-title';
 
-export default function ResourceEdit({ model, ...props }) {
-  let initialValues = {};
-  let View;
+export default class ResourceEdit extends Component {
+  static propTypes = {
+    model: PropTypes.object.isRequired
+  };
 
-  if (model.isTitleCustom === true || model.destroy.params.isTitleCustom === true) {
-    View = CustomResourceEdit;
-    initialValues = {
-      isSelected: model.isSelected,
-      isVisible: !model.visibilityData.isHidden,
-      customCoverages: model.customCoverages,
-      coverageStatement: model.coverageStatement,
-      hasCoverageStatement: model.coverageStatement.length > 0 ? 'yes' : 'no',
-      customEmbargoValue: model.customEmbargoPeriod.embargoValue,
-      customEmbargoUnit: model.customEmbargoPeriod.embargoUnit,
-      customUrl: model.url,
-      proxyId: model.proxy.id
-    };
-  } else if (model.isTitleCustom === false) {
-    View = ManagedResourceEdit;
-    initialValues = {
-      isSelected: model.isSelected,
-      isVisible: !model.visibilityData.isHidden,
-      customCoverages: model.customCoverages,
-      coverageStatement: model.coverageStatement,
-      hasCoverageStatement: model.coverageStatement.length > 0 ? 'yes' : 'no',
-      customEmbargoValue: model.customEmbargoPeriod.embargoValue,
-      customEmbargoUnit: model.customEmbargoPeriod.embargoUnit,
-      proxyId: model.proxy.id
-    };
+
+  renderView() {
+    const {
+      model,
+      ...props
+    } = this.props;
+
+    const View = model.isTitleCustom
+      ? CustomResourceEdit
+      : ManagedResourceEdit;
+
+    return (
+      <View
+        model={model}
+        {...props}
+      />
+    );
   }
 
-  return (
-    <View
-      model={model}
-      initialValues={initialValues}
-      {...props}
-    />
-  );
-}
+  render() {
+    const {
+      model: { isLoaded },
+    } = this.props;
 
-ResourceEdit.propTypes = {
-  model: PropTypes.object.isRequired
-};
+    return isLoaded
+      ? this.renderView()
+      : (
+        <Icon
+          icon="spinner-ellipsis"
+          iconSize="small"
+        />
+      );
+  }
+}

--- a/src/components/resource/resource-edit.js
+++ b/src/components/resource/resource-edit.js
@@ -8,7 +8,10 @@ import CustomResourceEdit from './edit-custom-title';
 
 export default class ResourceEdit extends Component {
   static propTypes = {
-    model: PropTypes.object.isRequired
+    model: PropTypes.object.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    proxyTypes: PropTypes.object.isRequired,
   };
 
   renderRequestErrorMessage() {
@@ -39,7 +42,7 @@ export default class ResourceEdit extends Component {
       model,
       ...props
     } = this.props;
-
+    
     const View = model.isTitleCustom
       ? CustomResourceEdit
       : ManagedResourceEdit;

--- a/src/components/resource/resource-edit.js
+++ b/src/components/resource/resource-edit.js
@@ -11,6 +11,28 @@ export default class ResourceEdit extends Component {
     model: PropTypes.object.isRequired
   };
 
+  renderRequestErrorMessage() {
+    const { model } = this.props;
+
+    return (
+      <p data-test-eholdings-resource-edit-error>
+        {model.request.errors[0].title}
+      </p>
+    );
+  }
+
+  indicateModelIsNotLoaded() {
+    const { model } = this.props;
+
+    return model.request.isRejected
+      ? this.renderRequestErrorMessage()
+      : (
+        <Icon
+          icon="spinner-ellipsis"
+          iconSize="small"
+        />
+      );
+  }
 
   renderView() {
     const {
@@ -37,11 +59,6 @@ export default class ResourceEdit extends Component {
 
     return isLoaded
       ? this.renderView()
-      : (
-        <Icon
-          icon="spinner-ellipsis"
-          iconSize="small"
-        />
-      );
+      : this.indicateModelIsNotLoaded();
   }
 }

--- a/src/components/resource/resource-edit.js
+++ b/src/components/resource/resource-edit.js
@@ -42,7 +42,7 @@ export default class ResourceEdit extends Component {
       model,
       ...props
     } = this.props;
-    
+
     const View = model.isTitleCustom
       ? CustomResourceEdit
       : ManagedResourceEdit;

--- a/src/constants/coverageStatementExistenceStatuses.js
+++ b/src/constants/coverageStatementExistenceStatuses.js
@@ -1,0 +1,6 @@
+const coverageStatementExistenceStatuses = {
+  YES: 'yes',
+  NO: 'no',
+};
+
+export default coverageStatementExistenceStatuses;

--- a/src/constants/coverageStatementStatuses.js
+++ b/src/constants/coverageStatementStatuses.js
@@ -1,6 +1,6 @@
 const coverageStatementStatuses = {
-  YES: 'yes',
-  NO: 'no',
+  YES_STATUS: 'yes',
+  NO_STATUS: 'no',
 };
 
 export default coverageStatementStatuses;

--- a/src/constants/coverageStatementStatuses.js
+++ b/src/constants/coverageStatementStatuses.js
@@ -1,0 +1,6 @@
+const coverageStatementStatuses = {
+  YES: 'yes',
+  NO: 'no',
+};
+
+export default coverageStatementStatuses;

--- a/src/constants/coverageStatementStatuses.js
+++ b/src/constants/coverageStatementStatuses.js
@@ -1,6 +1,0 @@
-const coverageStatementStatuses = {
-  YES_STATUS: 'yes',
-  NO_STATUS: 'no',
-};
-
-export default coverageStatementStatuses;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,2 @@
+export { default as coverageStatementStatuses } from './coverageStatementStatuses';
+export { default as historyActions } from './historyActions';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,2 +1,2 @@
-export { default as coverageStatementStatuses } from './coverageStatementStatuses';
+export { default as coverageStatementExistenceStatuses } from './coverageStatementExistenceStatuses';
 export { default as historyActions } from './historyActions';

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -67,8 +67,7 @@ class ResourceEditRoute extends Component {
     let {
       coverageStatement,
       customCoverages,
-      customEmbargoValue,
-      customEmbargoUnit,
+      customEmbargoPeriod,
       customUrl,
       isVisible,
       proxyId
@@ -110,10 +109,7 @@ class ResourceEditRoute extends Component {
         url: customUrl,
         visibilityData: { isHidden: !isVisible },
         coverageStatement,
-        customEmbargoPeriod: {
-          embargoValue: customEmbargoValue,
-          embargoUnit: customEmbargoUnit
-        },
+        customEmbargoPeriod: customEmbargoPeriod[0] || { embargoValue: 0 },
         proxy: { id: proxyId },
       }));
     }

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -103,13 +103,15 @@ class ResourceEditRoute extends Component {
         };
       });
 
+      const defaultEmbargoPeriod = { embargoValue: 0 };
+
       updateResource(Object.assign(model, {
         customCoverages: newCustomCoverages,
         isSelected: values.isSelected,
         url: customUrl,
         visibilityData: { isHidden: !isVisible },
         coverageStatement,
-        customEmbargoPeriod: customEmbargoPeriod[0] || { embargoValue: 0 },
+        customEmbargoPeriod: customEmbargoPeriod[0] || defaultEmbargoPeriod,
         proxy: { id: proxyId },
       }));
     }

--- a/test/bigtest/interactors/resource-edit.js
+++ b/test/bigtest/interactors/resource-edit.js
@@ -75,7 +75,7 @@ import Datepicker from './datepicker';
   hasSaveButon = isPresent('[data-test-eholdings-resource-save-button]');
   hasCancelButton = isPresent('[data-test-eholdings-resource-cancel-button]');
   isSaveDisabled = property('[data-test-eholdings-resource-save-button]', 'disabled');
-  hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
+  hasErrors = isPresent('[data-test-eholdings-resource-edit-error]');
   isPeerReviewed = property('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]', 'checked');
   checkPeerReviewed = clickable('[data-test-eholdings-peer-reviewed-field] input[type=checkbox]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button]');
@@ -175,4 +175,4 @@ import Datepicker from './datepicker';
   dropDownMenu = new ResourceEditDropDownMenu();
 }
 
-export default new ResourceEditPage('[data-test-eholdings-details-view="resource"]');
+export default new ResourceEditPage();


### PR DESCRIPTION
## Purpose
In this PR, I fixed the bug with form staying pristine after removing the custom embargo field on the resource edit page. I also changed resource edit page so that it does not render the edit form until the data is loaded since we don't know what kind of form to render if the data hasn't been received. It also gave me a way to fix the issue with the pristine form.
## Approach
* Wrap the embargo fields in `FieldArray`. `FieldArray` makes it possible to handle situations when an input was removed from the page properly.
