### PR TITLE
UIEH-710, UIEH-711: Add tags filter to search modal

### DIFF
--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -287,7 +287,7 @@ class SearchForm extends Component {
                 activeFilters={combinedFilters}
                 onUpdate={this.handleUpdateFilter}
               />
-              {(searchType === searchTypes.PROVIDERS) && this.renderTagFilter()}
+              { this.renderTagFilter() }
             </div>
           )}
         </form>

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -33,6 +33,7 @@ class SearchModal extends React.PureComponent {
     onFilter: PropTypes.func,
     onSearch: PropTypes.func,
     query: PropTypes.object,
+    tagsModel: PropTypes.object.isRequired,
   };
 
   state = {
@@ -62,18 +63,12 @@ class SearchModal extends React.PureComponent {
   }
 
   updateSearch = () => {
-    this.setState({
-      isModalVisible: false,
-    });
-
+    this.close();
     this.updateFilter(this.state.query);
   }
 
   resetSearch = () => {
-    this.setState({
-      isModalVisible: false,
-    });
-
+    this.close();
     this.updateFilter({});
   }
 
@@ -117,8 +112,21 @@ class SearchModal extends React.PureComponent {
     }));
   }
 
+  handleTagFilterChange = (filter) => {
+    this.setState(({ query }) => ({
+      query: normalize({
+        sort: query.sort,
+        filter,
+        q: query.q
+      }),
+    }), () => {
+      this.updateFilter(this.state.query);
+      this.close();
+    });
+  }
+
   render() {
-    const { listType } = this.props;
+    const { listType, tagsModel } = this.props;
 
     const {
       isModalVisible,
@@ -168,6 +176,7 @@ class SearchModal extends React.PureComponent {
             }
           >
             <SearchForm
+              tagsModel={tagsModel}
               searchType={listType}
               searchString={query.q}
               searchFilter={query.filter}
@@ -179,6 +188,7 @@ class SearchModal extends React.PureComponent {
               onFilterChange={this.handleFilterChange}
               onSearchChange={this.handleSearchQueryChange}
               onSearchFieldChange={this.handleSearchFieldChange}
+              onTagFilterChange={this.handleTagFilterChange}
             />
           </Modal>
         )}

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -258,6 +258,7 @@ class PackageShowRoute extends Component {
           searchModal={
             <SearchModal
               key={queryId}
+              tagsModel={tagsModel}
               listType={listTypes.TITLES}
               query={pkgSearchParams}
               onSearch={this.searchTitles}

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -155,6 +155,7 @@ class ProviderShowRoute extends Component {
           updateFolioTags={updateFolioTags}
           searchModal={
             <SearchModal
+              tagsModel={tagsModel}
               key={queryId}
               listType={listTypes.PACKAGES}
               query={pkgSearchParams}


### PR DESCRIPTION
https://issues.folio.org/browse/UIEH-710
https://issues.folio.org/browse/UIEH-711

## Purpose
There is search modal on package show and provider show pages. The purpose is to add tags filter to this modal. Tags filter performs search hot right after the choosing necessary tag. It works independently. For now disabling of another filters is out of scope.

## Approach
- Add `MultiSelectionFilter` to the bottom of `SearchModal`
- Provide modal with tags.
- Add filter handler to search modal
