### PR TITLE
Make prefer-const rule effective

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
     "import/no-extraneous-dependencies": "off",
     "jsx-quotes": "off",
     "no-console": "warn",
-    "prefer-const": "off",
     "react/forbid-prop-types": "off",
     "react/destructuring-assignment": "off",
     "react/sort-prop-types": ["error"]

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@ module.exports = (config) => {
   const preprocessors = {};
   preprocessors[`${testIndex}`] = ['webpack'];
 
-  let configuration = {
+  const configuration = {
     files: [
       { pattern: testIndex, watched: false },
     ],

--- a/src/components/contributors-list.js
+++ b/src/components/contributors-list.js
@@ -4,7 +4,7 @@ import capitalize from 'lodash/capitalize';
 import { KeyValue } from '@folio/stripes/components';
 
 export default function ContributorsList({ data }) {
-  let contributorsByType = data.reduce((byType, contributor) => {
+  const contributorsByType = data.reduce((byType, contributor) => {
     byType[contributor.type] = byType[contributor.type] || [];
     byType[contributor.type].push(contributor.contributor);
     return byType;
@@ -13,7 +13,7 @@ export default function ContributorsList({ data }) {
   return (
     <div>
       {Object.keys(contributorsByType).map((key) => {
-        let names = contributorsByType[key];
+        const names = contributorsByType[key];
         let capitalizedKey = capitalize(key);
 
         // would be better with a pluralization tool

--- a/src/components/coverage-date-list/coverage-date-list.js
+++ b/src/components/coverage-date-list/coverage-date-list.js
@@ -34,11 +34,11 @@ class CoverageDateList extends React.Component {
   }
 
   formatCoverageFullDate({ beginCoverage, endCoverage }) {
-    let startDate = beginCoverage ?
+    const startDate = beginCoverage ?
       <FormattedDate value={beginCoverage} timeZone="UTC" /> :
       '';
 
-    let endDate = endCoverage ?
+    const endDate = endCoverage ?
       <FormattedDate value={endCoverage} timeZone="UTC" /> :
       <FormattedMessage id="ui-eholdings.date.present" />;
 
@@ -56,11 +56,11 @@ class CoverageDateList extends React.Component {
   }
 
   formatCoverageYear({ beginCoverage, endCoverage }) {
-    let startYear = beginCoverage ?
+    const startYear = beginCoverage ?
       <FormattedDate value={beginCoverage} timeZone="UTC" year="numeric" /> :
       '';
 
-    let endYear = endCoverage ?
+    const endYear = endCoverage ?
       <FormattedDate value={endCoverage} timeZone="UTC" year="numeric" /> :
       '';
 
@@ -80,7 +80,7 @@ class CoverageDateList extends React.Component {
   }
 
   render() {
-    let {
+    const {
       coverageArray,
       id,
       isYearOnly

--- a/src/components/details-view/accordion-list-header.js
+++ b/src/components/details-view/accordion-list-header.js
@@ -8,9 +8,9 @@ function AccordionListHeader(props) {
   // RM API does not return exact number of results when count is over 10K
   // For title lists, resultsLength of 10000 indicates this.
   // For other lists (package and provider) resultsLength of 10001 indicates this.
-  let overCount = props.listType === 'titles' ? 10000 : 10001;
-  let showOver = props.resultsLength === overCount;
-  let displayOverCount = 10000;
+  const overCount = props.listType === 'titles' ? 10000 : 10001;
+  const showOver = props.resultsLength === overCount;
+  const displayOverCount = 10000;
   return (
     <div className={styles['accordion-list-header']}>
       <DefaultAccordionHeader {...props} />

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -95,7 +95,7 @@ class DetailsView extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    let { model } = this.props;
+    const { model } = this.props;
 
     // if the model just finished loading focus the heading
     if (!prevProps.model.isLoaded && model.isLoaded) {
@@ -115,8 +115,8 @@ class DetailsView extends Component {
    */
   handleLayout = () => {
     if (this.$container && this.$sticky && this.$list) {
-      let stickyHeight = this.$sticky.offsetHeight;
-      let containerHeight = this.$container.offsetHeight;
+      const stickyHeight = this.$sticky.offsetHeight;
+      const containerHeight = this.$container.offsetHeight;
 
       this.shouldHandleScroll = stickyHeight >= containerHeight;
 
@@ -135,7 +135,7 @@ class DetailsView extends Component {
    * the list's "sticky" behavior
    */
   handleScroll = e => {
-    let { isSticky } = this.state;
+    const { isSticky } = this.state;
 
     // bail if we shouldn't handle scrolling
     if (!this.shouldHandleScroll) return;
@@ -152,11 +152,11 @@ class DetailsView extends Component {
 
       // don't do these calculations when not scrolling the container
     } else if (e.currentTarget === e.target) {
-      let top = e.currentTarget.scrollTop;
-      let height = e.currentTarget.offsetHeight;
-      let scrollHeight = e.currentTarget.scrollHeight;
+      const top = e.currentTarget.scrollTop;
+      const height = e.currentTarget.offsetHeight;
+      const scrollHeight = e.currentTarget.scrollHeight;
       // these will be equal when scrolled all the way down
-      let bottomedOut = top + height === scrollHeight;
+      const bottomedOut = top + height === scrollHeight;
 
       // if bottoming out, enable isSticky
       if (bottomedOut && !isSticky) {
@@ -178,10 +178,10 @@ class DetailsView extends Component {
     // this does not need to run if we do not have a list element
     if (!this.$list) return;
 
-    let { isSticky } = this.state;
-    let scrollingUp = e.deltaY < 0;
-    let notInList = !this.$list.contains(e.target);
-    let listAtTop = this.$list.firstElementChild.scrollTop === 0;
+    const { isSticky } = this.state;
+    const scrollingUp = e.deltaY < 0;
+    const notInList = !this.$list.contains(e.target);
+    const listAtTop = this.$list.firstElementChild.scrollTop === 0;
 
     if (isSticky && scrollingUp && (notInList || listAtTop)) {
       // prevent scroll logic around bottoming out by scrolling up 1px
@@ -195,7 +195,7 @@ class DetailsView extends Component {
   }
 
   render() {
-    let {
+    const {
       type,
       model,
       bodyContent,
@@ -215,15 +215,15 @@ class DetailsView extends Component {
       location
     } = this.props;
 
-    let { isSticky } = this.state;
+    const { isSticky } = this.state;
 
-    let containerClassName = cx('container', {
+    const containerClassName = cx('container', {
       locked: isSticky
     });
 
-    let historyState = history.location.state;
+    const historyState = history.location.state;
 
-    let isListAccordionOpen = sections && sections[listSectionId];
+    const isListAccordionOpen = sections && sections[listSectionId];
     const { searchType } = queryString.parse(location.search, { ignoreQueryPrefix: true });
 
     return (

--- a/src/components/identifiers-list.js
+++ b/src/components/identifiers-list.js
@@ -4,10 +4,10 @@ import { KeyValue } from '@folio/stripes/components';
 
 export default function IdentifiersList({ data }) {
   // get rid of identifiers we received that aren't ISSN or ISBN
-  let filteredData = data.filter(identifier => ['ISSN', 'ISBN'].includes(identifier.type));
+  const filteredData = data.filter(identifier => ['ISSN', 'ISBN'].includes(identifier.type));
 
   // turn type and subtype into compound types
-  let identifiersWithCompoundTypes = filteredData.map((identifier) => {
+  const identifiersWithCompoundTypes = filteredData.map((identifier) => {
     let compoundType = identifier.type;
 
     if (identifier.subtype !== 'Empty') {
@@ -21,8 +21,8 @@ export default function IdentifiersList({ data }) {
   });
 
   // group by type/subtype combination
-  let identifiersByType = identifiersWithCompoundTypes.reduce((byType, identifier) => {
-    let key = identifier.compoundType;
+  const identifiersByType = identifiersWithCompoundTypes.reduce((byType, identifier) => {
+    const key = identifier.compoundType;
     byType[key] = byType[key] || [];
     byType[key].push(identifier.id);
     return byType;

--- a/src/components/impagination.js
+++ b/src/components/impagination.js
@@ -21,8 +21,8 @@ function patchDatasetState(dataset) {
      */
     slice: {
       value(start, end) {
-        let last = Math.min(end, this.length) - 1;
-        let ret = [];
+        const last = Math.min(end, this.length) - 1;
+        const ret = [];
 
         for (let i = start; i <= last; i++) {
           ret.push(this.getRecord(i));
@@ -37,12 +37,12 @@ function patchDatasetState(dataset) {
      */
     pagesWithinHorizon: {
       get() {
-        let withinHorizon = [];
+        const withinHorizon = [];
 
         // this private api is useful for getting the min and max pages in
         // a load horizon; it simply does some math around the readOffset
         // and loadHorizon properties so we also don't have to do it here
-        let { minLoadHorizon, maxLoadHorizon } = this._getLoadHorizons();
+        const { minLoadHorizon, maxLoadHorizon } = this._getLoadHorizons();
 
         for (let i = minLoadHorizon; i < maxLoadHorizon; i++) {
           withinHorizon.push(this.getPage(i));
@@ -57,11 +57,11 @@ function patchDatasetState(dataset) {
 //  Updates the dataset immutably and triggers the `fetch` property
 //  when there are unrequested pages.
 function updateDataset(props, state) {
-  let { collection, pageSize, loadHorizon, readOffset, fetch } = props;
+  const { collection, pageSize, loadHorizon, readOffset, fetch } = props;
   let dataset = state.dataset;
 
-  let isNewCollection = collection.key !== state.collection.key;
-  let hasUnloaded = patchDatasetState(dataset).pagesWithinHorizon.some(({ offset }) => {
+  const isNewCollection = collection.key !== state.collection.key;
+  const hasUnloaded = patchDatasetState(dataset).pagesWithinHorizon.some(({ offset }) => {
     return collection.getPage(offset + 1).request.hasUnloaded;
   });
 
@@ -99,7 +99,7 @@ function updateDataset(props, state) {
   // resolve or reject all pages within the load horizon
   patchDatasetState(dataset).pagesWithinHorizon.forEach((page) => {
     // we use a 1-based page number
-    let { request, records } = collection.getPage(page.offset + 1);
+    const { request, records } = collection.getPage(page.offset + 1);
 
     if (page.isRequested && !request.hasUnloaded) {
       if (request.isResolved) {
@@ -156,7 +156,7 @@ export default class Impagination extends Component {
   // state. Notice we do not import React because we are not using any
   // JSX in this component
   render() {
-    let dataset = patchDatasetState(this.state.dataset);
+    const dataset = patchDatasetState(this.state.dataset);
     return this.props.children(dataset);
   }
 }

--- a/src/components/inline-form/inline-form.js
+++ b/src/components/inline-form/inline-form.js
@@ -14,7 +14,7 @@ export default class InlineForm extends Component {
   }
 
   render() {
-    let {
+    const {
       pristine,
       isPending,
       onSubmit,

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -24,7 +24,7 @@ class PackageCoverageFields extends Component {
   };
 
   validateDateRange = (values) => {
-    let errorArray = [];
+    const errorArray = [];
 
     values.forEach(({ beginCoverage, endCoverage }) => {
       const errors = {};
@@ -42,7 +42,7 @@ class PackageCoverageFields extends Component {
   validateCoverageDate = (value) => {
     const { intl } = this.props;
     moment.locale(intl.locale);
-    let dateFormat = moment.localeData()._longDateFormat.L;
+    const dateFormat = moment.localeData()._longDateFormat.L;
     let errors;
 
     if (value && !moment.utc(value).isValid()) {

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -63,7 +63,7 @@ export default class PackageCreate extends Component {
   }
 
   render() {
-    let {
+    const {
       request,
       onCancel,
       onSubmit,

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -225,20 +225,20 @@ export default class CustomPackageEdit extends Component {
   }
 
   render() {
-    let {
+    const {
       model,
       proxyTypes,
       provider
     } = this.props;
 
-    let {
+    const {
       initialValues,
       showSelectionModal,
       packageSelected,
       sections,
     } = this.state;
 
-    let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
+    const visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
 
     return (
       <Form

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -273,25 +273,25 @@ export default class ManagedPackageEdit extends Component {
   }
 
   render() {
-    let {
+    const {
       model,
       proxyTypes,
       provider
     } = this.props;
 
-    let {
+    const {
       initialValues,
       showSelectionModal,
       packageSelected,
       sections
     } = this.state;
 
-    let visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
+    const visibilityMessage = model.visibilityData.reason && `(${model.visibilityData.reason})`;
 
-    let supportsProviderTokens = provider && provider.isLoaded && provider.providerToken && provider.providerToken.prompt;
-    let supportsPackageTokens = model && model.isLoaded && model.packageToken && model.packageToken.prompt;
-    let hasProviderTokenValue = provider && provider.isLoaded && provider.providerToken && provider.providerToken.value;
-    let hasPackageTokenValue = model && model.isLoaded && model.packageToken && model.packageToken.value;
+    const supportsProviderTokens = provider && provider.isLoaded && provider.providerToken && provider.providerToken.prompt;
+    const supportsPackageTokens = model && model.isLoaded && model.packageToken && model.packageToken.prompt;
+    const hasProviderTokenValue = provider && provider.isLoaded && provider.providerToken && provider.providerToken.value;
+    const hasPackageTokenValue = model && model.isLoaded && model.packageToken && model.packageToken.value;
 
     return (
       <Form

--- a/src/components/package/selection-status.js
+++ b/src/components/package/selection-status.js
@@ -52,7 +52,7 @@ function SelectionStatusMessage({ model }) {
 
 function SelectionStatusButton({ model, onAddToHoldings }) {
   if (model.isPartiallySelected || !model.isSelected || model.isInFlight) {
-    let messageId = model.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings';
+    const messageId = model.isPartiallySelected ? 'addAllToHoldings' : 'addToHoldings';
     return (
       <Button
         type="button"

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -120,12 +120,12 @@ class PackageShow extends Component {
   };
 
   handleSectionToggle = ({ id }) => {
-    let next = update(`sections.${id}`, value => !value, this.state);
+    const next = update(`sections.${id}`, value => !value, this.state);
     this.setState(next);
   }
 
   handleExpandAll = (sections) => {
-    let next = set('sections', sections, this.state);
+    const next = set('sections', sections, this.state);
     this.setState(next);
   }
 
@@ -570,7 +570,7 @@ class PackageShow extends Component {
   }
 
   render() {
-    let {
+    const {
       model,
       searchModal,
       isFreshlySaved,
@@ -578,13 +578,13 @@ class PackageShow extends Component {
       isDestroyed,
     } = this.props;
 
-    let {
+    const {
       showSelectionModal,
       isCoverageEditable,
       sections
     } = this.state;
 
-    let modalMessage = model.isCustom ?
+    const modalMessage = model.isCustom ?
       {
         header: <FormattedMessage id="ui-eholdings.package.modal.header.isCustom" />,
         body: <FormattedMessage id="ui-eholdings.package.modal.body.isCustom" />,
@@ -598,7 +598,7 @@ class PackageShow extends Component {
         buttonCancel: <FormattedMessage id="ui-eholdings.package.modal.buttonCancel" />
       };
 
-    let toasts = [
+    const toasts = [
       ...processErrors(model),
     ];
 

--- a/src/components/pane-header-button/pane-header-button.js
+++ b/src/components/pane-header-button/pane-header-button.js
@@ -10,7 +10,7 @@ import styles from './pane-header-button.css';
 classNames.bind(styles);
 
 export default function PaneHeaderButton(props) {
-  let { children, ...rest } = props;
+  const { children, ...rest } = props;
   return (
     <Button
       buttonClass={styles['pane-header-button']}

--- a/src/components/paneset/Pane.js
+++ b/src/components/paneset/Pane.js
@@ -67,7 +67,7 @@ export default class Pane extends Component {
   };
 
   handleEntering = () => {
-    let { onEntering } = this.props;
+    const { onEntering } = this.props;
 
     this.setState({ entered: true }, () => {
       if (onEntering) onEntering();
@@ -75,7 +75,7 @@ export default class Pane extends Component {
   };
 
   handleExiting = () => {
-    let { onExiting } = this.props;
+    const { onExiting } = this.props;
 
     this.setState({ entered: false }, () => {
       if (onExiting) onExiting();
@@ -112,8 +112,8 @@ export default class Pane extends Component {
       entered
     } = this.state;
 
-    let Element = tagName;
-    let animDuration = 300;
+    const Element = tagName;
+    const animDuration = 300;
 
     return (
       <Fragment>

--- a/src/components/paneset/Paneset.js
+++ b/src/components/paneset/Paneset.js
@@ -6,7 +6,7 @@ import css from './Paneset.css';
 function nodeOfType(Type) {
   // eslint-disable-next-line consistent-return
   return (props, propName, componentName) => {
-    for (let child of Children.toArray(props[propName])) {
+    for (const child of Children.toArray(props[propName])) {
       if (!(child.type.prototype instanceof Type)) {
         return new Error(`\`${componentName}\` ${propName} should be of type \`${Type.name}\`.`);
       }

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -65,15 +65,15 @@ export default class ProviderEdit extends Component {
   }
 
   render() {
-    let {
+    const {
       model,
       proxyTypes,
       rootProxy,
       onSubmit,
     } = this.props;
 
-    let supportsTokens = model.providerToken && model.providerToken.prompt;
-    let hasTokenValue = model.providerToken && model.providerToken.value;
+    const supportsTokens = model.providerToken && model.providerToken.prompt;
+    const hasTokenValue = model.providerToken && model.providerToken.value;
 
     return (
       <Form

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -66,18 +66,18 @@ class ProviderShow extends Component {
   };
 
   handleSectionToggle = ({ id }) => {
-    let next = update(`sections.${id}`, value => !value, this.state);
+    const next = update(`sections.${id}`, value => !value, this.state);
     this.setState(next);
   }
 
   handleExpandAll = (sections) => {
-    let next = set('sections', sections, this.state);
+    const next = set('sections', sections, this.state);
     this.setState(next);
   }
 
   get toasts() {
-    let { model, isFreshlySaved } = this.props;
-    let toasts = processErrors(model);
+    const { model, isFreshlySaved } = this.props;
+    const toasts = processErrors(model);
 
     // if coming from saving edits to the package, show a success toast
     if (isFreshlySaved) {
@@ -125,7 +125,7 @@ class ProviderShow extends Component {
   }
 
   renderLastMenu() {
-    let {
+    const {
       model: { name },
       onEdit,
     } = this.props;

--- a/src/components/proxy-display.js
+++ b/src/components/proxy-display.js
@@ -4,13 +4,13 @@ import { FormattedMessage } from 'react-intl';
 import { KeyValue, Icon } from '@folio/stripes/components';
 
 export default function ProxyDisplay({ model, proxyTypes, inheritedProxyId }) {
-  let proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
+  const proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
 
   if (proxyTypesRecords && model.proxy && model.proxy.id && inheritedProxyId) {
-    let proxyId = model.proxy.id;
-    let selectedValue = proxyTypesRecords[Object.keys(proxyTypesRecords).find(key => key.toLowerCase() === proxyId.toLowerCase())];
-    let name = selectedValue.attributes.name;
-    let checkIfInherited = inheritedProxyId.toLowerCase() === proxyId.toLowerCase();
+    const proxyId = model.proxy.id;
+    const selectedValue = proxyTypesRecords[Object.keys(proxyTypesRecords).find(key => key.toLowerCase() === proxyId.toLowerCase())];
+    const name = selectedValue.attributes.name;
+    const checkIfInherited = inheritedProxyId.toLowerCase() === proxyId.toLowerCase();
 
     return (
       <KeyValue label={<FormattedMessage id="ui-eholdings.proxy" />}>

--- a/src/components/proxy-select/proxy-select-field.js
+++ b/src/components/proxy-select/proxy-select-field.js
@@ -6,9 +6,9 @@ import { FormattedMessage } from 'react-intl';
 import { Select } from '@folio/stripes/components';
 
 function ProxySelectField({ proxyTypes, inheritedProxyId }) {
-  let proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
+  const proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
 
-  let checkIfInherited = proxyTypeId => (inheritedProxyId && inheritedProxyId.toLowerCase() === proxyTypeId.toLowerCase());
+  const checkIfInherited = proxyTypeId => (inheritedProxyId && inheritedProxyId.toLowerCase() === proxyTypeId.toLowerCase());
 
   let options = [];
 

--- a/src/components/query-list/query-list.js
+++ b/src/components/query-list/query-list.js
@@ -49,7 +49,7 @@ export default class QueryList extends Component {
   };
 
   render() {
-    let {
+    const {
       type,
       pageSize,
       loadHorizon,
@@ -62,7 +62,7 @@ export default class QueryList extends Component {
       length,
       fullWidth
     } = this.props;
-    let {
+    const {
       offset
     } = this.state;
 

--- a/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
+++ b/src/components/resource/_fields/coverage-statement/coverage-statement-fields.js
@@ -26,7 +26,7 @@ export default class CoverageStatementFields extends Component {
   };
 
   render() {
-    let { coverageDates } = this.props;
+    const { coverageDates } = this.props;
 
     return (
       <fieldset>

--- a/src/components/resource/_fields/visibility/visibility-field.js
+++ b/src/components/resource/_fields/visibility/visibility-field.js
@@ -13,8 +13,8 @@ class VisibilityField extends Component {
   };
 
   render() {
-    let { disabled } = this.props;
-    let disabledReason = typeof disabled === 'boolean' ? '' : disabled;
+    const { disabled } = this.props;
+    const disabledReason = typeof disabled === 'boolean' ? '' : disabled;
 
     return (
       <fieldset

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -62,7 +62,7 @@ export default class ResourceEditCustomTitle extends Component {
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    let stateUpdates = {};
+    const stateUpdates = {};
 
     if (nextProps.model.destroy.errors.length) {
       stateUpdates.showSelectionModal = false;
@@ -237,12 +237,12 @@ export default class ResourceEditCustomTitle extends Component {
   }
 
   render() {
-    let {
+    const {
       model,
       proxyTypes,
     } = this.props;
 
-    let {
+    const {
       showSelectionModal,
       resourceSelected,
       sections,

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -61,7 +61,7 @@ export default class ResourceEditManagedTitle extends Component {
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    let stateUpdates = {};
+    const stateUpdates = {};
 
     if (nextProps.model.update.errors.length) {
       stateUpdates.showSelectionModal = false;

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -96,12 +96,12 @@ class ResourceShow extends Component {
   };
 
   handleSectionToggle = ({ id }) => {
-    let next = update(`sections.${id}`, value => !value, this.state);
+    const next = update(`sections.${id}`, value => !value, this.state);
     this.setState(next);
   }
 
   handleExpandAll = (sections) => {
-    let next = set('sections', sections, this.state);
+    const next = set('sections', sections, this.state);
     this.setState(next);
   }
 
@@ -191,7 +191,7 @@ class ResourceShow extends Component {
 
 
   render() {
-    let {
+    const {
       model,
       proxyTypes,
       isFreshlySaved,
@@ -200,33 +200,33 @@ class ResourceShow extends Component {
       updateFolioTags,
     } = this.props;
 
-    let {
+    const {
       showSelectionModal,
       resourceSelected,
       sections
     } = this.state;
 
-    let isSelectInFlight = model.update.isPending && 'isSelected' in model.update.changedAttributes;
-    let visibilityMessage = model.package.visibilityData.isHidden ?
+    const isSelectInFlight = model.update.isPending && 'isSelected' in model.update.changedAttributes;
+    const visibilityMessage = model.package.visibilityData.isHidden ?
       <FormattedMessage id="ui-eholdings.resource.visibilityData.isHidden" /> :
       model.visibilityData.reason && `(${model.visibilityData.reason})`;
 
-    let hasManagedCoverages = model.managedCoverages.length > 0 &&
+    const hasManagedCoverages = model.managedCoverages.length > 0 &&
       isValidCoverageList(model.managedCoverages);
-    let hasManagedEmbargoPeriod = model.managedEmbargoPeriod &&
+    const hasManagedEmbargoPeriod = model.managedEmbargoPeriod &&
       model.managedEmbargoPeriod.embargoUnit &&
       model.managedEmbargoPeriod.embargoValue;
-    let hasCustomEmbargoPeriod = model.customEmbargoPeriod &&
+    const hasCustomEmbargoPeriod = model.customEmbargoPeriod &&
       model.customEmbargoPeriod.embargoUnit &&
       model.customEmbargoPeriod.embargoValue;
-    let hasCustomCoverages = model.customCoverages.length > 0 &&
+    const hasCustomCoverages = model.customCoverages.length > 0 &&
       isValidCoverageList(model.customCoverages);
-    let hasInheritedProxy = model.package &&
+    const hasInheritedProxy = model.package &&
       model.package.proxy &&
       model.package.proxy.id;
     const isTokenNeeded = model.data.attributes && model.data.attributes.isTokenNeeded;
 
-    let toasts = processErrors(model);
+    const toasts = processErrors(model);
     const addToEholdingsButtonIsAvailable = (!resourceSelected && !isSelectInFlight)
      || (!model.isSelected && isSelectInFlight);
 

--- a/src/components/scroll-view/scroll-view.js
+++ b/src/components/scroll-view/scroll-view.js
@@ -73,15 +73,15 @@ export default class ScrollView extends Component {
 
   // debounce the `onUpdate` prop
   triggerUpdate = debounce((offset) => {
-    let { onUpdate } = this.props;
+    const { onUpdate } = this.props;
     if (onUpdate) onUpdate(offset);
   }, 300);
 
   // Sets the list's scrollTop based on the itemHeight and
   // current offset
   setScrollOffset() {
-    let { itemHeight } = this.props;
-    let { offset } = this.state;
+    const { itemHeight } = this.props;
+    const { offset } = this.state;
 
     // $list is populated via the ref in the render method below
     if (this.$list) {
@@ -93,10 +93,10 @@ export default class ScrollView extends Component {
   // position. Also calls `onUpdate` when an item has crossed the
   // threshold of what's considered to be active in the view
   handleScroll = (e) => {
-    let { itemHeight } = this.props;
+    const { itemHeight } = this.props;
 
-    let top = e.currentTarget.scrollTop;
-    let offset = Math.floor(top / itemHeight);
+    const top = e.currentTarget.scrollTop;
+    const offset = Math.floor(top / itemHeight);
 
     // update impagination's readOffset
     if (this.state.offset !== offset) {
@@ -106,11 +106,11 @@ export default class ScrollView extends Component {
 
   // Handles updating our visible items count based on the list height
   handleListLayout = () => {
-    let { itemHeight } = this.props;
+    const { itemHeight } = this.props;
 
     if (this.$list) {
-      let listHeight = this.$list.offsetHeight;
-      let visibleItems = Math.ceil(listHeight / itemHeight);
+      const listHeight = this.$list.offsetHeight;
+      const visibleItems = Math.ceil(listHeight / itemHeight);
 
       if (visibleItems !== this.state.visibleItems) {
         this.setState({ visibleItems });
@@ -119,18 +119,18 @@ export default class ScrollView extends Component {
   };
 
   renderChildren() {
-    let { items, length, itemHeight, children } = this.props;
-    let { offset, visibleItems } = this.state;
+    const { items, length, itemHeight, children } = this.props;
+    const { offset, visibleItems } = this.state;
 
-    let threshold = 5;
-    let lower = Math.max(offset - threshold, 0);
-    let upper = Math.min(offset + visibleItems + threshold, (length || items.length) - 1);
+    const threshold = 5;
+    const lower = Math.max(offset - threshold, 0);
+    const upper = Math.min(offset + visibleItems + threshold, (length || items.length) - 1);
 
     // slice the visible items and map them to `children`
     return items.slice(lower, upper + 1).map((item, i) => {
-      let index = lower + i;
+      const index = lower + i;
 
-      let style = {
+      const style = {
         height: itemHeight,
         top: itemHeight * index
       };
@@ -145,7 +145,6 @@ export default class ScrollView extends Component {
 
   render() {
     // strip all other props to pass along the rest to the div
-    // eslint-disable-next-line no-unused-vars
     const {
       items,
       length,
@@ -159,6 +158,7 @@ export default class ScrollView extends Component {
       offset,
       visibleItems,
     } = this.state;
+
 
     let listHeight = (length || items.length) * itemHeight;
 

--- a/src/components/search-form/search-filters.js
+++ b/src/components/search-form/search-filters.js
@@ -44,12 +44,12 @@ export default function SearchFilters({
                 value={value}
                 checked={isChecked}
                 onChange={() => {
-                  let replaced = {
+                  const replaced = {
                     ...activeFilters,
                     // if this option is a default, clear the filter
                     [name]: value === defaultValue ? undefined : value
                   };
-                  let withoutDefault = filter(item => item.value !== undefined, replaced);
+                  const withoutDefault = filter(item => item.value !== undefined, replaced);
 
                   return onUpdate(withoutDefault);
                 }}

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -61,7 +61,7 @@ class SearchForm extends Component {
   };
 
   handleUpdateFilter = (filter) => {
-    let { sort, ...searchFilter } = filter;
+    const { sort, ...searchFilter } = filter;
 
     this.props.onFilterChange(sort, searchFilter);
   };
@@ -87,7 +87,7 @@ class SearchForm extends Component {
   };
 
   render() {
-    let {
+    const {
       searchType,
       searchTypeUrls,
       displaySearchTypeSwitcher,
@@ -98,10 +98,10 @@ class SearchForm extends Component {
       searchString,
       sort
     } = this.props;
-    let Filters = this.getFiltersComponent(searchType);
+    const Filters = this.getFiltersComponent(searchType);
     // sort is treated separately from the rest of the filters on submit,
     // but treated together when rendering the filters.
-    let combinedFilters = { sort, ...searchFilter };
+    const combinedFilters = { sort, ...searchFilter };
 
     return (
       <div className={styles['search-form-container']} data-test-search-form={searchType}>

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -78,7 +78,7 @@ class SearchModal extends React.PureComponent {
   }
 
   handleListSearch = (params) => {
-    let { query } = this.props;
+    const { query } = this.props;
 
     if (this.props.onSearch) {
       this.props.onSearch(params);
@@ -118,18 +118,18 @@ class SearchModal extends React.PureComponent {
   }
 
   render() {
-    let { listType } = this.props;
+    const { listType } = this.props;
 
-    let {
+    const {
       isModalVisible,
       query
     } = this.state;
 
-    let queryFromProps = normalize(this.props.query);
+    const queryFromProps = normalize(this.props.query);
 
-    let filterCount = filterCountFromQuery(queryFromProps);
+    const filterCount = filterCountFromQuery(queryFromProps);
 
-    let hasChanges = !isEqual(queryFromProps, query);
+    const hasChanges = !isEqual(queryFromProps, query);
 
     return (
       <Fragment>

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -39,7 +39,7 @@ export default class SearchPaneset extends Component {
   // providing a location prop, we can safely animate it when the real route
   // changes and manually update it's location after the animation.
   static getDerivedStateFromProps(nextProps, nextState) {
-    let { detailsView, location } = nextProps;
+    const { detailsView, location } = nextProps;
 
     return {
       detailsView: detailsView
@@ -62,8 +62,8 @@ export default class SearchPaneset extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    let isNewSearch = prevProps.location.search !== this.props.location.search;
-    let isSameSearchType = prevProps.resultsType === this.props.resultsType;
+    const isNewSearch = prevProps.location.search !== this.props.location.search;
+    const isSameSearchType = prevProps.resultsType === this.props.resultsType;
 
     // focus the pane title when a new search happens within the same search type
     if (isNewSearch && isSameSearchType && this.$title.current) {
@@ -98,7 +98,7 @@ export default class SearchPaneset extends Component {
   };
 
   render() {
-    let {
+    const {
       searchForm,
       resultsLabel,
       resultsType,
@@ -109,12 +109,13 @@ export default class SearchPaneset extends Component {
       filterCount,
       onClosePreview
     } = this.props;
-    let {
+
+    const {
       detailsView,
       showDetailsView
     } = this.state;
 
-    hideFilters = hideFilters && !!resultsView;
+    const areFiltersHidden = hideFilters && !!resultsView;
 
     let newButton = (<PaneMenu />);
     if (resultsType === 'packages' || resultsType === 'titles') {
@@ -133,10 +134,12 @@ export default class SearchPaneset extends Component {
       );
     }
 
-    let showApply = resultsView && !hideFilters;
+    const showApply = resultsView && !areFiltersHidden;
 
     // do not show filter count when filters are open
-    filterCount = hideFilters ? filterCount : 0;
+    const filterCountToDisplay = areFiltersHidden
+      ? filterCount
+      : 0;
 
     return (
       <Paneset>
@@ -173,7 +176,7 @@ export default class SearchPaneset extends Component {
               <SearchBadge
                 data-test-eholdings-results-pane-search-badge
                 onClick={this.toggleFilters}
-                filterCount={filterCount}
+                filterCount={filterCountToDisplay}
               />
             </div>
           ) : null}

--- a/src/components/settings-detail-pane/settings-detail-pane.js
+++ b/src/components/settings-detail-pane/settings-detail-pane.js
@@ -15,7 +15,7 @@ class SettingsDetailPane extends Component {
   };
 
   render() {
-    let {
+    const {
       children,
       paneTitle,
       ...paneProps

--- a/src/components/settings-knowledge-base/settings-knowledge-base.js
+++ b/src/components/settings-knowledge-base/settings-knowledge-base.js
@@ -33,11 +33,11 @@ export default class SettingsKnowledgeBase extends Component {
   };
 
   componentDidUpdate(prevProps) {
-    let wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
-    let needsUpdate = !isEqual(prevProps.model, this.props.model);
-    let isRejected = this.props.model.update.isRejected;
+    const wasPending = prevProps.model.update.isPending && !this.props.model.update.isPending;
+    const needsUpdate = !isEqual(prevProps.model, this.props.model);
+    const isRejected = this.props.model.update.isRejected;
 
-    let { router } = this.context;
+    const { router } = this.context;
 
     if (wasPending && needsUpdate && !isRejected) {
       router.history.push({
@@ -57,14 +57,14 @@ export default class SettingsKnowledgeBase extends Component {
   }
 
   render() {
-    let {
+    const {
       model,
       onSubmit
     } = this.props;
 
-    let { router } = this.context;
+    const { router } = this.context;
 
-    let toasts = processErrors(model);
+    const toasts = processErrors(model);
 
     if (router.history.action === 'PUSH' &&
         router.history.location.state &&

--- a/src/components/settings-root-proxy/_fields/root-proxy-select/root-proxy-select-field.js
+++ b/src/components/settings-root-proxy/_fields/root-proxy-select/root-proxy-select-field.js
@@ -7,11 +7,11 @@ import { Select } from '@folio/stripes/components';
 import styles from './root-proxy-select-field.css';
 
 function RootProxySelectField({ proxyTypes }) {
-  let proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
-  let options = [];
+  const proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
+  const options = [];
 
   if (proxyTypesRecords) {
-    for (let proxyTypesRecord in proxyTypesRecords) {
+    for (const proxyTypesRecord in proxyTypesRecords) {
       if (Object.prototype.hasOwnProperty.call(proxyTypesRecords, proxyTypesRecord)) {
         options.push(
           <option

--- a/src/components/settings-root-proxy/settings-root-proxy.js
+++ b/src/components/settings-root-proxy/settings-root-proxy.js
@@ -26,13 +26,13 @@ export default class SettingsRootProxy extends Component {
   };
 
   render() {
-    let {
+    const {
       rootProxy,
       proxyTypes,
       onSubmit,
       isFreshlySaved
     } = this.props;
-    let toasts = processErrors(rootProxy);
+    const toasts = processErrors(rootProxy);
 
     if (isFreshlySaved) {
       toasts.push({

--- a/src/components/title/_field-groups/add-title-to-package.js
+++ b/src/components/title/_field-groups/add-title-to-package.js
@@ -5,7 +5,7 @@ import PackageSelectField from '../_fields/package-select';
 import CustomURLField from '../_fields/custom-url';
 
 function AddTitleToPackage({ packageOptions }) {
-  let filteredPackageOptions = packageOptions.filter(pkg => pkg.label !== '');
+  const filteredPackageOptions = packageOptions.filter(pkg => pkg.label !== '');
   return (
     <Fragment>
       <PackageSelectField options={filteredPackageOptions} />

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -64,14 +64,14 @@ export default class TitleCreate extends Component {
   }
 
   render() {
-    let {
+    const {
       customPackages,
       onSubmit,
       onCancel,
       request
     } = this.props;
 
-    let packageOptions = customPackages.map(pkg => ({
+    const packageOptions = customPackages.map(pkg => ({
       label: pkg.name,
       value: pkg.id
     }));

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -70,7 +70,7 @@ export default class TitleEdit extends Component {
   }
 
   render() {
-    let {
+    const {
       model,
       onSubmit,
       updateRequest,

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -133,8 +133,8 @@ class TitleShow extends Component {
   }
 
   get toasts() {
-    let { model, isFreshlySaved, isNewRecord } = this.props;
-    let toasts = processErrors(model);
+    const { model, isFreshlySaved, isNewRecord } = this.props;
+    const toasts = processErrors(model);
 
     // if coming from creating a new custom package, show a success toast
     if (isNewRecord) {
@@ -158,7 +158,7 @@ class TitleShow extends Component {
   }
 
   get customPackageOptions() {
-    let titlePackageIds = this.props.model.resources.map(({ id }) => id);
+    const titlePackageIds = this.props.model.resources.map(({ id }) => id);
     this.props.customPackages.pageSize = 100;
 
     return this.props.customPackages.map(pkg => ({
@@ -175,12 +175,12 @@ class TitleShow extends Component {
   }
 
   handleSectionToggle = ({ id }) => {
-    let next = update(`sections.${id}`, value => !value, this.state);
+    const next = update(`sections.${id}`, value => !value, this.state);
     this.setState(next);
   }
 
   handleExpandAll = (sections) => {
-    let next = set('sections', sections, this.state);
+    const next = set('sections', sections, this.state);
     this.setState(next);
   }
 
@@ -193,9 +193,9 @@ class TitleShow extends Component {
       updateEntityTags,
       updateFolioTags,
     } = this.props;
-    let { showCustomPackageModal, sections } = this.state;
+    const { showCustomPackageModal, sections } = this.state;
 
-    let modalMessage =
+    const modalMessage =
     {
       header: <FormattedMessage id="ui-eholdings.title.modalMessage.addTitleToCustomPackage" />,
       saving: <FormattedMessage id="ui-eholdings.saving" />,

--- a/src/components/toaster/toast.js
+++ b/src/components/toaster/toast.js
@@ -62,9 +62,9 @@ class Toast extends Component {
   }
 
   render() {
-    let { isOpen } = this.state;
-    let { type, animationPosition } = this.props;
-    let toastClass = classNames({
+    const { isOpen } = this.state;
+    const { type, animationPosition } = this.props;
+    const toastClass = classNames({
       [style.toast]: true,
       [style[type]]: true
     });

--- a/src/components/toaster/toaster.js
+++ b/src/components/toaster/toaster.js
@@ -61,8 +61,8 @@ class Toaster extends Component {
   }
 
   renderToasts() {
-    let { position } = this.props;
-    let { toasts } = this.state;
+    const { position } = this.props;
+    const { toasts } = this.state;
 
     if (!toasts.length) { return null; }
 
@@ -83,8 +83,8 @@ class Toaster extends Component {
   }
 
   render() {
-    let { position } = this.props;
-    let containerClass = classNames({
+    const { position } = this.props;
+    const containerClass = classNames({
       [style.container]: true,
       [style[position]]: true
     });

--- a/src/components/toggle-switch/toggle-switch.js
+++ b/src/components/toggle-switch/toggle-switch.js
@@ -39,7 +39,7 @@ export default class ToggleSwitch extends Component {
   }
 
   render() {
-    let { isPending, id, name, disabled, checked } = this.props;
+    const { isPending, id, name, disabled, checked } = this.props;
     let inputChecked;
     if (this.props.input && this.props.checked) {
       inputChecked = this.state.inputChecked;

--- a/src/components/token/token-field.js
+++ b/src/components/token/token-field.js
@@ -34,9 +34,9 @@ export default class TokenField extends Component {
 
   render() {
     /* eslint-disable react/no-danger */
-    let { token, type } = this.props;
-    let { showInputs } = this.state;
-    let helpTextMarkup = { __html: token.helpText };
+    const { token, type } = this.props;
+    const { showInputs } = this.state;
+    const helpTextMarkup = { __html: token.helpText };
 
     return (showInputs) ? (
       <div>

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -3,7 +3,7 @@ import queryString from 'qs';
 import get from 'lodash/get';
 
 export function isBookPublicationType(publicationType) {
-  let publicationTypeIsBook = {
+  const publicationTypeIsBook = {
     'All': false,
     'Audiobook': true,
     'Book': true,
@@ -48,16 +48,16 @@ export const qs = {
 };
 
 export const processErrors = ({ request, update, destroy }) => {
-  let processErrorsSet = ({ errors, timestamp }) => errors.map((error, index) => ({
+  const processErrorsSet = ({ errors, timestamp }) => errors.map((error, index) => ({
     message: error.title,
     type: 'error',
     id: `error-${timestamp}-${index}`
   }));
 
-  let hasErrors = update.isRejected || request.isRejected || destroy.isRejected;
-  let putErrors = hasErrors ? processErrorsSet(update) : [];
-  let getErrors = hasErrors ? processErrorsSet(request) : [];
-  let destroyErrors = hasErrors ? processErrorsSet(destroy) : [];
+  const hasErrors = update.isRejected || request.isRejected || destroy.isRejected;
+  const putErrors = hasErrors ? processErrorsSet(update) : [];
+  const getErrors = hasErrors ? processErrorsSet(request) : [];
+  const destroyErrors = hasErrors ? processErrorsSet(destroy) : [];
 
   return [...putErrors, ...getErrors, ...destroyErrors];
 };
@@ -69,12 +69,31 @@ export const processErrors = ({ request, update, destroy }) => {
  */
 export function transformQueryParams(searchType, params) {
   if (searchType === 'titles') {
-    let { q, searchfield = 'name', filter = {}, ...searchParams } = params;
-    if (searchfield === 'title') { searchfield = 'name'; }
-    let searchfilter = { ...filter, [searchfield]: q };
-    return { ...searchParams, filter: searchfilter };
-  } else { return params; }
+    const {
+      q,
+      filter = {},
+      ...searchParams
+    } = params;
+
+    let { searchfield = 'name' } = params;
+
+    if (searchfield === 'title') {
+      searchfield = 'name';
+    }
+
+    const searchfilter = {
+      ...filter,
+      [searchfield]: q
+    };
+
+    return {
+      ...searchParams,
+      filter: searchfilter
+    };
+  }
+  return params;
 }
+
 /**
  *  Getter helper for the entity tags
  * @param {Object} entityModel - entity model that has tags attibute as tags:{taglist:[]}

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ class EHoldings extends Component {
   }
 
   render() {
-    let {
+    const {
       showSettings,
       match: { path: rootPath }
     } = this.props;

--- a/src/redux/application.js
+++ b/src/redux/application.js
@@ -23,7 +23,7 @@ export const Configuration = model({
     apiKey = '';
 
     serialize() {
-      let data = {
+      const data = {
         id: this.id,
         type: this.type,
         attributes: {

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -251,7 +251,7 @@ const getRecord = (store, id) => (
  * @param {Function} fn - the actual reducing function
  */
 const reduceData = (type, state, fn) => {
-  let store = state[type] || {
+  const store = state[type] || {
     requests: {},
     records: {}
   };
@@ -271,7 +271,7 @@ const reduceData = (type, state, fn) => {
  * @returns {Array} array of error objects
  */
 const formatErrors = (errors) => {
-  let format = (err) => {
+  const format = (err) => {
     if (typeof err === 'string') {
       return { title: err };
     } else if (err && err.message) {
@@ -298,11 +298,11 @@ const formatErrors = (errors) => {
  * @returns {Object} set of attributes with change
  */
 const getChangedAttributes = (oldData, newData) => {
-  let diffData = Object.create(null);
-  let newDataKeys = Object.keys(newData);
+  const diffData = Object.create(null);
+  const newDataKeys = Object.keys(newData);
 
   for (let i = 0, length = newDataKeys.length; i < length; i++) {
-    let key = newDataKeys[i];
+    const key = newDataKeys[i];
     if (oldData[key] !== newData[key]) {
       diffData[key] = {
         prev: oldData[key],
@@ -327,7 +327,7 @@ const handlers = {
     return reduceData(data.resourceType, state, store => ({
 
       requests: Object.keys(store.requests).reduce((reqs, timestamp) => {
-        let request = store.requests[timestamp];
+        const request = store.requests[timestamp];
 
         // keep the request only if it's not of the type which we want to remove
         if (request.type !== data.requestType) {
@@ -382,7 +382,7 @@ const handlers = {
    */
   [actionTypes.SAVE]: (state, { data, payload }) => {
     return reduceData(data.type, state, (store) => {
-      let record = getRecord(store, data.params.id);
+      const record = getRecord(store, data.params.id);
 
       return {
         requests: {
@@ -452,7 +452,7 @@ const handlers = {
 
       // remove requests for this record and flag query requests with `hasUnloaded`
       requests: Object.keys(store.requests).reduce((reqs, timestamp) => {
-        let request = store.requests[timestamp];
+        const request = store.requests[timestamp];
 
         // if the request does not include any unloaded ids, keep it
         if (request.type === 'destroy' || !request.records.some(id => data.ids.includes(id))) {
@@ -478,7 +478,7 @@ const handlers = {
    * @param {Array} action.records - array of resolved records
    */
   [actionTypes.RESOLVE]: (state, action) => {
-    let { request, records } = action;
+    const { request, records } = action;
     // first we reduce the request state object
     let next = reduceData(request.resource, state, store => ({
       requests: {
@@ -499,7 +499,7 @@ const handlers = {
       // then we reduce each record in the set of records
       next = records.reduce((next, record) => { // eslint-disable-line no-shadow
         return reduceData(record.type, next, (store) => {
-          let recordState = getRecord(store, record.id);
+          const recordState = getRecord(store, record.id);
 
           return {
             records: {
@@ -571,7 +571,7 @@ const handlers = {
  */
 const getHeaders = (method, { okapi }, url) => {
   let contentType = 'application/json';
-  let headers = {
+  const headers = {
     'X-Okapi-Tenant': okapi.tenant,
     'X-Okapi-Token': okapi.token
   };
@@ -618,7 +618,7 @@ export function reducer(state = {}, action) { // NOSONAR
  * @param {Function} store.getState - get's the most recent redux state
  */
 export function epic(action$, { getState }) {
-  let actionMethods = {
+  const actionMethods = {
     [actionTypes.QUERY]: 'GET',
     [actionTypes.FIND]: 'GET',
     [actionTypes.SAVE]: 'PUT',
@@ -629,16 +629,16 @@ export function epic(action$, { getState }) {
   return action$
     .filter(({ type }) => actionMethods[type])
     .mergeMap(({ type, data, payload }) => {
-      let state = getState();
-      let method = actionMethods[type];
+      const state = getState();
+      const method = actionMethods[type];
 
       // the request object created from this action
-      let request = state.eholdings.data[data.type].requests[data.timestamp];
+      const request = state.eholdings.data[data.type].requests[data.timestamp];
 
       // used for the actual request
       let url = `${state.okapi.url}${data.path}`;
 
-      let headers = getHeaders(method, state, url);
+      const headers = getHeaders(method, state, url);
       let body;
 
       // if we're querying a set of records, data.params are the
@@ -661,7 +661,7 @@ export function epic(action$, { getState }) {
       }
 
       // request which rejects when not OK
-      let promise = fetch(url, { headers, method, body })
+      const promise = fetch(url, { headers, method, body })
         .then(response => Promise.all([response.ok, parseResponseBody(response)]))
         .then(([ok, body]) => (ok ? body : Promise.reject(body.errors))); // eslint-disable-line no-shadow
 

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -22,8 +22,8 @@ import {
  */
 export class Collection {
   constructor({ type, params = {}, path }, resolver) {
-    let { page = 1, ...queryParams } = params;
-    let { pageSize = 25 } = queryParams;
+    const { page = 1, ...queryParams } = params;
+    const { pageSize = 25 } = queryParams;
 
     this.type = type;
     this.params = params;
@@ -61,7 +61,7 @@ export class Collection {
         });
       }
 
-      let records = request.records.map((id) => {
+      const records = request.records.map((id) => {
         return this.resolver.find(this.type, id);
       });
 
@@ -79,10 +79,10 @@ export class Collection {
    */
   getRecord(offset) {
     if (!this.records[offset]) {
-      let pageOffset = Math.floor(offset / this.pageSize);
-      let recordOffset = offset % this.pageSize;
-      let page = this.getPage(pageOffset + 1);
-      let record = page.records[recordOffset];
+      const pageOffset = Math.floor(offset / this.pageSize);
+      const recordOffset = offset % this.pageSize;
+      const page = this.getPage(pageOffset + 1);
+      const record = page.records[recordOffset];
 
       // the record does not exist, return an empty one
       if (!record) {
@@ -103,11 +103,11 @@ export class Collection {
    */
   get request() {
     // eslint-disable-next-line no-unused-vars
-    let { page, ...queryParams } = this.params;
+    const { page, ...queryParams } = this.params;
 
     // without including the page param, this will return the last
     // query request for any page of this collection
-    let request = this.resolver.getRequest('query', {
+    const request = this.resolver.getRequest('query', {
       type: this.type,
       params: queryParams,
       path: this.path
@@ -135,7 +135,7 @@ export class Collection {
    * @returns {Number} total pages
    */
   get totalPages() {
-    let total = Math.ceil(this.length / this.pageSize);
+    const total = Math.ceil(this.length / this.pageSize);
 
     // cache the total for this instance
     Object.defineProperty(this, 'totalPages', {
@@ -155,7 +155,7 @@ export class Collection {
   map(callback, ctx) {
     let offset = 0;
     let record = this.getRecord(offset);
-    let ret = [];
+    const ret = [];
 
     while (offset < this.length || record.id) {
       ret.push(callback.call(ctx, record, offset));
@@ -173,11 +173,11 @@ export class Collection {
    * @returns {Array} array of records for the range
    */
   slice(start, end) {
-    let last = Math.min(end, this.length) - 1;
-    let ret = [];
+    const last = Math.min(end, this.length) - 1;
+    const ret = [];
 
     for (let i = start; i <= last; i++) {
-      let record = this.getRecord(i);
+      const record = this.getRecord(i);
 
       if (record.id) {
         ret.push(record);
@@ -195,8 +195,8 @@ export class Collection {
    * @returns {Boolean}
    */
   get isLoading() {
-    let { request } = this.getPage(this.currentPage);
-    let isRequested = !!request.timestamp || !!this.length;
+    const { request } = this.getPage(this.currentPage);
+    const isRequested = !!request.timestamp || !!this.length;
     return request.isPending || !isRequested;
   }
 
@@ -215,7 +215,7 @@ export class Collection {
    */
   get hasUnloaded() {
     let hasUnloaded = !!this.getPage(this.currentPage).request.hasUnloaded;
-    let pageLimit = this.totalPages;
+    const pageLimit = this.totalPages;
     let page = 1;
 
     // find the first page up to a page limit with an unloaded record
@@ -324,7 +324,7 @@ class BaseModel {
    * @param {Object} attrs - the record's attributes
    */
   static create(attrs) {
-    let newModel = new this.prototype.constructor();
+    const newModel = new this.prototype.constructor();
     newModel.data.attributes = attrs;
 
     return create(this.type, newModel.serialize(), {
@@ -384,13 +384,13 @@ class BaseModel {
    * @returns {Object} JSON API serialized data
    */
   serialize() {
-    let data = {
+    const data = {
       id: this.id,
       type: this.type,
       attributes: {}
     };
 
-    for (let attr of Object.keys(this.data.attributes)) {
+    for (const attr of Object.keys(this.data.attributes)) {
       data.attributes[attr] = this[attr];
     }
 
@@ -402,7 +402,7 @@ class BaseModel {
    * @returns {Object} the find request state object
    */
   get request() {
-    let request = this.resolver.getRequest('find', {
+    const request = this.resolver.getRequest('find', {
       type: this.type,
       params: { id: this.id }
     });
@@ -420,7 +420,7 @@ class BaseModel {
    * @returns {Object} the update request state object
    */
   get update() {
-    let update = this.resolver.getRequest('update', {
+    const update = this.resolver.getRequest('update', {
       type: this.type,
       params: { id: this.id }
     });
@@ -438,7 +438,7 @@ class BaseModel {
    * @returns {Object} the delete request state object
    */
   get destroy() {
-    let destroyReq = this.resolver.getRequest('destroy', {
+    const destroyReq = this.resolver.getRequest('destroy', {
       type: this.type,
       params: { id: this.id }
     });
@@ -528,10 +528,10 @@ function describeHasMany(key, relType = key) {
 function describeBelongsTo(key, relType = pluralize(key)) {
   return {
     get() {
-      let Model = this.resolver.modelFor(relType);
+      const Model = this.resolver.modelFor(relType);
       let model = new Model(null, this.resolver); // eslint-disable-line no-shadow
 
-      let relId = `${key}Id`;
+      const relId = `${key}Id`;
 
       // check for related records first based on `relationship` if it exists
       if (hasOwnProperty(this.data.relationships, key) && this.data.relationships[key].data) {
@@ -585,20 +585,20 @@ function describeAttribute(key, defaultValue) {
  */
 export default function model({ type, path } = {}) {
   return (Class) => {
-    let modelType = type || pluralize(Class.name).toLowerCase();
-    let modelPath = path || `/${modelType}`;
+    const modelType = type || pluralize(Class.name).toLowerCase();
+    const modelPath = path || `/${modelType}`;
 
-    let instance = new Class();
-    let properties = Object.getOwnPropertyNames(instance);
-    let relTypes = {};
+    const instance = new Class();
+    const properties = Object.getOwnPropertyNames(instance);
+    const relTypes = {};
 
     // strip the constructor so not to override the BaseModel constructor
     // eslint-disable-next-line no-unused-vars
-    let { constructor, ...proto } = Object.getOwnPropertyDescriptors(Class.prototype);
+    const { constructor, ...proto } = Object.getOwnPropertyDescriptors(Class.prototype);
 
     for (let i = 0, l = properties.length; i < l; i++) {
-      let key = properties[i];
-      let value = instance[key];
+      const key = properties[i];
+      const value = instance[key];
 
       if (value && hasOwnProperty(value, '_hasMany')) {
         proto[key] = describeHasMany(key, value._hasMany);

--- a/src/redux/resolver.js
+++ b/src/redux/resolver.js
@@ -29,7 +29,7 @@ export default class Resolver {
    * @throws {Error} when the model can not be found
    */
   modelFor(type) {
-    let ModelClass = this.models[type];
+    const ModelClass = this.models[type];
 
     if (!ModelClass) {
       throw Error(`Could not resolve model for "${type}"`);
@@ -51,11 +51,11 @@ export default class Resolver {
    * the provided data
    */
   getRequest(type, data, filter = () => true) {
-    let store = this.state[data.type];
-    let params = Object.keys(data.params || {});
+    const store = this.state[data.type];
+    const params = Object.keys(data.params || {});
 
     // used when the request is not found
-    let emptyRequest = {
+    const emptyRequest = {
       timestamp: 0,
       type,
       params: data.params || {},
@@ -69,10 +69,10 @@ export default class Resolver {
 
     if (store) {
       return Object.keys(store.requests).reduce((ret, timestamp) => {
-        let request = store.requests[timestamp];
+        const request = store.requests[timestamp];
         let isMatch = request.type === type &&
           params.every(key => isEqual(request.params[key], data.params[key]));
-        let isNewer = timestamp > ret.timestamp;
+        const isNewer = timestamp > ret.timestamp;
 
         // if a path was specified, ensure it too matches
         if (isMatch && Object.hasOwnProperty.call(data, 'path')) {
@@ -125,7 +125,7 @@ export default class Resolver {
    * @returns {Model} the model for the record
    */
   find(type, id) {
-    let ModelClass = this.modelFor(type);
+    const ModelClass = this.modelFor(type);
     return new ModelClass(id, this);
   }
 }

--- a/src/redux/title.js
+++ b/src/redux/title.js
@@ -20,9 +20,9 @@ class Title {
   // slightly customized serializer that adds included resources to
   // new title record payloads
   serialize() {
-    let data = { id: this.id, type: this.type };
-    let { resources, ...attributes } = this.data.attributes;
-    let payload = { data };
+    const data = { id: this.id, type: this.type };
+    const { resources, ...attributes } = this.data.attributes;
+    const payload = { data };
     const readOnlyAttributes = ['isTitleCustom', 'subjects'];
 
     data.attributes = Object.keys(attributes).reduce((attrs, attr) => {

--- a/src/routes/application.js
+++ b/src/routes/application.js
@@ -24,7 +24,7 @@ class ApplicationRoute extends Component {
   }
 
   render() {
-    let {
+    const {
       status,
       interfaces: { eholdings: version },
       showSettings,

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -29,7 +29,7 @@ class PackageCreateRoute extends Component {
   }
 
   packageCreateSubmitted = (values) => {
-    let attrs = {};
+    const attrs = {};
 
     if (values.customCoverages[0]) {
       attrs.customCoverage = {

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -35,15 +35,15 @@ class PackageEditRoute extends Component {
 
   constructor(props) {
     super(props);
-    let { packageId } = props.match.params;
-    let [providerId] = packageId.split('-');
+    const { packageId } = props.match.params;
+    const [providerId] = packageId.split('-');
     props.getPackage(packageId);
     props.getProxyTypes();
     props.getProvider(providerId);
   }
 
   componentDidUpdate(prevProps) {
-    let {
+    const {
       model: next,
       match,
       getPackage,
@@ -51,11 +51,11 @@ class PackageEditRoute extends Component {
       history,
       location
     } = this.props;
-    let {
+    const {
       model: old,
       match: oldMatch
     } = prevProps;
-    let { packageId } = match.params;
+    const { packageId } = match.params;
 
     if (!prevProps.model.destroy.isResolved && next.destroy.isResolved) {
       // if package was reached based on search
@@ -77,11 +77,11 @@ class PackageEditRoute extends Component {
       unloadResources(next.resources);
     }
 
-    let wasPending = prevProps.model.update.isPending && !next.update.isPending;
-    let needsUpdate = !isEqual(prevProps.model, next);
-    let isRejected = this.props.model.update.isRejected;
-    let wasUnSelected = prevProps.model.isSelected && !next.isSelected;
-    let isCurrentlySelected = prevProps.model.isSelected && next.isSelected;
+    const wasPending = prevProps.model.update.isPending && !next.update.isPending;
+    const needsUpdate = !isEqual(prevProps.model, next);
+    const isRejected = this.props.model.update.isRejected;
+    const wasUnSelected = prevProps.model.isSelected && !next.isSelected;
+    const isCurrentlySelected = prevProps.model.isSelected && next.isSelected;
 
     if (wasPending && needsUpdate && !isRejected && (wasUnSelected || isCurrentlySelected)) {
       history.push({
@@ -97,13 +97,13 @@ class PackageEditRoute extends Component {
   }
 
   providerEditSubmitted = (values) => {
-    let { provider, updateProvider } = this.props;
+    const { provider, updateProvider } = this.props;
     provider.providerToken.value = values.providerTokenValue;
     updateProvider(provider);
   };
 
   packageEditSubmitted = (values) => {
-    let { model, updatePackage, destroyPackage } = this.props;
+    const { model, updatePackage, destroyPackage } = this.props;
     // if the package is custom setting the holding status to false
     // or deselecting the package will delete the package from holdings
     if (model.isCustom && values.isSelected === false) {
@@ -175,7 +175,7 @@ class PackageEditRoute extends Component {
    * This should be refactored once we can share model between the routes.
   */
   addPackageToHoldings = () => {
-    let { model, updatePackage } = this.props;
+    const { model, updatePackage } = this.props;
     model.isSelected = true;
     model.selectedCount = model.titleCount;
     model.allowKbToAddTitles = true;
@@ -252,8 +252,8 @@ class PackageEditRoute extends Component {
 
 export default connect(
   ({ eholdings: { data } }, { match }) => {
-    let resolver = createResolver(data);
-    let model = resolver.find('packages', match.params.packageId);
+    const resolver = createResolver(data);
+    const model = resolver.find('packages', match.params.packageId);
     return {
       model,
       proxyTypes: resolver.query('proxyTypes'),

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -43,8 +43,8 @@ class PackageShowRoute extends Component {
 
   constructor(props) {
     super(props);
-    let { packageId } = props.match.params;
-    let [providerId] = packageId.split('-');
+    const { packageId } = props.match.params;
+    const [providerId] = packageId.split('-');
     props.getPackage(packageId);
     props.getProxyTypes();
     props.getProvider(providerId);
@@ -103,9 +103,9 @@ class PackageShowRoute extends Component {
   }
 
   getTitleResults() {
-    let { match, resolver } = this.props;
-    let { pkgSearchParams } = this.state;
-    let { packageId } = match.params;
+    const { match, resolver } = this.props;
+    const { pkgSearchParams } = this.state;
+    const { packageId } = match.params;
     const params = transformQueryParams('titles', pkgSearchParams);
     const collection = resolver.query('resources', params, {
       path: `${Package.pathFor(packageId)}/resources`
@@ -117,7 +117,7 @@ class PackageShowRoute extends Component {
    * This should be refactored once we can share model between the routes.
   */
   addPackageToHoldings = () => {
-    let { model, updatePackage } = this.props;
+    const { model, updatePackage } = this.props;
     model.isSelected = true;
     model.selectedCount = model.titleCount;
     model.allowKbToAddTitles = true;
@@ -125,7 +125,7 @@ class PackageShowRoute extends Component {
   };
 
   toggleSelected = () => {
-    let { model, updatePackage, destroyPackage } = this.props;
+    const { model, updatePackage, destroyPackage } = this.props;
     // if the package is custom setting the holding status to false
     // or deselecting the package will delete the package from holdings
     if (model.isCustom && !model.isSelected === false) {
@@ -150,7 +150,7 @@ class PackageShowRoute extends Component {
   };
 
   fetchPackageTitles = (page) => {
-    let { pkgSearchParams } = this.state;
+    const { pkgSearchParams } = this.state;
     this.searchTitles({ ...pkgSearchParams, page });
   }
 

--- a/src/routes/provider-edit.js
+++ b/src/routes/provider-edit.js
@@ -29,8 +29,8 @@ class ProviderEditRoute extends Component {
 
   constructor(props) {
     super(props);
-    let { match, getProvider, getProxyTypes, getRootProxy } = props;
-    let { providerId } = match.params;
+    const { match, getProvider, getProxyTypes, getRootProxy } = props;
+    const { providerId } = match.params;
     getProvider(providerId);
     getProxyTypes();
     getRootProxy();
@@ -38,16 +38,16 @@ class ProviderEditRoute extends Component {
 
 
   componentDidUpdate(prevProps) {
-    let { match, getProvider, history, location, model } = this.props;
-    let { providerId } = match.params;
+    const { match, getProvider, history, location, model } = this.props;
+    const { providerId } = match.params;
 
     if (providerId !== prevProps.match.params.providerId) {
       getProvider(providerId);
     }
 
-    let wasPending = prevProps.model.update.isPending && !model.update.isPending;
-    let needsUpdate = !isEqual(prevProps.model, model);
-    let isRejected = model.update.isRejected;
+    const wasPending = prevProps.model.update.isPending && !model.update.isPending;
+    const needsUpdate = !isEqual(prevProps.model, model);
+    const isRejected = model.update.isRejected;
 
     if (wasPending && needsUpdate && !isRejected) {
       history.push({
@@ -63,7 +63,7 @@ class ProviderEditRoute extends Component {
   }
 
   providerEditSubmitted = (values) => {
-    let { model, updateProvider } = this.props;
+    const { model, updateProvider } = this.props;
     model.proxy.id = values.proxyId;
     model.providerToken.value = values.providerTokenValue;
     updateProvider(model);

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -35,7 +35,7 @@ class ProviderShowRoute extends Component {
 
   constructor(props) {
     super(props);
-    let { providerId } = props.match.params;
+    const { providerId } = props.match.params;
     props.getProvider(providerId);
     props.getProxyTypes();
     props.getRootProxy();
@@ -48,9 +48,9 @@ class ProviderShowRoute extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    let { match, getPackages, getProvider } = this.props;
-    let { pkgSearchParams } = this.state;
-    let { providerId } = match.params;
+    const { match, getPackages, getProvider } = this.props;
+    const { pkgSearchParams } = this.state;
+    const { providerId } = match.params;
 
     if (providerId !== prevProps.match.params.providerId) {
       getProvider(providerId);
@@ -62,9 +62,9 @@ class ProviderShowRoute extends Component {
   }
 
   getPkgResults() {
-    let { match, resolver } = this.props;
-    let { pkgSearchParams } = this.state;
-    let { providerId } = match.params;
+    const { match, resolver } = this.props;
+    const { pkgSearchParams } = this.state;
+    const { providerId } = match.params;
 
     return resolver.query('packages', pkgSearchParams, {
       path: `${Provider.pathFor(providerId)}/packages`
@@ -79,7 +79,7 @@ class ProviderShowRoute extends Component {
   };
 
   fetchPackages = (page) => {
-    let { pkgSearchParams } = this.state;
+    const { pkgSearchParams } = this.state;
     this.searchPackages({ ...pkgSearchParams, page });
   };
 
@@ -187,7 +187,7 @@ class ProviderShowRoute extends Component {
 }
 export default connect(
   ({ eholdings: { data } }, { match }) => {
-    let resolver = createResolver(data);
+    const resolver = createResolver(data);
     return {
       model: resolver.find('providers', match.params.providerId),
       proxyTypes: resolver.query('proxyTypes'),

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -27,16 +27,16 @@ class ResourceEditRoute extends Component {
 
   constructor(props) {
     super(props);
-    let { match, getResource, getProxyTypes } = props;
-    let { id } = match.params;
+    const { match, getResource, getProxyTypes } = props;
+    const { id } = match.params;
     getResource(id);
     getProxyTypes();
   }
 
   componentDidUpdate(prevProps) {
-    let { packageName, packageId } = prevProps.model;
-    let { match, getResource, history, location, model } = this.props;
-    let { id } = match.params;
+    const { packageName, packageId } = prevProps.model;
+    const { match, getResource, history, location, model } = this.props;
+    const { id } = match.params;
 
     if (!prevProps.model.destroy.isResolved && this.props.model.destroy.isResolved) {
       history.replace(`/eholdings/packages/${packageId}?searchType=packages&q=${packageName}`,
@@ -47,11 +47,11 @@ class ResourceEditRoute extends Component {
       getResource(id);
     }
 
-    let wasPending = prevProps.model.update.isPending && !model.update.isPending;
-    let needsUpdate = !isEqual(prevProps.model, model);
-    let isRejected = model.update.isRejected;
-    let wasUnSelected = prevProps.model.isSelected && !model.isSelected;
-    let isCurrentlySelected = prevProps.model.isSelected && model.isSelected;
+    const wasPending = prevProps.model.update.isPending && !model.update.isPending;
+    const needsUpdate = !isEqual(prevProps.model, model);
+    const isRejected = model.update.isRejected;
+    const wasUnSelected = prevProps.model.isSelected && !model.isSelected;
+    const isCurrentlySelected = prevProps.model.isSelected && model.isSelected;
 
     if (wasPending && needsUpdate && !isRejected && (wasUnSelected || isCurrentlySelected)) {
       history.push({
@@ -63,8 +63,8 @@ class ResourceEditRoute extends Component {
   }
 
   resourceEditSubmitted = (values) => {
-    let { model, updateResource, destroyResource } = this.props;
-    let {
+    const { model, updateResource, destroyResource } = this.props;
+    const {
       coverageStatement,
       customCoverages,
       customEmbargoPeriod,
@@ -94,8 +94,8 @@ class ResourceEditRoute extends Component {
       }));
     } else {
       const newCustomCoverages = customCoverages.map((dateRange) => {
-        let beginCoverage = !dateRange.beginCoverage ? null : moment.utc(dateRange.beginCoverage).format('YYYY-MM-DD');
-        let endCoverage = !dateRange.endCoverage ? null : moment.utc(dateRange.endCoverage).format('YYYY-MM-DD');
+        const beginCoverage = !dateRange.beginCoverage ? null : moment.utc(dateRange.beginCoverage).format('YYYY-MM-DD');
+        const endCoverage = !dateRange.endCoverage ? null : moment.utc(dateRange.endCoverage).format('YYYY-MM-DD');
 
         return {
           beginCoverage,
@@ -136,7 +136,7 @@ class ResourceEditRoute extends Component {
   }
 
   render() {
-    let {
+    const {
       model,
       proxyTypes,
     } = this.props;

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -43,11 +43,11 @@ class ResourceShowRoute extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    let wasUpdated = !this.props.model.update.isPending && prevProps.model.update.isPending && (!this.props.model.update.errors.length > 0);
-    let { match, getResource, history, location } = this.props;
-    let { id } = match.params;
+    const wasUpdated = !this.props.model.update.isPending && prevProps.model.update.isPending && (!this.props.model.update.errors.length > 0);
+    const { match, getResource, history, location } = this.props;
+    const { id } = match.params;
 
-    let { packageName, packageId } = prevProps.model;
+    const { packageName, packageId } = prevProps.model;
     if (!prevProps.model.destroy.isResolved && this.props.model.destroy.isResolved) {
       history.replace(`/eholdings/packages/${packageId}?searchType=packages&q=${packageName}`,
         { eholdings: true, isDestroyed: true });
@@ -67,7 +67,7 @@ class ResourceShowRoute extends Component {
   }
 
   toggleSelected = () => {
-    let { model, updateResource, destroyResource } = this.props;
+    const { model, updateResource, destroyResource } = this.props;
     model.isSelected = !model.isSelected;
 
     if (model.isSelected === false && model.package.isCustom) {
@@ -145,7 +145,7 @@ export default connect(
       eholdings: { data },
     } = store;
 
-    let resolver = createResolver(data);
+    const resolver = createResolver(data);
 
     return {
       model: resolver.find('resources', match.params.id),

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -36,7 +36,7 @@ class SearchRoute extends Component {
     super(props);
 
     // the current location's query params, minus the search type
-    let { searchType, ...params } = qs.parse(props.location.search);
+    const { searchType, ...params } = qs.parse(props.location.search);
 
     // cache queries so we can restore them with the search type buttons
     this.queries = {};
@@ -60,9 +60,9 @@ class SearchRoute extends Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    let { location, match } = nextProps;
-    let { searchType, ...params } = qs.parse(location.search);
-    let hideDetails = /^\/eholdings\/?$/.test(location.pathname);
+    const { location, match } = nextProps;
+    const { searchType, ...params } = qs.parse(location.search);
+    const hideDetails = /^\/eholdings\/?$/.test(location.pathname);
     let shouldFocusItem = null;
 
     if (hideDetails && match.params.id !== (prevState.match && prevState.match.params.id)) {
@@ -118,11 +118,11 @@ class SearchRoute extends Component {
    * @returns {Collection} a collection instance
    */
   getResults() {
-    let { resolver } = this.props;
-    let { searchType, params } = this.state;
-    let { offset = 0, ...queryParams } = params;
-    let searchParams = transformQueryParams(searchType, queryParams);
-    let page = Math.floor(offset / 25) + 1;
+    const { resolver } = this.props;
+    const { searchType, params } = this.state;
+    const { offset = 0, ...queryParams } = params;
+    const searchParams = transformQueryParams(searchType, queryParams);
+    const page = Math.floor(offset / 25) + 1;
 
     return resolver.query(searchType, {
       filter: undefined,
@@ -139,7 +139,7 @@ class SearchRoute extends Component {
    * @returns {String} the final url for a search type, including a query
    */
   buildSearchUrl(pathname, query = '', searchType = this.state.searchType) {
-    let queryString = typeof query === 'string' ? query : qs.stringify(query);
+    const queryString = typeof query === 'string' ? query : qs.stringify(query);
     let url = `${pathname}?searchType=${searchType}`;
 
     if (queryString) {
@@ -155,9 +155,9 @@ class SearchRoute extends Component {
    */
   getSearchTypeUrls() {
     return ['providers', 'packages', 'titles'].reduce((locations, type) => {
-      let lastQuery = this.queries[type] || {};
-      let lastPath = this.path[type] || '/eholdings';
-      let url = this.buildSearchUrl(lastPath, lastQuery, type);
+      const lastQuery = this.queries[type] || {};
+      const lastPath = this.path[type] || '/eholdings';
+      const url = this.buildSearchUrl(lastPath, lastQuery, type);
       return { ...locations, [type]: url };
     }, {});
   }
@@ -167,7 +167,7 @@ class SearchRoute extends Component {
    * @param {Object} params - query param object
    */
   updateURLParams(params) {
-    let { location, history } = this.props;
+    const { location, history } = this.props;
 
     // if the new query is different from our location, update the location
     if (qs.stringify(params) !== qs.stringify(this.state.params)) {
@@ -192,8 +192,8 @@ class SearchRoute extends Component {
    * @param {Object} params - search params for the action
    */
   search(params) {
-    let { searchType } = this.state;
-    let searchParams = transformQueryParams(searchType, params);
+    const { searchType } = this.state;
+    const searchParams = transformQueryParams(searchType, params);
     if (searchType === 'providers') this.props.searchProviders(searchParams);
     if (searchType === 'packages') this.props.searchPackages(searchParams);
     if (searchType === 'titles') this.props.searchTitles(searchParams);
@@ -204,7 +204,7 @@ class SearchRoute extends Component {
    * @param {Object} params - query param object
    */
   handleSearch = () => {
-    let params = {
+    const params = {
       q: this.state.searchString,
       filter: this.state.searchFilter,
       sort: this.state.sort,
@@ -221,7 +221,7 @@ class SearchRoute extends Component {
    * has been scrolled to
    */
   handleOffset = (offset) => {
-    let { params } = this.state;
+    const { params } = this.state;
     this.updateURLParams({ ...params, offset });
   };
 
@@ -231,7 +231,7 @@ class SearchRoute extends Component {
    */
   fetchPage = (page) => {
     // eslint-disable-next-line no-unused-vars
-    let { offset, ...params } = this.state.params;
+    const { offset, ...params } = this.state.params;
     this.search({ ...params, page });
   };
 
@@ -239,10 +239,10 @@ class SearchRoute extends Component {
    * Renders the search component specific to the current search type
    */
   renderResults() {
-    let { searchType, params, shouldFocusItem } = this.state;
-    let { history, location, match: { params: { id } } } = this.props;
+    const { searchType, params, shouldFocusItem } = this.state;
+    const { history, location, match: { params: { id } } } = this.props;
 
-    let props = {
+    const props = {
       params,
       activeId: id,
       shouldFocusItem,
@@ -277,8 +277,8 @@ class SearchRoute extends Component {
    * render the search paneset, otherwise simply render our children
    */
   render() {
-    let { children, history, location } = this.props;
-    let {
+    const { children, history, location } = this.props;
+    const {
       searchType,
       params,
       hideDetails,
@@ -290,9 +290,9 @@ class SearchRoute extends Component {
     } = this.state;
 
     if (searchType) {
-      let results = this.getResults();
+      const results = this.getResults();
 
-      let filterCount = filterCountFromQuery({
+      const filterCount = filterCountFromQuery({
         sort: params.sort,
         q: params.q,
         filter: params.filter

--- a/src/routes/settings-knowledge-base.js
+++ b/src/routes/settings-knowledge-base.js
@@ -21,7 +21,7 @@ class SettingsKnowledgeBaseRoute extends Component {
   }
 
   updateConfig = ({ rmapiBaseUrl, customerId, apiKey }) => {
-    let { config, updateBackendConfig } = this.props;
+    const { config, updateBackendConfig } = this.props;
 
     config.rmapiBaseUrl = rmapiBaseUrl;
     config.customerId = customerId;
@@ -31,7 +31,7 @@ class SettingsKnowledgeBaseRoute extends Component {
   };
 
   render() {
-    let { config } = this.props;
+    const { config } = this.props;
 
     return (
       <TitleManager page="eHoldings settings" record="Knowledge base">

--- a/src/routes/settings-root-proxy.js
+++ b/src/routes/settings-root-proxy.js
@@ -27,9 +27,9 @@ class SettingsRootProxyRoute extends Component {
 
   componentDidUpdate(prevProps) {
     const { history, rootProxy } = this.props;
-    let wasPending = prevProps.rootProxy.update.isPending && !rootProxy.update.isPending;
-    let needsUpdate = !isEqual(prevProps.rootProxy, rootProxy);
-    let isRejected = rootProxy.update.isRejected;
+    const wasPending = prevProps.rootProxy.update.isPending && !rootProxy.update.isPending;
+    const needsUpdate = !isEqual(prevProps.rootProxy, rootProxy);
+    const isRejected = rootProxy.update.isRejected;
 
     if (wasPending && needsUpdate && !isRejected) {
       history.push({
@@ -40,7 +40,7 @@ class SettingsRootProxyRoute extends Component {
   }
 
   rootProxySubmitted = (values) => {
-    let { rootProxy, updateRootProxy } = this.props;
+    const { rootProxy, updateRootProxy } = this.props;
 
     rootProxy.proxyTypeId = values.rootProxyServer;
 
@@ -48,7 +48,7 @@ class SettingsRootProxyRoute extends Component {
   }
 
   render() {
-    let { proxyTypes, rootProxy, history } = this.props;
+    const { proxyTypes, rootProxy, history } = this.props;
 
     return (
       <TitleManager page="eHoldings settings" record="Root proxy">

--- a/src/routes/title-create.js
+++ b/src/routes/title-create.js
@@ -43,13 +43,13 @@ class TitleCreateRoute extends Component {
 
   expandIdentifiers = (identifiers) => {
     return identifiers ? identifiers.map(({ id, flattenedType }) => {
-      let flattenedTypeIndex = flattenedType || 0;
+      const flattenedTypeIndex = flattenedType || 0;
       return { id, ...this.flattenedIdentifiers[flattenedTypeIndex] };
     }) : [];
   }
 
   createTitle = (values) => {
-    let { packageId, ...attrs } = values;
+    const { packageId, ...attrs } = values;
 
     // a resource is created along with the title
     attrs.resources = [{ packageId }];
@@ -60,7 +60,7 @@ class TitleCreateRoute extends Component {
   };
 
   render() {
-    let {
+    const {
       customPackages,
       history,
       location,
@@ -89,7 +89,7 @@ class TitleCreateRoute extends Component {
 
 export default connect(
   ({ eholdings: { data } }) => {
-    let resolver = createResolver(data);
+    const resolver = createResolver(data);
 
     return {
       createRequest: resolver.getRequest('create', { type: 'titles' }),

--- a/src/routes/title-edit.js
+++ b/src/routes/title-edit.js
@@ -27,14 +27,14 @@ class TitleEditRoute extends Component {
 
   constructor(props) {
     super(props);
-    let { match, getTitle } = props;
-    let { titleId } = match.params;
+    const { match, getTitle } = props;
+    const { titleId } = match.params;
     getTitle(titleId);
   }
 
   componentDidUpdate(prevProps) {
-    let { match, getTitle, history, location, model } = this.props;
-    let { titleId } = match.params;
+    const { match, getTitle, history, location, model } = this.props;
+    const { titleId } = match.params;
 
     // prevent being able to visit an edit form for uneditable managed titles
     if (model.isLoaded && !model.isTitleCustom) {
@@ -55,9 +55,9 @@ class TitleEditRoute extends Component {
       getTitle(titleId);
     }
 
-    let wasPending = prevProps.model.update.isPending && !model.update.isPending;
-    let needsUpdate = !isEqual(prevProps.model, model);
-    let isRejected = model.update.isRejected;
+    const wasPending = prevProps.model.update.isPending && !model.update.isPending;
+    const needsUpdate = !isEqual(prevProps.model, model);
+    const isRejected = model.update.isRejected;
 
     if (wasPending && needsUpdate && !isRejected) {
       history.push({
@@ -96,7 +96,7 @@ class TitleEditRoute extends Component {
 
   expandIdentifiers = (identifiers) => {
     return identifiers.map(({ id, flattenedType }) => {
-      let flattenedTypeIndex = flattenedType || 0;
+      const flattenedTypeIndex = flattenedType || 0;
       return { id, ...this.flattenedIdentifiers[flattenedTypeIndex] };
     });
   }
@@ -207,7 +207,7 @@ class TitleEditRoute extends Component {
   }
 
   render() {
-    let { model } = this.props;
+    const { model } = this.props;
 
     return model.isLoaded
       ? this.renderView()

--- a/src/routes/title-show.js
+++ b/src/routes/title-show.js
@@ -45,8 +45,8 @@ class TitleShowRoute extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    let { match, createRequest } = prevProps;
-    let { titleId } = this.props.match.params;
+    const { match, createRequest } = prevProps;
+    const { titleId } = this.props.match.params;
 
     if (match.params.titleId !== titleId) {
       this.props.getTitle(titleId);
@@ -61,8 +61,8 @@ class TitleShowRoute extends Component {
   }
 
   createResource = ({ packageId, customUrl }) => {
-    let { match, createResource } = this.props;
-    let { titleId } = match.params;
+    const { match, createResource } = this.props;
+    const { titleId } = match.params;
 
     createResource({
       url: customUrl,
@@ -151,7 +151,7 @@ class TitleShowRoute extends Component {
 
 export default connect(
   ({ eholdings: { data } }, { match }) => {
-    let resolver = createResolver(data);
+    const resolver = createResolver(data);
 
     return {
       model: resolver.find('titles', match.params.titleId),

--- a/test/bigtest/helpers/setup-block-server.js
+++ b/test/bigtest/helpers/setup-block-server.js
@@ -1,8 +1,8 @@
 export default function setupBlockServer(server) {
   server.block = function block() {
-    let { pretender } = this;
-    let blocks = [];
-    let _handlerFor = pretender._handlerFor;
+    const { pretender } = this;
+    const blocks = [];
+    const _handlerFor = pretender._handlerFor;
     pretender._handlerFor = (...args) => {
       return {
         handler(request) {

--- a/test/bigtest/interactors/helpers.js
+++ b/test/bigtest/interactors/helpers.js
@@ -8,7 +8,7 @@ export const hasClassBeginningWith = (selector, className) => {
 
 export const getComputedStyle = (selector, className) => {
   return computed(function () {
-    let element = this.$(selector);
+    const element = this.$(selector);
     return window.getComputedStyle(element)[className];
   });
 };

--- a/test/bigtest/interactors/package-edit.js
+++ b/test/bigtest/interactors/package-edit.js
@@ -79,12 +79,12 @@ import PackageSelectionStatus from './selection-status';
   isVisibilityFieldPresent = isPresent('[data-test-eholdings-package-visibility-field]');
   isVisibleToPatrons = property('[data-test-eholdings-package-visibility-field] input[value="true"]', 'checked');
   toggleIsVisible() {
-    let isVisible = (!this.isVisibleToPatrons).toString();
+    const isVisible = (!this.isVisibleToPatrons).toString();
     return this.click(`[data-test-eholdings-package-visibility-field] input[value="${isVisible}"]`);
   }
 
   isHiddenMessage = computed(function () {
-    let $node = this.$('[data-test-eholdings-package-visibility-field] input[value="false"] ~ span:last-child');
+    const $node = this.$('[data-test-eholdings-package-visibility-field] input[value="false"] ~ span:last-child');
     return $node.textContent.replace(/^No(\s\((.*)\))?$/, '$2');
   });
 

--- a/test/bigtest/interactors/provider-search.js
+++ b/test/bigtest/interactors/provider-search.js
@@ -60,7 +60,7 @@ import SearchBadge from './search-badge';
   scrollToOffset = action(function (readOffset) {
     return this.find('[data-test-query-list="providers"] li')
       .do((firstItem) => {
-        let scrollOffset = firstItem.offsetHeight * readOffset;
+        const scrollOffset = firstItem.offsetHeight * readOffset;
         return this.scroll('[data-test-query-list="providers"]', { top: scrollOffset });
       })
       .run();

--- a/test/bigtest/interactors/resource-edit.js
+++ b/test/bigtest/interactors/resource-edit.js
@@ -85,7 +85,7 @@ import Datepicker from './datepicker';
   isResourceShowToPatronsVisible = isPresent('[data-test-eholdings-resource-visibility-field]');
   isCoverageSettingsDatesField = isPresent('[data-test-eholdings-resource-coverage-fields]');
   isHiddenMessage = computed(function () {
-    let $node = this.$('[data-test-eholdings-resource-visibility-field] input[value="false"] ~ span:last-child');
+    const $node = this.$('[data-test-eholdings-resource-visibility-field] input[value="false"] ~ span:last-child');
     return $node.textContent.replace(/^No(\s\((.*)\))?$/, '$2');
   });
 
@@ -98,7 +98,7 @@ import Datepicker from './datepicker';
 
   toggleIsSelected = clickable('[data-test-eholdings-resource-holding-status] input');
   toggleIsVisible() {
-    let isVisible = (!this.isResourceVisible).toString();
+    const isVisible = (!this.isResourceVisible).toString();
     return this.click(`[data-test-eholdings-resource-visibility-field] input[value="${isVisible}"]`);
   }
 

--- a/test/bigtest/interactors/title-create.js
+++ b/test/bigtest/interactors/title-create.js
@@ -42,7 +42,7 @@ import {
 
   hasIdentifiersBtn = isPresent('[data-test-eholdings-identifiers-fields] [data-test-repeatable-field-add-item-button]');
   addIdentifier(type, id) {
-    let values = {
+    const values = {
       'ISSN (Online)': '0',
       'ISSN (Print)': '1',
       'ISBN (Online)': '2',

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -224,7 +224,7 @@ export default function config() {
   }));
 
   this.get('/providers/:id', ({ providers }, request) => {
-    let provider = providers.find(request.params.id);
+    const provider = providers.find(request.params.id);
 
     if (provider && provider.packages.length > 25) {
       provider.packages = provider.packages.slice(0, 25);
@@ -234,9 +234,9 @@ export default function config() {
   });
 
   this.put('/providers/:id', ({ providers }, request) => {
-    let matchingProvider = providers.find(request.params.id);
-    let body = JSON.parse(request.requestBody);
-    let {
+    const matchingProvider = providers.find(request.params.id);
+    const body = JSON.parse(request.requestBody);
+    const {
       proxy,
       providerToken
     } = body.data.attributes;
@@ -246,11 +246,11 @@ export default function config() {
   });
 
   // Package resources
-  let packagesFilter = (pkg, req) => {
-    let params = req.queryParams;
-    let type = params['filter[type]'];
-    let selected = params['filter[selected]'];
-    let custom = params['filter[custom]'];
+  const packagesFilter = (pkg, req) => {
+    const params = req.queryParams;
+    const type = params['filter[type]'];
+    const selected = params['filter[selected]'];
+    const custom = params['filter[custom]'];
     let filtered = true;
 
     if (params.q && pkg.name) {
@@ -277,7 +277,7 @@ export default function config() {
   this.get('/providers/:id/packages', nestedResourceRouteFor('provider', 'packages', packagesFilter));
 
   this.get('/packages/:id', ({ packages }, request) => {
-    let pkg = packages.find(request.params.id);
+    const pkg = packages.find(request.params.id);
 
     if (pkg && pkg.resources.length > 25) {
       pkg.resources = pkg.resources.slice(0, 25);
@@ -287,13 +287,13 @@ export default function config() {
   });
 
   this.put('/packages/:id', ({ packages, resources }, request) => {
-    let matchingPackage = packages.find(request.params.id);
-    let matchingResources = resources.where({
+    const matchingPackage = packages.find(request.params.id);
+    const matchingResources = resources.where({
       packageId: request.params.id
     });
 
-    let body = JSON.parse(request.requestBody);
-    let {
+    const body = JSON.parse(request.requestBody);
+    const {
       isSelected,
       allowKbToAddTitles,
       customCoverage,
@@ -304,7 +304,7 @@ export default function config() {
       packageToken
     } = body.data.attributes;
 
-    let selectedCount = isSelected ? matchingResources.length : 0;
+    const selectedCount = isSelected ? matchingResources.length : 0;
 
     matchingResources.update('isSelected', isSelected);
     matchingResources.update('visibilityData', visibilityData);
@@ -321,10 +321,10 @@ export default function config() {
   });
 
   this.post('/packages', ({ packages }, request) => {
-    let body = JSON.parse(request.requestBody);
-    let pkg = packages.create(body.data.attributes);
+    const body = JSON.parse(request.requestBody);
+    const pkg = packages.create(body.data.attributes);
 
-    let { customCoverages } = body.data.attributes;
+    const { customCoverages } = body.data.attributes;
 
     pkg.update('customCoverages', customCoverages);
     pkg.update('isSelected', true);
@@ -334,8 +334,8 @@ export default function config() {
   });
 
   this.delete('/packages/:id', ({ packages, resources }, request) => {
-    let matchingPackage = packages.find(request.params.id);
-    let matchingResources = resources.where({
+    const matchingPackage = packages.find(request.params.id);
+    const matchingResources = resources.where({
       packageId: request.params.id
     });
 
@@ -347,13 +347,13 @@ export default function config() {
 
   // Title resources
   this.get('/titles', searchRouteFor('titles', (title, req) => {
-    let params = req.queryParams;
-    let type = params['filter[type]'];
-    let selected = params['filter[selected]'];
-    let name = params['filter[name]'];
-    let isxn = params['filter[isxn]'];
-    let subject = params['filter[subject]'];
-    let publisher = params['filter[publisher]'];
+    const params = req.queryParams;
+    const type = params['filter[type]'];
+    const selected = params['filter[selected]'];
+    const name = params['filter[name]'];
+    const isxn = params['filter[isxn]'];
+    const subject = params['filter[subject]'];
+    const publisher = params['filter[publisher]'];
     let filtered = true;
 
     if (name) {
@@ -384,15 +384,15 @@ export default function config() {
   });
 
   this.post('/titles', (schema, request) => {
-    let body = JSON.parse(request.requestBody);
-    let title = schema.titles.create(body.data.attributes);
+    const body = JSON.parse(request.requestBody);
+    const title = schema.titles.create(body.data.attributes);
 
     title.update('isSelected', true);
     title.update('isTitleCustom', true);
 
-    for (let include of body.included) {
+    for (const include of body.included) {
       if (include.type === 'resource') {
-        let pkg = schema.packages.find(include.attributes.packageId);
+        const pkg = schema.packages.find(include.attributes.packageId);
         schema.resources.create({ package: pkg, title });
       }
     }
@@ -415,14 +415,14 @@ export default function config() {
 
   // Resources
   this.get('/packages/:id/resources', nestedResourceRouteFor('package', 'resources', (resource, req) => {
-    let title = resource.title;
-    let params = req.queryParams;
-    let type = params['filter[type]'];
-    let selected = params['filter[selected]'];
-    let name = params['filter[name]'];
-    let isxn = params['filter[isxn]'];
-    let subject = params['filter[subject]'];
-    let publisher = params['filter[publisher]'];
+    const title = resource.title;
+    const params = req.queryParams;
+    const type = params['filter[type]'];
+    const selected = params['filter[selected]'];
+    const name = params['filter[name]'];
+    const isxn = params['filter[isxn]'];
+    const subject = params['filter[subject]'];
+    const publisher = params['filter[publisher]'];
     let filtered = true;
 
     if (name) {
@@ -453,15 +453,15 @@ export default function config() {
   }));
 
   this.get('/resources/:id', ({ resources }, request) => {
-    let resource = resources.find(request.params.id);
+    const resource = resources.find(request.params.id);
 
     return resource;
   });
 
   this.put('/resources/:id', ({ resources }, request) => {
-    let matchingResource = resources.find(request.params.id);
-    let body = JSON.parse(request.requestBody);
-    let {
+    const matchingResource = resources.find(request.params.id);
+    const body = JSON.parse(request.requestBody);
+    const {
       isSelected,
       visibilityData,
       contributors,
@@ -500,11 +500,11 @@ export default function config() {
   });
 
   this.post('/resources', ({ resources, packages }, request) => {
-    let body = JSON.parse(request.requestBody);
-    let { packageId, titleId, url } = body.data.attributes;
-    let { providerId } = packages.find(packageId);
+    const body = JSON.parse(request.requestBody);
+    const { packageId, titleId, url } = body.data.attributes;
+    const { providerId } = packages.find(packageId);
 
-    let resource = resources.create({
+    const resource = resources.create({
       isSelected: true,
       providerId,
       packageId,
@@ -516,7 +516,7 @@ export default function config() {
   });
 
   this.delete('/resources/:id', ({ resources }, request) => {
-    let matchingResource = resources.find(request.params.id);
+    const matchingResource = resources.find(request.params.id);
 
     matchingResource.destroy();
 

--- a/test/bigtest/network/factories/package.js
+++ b/test/bigtest/network/factories/package.js
@@ -1,6 +1,6 @@
 import { Factory, faker, trait } from '@bigtest/mirage';
 
-let helpText = '<ul><li>Enter your Gale token</li></ul>';
+const helpText = '<ul><li>Enter your Gale token</li></ul>';
 
 export default Factory.extend({
   name: () => faker.commerce.productName(),
@@ -52,7 +52,7 @@ export default Factory.extend({
 
   withProvider: trait({
     afterCreate(packageObj, server) {
-      let provider = server.create('provider');
+      const provider = server.create('provider');
       packageObj.provider = provider;
       packageObj.save();
     }
@@ -60,7 +60,7 @@ export default Factory.extend({
 
   isHidden: trait({
     afterCreate(packageObj, server) {
-      let visibilityData = server.create('visibility-data', {
+      const visibilityData = server.create('visibility-data', {
         isHidden: true,
         reason: 'The content is for mature audiences only.'
       });
@@ -70,7 +70,7 @@ export default Factory.extend({
 
   isHiddenWithoutReason: trait({
     afterCreate(packageObj, server) {
-      let visibilityData = server.create('visibility-data', {
+      const visibilityData = server.create('visibility-data', {
         isHidden: true,
         reason: ''
       });
@@ -80,7 +80,7 @@ export default Factory.extend({
 
   withProxy: trait({
     afterCreate(packageObj, server) {
-      let proxy = server.create('proxy', {
+      const proxy = server.create('proxy', {
         inherited: false,
         id: 'microstates'
       });
@@ -91,7 +91,7 @@ export default Factory.extend({
 
   withInheritedProxy: trait({
     afterCreate(packageObj, server) {
-      let proxy = server.create('proxy', {
+      const proxy = server.create('proxy', {
         inherited: true,
         id: 'bigTestJS'
       });
@@ -102,14 +102,14 @@ export default Factory.extend({
 
   withCustomCoverage: trait({
     afterCreate(packageObj, server) {
-      let customCoverage = server.create('custom-coverage');
+      const customCoverage = server.create('custom-coverage');
       packageObj.update('customCoverage', customCoverage.toJSON());
     }
   }),
 
   withPackageToken: trait({
     afterCreate(packageObj, server) {
-      let token = server.create('token', {
+      const token = server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText,
@@ -122,7 +122,7 @@ export default Factory.extend({
 
   withPackageTokenAndValue: trait({
     afterCreate(packageObj, server) {
-      let token = server.create('token', {
+      const token = server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText,
@@ -135,13 +135,13 @@ export default Factory.extend({
 
   afterCreate(packageObj, server) {
     if (!packageObj.visibilityData) {
-      let visibilityData = server.create('visibility-data');
+      const visibilityData = server.create('visibility-data');
       packageObj.update('visibilityData', visibilityData.toJSON());
       packageObj.save();
     }
 
     if (!packageObj.proxy) {
-      let proxy = server.create('proxy', {
+      const proxy = server.create('proxy', {
         inherited: false,
         id: 'bigTestJS'
       });
@@ -150,7 +150,7 @@ export default Factory.extend({
     }
 
     if (!packageObj.token) {
-      let token = server.create('token', {
+      const token = server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText,

--- a/test/bigtest/network/factories/provider.js
+++ b/test/bigtest/network/factories/provider.js
@@ -1,6 +1,6 @@
 import { Factory, faker, trait } from '@bigtest/mirage';
 
-let helpText = '<ul><li>Enter your Gale token</li></ul>';
+const helpText = '<ul><li>Enter your Gale token</li></ul>';
 
 export default Factory.extend({
   name: () => faker.company.companyName(),
@@ -38,7 +38,7 @@ export default Factory.extend({
 
   withProxy: trait({
     afterCreate(provider, server) {
-      let proxy = server.create('proxy', {
+      const proxy = server.create('proxy', {
         inherited: false,
         id: 'microstates'
       });
@@ -49,7 +49,7 @@ export default Factory.extend({
 
   withInheritedProxy: trait({
     afterCreate(provider, server) {
-      let proxy = server.create('proxy', {
+      const proxy = server.create('proxy', {
         inherited: true,
         id: 'bigTestJS'
       });
@@ -60,7 +60,7 @@ export default Factory.extend({
 
   withToken: trait({
     afterCreate(provider, server) {
-      let token = server.create('token', {
+      const token = server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText,
@@ -73,7 +73,7 @@ export default Factory.extend({
 
   withTokenAndValue: trait({
     afterCreate(provider, server) {
-      let token = server.create('token', {
+      const token = server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText,
@@ -86,7 +86,7 @@ export default Factory.extend({
 
   afterCreate(provider, server) {
     if (!provider.proxy) {
-      let proxy = server.create('proxy', {
+      const proxy = server.create('proxy', {
         inherited: false,
         id: 'bigTestJS'
       });
@@ -95,7 +95,7 @@ export default Factory.extend({
     }
 
     if (!provider.token) {
-      let token = server.create('token', {
+      const token = server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText,

--- a/test/bigtest/network/factories/resource.js
+++ b/test/bigtest/network/factories/resource.js
@@ -12,7 +12,7 @@ export default Factory.extend({
 
   withTitle: trait({
     afterCreate(resource, server) {
-      let title = server.create('title', 'withSubjects', 'withContributors', 'withIdentifiers');
+      const title = server.create('title', 'withSubjects', 'withContributors', 'withIdentifiers');
       resource.title = title;
       resource.save();
     }
@@ -20,7 +20,7 @@ export default Factory.extend({
 
   withPackage: trait({
     afterCreate(resource, server) {
-      let packageObj = server.create('package', 'withProvider');
+      const packageObj = server.create('package', 'withProvider');
       resource.update({
         package: packageObj
       });
@@ -30,7 +30,7 @@ export default Factory.extend({
 
   withManagedCoverage: trait({
     afterCreate(resource, server) {
-      let managedCoverages = server.createList('managed-coverage', 1);
+      const managedCoverages = server.createList('managed-coverage', 1);
       resource.update('managedCoverages', managedCoverages.map(item => item.toJSON()));
       resource.save();
     }
@@ -38,7 +38,7 @@ export default Factory.extend({
 
   isHidden: trait({
     afterCreate(resource, server) {
-      let visibilityData = server.create('visibility-data', {
+      const visibilityData = server.create('visibility-data', {
         isHidden: true,
         reason: 'The content is for mature audiences only.'
       });
@@ -49,7 +49,7 @@ export default Factory.extend({
 
   isHiddenWithoutReason: trait({
     afterCreate(resource, server) {
-      let visibilityData = server.create('visibility-data', {
+      const visibilityData = server.create('visibility-data', {
         isHidden: true,
         reason: ''
       });
@@ -60,7 +60,7 @@ export default Factory.extend({
 
   withProxy: trait({
     afterCreate(resource, server) {
-      let proxy = server.create('proxy', {
+      const proxy = server.create('proxy', {
         inherited: false,
         id: 'microstates'
       });
@@ -71,7 +71,7 @@ export default Factory.extend({
 
   withInheritedProxy: trait({
     afterCreate(resource, server) {
-      let proxy = server.create('proxy', {
+      const proxy = server.create('proxy', {
         inherited: true,
         id: 'bigTestJS'
       });
@@ -82,13 +82,13 @@ export default Factory.extend({
 
   afterCreate(resource, server) {
     if (!resource.visibilityData) {
-      let visibilityData = server.create('visibility-data');
+      const visibilityData = server.create('visibility-data');
       resource.update('visibilityData', visibilityData.toJSON());
       resource.save();
     }
 
     if (!resource.customEmbargoPeriod) {
-      let customEmbargoPeriod = server.create('embargo-period', {
+      const customEmbargoPeriod = server.create('embargo-period', {
         embargoUnit: '',
         embargoValue: 0
       });
@@ -97,7 +97,7 @@ export default Factory.extend({
     }
 
     if (!resource.managedEmbargoPeriod) {
-      let managedEmbargoPeriod = server.create('embargo-period', {
+      const managedEmbargoPeriod = server.create('embargo-period', {
         embargoUnit: '',
         embargoValue: 0
       });
@@ -105,7 +105,7 @@ export default Factory.extend({
       resource.save();
     }
     if (!resource.proxy) {
-      let proxy = server.create('proxy', {
+      const proxy = server.create('proxy', {
         inherited: false,
         id: 'bigTestJS'
       });

--- a/test/bigtest/network/factories/title.js
+++ b/test/bigtest/network/factories/title.js
@@ -33,10 +33,10 @@ export default Factory.extend({
   withPackages: trait({
     afterCreate(title, server) {
       // Decide how many to create (1 to 10)
-      let total = faker.random.number({ min: 1, max: 10 });
+      const total = faker.random.number({ min: 1, max: 10 });
 
       // Decide how many will be selected (0 to total)
-      let selectedCount = faker.random.number({ min: 0, max: total });
+      const selectedCount = faker.random.number({ min: 0, max: total });
 
       server.createList('resource', selectedCount, 'withPackage', 'withManagedCoverage', {
         title,
@@ -52,7 +52,7 @@ export default Factory.extend({
 
   withSubjects: trait({
     afterCreate(title, server) {
-      let subjects = server.createList('subject', 3);
+      const subjects = server.createList('subject', 3);
       title.subjects = subjects.map(item => item.toJSON());
       title.save();
     }
@@ -60,7 +60,7 @@ export default Factory.extend({
 
   withContributors: trait({
     afterCreate(title, server) {
-      let contributors = server.createList('contributor', 3);
+      const contributors = server.createList('contributor', 3);
       title.contributors = contributors.map(item => item.toJSON());
       title.save();
     }
@@ -68,7 +68,7 @@ export default Factory.extend({
 
   withIdentifiers: trait({
     afterCreate(title, server) {
-      let identifiers = server.createList('identifier', 3);
+      const identifiers = server.createList('identifier', 3);
       title.identifiers = identifiers.map(item => item.toJSON());
       title.save();
     }

--- a/test/bigtest/network/fixtures/packages.js
+++ b/test/bigtest/network/fixtures/packages.js
@@ -1,7 +1,7 @@
 import padStart from 'lodash/padStart';
 
 // package with pages of resources
-let pagedPackage = {
+const pagedPackage = {
   id: 'paged_pkg',
   name: 'Paged Package',
   providerId: 'rel_provider',
@@ -11,7 +11,7 @@ let pagedPackage = {
 };
 
 // related packages for the paged provider
-let providerPackages = new Array(50).fill().map((_, i) => {
+const providerPackages = new Array(50).fill().map((_, i) => {
   return {
     id: `provider_pkg_${padStart(i, 3, '0')}`,
     name: `Provider Package ${i + 1}`,
@@ -20,7 +20,7 @@ let providerPackages = new Array(50).fill().map((_, i) => {
 });
 
 // related packages for the paged title resources
-let titlePackages = new Array(50).fill().map((_, i) => {
+const titlePackages = new Array(50).fill().map((_, i) => {
   return {
     id: `title_pkg_${padStart(i, 3, '0')}`,
     name: `Title Package ${i + 1}`,

--- a/test/bigtest/network/fixtures/providers.js
+++ b/test/bigtest/network/fixtures/providers.js
@@ -1,7 +1,7 @@
 import padStart from 'lodash/padStart';
 
 // provider with pages of packages
-let pagedProvider = {
+const pagedProvider = {
   id: 'paged_provider',
   name: 'Paged Provider',
   packageIds: new Array(50).fill().map((_, i) => {
@@ -10,7 +10,7 @@ let pagedProvider = {
 };
 
 // related provider for the paged package and paged title
-let relatedProvider = {
+const relatedProvider = {
   id: 'rel_provider',
   name: 'Related Provider'
 };

--- a/test/bigtest/network/fixtures/resources.js
+++ b/test/bigtest/network/fixtures/resources.js
@@ -1,7 +1,7 @@
 import padStart from 'lodash/padStart';
 
 // related resources for the paged package
-let packageResources = new Array(50).fill().map((_, i) => {
+const packageResources = new Array(50).fill().map((_, i) => {
   return {
     id: `pkg_cust_${padStart(i, 3, '0')}`,
     titleId: `pkg_title_${padStart(i, 3, '0')}`,
@@ -10,7 +10,7 @@ let packageResources = new Array(50).fill().map((_, i) => {
 });
 
 // related resources for the paged title
-let titleResources = new Array(50).fill().map((_, i) => {
+const titleResources = new Array(50).fill().map((_, i) => {
   return {
     id: `title_cust_${padStart(i, 3, '0')}`,
     packageId: `title_pkg_${padStart(i, 3, '0')}`,

--- a/test/bigtest/network/fixtures/titles.js
+++ b/test/bigtest/network/fixtures/titles.js
@@ -1,7 +1,7 @@
 import padStart from 'lodash/padStart';
 
 // title with pages of resources
-let pagedTitle = {
+const pagedTitle = {
   id: 'paged_title',
   name: 'Paged Title',
   resourceIds: new Array(50).fill().map((_, i) => {
@@ -10,7 +10,7 @@ let pagedTitle = {
 };
 
 // related titles for the paged package resources
-let packageTitles = new Array(50).fill().map((_, i) => {
+const packageTitles = new Array(50).fill().map((_, i) => {
   return {
     id: `pkg_title_${padStart(i, 3, '0')}`,
     name: `Package Title ${i + 1}`

--- a/test/bigtest/network/helpers.js
+++ b/test/bigtest/network/helpers.js
@@ -6,8 +6,8 @@
  *  base for a case insensitive sort
  */
 export function nameCompare(model, modelCompare) {
-  let name = model.attributes.name;
-  let compareName = modelCompare.attributes.name;
+  const name = model.attributes.name;
+  const compareName = modelCompare.attributes.name;
   if (name && compareName) {
     return name.localeCompare(compareName, undefined, { numeric: true, sensitivity: 'base' });
   }
@@ -24,15 +24,15 @@ export function nameCompare(model, modelCompare) {
  */
 export function relevanceCompare(query) {
   return function RelSort(model, modelCompare) {
-    let name = model.attributes.name;
-    let compareName = modelCompare.attributes.name;
+    const name = model.attributes.name;
+    const compareName = modelCompare.attributes.name;
     if (name && compareName) {
-      let words = query.split(' ');
+      const words = query.split(' ');
       words.push(query);
-      let modelCount = words.reduce((total, word) => {
+      const modelCount = words.reduce((total, word) => {
         return name.toLowerCase().includes(word) ? total + 1 : total;
       }, 0);
-      let modelCompareCount = words.reduce((total, word) => {
+      const modelCompareCount = words.reduce((total, word) => {
         return compareName.toLowerCase().includes(word) ? total + 1 : total;
       }, 0);
       if (modelCount !== modelCompareCount) {
@@ -52,10 +52,10 @@ export function relevanceCompare(query) {
  */
 export function getQuery(resourceType, req) {
   if (resourceType === 'titles') {
-    let name = req.queryParams['filter[name]'];
-    let isxn = req.queryParams['filter[isxn]'];
-    let subject = req.queryParams['filter[subject]'];
-    let publisher = req.queryParams['filter[publisher]'];
+    const name = req.queryParams['filter[name]'];
+    const isxn = req.queryParams['filter[isxn]'];
+    const subject = req.queryParams['filter[subject]'];
+    const publisher = req.queryParams['filter[publisher]'];
 
     if (name) {
       return name.toLowerCase();
@@ -97,21 +97,21 @@ export function includesWords(testString, query) {
  */
 export function searchRouteFor(resourceType, filter) {
   return function (schema, req) { // eslint-disable-line func-names
-    let page = Math.max(parseInt(req.queryParams.page || 1, 10), 1);
-    let count = parseInt(req.queryParams.count || 25, 10);
-    let offset = (page - 1) * count;
+    const page = Math.max(parseInt(req.queryParams.page || 1, 10), 1);
+    const count = parseInt(req.queryParams.count || 25, 10);
+    const offset = (page - 1) * count;
 
-    let collection = schema[resourceType];
+    const collection = schema[resourceType];
     // `resourceType` is typically pluralized, the serializer is not
-    let serializerType = `${resourceType.slice(0, -1)}-list`;
-    let json = this.serialize(collection.all().filter((model) => {
+    const serializerType = `${resourceType.slice(0, -1)}-list`;
+    const json = this.serialize(collection.all().filter((model) => {
       return filter(model, req);
     }), serializerType);
 
     json.meta = { totalResults: json.data.length };
 
-    let sort = req.queryParams.sort;
-    let query = getQuery(resourceType, req);
+    const sort = req.queryParams.sort;
+    const query = getQuery(resourceType, req);
 
     if (sort && sort === 'name') {
       json.data = json.data.sort(nameCompare);
@@ -134,16 +134,16 @@ export function searchRouteFor(resourceType, filter) {
  */
 export function nestedResourceRouteFor(foreignKey, resourceType, filter = () => true) {
   return function (schema, req) { // eslint-disable-line func-names
-    let page = Math.max(parseInt(req.queryParams.page || 1, 10), 1);
-    let count = parseInt(req.queryParams.count || 25, 10);
-    let offset = (page - 1) * count;
+    const page = Math.max(parseInt(req.queryParams.page || 1, 10), 1);
+    const count = parseInt(req.queryParams.count || 25, 10);
+    const offset = (page - 1) * count;
 
-    let json = this.serialize(schema[resourceType].where({
+    const json = this.serialize(schema[resourceType].where({
       [`${foreignKey}Id`]: req.params.id
     }).filter((model) => filter(model, req)));
 
-    let sort = req.queryParams.sort;
-    let query = getQuery(resourceType, req);
+    const sort = req.queryParams.sort;
+    const query = getQuery(resourceType, req);
 
     if (sort && sort === 'name') {
       json.data = json.data.sort(nameCompare);

--- a/test/bigtest/network/scenarios/default.js
+++ b/test/bigtest/network/scenarios/default.js
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 export default function defaultScenario(server) {
   function createProvider(name, packages = []) {
-    let provider = server.create('provider', {
+    const provider = server.create('provider', {
       packagesTotal: packages.length,
       name
     });
@@ -11,13 +11,13 @@ export default function defaultScenario(server) {
     });
   }
 
-  let customProvider = server.create('provider', {
+  const customProvider = server.create('provider', {
     name: 'Atlanta A&T Library',
     packagesSelected: 1,
     packagesTotal: 1
   });
 
-  let customPackage = server.create('package', {
+  const customPackage = server.create('package', {
     provider: customProvider,
     name: 'Atlanta A&T Drumming Books',
     contentType: 'AggregatedFullText',
@@ -27,7 +27,7 @@ export default function defaultScenario(server) {
     titleCount: 1
   });
 
-  let customTitle = server.create('title', {
+  const customTitle = server.create('title', {
     name: 'Single, Double, and Triple Paradiddles',
     isTitleCustom: true,
     isPeerReviewed: false,

--- a/test/bigtest/network/scenarios/no-backend.js
+++ b/test/bigtest/network/scenarios/no-backend.js
@@ -1,5 +1,5 @@
 export default function noBackendScenario(server) {
-  let ns = server.namespace;
+  const ns = server.namespace;
   server.namespace = '';
   server.get('/_/proxy/modules', []);
   server.get('_/proxy/tenants/:id/modules', []);

--- a/test/bigtest/network/serializers/package.js
+++ b/test/bigtest/network/serializers/package.js
@@ -11,7 +11,7 @@ function mapPackageProvider(hash, provider) {
 
 export default ApplicationSerializer.extend({
   getHashForResource(pkg) {
-    let hash = ApplicationSerializer.prototype.getHashForResource.apply(this, arguments); // eslint-disable-line prefer-rest-params
+    const hash = ApplicationSerializer.prototype.getHashForResource.apply(this, arguments); // eslint-disable-line prefer-rest-params
 
     if (Array.isArray(hash)) {
       return hash.map((h, i) => mapPackageProvider(h, pkg.models[i].provider));

--- a/test/bigtest/network/serializers/resource.js
+++ b/test/bigtest/network/serializers/resource.js
@@ -26,7 +26,7 @@ function mapResourceAttrs(hash, resource) {
 
 export default ApplicationSerializer.extend({
   getHashForResource(resource) {
-    let hash = ApplicationSerializer.prototype.getHashForResource.apply(this, arguments); // eslint-disable-line prefer-rest-params
+    const hash = ApplicationSerializer.prototype.getHashForResource.apply(this, arguments); // eslint-disable-line prefer-rest-params
 
     if (Array.isArray(hash)) {
       return hash.map((h, i) => mapResourceAttrs(h, resource.models[i]));

--- a/test/bigtest/tests/custom-resource-edit-custom-coverage-test.js
+++ b/test/bigtest/tests/custom-resource-edit-custom-coverage-test.js
@@ -219,7 +219,7 @@ describe('CustomResourceEditCustomCoverage', () => {
   describe('visiting a selected custom resource edit page with custom coverage', () => {
     beforeEach(function () {
       resource.isSelected = true;
-      let customCoverages = [
+      const customCoverages = [
         this.server.create('custom-coverage', {
           beginCoverage: '2018-12-16',
           endCoverage: '2018-12-19'
@@ -268,7 +268,7 @@ describe('CustomResourceEditCustomCoverage', () => {
   describe('visiting a selected custom resource edit page with multiple custom coverages', () => {
     beforeEach(function () {
       resource.isSelected = true;
-      let customCoverages = [
+      const customCoverages = [
         this.server.create('custom-coverage', {
           beginCoverage: '2018-12-17',
           endCoverage: '2018-12-20'

--- a/test/bigtest/tests/custom-resource-edit-proxy-test.js
+++ b/test/bigtest/tests/custom-resource-edit-proxy-test.js
@@ -24,7 +24,7 @@ describe('CustomResourceEditProxy', () => {
       isCustom: true
     });
 
-    let packageProxy = this.server.create('proxy', {
+    const packageProxy = this.server.create('proxy', {
       inherited: true,
       id: 'bigTestJS'
     });
@@ -51,7 +51,7 @@ describe('CustomResourceEditProxy', () => {
 
   describe('visiting the resource edit page with an inherited proxy', () => {
     beforeEach(function () {
-      let resourceProxy = this.server.create('proxy', {
+      const resourceProxy = this.server.create('proxy', {
         inherited: true,
         id: 'bigTestJS'
       });

--- a/test/bigtest/tests/custom-resource-edit-selection-test.js
+++ b/test/bigtest/tests/custom-resource-edit-selection-test.js
@@ -102,7 +102,7 @@ describe('CustomResourceHoldingSelection', () => {
 
         beforeEach(async function () {
           this.server.delete('/resources/:id', ({ resources }, request) => {
-            let matchingResource = resources.find(request.params.id);
+            const matchingResource = resources.find(request.params.id);
 
             matchingResource.destroy();
 

--- a/test/bigtest/tests/details-view-test.js
+++ b/test/bigtest/tests/details-view-test.js
@@ -89,7 +89,7 @@ describe('DetailsView', () => {
 
     describe('then visiting a title page with few resources', () => {
       beforeEach(function () {
-        let title = this.server.create('title');
+        const title = this.server.create('title');
 
         this.visit(`/eholdings/titles/${title.id}`);
       });

--- a/test/bigtest/tests/managed-package-edit-tokens-test.js
+++ b/test/bigtest/tests/managed-package-edit-tokens-test.js
@@ -177,7 +177,7 @@ describe('ManagedPackageEditTokens', () => {
 
   describe('visiting the managed package edit page with a provider token without a value and package token with value', () => {
     beforeEach(function () {
-      let token = this.server.create('token', {
+      const token = this.server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText: '<ul><li>Enter your token</li></ul>',
@@ -226,7 +226,7 @@ describe('ManagedPackageEditTokens', () => {
 
   describe('visiting the managed package edit page with a provider token with a value and package token without value', () => {
     beforeEach(function () {
-      let token = this.server.create('token', {
+      const token = this.server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText: '<ul><li>Enter your token</li></ul>',

--- a/test/bigtest/tests/managed-resource-edit-custom-coverage-test.js
+++ b/test/bigtest/tests/managed-resource-edit-custom-coverage-test.js
@@ -214,7 +214,7 @@ describe('ManagedResourceEditCustomCoverage', () => {
   describe('visiting a selected custom resource edit page with custom coverage', () => {
     beforeEach(function () {
       resource.isSelected = true;
-      let customCoverages = [
+      const customCoverages = [
         this.server.create('custom-coverage', {
           beginCoverage: '2018-12-16',
           endCoverage: '2018-12-19'
@@ -263,7 +263,7 @@ describe('ManagedResourceEditCustomCoverage', () => {
   describe('visiting a selected custom resource edit page with multiple custom coverages', () => {
     beforeEach(function () {
       resource.isSelected = true;
-      let customCoverages = [
+      const customCoverages = [
         this.server.create('custom-coverage', {
           beginCoverage: '2018-12-01',
           endCoverage: '2018-12-15'

--- a/test/bigtest/tests/managed-resource-edit-proxy-test.js
+++ b/test/bigtest/tests/managed-resource-edit-proxy-test.js
@@ -23,7 +23,7 @@ describe('ManagedResourceEditProxy', () => {
       contentType: 'Online'
     });
 
-    let packageProxy = this.server.create('proxy', {
+    const packageProxy = this.server.create('proxy', {
       inherited: true,
       id: 'bigTestJS'
     });
@@ -48,7 +48,7 @@ describe('ManagedResourceEditProxy', () => {
 
   describe('visiting the resource edit page with a proxy', () => {
     beforeEach(function () {
-      let resourceProxy = this.server.create('proxy', {
+      const resourceProxy = this.server.create('proxy', {
         inherited: false,
         id: 'microstates'
       });

--- a/test/bigtest/tests/package-custom-coverage-test.js
+++ b/test/bigtest/tests/package-custom-coverage-test.js
@@ -34,7 +34,7 @@ describe('PackageCustomCoverage', () => {
 
   describe('visiting the package show page with custom coverage', () => {
     beforeEach(function () {
-      let customCoverage = this.server.create('custom-coverage', {
+      const customCoverage = this.server.create('custom-coverage', {
         beginCoverage: '1969-07-16',
         endCoverage: '1972-12-19'
       }).toJSON();

--- a/test/bigtest/tests/package-search-test.js
+++ b/test/bigtest/tests/package-search-test.js
@@ -141,7 +141,7 @@ describe('PackageSearch', () => {
         it('preserves the last history entry', function () {
           // this is a check to make sure duplicate entries are not added
           // to the history. Ensuring the back button works as expected
-          let history = this.app.props.history;
+          const history = this.app.props.history;
           expect(history.entries[history.index - 1].search).to.include('q=Package');
         });
       });

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -152,7 +152,7 @@ describe('PackageShow', () => {
 
     describe('then visiting another package details page', () => {
       beforeEach(function () {
-        let otherPackage = this.server.create('package', 'withTitles', {
+        const otherPackage = this.server.create('package', 'withTitles', {
           provider,
           name: 'Other Package',
           titleCount: 2
@@ -344,7 +344,7 @@ describe('PackageShow', () => {
     beforeEach(function () {
       providerPackage.isSelected = true;
 
-      let token = this.server.create('token', {
+      const token = this.server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText: '',
@@ -375,7 +375,7 @@ describe('PackageShow', () => {
     beforeEach(function () {
       providerPackage.isSelected = true;
 
-      let token = this.server.create('token', {
+      const token = this.server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText: '',
@@ -411,7 +411,7 @@ describe('PackageShow', () => {
     beforeEach(function () {
       providerPackage.isSelected = true;
 
-      let token = this.server.create('token', {
+      const token = this.server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText: '',

--- a/test/bigtest/tests/package-show-titles-search-test.js
+++ b/test/bigtest/tests/package-show-titles-search-test.js
@@ -237,7 +237,7 @@ describe('Package Show Title Search', () => {
 
   describe('navigating to package show page with over 10k related resources', () => {
     beforeEach(function () {
-      let largeProviderPackage = this.server.create(
+      const largeProviderPackage = this.server.create(
         'package',
         {
           provider,

--- a/test/bigtest/tests/provider-edit-test.js
+++ b/test/bigtest/tests/provider-edit-test.js
@@ -138,7 +138,7 @@ describe('ProviderEdit', () => {
 
   describe('visiting the provider edit page with no selected packages', () => {
     beforeEach(function () {
-      let provider2 = this.server.create('provider', {
+      const provider2 = this.server.create('provider', {
         name: 'Sam is awesome',
       });
 

--- a/test/bigtest/tests/provider-edit-token-test.js
+++ b/test/bigtest/tests/provider-edit-token-test.js
@@ -90,7 +90,7 @@ describe('ProviderEditToken', () => {
 
   describe('visiting the provider edit page with a token without a value ', () => {
     beforeEach(function () {
-      let token = this.server.create('token', {
+      const token = this.server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText: '<ul><li>Enter your token</li></ul>',

--- a/test/bigtest/tests/provider-search-test.js
+++ b/test/bigtest/tests/provider-search-test.js
@@ -108,7 +108,7 @@ describe('ProviderSearch', () => {
         it('preserves the last history entry', function () {
           // this is a check to make sure duplicate entries are not added
           // to the history. Ensuring the back button works as expected
-          let history = this.app.props.history;
+          const history = this.app.props.history;
           expect(history.entries[history.index - 1].search).to.include('q=Provider');
         });
       });

--- a/test/bigtest/tests/provider-show-package-search-test.js
+++ b/test/bigtest/tests/provider-show-package-search-test.js
@@ -227,7 +227,7 @@ describe('ProviderShow package search', () => {
 
   describe('navigating to provider show page with over 10k related packages', () => {
     beforeEach(function () {
-      let largeProvider = this.server.create('provider',
+      const largeProvider = this.server.create('provider',
         {
           name: 'Large Provider Test',
           packagesTotal: 1500000

--- a/test/bigtest/tests/provider-show-test.js
+++ b/test/bigtest/tests/provider-show-test.js
@@ -136,7 +136,7 @@ describe('ProviderShow', () => {
 
   describe('visiting the provider details page with an inherited proxy', () => {
     beforeEach(function () {
-      let proxy = this.server.create('proxy', {
+      const proxy = this.server.create('proxy', {
         inherited: true,
         id: 'bigTestJS'
       });
@@ -154,7 +154,7 @@ describe('ProviderShow', () => {
 
   describe('visiting the provider details page with a none proxy', () => {
     beforeEach(function () {
-      let proxy = this.server.create('proxy', {
+      const proxy = this.server.create('proxy', {
         inherited: false,
         id: '<n>'
       });
@@ -171,7 +171,7 @@ describe('ProviderShow', () => {
 
   describe('visiting the provider details page with a token without value', () => {
     beforeEach(function () {
-      let token = this.server.create('token', {
+      const token = this.server.create('token', {
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText: '',

--- a/test/bigtest/tests/resource-custom-coverage-test.js
+++ b/test/bigtest/tests/resource-custom-coverage-test.js
@@ -44,7 +44,7 @@ describe('ResourceCustomCoverage', () => {
 
   describe('visiting a selected resource show page with custom coverage', () => {
     beforeEach(function () {
-      let customCoverages = [
+      const customCoverages = [
         this.server.create('custom-coverage', {
           beginCoverage: '1969-07-16',
           endCoverage: '1972-12-19'
@@ -74,7 +74,7 @@ describe('ResourceCustomCoverage', () => {
 
   describe('visiting the resource page with single custom coverage', () => {
     beforeEach(function () {
-      let customCoverages = [
+      const customCoverages = [
         this.server.create('custom-coverage', {
           beginCoverage: '1969-07-16',
           endCoverage: '1972-12-19'

--- a/test/bigtest/tests/resource-edit-custom-title-test.js
+++ b/test/bigtest/tests/resource-edit-custom-title-test.js
@@ -23,7 +23,7 @@ describe('ResourceEditCustomTitle', () => {
       titleCount: 5
     });
 
-    let title = this.server.create('title', {
+    const title = this.server.create('title', {
       name: 'Best Title Ever',
       publicationType: 'Streaming Video',
       publisherName: 'Amazing Publisher',
@@ -51,7 +51,7 @@ describe('ResourceEditCustomTitle', () => {
 
   describe('visting the custom resource edit page but the resource is unselected', () => {
     beforeEach(function () {
-      let title = this.server.create('title', {
+      const title = this.server.create('title', {
         name: 'Best Title Ever',
         publicationType: 'Streaming Video',
         publisherName: 'Amazing Publisher',
@@ -380,7 +380,7 @@ describe('ResourceEditCustomTitle', () => {
 
   describe('visiting the resource edit page with coverage dates, statements, and embargo', () => {
     beforeEach(function () {
-      let customCoverages = [
+      const customCoverages = [
         this.server.create('custom-coverage', {
           beginCoverage: '1969-07-16',
           endCoverage: '1972-12-19'

--- a/test/bigtest/tests/resource-edit-managed-title-in-custom-package-test.js
+++ b/test/bigtest/tests/resource-edit-managed-title-in-custom-package-test.js
@@ -25,7 +25,7 @@ describe('ResourceEditManagedTitleInCustomPackage', () => {
       isSelected: true
     });
 
-    let title = this.server.create('title', {
+    const title = this.server.create('title', {
       name: 'Empire Strikes Back Directors Cut',
       publicationType: 'Streaming Video',
       publisherName: 'Amazing Publisher',

--- a/test/bigtest/tests/resource-edit-managed-title-test.js
+++ b/test/bigtest/tests/resource-edit-managed-title-test.js
@@ -23,7 +23,7 @@ describe('ResourceEditManagedTitleInManagedPackage', () => {
       titleCount: 5
     });
 
-    let title = this.server.create('title', {
+    const title = this.server.create('title', {
       name: 'Best Title Ever',
       publicationType: 'Streaming Video',
       publisherName: 'Amazing Publisher'
@@ -183,7 +183,7 @@ describe('ResourceEditManagedTitleInManagedPackage', () => {
   describe('visiting the resource edit page with coverage dates, statement, and embargo', () => {
     beforeEach(function () {
       resource.coverageStatement = 'Use this one weird trick to get access.';
-      let customCoverages = [
+      const customCoverages = [
         this.server.create('custom-coverage', {
           beginCoverage: '1969-07-16',
           endCoverage: '1972-12-19'

--- a/test/bigtest/tests/resource-edit-selection-test.js
+++ b/test/bigtest/tests/resource-edit-selection-test.js
@@ -25,7 +25,7 @@ describe('ResourceEditSelection', () => {
       titleCount: 5
     });
 
-    let title = this.server.create('title', {
+    const title = this.server.create('title', {
       publicationType: 'Streaming Video'
     });
 

--- a/test/bigtest/tests/resource-selection-test.js
+++ b/test/bigtest/tests/resource-selection-test.js
@@ -24,7 +24,7 @@ describe('ResourceSelection', () => {
       titleCount: 5
     });
 
-    let title = this.server.create('title', {
+    const title = this.server.create('title', {
       publicationType: 'Streaming Video'
     });
 

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -24,7 +24,7 @@ describe('ResourceShow', () => {
       titleCount: 5
     });
 
-    let packageProxy = this.server.create('proxy', {
+    const packageProxy = this.server.create('proxy', {
       inherited: true,
       id: 'microstates'
     });
@@ -32,7 +32,7 @@ describe('ResourceShow', () => {
     providerPackage.update('proxy', packageProxy.toJSON());
     providerPackage.save();
 
-    let title = this.server.create('title', {
+    const title = this.server.create('title', {
       name: 'Best Title Ever',
       edition: 'Best Edition',
       publicationType: 'Streaming Video',
@@ -68,7 +68,7 @@ describe('ResourceShow', () => {
       isTokenNeeded: false
     });
 
-    let proxy = this.server.create('proxy', {
+    const proxy = this.server.create('proxy', {
       inherited: true,
       id: 'microstates'
     });
@@ -355,7 +355,7 @@ describe('ResourceShow', () => {
         titleCount: 5
       });
 
-      let title = this.server.create('title', {
+      const title = this.server.create('title', {
         name: 'Best Title Ever',
         edition: 'Best Edition Ever',
         publicationType: ''
@@ -396,7 +396,7 @@ describe('ResourceShow', () => {
         titleCount: 5
       });
 
-      let title = this.server.create('title', {
+      const title = this.server.create('title', {
         name: 'Best Title Ever',
         publicationType: 'UnknownPublicationType'
       });

--- a/test/bigtest/tests/title-add-to-custom-package-test.js
+++ b/test/bigtest/tests/title-add-to-custom-package-test.js
@@ -43,8 +43,8 @@ describe('TitleShowAddToCustomPackage', () => {
 
     it('contains a list of custom packages with existing relationships disabled', () => {
       // index `0` is the "Choose a package" placeholder option
-      let first = TitleShowPage.customPackageModal.packages(1);
-      let second = TitleShowPage.customPackageModal.packages(2);
+      const first = TitleShowPage.customPackageModal.packages(1);
+      const second = TitleShowPage.customPackageModal.packages(2);
 
       expect(first.text).to.equal('Custom Package 1');
       expect(first.isDisabled).to.be.true;

--- a/test/bigtest/tests/title-search-test.js
+++ b/test/bigtest/tests/title-search-test.js
@@ -153,7 +153,7 @@ describe('TitleSearch', () => {
         it('preserves the last history entry', function () {
           // this is a check to make sure duplicate entries are not added
           // to the history. Ensuring the back button works as expected
-          let history = this.app.props.history;
+          const history = this.app.props.history;
           expect(history.entries[history.index - 1].search).to.include('q=Title');
         });
       });

--- a/test/bigtest/tests/unit/redux-merge-attributes-test.js
+++ b/test/bigtest/tests/unit/redux-merge-attributes-test.js
@@ -20,7 +20,7 @@ describe('mergeAttributes', () => {
     });
 
     it('does not overwrite populated keys with empty incoming data', () => {
-      let result = mergeAttributes(existing, incoming);
+      const result = mergeAttributes(existing, incoming);
       expect(result.description).to.equal('description');
       expect(result.isSelected).to.be.false;
     });
@@ -35,7 +35,7 @@ describe('mergeAttributes', () => {
     });
 
     it('replaces existing data with incoming data', () => {
-      let result = mergeAttributes(existing, incoming);
+      const result = mergeAttributes(existing, incoming);
       expect(result.description).to.equal('no, this description');
       expect(result.isSelected).to.be.true;
     });

--- a/test/bigtest/tests/unit/redux-merge-relationships-test.js
+++ b/test/bigtest/tests/unit/redux-merge-relationships-test.js
@@ -24,7 +24,7 @@ describe('mergeRelationships', () => {
     });
 
     it('does not overwrite populated keys with empty incoming data', () => {
-      let result = lazy.merged(existing, incoming);
+      const result = lazy.merged(existing, incoming);
       expect(result.providers.data).to.equal('data');
     });
   });
@@ -37,7 +37,7 @@ describe('mergeRelationships', () => {
     });
 
     it('replaces existing data with incoming data', () => {
-      let result = lazy.merged(existing, incoming);
+      const result = lazy.merged(existing, incoming);
       expect(result.providers.data).to.equal('no, this data');
     });
   });


### PR DESCRIPTION
In this small PR, I made the `prefer-const` rule effective again. All variable declarations which violated the rule were automatically changed to use `const` keyword. `eslint --fix` was used for it.