### PR TITLE
UIEH-706: Package: Search within Titles popup: Title search dropdown is not sticky

### DIFF
--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -112,6 +112,7 @@ class SearchModal extends React.PureComponent {
       query: normalize({
         sort,
         filter,
+        searchfield: query.searchfield,
         q: query.q
       }),
     }));


### PR DESCRIPTION
## Purpose
The nature of this but was in resetting the state of the search dropdown when any of the filters changed and the search dropdown not changed.