### PR TITLE
UIEH-685 Title: Remove Tags functionality

### DIFF
--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -32,7 +32,6 @@ import IdentifiersList from '../../identifiers-list';
 import ContributorsList from '../../contributors-list';
 import AddTitleToPackage from '../_field-groups/add-title-to-package';
 import Toaster from '../../toaster';
-import TagsAccordion from '../../tags';
 import KeyValueColumns from '../../key-value-columns';
 import styles from './title-show.css';
 
@@ -52,9 +51,6 @@ class TitleShow extends Component {
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
     }).isRequired,
-    tagsModel: PropTypes.object,
-    updateEntityTags: PropTypes.func.isRequired,
-    updateFolioTags: PropTypes.func.isRequired,
   };
 
   state = {
@@ -189,9 +185,6 @@ class TitleShow extends Component {
       model,
       addCustomPackage,
       request,
-      tagsModel,
-      updateEntityTags,
-      updateFolioTags,
     } = this.props;
     const { showCustomPackageModal, sections } = this.state;
 
@@ -218,15 +211,6 @@ class TitleShow extends Component {
           lastMenu={this.lastMenu}
           bodyContent={(
             <Fragment>
-              <TagsAccordion
-                id="titleShowTags"
-                model={model}
-                onToggle={this.handleSectionToggle}
-                open={sections.titleShowTags}
-                tagsModel={tagsModel}
-                updateFolioTags={updateFolioTags}
-                updateEntityTags={updateEntityTags}
-              />
 
               <Accordion
                 label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.title.titleInformation" /></Headline>}

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -211,84 +211,84 @@ class TitleShow extends Component {
           lastMenu={this.lastMenu}
           bodyContent={(
 
-              <Accordion
-                label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.title.titleInformation" /></Headline>}
-                open={sections.titleShowTitleInformation}
-                id="titleShowTitleInformation"
-                onToggle={this.handleSectionToggle}
-              >
-                <KeyValueColumns>
-                  <div>
-                    <ContributorsList data={model.contributors} />
+            <Accordion
+              label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.title.titleInformation" /></Headline>}
+              open={sections.titleShowTitleInformation}
+              id="titleShowTitleInformation"
+              onToggle={this.handleSectionToggle}
+            >
+              <KeyValueColumns>
+                <div>
+                  <ContributorsList data={model.contributors} />
 
-                    {model.edition && (
-                      <KeyValue label={<FormattedMessage id="ui-eholdings.title.edition" />}>
-                        <div data-test-eholdings-title-show-edition>
-                          {model.edition}
-                        </div>
-                      </KeyValue>
-                    )}
-
-                    {model.publisherName && (
-                      <KeyValue label={<FormattedMessage id="ui-eholdings.title.publisherName" />}>
-                        <div data-test-eholdings-title-show-publisher-name>
-                          {model.publisherName}
-                        </div>
-                      </KeyValue>
-                    )}
-
-                    {model.publicationType && (
-                      <KeyValue label={<FormattedMessage id="ui-eholdings.title.publicationType" />}>
-                        <div data-test-eholdings-title-show-publication-type>
-                          {model.publicationType}
-                        </div>
-                      </KeyValue>
-                    )}
-
-                    <IdentifiersList data={model.identifiers} />
-
-                  </div>
-                  <div>
-
-                    {model.subjects.length > 0 && (
-                      <KeyValue label={<FormattedMessage id="ui-eholdings.title.subjects" />}>
-                        <div data-test-eholdings-title-show-subjects-list>
-                          {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
-                        </div>
-                      </KeyValue>
-                    )}
-
-                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.peerReviewed" />}>
-                      <div data-test-eholdings-peer-reviewed-field>
-                        {model.isPeerReviewed ? (<FormattedMessage id="ui-eholdings.yes" />) : (<FormattedMessage id="ui-eholdings.no" />)}
+                  {model.edition && (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.edition" />}>
+                      <div data-test-eholdings-title-show-edition>
+                        {model.edition}
                       </div>
                     </KeyValue>
+                  )}
 
-                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.titleType" />}>
-                      <div data-test-eholdings-title-details-type>
-                        {model.isTitleCustom ? (<FormattedMessage id="ui-eholdings.custom" />) : (<FormattedMessage id="ui-eholdings.managed" />)}
+                  {model.publisherName && (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.publisherName" />}>
+                      <div data-test-eholdings-title-show-publisher-name>
+                        {model.publisherName}
                       </div>
                     </KeyValue>
+                  )}
 
-                    {model.description && (
-                      <KeyValue label={<FormattedMessage id="ui-eholdings.title.description" />}>
-                        <div data-test-eholdings-description-field>
-                          {model.description}
-                        </div>
-                      </KeyValue>
-                    )}
-                  </div>
-                </KeyValueColumns>
+                  {model.publicationType && (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.publicationType" />}>
+                      <div data-test-eholdings-title-show-publication-type>
+                        {model.publicationType}
+                      </div>
+                    </KeyValue>
+                  )}
 
-                <div className={styles['add-to-custom-package-button']}>
-                  <Button
-                    data-test-eholdings-add-to-custom-package-button
-                    onClick={this.toggleCustomPackageModal}
-                  >
-                    <FormattedMessage id="ui-eholdings.title.addToCustomPackage" />
-                  </Button>
+                  <IdentifiersList data={model.identifiers} />
+
                 </div>
-              </Accordion>
+                <div>
+
+                  {model.subjects.length > 0 && (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.subjects" />}>
+                      <div data-test-eholdings-title-show-subjects-list>
+                        {model.subjects.map(subjectObj => subjectObj.subject).join('; ')}
+                      </div>
+                    </KeyValue>
+                  )}
+
+                  <KeyValue label={<FormattedMessage id="ui-eholdings.title.peerReviewed" />}>
+                    <div data-test-eholdings-peer-reviewed-field>
+                      {model.isPeerReviewed ? (<FormattedMessage id="ui-eholdings.yes" />) : (<FormattedMessage id="ui-eholdings.no" />)}
+                    </div>
+                  </KeyValue>
+
+                  <KeyValue label={<FormattedMessage id="ui-eholdings.title.titleType" />}>
+                    <div data-test-eholdings-title-details-type>
+                      {model.isTitleCustom ? (<FormattedMessage id="ui-eholdings.custom" />) : (<FormattedMessage id="ui-eholdings.managed" />)}
+                    </div>
+                  </KeyValue>
+
+                  {model.description && (
+                    <KeyValue label={<FormattedMessage id="ui-eholdings.title.description" />}>
+                      <div data-test-eholdings-description-field>
+                        {model.description}
+                      </div>
+                    </KeyValue>
+                  )}
+                </div>
+              </KeyValueColumns>
+
+              <div className={styles['add-to-custom-package-button']}>
+                <Button
+                  data-test-eholdings-add-to-custom-package-button
+                  onClick={this.toggleCustomPackageModal}
+                >
+                  <FormattedMessage id="ui-eholdings.title.addToCustomPackage" />
+                </Button>
+              </div>
+            </Accordion>
 
           )}
           listType={listTypes.PACKAGES}

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -210,7 +210,6 @@ class TitleShow extends Component {
           handleExpandAll={this.handleExpandAll}
           lastMenu={this.lastMenu}
           bodyContent={(
-            <Fragment>
 
               <Accordion
                 label={<Headline size="large" tag="h3"><FormattedMessage id="ui-eholdings.title.titleInformation" /></Headline>}
@@ -290,7 +289,7 @@ class TitleShow extends Component {
                   </Button>
                 </div>
               </Accordion>
-            </Fragment>
+
           )}
           listType={listTypes.PACKAGES}
           resultsLength={model.resources.length}

--- a/src/redux/title.js
+++ b/src/redux/title.js
@@ -13,9 +13,7 @@ class Title {
   identifiers = [];
   subjects = [];
   resources = hasMany();
-  tags = {
-    tagList: [],
-  };
+
 
   // slightly customized serializer that adds included resources to
   // new title record payloads

--- a/src/routes/title-show.js
+++ b/src/routes/title-show.js
@@ -9,7 +9,6 @@ import { createResolver } from '../redux';
 import Title from '../redux/title';
 import Package from '../redux/package';
 import Resource from '../redux/resource';
-import Tag from '../redux/tag';
 import View from '../components/title/show';
 
 class TitleShowRoute extends Component {
@@ -18,15 +17,11 @@ class TitleShowRoute extends Component {
     createResource: PropTypes.func.isRequired,
     customPackages: PropTypes.object.isRequired,
     getCustomPackages: PropTypes.func.isRequired,
-    getTags: PropTypes.func.isRequired,
     getTitle: PropTypes.func.isRequired,
     history: ReactRouterPropTypes.history.isRequired,
     location: ReactRouterPropTypes.location.isRequired,
     match: ReactRouterPropTypes.match.isRequired,
     model: PropTypes.object.isRequired,
-    tagsModel: PropTypes.object.isRequired,
-    updateEntityTags: PropTypes.func.isRequired,
-    updateFolioTags: PropTypes.func.isRequired,
   };
 
   componentDidMount() {
@@ -34,14 +29,12 @@ class TitleShowRoute extends Component {
       match,
       getTitle,
       getCustomPackages,
-      getTags,
     } = this.props;
 
     const { titleId } = match.params;
 
     getTitle(titleId);
     getCustomPackages();
-    getTags();
   }
 
   componentDidUpdate(prevProps) {
@@ -116,17 +109,11 @@ class TitleShowRoute extends Component {
       customPackages,
       createRequest,
       history,
-      tagsModel,
-      updateEntityTags,
-      updateFolioTags,
     } = this.props;
 
     return (
       <TitleManager record={model.name}>
         <View
-          tagsModel={tagsModel}
-          updateEntityTags={updateEntityTags}
-          updateFolioTags={updateFolioTags}
           request={createRequest}
           model={model}
           customPackages={customPackages}
@@ -156,7 +143,6 @@ export default connect(
     return {
       model: resolver.find('titles', match.params.titleId),
       createRequest: resolver.getRequest('create', { type: 'resources' }),
-      tagsModel: resolver.query('tags'),
       customPackages: resolver.query('packages', {
         filter: { custom: true },
         count: 100
@@ -164,9 +150,6 @@ export default connect(
     };
   }, {
     getTitle: id => Title.find(id, { include: 'resources' }),
-    getTags: () => Tag.query(),
-    updateEntityTags: (model) => Title.save(model),
-    updateFolioTags: (model) => Tag.create(model),
     createResource: attrs => Resource.create(attrs),
     getCustomPackages: () => Package.query({
       filter: { custom: true },

--- a/test/bigtest/interactors/title-show.js
+++ b/test/bigtest/interactors/title-show.js
@@ -67,7 +67,6 @@ import Toast from './toast';
   descriptionText = text('[data-test-eholdings-description-field]');
   clickEditButton = clickable('[data-test-eholdings-title-edit-link]');
   hasEditButton = isPresent('[data-test-eholdings-title-edit-link]');
-  isTagsPresent = isPresent('[data-test-eholdings-details-tags]');
 
   toast = Toast
 

--- a/test/bigtest/tests/custom-title-edit-test.js
+++ b/test/bigtest/tests/custom-title-edit-test.js
@@ -45,9 +45,6 @@ describe('CustomTitleEdit', () => {
       ],
       isTitleCustom: true,
       description: 'custom description',
-      tags: {
-        tagList: [],
-      },
     });
 
     title.save();

--- a/test/bigtest/tests/title-show-test.js
+++ b/test/bigtest/tests/title-show-test.js
@@ -295,10 +295,6 @@ describe('TitleShow', () => {
     it('displays the edit button for a custom title', () => {
       expect(TitleShowPage.hasEditButton).to.be.true;
     });
-
-    it('displays tags accordion for a custom title', () => {
-      expect(TitleShowPage.isTagsPresent).to.be.true;
-    });
   });
 
   describe('encountering a server error', () => {


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/UIEH-685 we are removing tags from title records.

Tags will be supported on resource records (aka title+package records). When performing a filter by tags from Search&Filter for Titles, we will lookup tags associated with resources to support this.
https://issues.folio.org/browse/UIEH-701

## Approach
- Remove tags accordion and associated methods from Title Show Page Component
- Remove tag methods and model information from Title Show Route
- Remove/Update related tests
- Update Redux title (removing taglist)

#### TODOS and Open Questions
- [ ] Decided to remove tags from Title Redux layer (no longer used by UI although still available in the back end)

## Screenshots

Before
![Screen Shot 2019-05-21 at 4 46 49 PM](https://user-images.githubusercontent.com/19415226/58130542-3ef02500-7bea-11e9-813a-b4c7c1710c2f.png)

After
![Screen Shot 2019-05-21 at 4 45 15 PM](https://user-images.githubusercontent.com/19415226/58130553-46173300-7bea-11e9-9712-98724fc682bf.png)

