### PR TITLE
UIEH-680: Badge for agreements section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [1.6.0]
 
-* Add New button to agreements accordion on Package and Resource show pages for redirecting the user to creation page.
+* Add New button to agreements accordion on Package and Resource show pages for redirecting the user to creation page. (UIEH-629, UIEH-631)
+* Add badge with agreements quantity to agreements section on Package and Resource show pages (UIEH-680)
 
 ## [1.5.0](https://github.com/folio-org/ui-eholdings/tree/v1.5.0) (2019-03-25)
 

--- a/src/features/agreements-accordion/agreements-accordion.js
+++ b/src/features/agreements-accordion/agreements-accordion.js
@@ -13,6 +13,7 @@ import {
   Accordion,
   Headline,
   Button,
+  Badge,
 } from '@folio/stripes/components';
 
 import selectAgreements from '../../redux/selectors';
@@ -91,6 +92,14 @@ class AgreementsAccordion extends Component {
     );
   }
 
+  renderBadge() {
+    return (
+      <Badge>
+        {this.props.agreements.items.length}
+      </Badge>
+    );
+  }
+
   onAddAgreementHandler = ({ name, id }) => {
     const {
       refId,
@@ -118,6 +127,7 @@ class AgreementsAccordion extends Component {
         open={isOpen}
         label={this.getAgreementsAccordionHeader()}
         displayWhenOpen={this.getAgreementsAccordionButtons()}
+        displayWhenClosed={this.renderBadge()}
         onToggle={onToggle}
       >
         <AgreementsList agreements={agreements} />

--- a/test/bigtest/interactors/agreements-accordion.js
+++ b/test/bigtest/interactors/agreements-accordion.js
@@ -1,0 +1,18 @@
+import {
+  clickable,
+  collection,
+  interactor,
+  isPresent,
+  text,
+  attribute,
+} from '@bigtest/interactor';
+
+export default @interactor class {
+  isExpanded = !!attribute('#accordion-toggle-button-packageShowAgreements', 'aria-expanded');
+  agreements = collection('[data-test-agreements-list-item]');
+  hasNewButton = isPresent('[data-test-new-button]');
+  clickNewButton = clickable('[data-test-new-button]');
+  clickSection = clickable('[class^=defaultCollapseButton]');
+  hasBadge = isPresent('[class^="badge"]');
+  agreementsQuantity = text('[class^="badge"]');
+}

--- a/test/bigtest/interactors/package-show.js
+++ b/test/bigtest/interactors/package-show.js
@@ -13,7 +13,12 @@ import {
   is,
   attribute,
 } from '@bigtest/interactor';
-import { getComputedStyle, hasClassBeginningWith } from './helpers';
+
+import AgreementsAccordion from './agreements-accordion';
+import {
+  getComputedStyle,
+  hasClassBeginningWith,
+} from './helpers';
 import Datepicker from './datepicker';
 import Toast from './toast';
 import SearchModal from './search-modal';
@@ -33,13 +38,6 @@ import PackageSelectionStatus from './selection-status';
 @interactor class PackageShowDropDownMenu {
   addToHoldings = new Interactor('.tether-element [data-test-eholdings-package-add-to-holdings-action]');
   removeFromHoldings = new Interactor('.tether-element [data-test-eholdings-package-remove-from-holdings-action]');
-}
-
-@interactor class AgreementsSection {
-  isExpanded = !!attribute('#accordion-toggle-button-packageShowAgreements', 'aria-expanded');
-  agreements = collection('[data-test-agreements-list-item]');
-  hasNewButton = isPresent('[data-test-new-button]');
-  clickNewButton = clickable('[data-test-new-button]');
 }
 
 @interactor class PackageShowPage {
@@ -141,7 +139,7 @@ import PackageSelectionStatus from './selection-status';
 
   toast = Toast;
 
-  agreementsSection = new AgreementsSection('#packageShowAgreements');
+  agreementsSection = new AgreementsAccordion('#packageShowAgreements');
   findAgreementsModalIsVisible = isPresent('[class^="modal"] #list-agreements');
 
   selectPackage() {

--- a/test/bigtest/interactors/resource-show.js
+++ b/test/bigtest/interactors/resource-show.js
@@ -9,6 +9,8 @@ import {
   text,
   is
 } from '@bigtest/interactor';
+
+import AgreementsAccordion from './agreements-accordion';
 import Toast from './toast';
 
 
@@ -30,13 +32,6 @@ import Toast from './toast';
 }
 
 @interactor class ResourceShowNavigationModal {}
-
-@interactor class AgreementsSection {
-  isExpanded = !!attribute('#accordion-toggle-button-resourceShowAgreements', 'aria-expanded');
-  agreements = collection('[data-test-agreements-list-item]');
-  hasNewButton = isPresent('[data-test-new-button]');
-  clickNewButton = clickable('[data-test-new-button]');
-}
 
 @interactor class ResourceShowPage {
   isLoaded = isPresent('[data-test-eholdings-details-view-name="resource"]');
@@ -132,7 +127,7 @@ import Toast from './toast';
     contributorText: text()
   });
 
-  agreementsSection = new AgreementsSection('#resourceShowAgreements');
+  agreementsSection = new AgreementsAccordion('#resourceShowAgreements');
 }
 
 export default new ResourceShowPage('[data-test-eholdings-details-view="resource"]');

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -91,35 +91,51 @@ describe('PackageShow', () => {
         expect(PackageShowPage.agreementsSection.isExpanded).to.be.true;
       });
 
-      it('should display "New" button', () => {
-        expect(PackageShowPage.agreementsSection.hasNewButton).to.be.true;
+      describe('when open', () => {
+        it('should display "New" button', () => {
+          expect(PackageShowPage.agreementsSection.hasNewButton).to.be.true;
+        });
+
+        describe('after click on "New" button', () => {
+          beforeEach(async () => {
+            await PackageShowPage.agreementsSection.clickNewButton();
+          });
+
+          it('should redirect to create page of agreements app', function () {
+            const agreementCreatePageUrl = `/erm/agreements?layer=create&authority=${entityAuthorityTypes.PACKAGE}&referenceId=${providerPackage.id}`;
+
+            expect(this.location.pathname + this.location.search).to.contain(agreementCreatePageUrl);
+          });
+        });
+
+        it('should not display badge with agreements quantity', () => {
+          expect(PackageShowPage.agreementsSection.hasBadge).to.be.false;
+        });
+
+        it('should display a 3 items in the list of agreements', () => {
+          expect(PackageShowPage.agreementsSection.agreements().length).to.equal(3);
+        });
+
+        describe('after click on first agreement', () => {
+          beforeEach(async () => {
+            await PackageShowPage.agreementsSection.agreements(0).click();
+          });
+
+          it('should redirect to agreement details page', function () {
+            const itemDetailsUrl = '/erm/agreements/view/2c918098689ba8f70168a349f1160027';
+
+            expect(this.location.pathname).to.contain(itemDetailsUrl);
+          });
+        });
       });
 
-      describe('after click on "New" button', () => {
+      describe('when closed', () => {
         beforeEach(async () => {
-          await PackageShowPage.agreementsSection.clickNewButton();
+          await PackageShowPage.agreementsSection.clickSection();
         });
 
-        it('should redirect to create page of agreements app', function () {
-          const agreementCreatePageUrl = `/erm/agreements?layer=create&authority=${entityAuthorityTypes.PACKAGE}&referenceId=${providerPackage.id}`;
-
-          expect(this.location.pathname + this.location.search).to.contain(agreementCreatePageUrl);
-        });
-      });
-
-      it('should display a 3 items in the list of agreements', () => {
-        expect(PackageShowPage.agreementsSection.agreements().length).to.equal(3);
-      });
-
-      describe('after click on first agreement', () => {
-        beforeEach(async () => {
-          await PackageShowPage.agreementsSection.agreements(0).click();
-        });
-
-        it('should redirect to agreement details page', function () {
-          const itemDetailsUrl = '/erm/agreements/view/2c918098689ba8f70168a349f1160027';
-
-          expect(this.location.pathname).to.contain(itemDetailsUrl);
+        it('should display badge with agreements quantity equal to 3', () => {
+          expect(PackageShowPage.agreementsSection.agreementsQuantity).to.equal('3');
         });
       });
     });

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -143,35 +143,51 @@ describe('ResourceShow', () => {
         expect(ResourcePage.agreementsSection.isExpanded).to.be.true;
       });
 
-      it('should display "New" button', () => {
-        expect(ResourcePage.agreementsSection.hasNewButton).to.be.true;
+      describe('when open', () => {
+        it('should display "New" button', () => {
+          expect(ResourcePage.agreementsSection.hasNewButton).to.be.true;
+        });
+
+        describe('after click on "New" button', () => {
+          beforeEach(async () => {
+            await ResourcePage.agreementsSection.clickNewButton();
+          });
+
+          it('should redirect to create page of agreements app', function () {
+            const agreementCreatePageUrl = `/erm/agreements?layer=create&authority=${entityAuthorityTypes.RESOURCE}&referenceId=${resource.id}`;
+
+            expect(this.location.pathname + this.location.search).to.contain(agreementCreatePageUrl);
+          });
+        });
+
+        it('should not display badge with agreements quantity', () => {
+          expect(ResourcePage.agreementsSection.hasBadge).to.be.false;
+        });
+
+        it('should display a 3 items in the list of agreements', () => {
+          expect(ResourcePage.agreementsSection.agreements().length).to.equal(3);
+        });
+
+        describe('after click on first agreement', () => {
+          beforeEach(async () => {
+            await ResourcePage.agreementsSection.agreements(0).click();
+          });
+
+          it('should redirect to agreement details page', function () {
+            const itemDetailsUrl = '/erm/agreements/view/2c918098689ba8f70168a349f1160027';
+
+            expect(this.location.pathname).to.contain(itemDetailsUrl);
+          });
+        });
       });
 
-      describe('after click on "New" button', () => {
+      describe('when closed', () => {
         beforeEach(async () => {
-          await ResourcePage.agreementsSection.clickNewButton();
+          await ResourcePage.agreementsSection.clickSection();
         });
 
-        it('should redirect to create page of agreements app', function () {
-          const agreementCreatePageUrl = `/erm/agreements?layer=create&authority=${entityAuthorityTypes.RESOURCE}&referenceId=${resource.id}`;
-
-          expect(this.location.pathname + this.location.search).to.contain(agreementCreatePageUrl);
-        });
-      });
-
-      it('should display a 3 items in the list of agreements', () => {
-        expect(ResourcePage.agreementsSection.agreements().length).to.equal(3);
-      });
-
-      describe('after click on first agreement', () => {
-        beforeEach(async () => {
-          await ResourcePage.agreementsSection.agreements(0).click();
-        });
-
-        it('should redirect to agreement details page', function () {
-          const itemDetailsUrl = '/erm/agreements/view/2c918098689ba8f70168a349f1160027';
-
-          expect(this.location.pathname).to.contain(itemDetailsUrl);
+        it('should display badge with agreements quantity equal to 3', () => {
+          expect(ResourcePage.agreementsSection.agreementsQuantity).to.equal('3');
         });
       });
     });


### PR DESCRIPTION
https://issues.folio.org/browse/UIEH-680

## Purpose
Add badge to the accordion with agreements on Package and Resource show pages.

## Approach
- Add badge with agreements quantity, which is visible only when accordion is collapsed
- Cover with tests Package and Resource show pages

## Screenshots
![2019-04-01 14 46 04](https://user-images.githubusercontent.com/43621626/55325214-06a35480-548d-11e9-921e-4105df4922b7.gif)


