### PR TITLE
ERM-253: Update Agreements URLs

### DIFF
--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -39,7 +39,7 @@ export default class AgreementsList extends React.Component {
       labelStrings,
     } = row;
 
-    const ermAgreementUrl = `/erm/agreements/view/${id}`;
+    const ermAgreementUrl = `/erm/agreements/${id}`;
     const ariaLabel = labelStrings && labelStrings.join('...');
 
     return (

--- a/src/features/agreements-accordion/agreements-accordion.js
+++ b/src/features/agreements-accordion/agreements-accordion.js
@@ -84,7 +84,7 @@ class AgreementsAccordion extends Component {
         <Button
           data-test-new-button
           buttonClass={styles['new-button']}
-          to={`/erm/agreements?layer=create&authority=${refType}&referenceId=${refId}`}
+          to={`/erm/agreements/create?authority=${refType}&referenceId=${refId}`}
         >
           <FormattedMessage id="ui-eholdings.new" />
         </Button>

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -102,7 +102,7 @@ describe('PackageShow', () => {
           });
 
           it('should redirect to create page of agreements app', function () {
-            const agreementCreatePageUrl = `/erm/agreements?layer=create&authority=${entityAuthorityTypes.PACKAGE}&referenceId=${providerPackage.id}`;
+            const agreementCreatePageUrl = `/erm/agreements/create?authority=${entityAuthorityTypes.PACKAGE}&referenceId=${providerPackage.id}`;
 
             expect(this.location.pathname + this.location.search).to.contain(agreementCreatePageUrl);
           });
@@ -122,7 +122,7 @@ describe('PackageShow', () => {
           });
 
           it('should redirect to agreement details page', function () {
-            const itemDetailsUrl = '/erm/agreements/view/2c918098689ba8f70168a349f1160027';
+            const itemDetailsUrl = '/erm/agreements/2c918098689ba8f70168a349f1160027';
 
             expect(this.location.pathname).to.contain(itemDetailsUrl);
           });

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -154,7 +154,7 @@ describe('ResourceShow', () => {
           });
 
           it('should redirect to create page of agreements app', function () {
-            const agreementCreatePageUrl = `/erm/agreements?layer=create&authority=${entityAuthorityTypes.RESOURCE}&referenceId=${resource.id}`;
+            const agreementCreatePageUrl = `/erm/agreements/create?authority=${entityAuthorityTypes.RESOURCE}&referenceId=${resource.id}`;
 
             expect(this.location.pathname + this.location.search).to.contain(agreementCreatePageUrl);
           });
@@ -174,7 +174,7 @@ describe('ResourceShow', () => {
           });
 
           it('should redirect to agreement details page', function () {
-            const itemDetailsUrl = '/erm/agreements/view/2c918098689ba8f70168a349f1160027';
+            const itemDetailsUrl = '/erm/agreements/2c918098689ba8f70168a349f1160027';
 
             expect(this.location.pathname).to.contain(itemDetailsUrl);
           });


### PR DESCRIPTION
## Purpose
The URLs to view and create agreements have changed with ERM-253 implemented in https://github.com/folio-org/ui-agreements/pull/219 This PR updates eHoldings to use those new URLs.

Feel free to push to this branch if I missed anything.

Also, there's [big underlying changes to the find-agreement plugin](https://github.com/folio-org/ui-plugin-find-agreement/pull/41), but it looks like eHoldings is completely decoupled from them since the public API has stayed the same and eHoldings doesn't declare a dependency on a particular version of ui-plugin-find-agreement (which makes sense).