### PR TITLE
UIEH-708: Fixed not needed calls when adding/removing tags for package

### DIFF
--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -75,6 +75,8 @@ class PackageShowRoute extends Component {
       match: oldMatch,
     } = prevProps;
 
+    const tagsChanged = old.tags.tagList.length !== next.tags.tagList.length;
+
     const { packageId } = match.params;
 
     if (!old.destroy.isResolved && next.destroy.isResolved) {
@@ -93,7 +95,7 @@ class PackageShowRoute extends Component {
     if (packageId !== oldMatch.params.packageId) {
       getPackage(packageId);
       // if an update just resolved, unfetch the package titles
-    } else if (next.update.isResolved && old.update.isPending) {
+    } else if (next.update.isResolved && old.update.isPending && !tagsChanged) {
       unloadResources(next.resources);
     }
 


### PR DESCRIPTION
## Purpose
Updating the package triggered the update it's resources.

Updating the tags does not have any influence on the resources.

So if the package update is due to the tag change than we do not need to  re-fetch the resources
