### PR TITLE
skip note creation tests

### DIFF
--- a/test/bigtest/tests/note-create-test.js
+++ b/test/bigtest/tests/note-create-test.js
@@ -7,22 +7,22 @@ import {
 import { expect } from 'chai';
 import faker from 'faker';
 
-import {
-  NoteFormInteractor,
-  NotesAccordionInteractor,
-} from '@folio/stripes/smart-components';
+// import {
+//   NoteFormInteractor,
+//   NotesAccordionInteractor,
+// } from '@folio/stripes/smart-components';
 
 import setupApplication from '../helpers/setup-application';
 
-const noteForm = new NoteFormInteractor();
-const notesAccordion = new NotesAccordionInteractor();
+// const noteForm = new NoteFormInteractor();
+// const notesAccordion = new NotesAccordionInteractor();
 
 let provider;
 let providerPackage;
 
-setupApplication();
+// setupApplication();
 
-describe('Create note page', () => {
+describe.skip('Create note page', () => {
   beforeEach(function () {
     provider = this.server.create('provider', {
       name: 'Cool Provider'

--- a/test/bigtest/tests/note-create-test.js
+++ b/test/bigtest/tests/note-create-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {
   beforeEach,
   describe,


### PR DESCRIPTION
## Approach
For now we can't run notes tests because notes interactors are not yet released.
## TODO
Unskip the tests after stripes-smart-components is released and notes related interactors are available for use in applications