### PR TITLE
UIEH-737: make search filters collapsed by default

### DIFF
--- a/src/components/search-form/search-filters.js
+++ b/src/components/search-form/search-filters.js
@@ -23,7 +23,7 @@ export default function SearchFilters({
           name={name}
           label={label}
           separator={false}
-          closedByDefault={false}
+          closedByDefault
           header={FilterAccordionHeader}
           displayClearButton={!!activeFilters[name] && activeFilters[name] !== defaultValue}
           onClearFilter={() => onUpdate({ ...activeFilters, [name]: undefined })}

--- a/src/components/search-form/search-form.css
+++ b/src/components/search-form/search-form.css
@@ -21,9 +21,9 @@
   }
 }
 
-.tag-filters {
+.tags-search-warning {
   margin-top: 0.5em;
-  margin-left: 1rem;
+  display: inline-block;
 }
 
 .search-field {

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -155,7 +155,10 @@ class SearchForm extends Component {
     return tagsModel.isLoading
       ? <Icon icon="spinner-ellipsis" />
       : (
-        <div data-test-eholdings-tag-filter>
+        <div
+          className={styles['search-filters']}
+          data-test-eholdings-tag-filter
+        >
           <Accordion
             label={<FormattedMessage id="ui-eholdings.tags" />}
             id="accordionTagFilter"
@@ -167,18 +170,19 @@ class SearchForm extends Component {
             onClearFilter={() => this.props.onTagFilterChange({ tags: undefined })}
             onToggle={this.toggleSection}
           >
-            <div className={styles['tag-filters']}>
-              <div data-test-eholdings-tag-message>
-                <FormattedMessage id="ui-eholdings.tags.filter.cannot.combine" />
-              </div>
-              <MultiSelectionFilter
-                id="selectTagFilter"
-                dataOptions={this.getSortedDataOptions()}
-                name="tags"
-                onChange={this.handleUpdateTagFilter}
-                selectedValues={tagsList}
-              />
-            </div>
+            <span
+              className={styles['tags-search-warning']}
+              data-test-eholdings-tag-message
+            >
+              <FormattedMessage id="ui-eholdings.tags.filter.cannot.combine" />
+            </span>
+            <MultiSelectionFilter
+              id="selectTagFilter"
+              dataOptions={this.getSortedDataOptions()}
+              name="tags"
+              onChange={this.handleUpdateTagFilter}
+              selectedValues={tagsList}
+            />
           </Accordion>
         </div>
       );

--- a/test/bigtest/interactors/package-search.js
+++ b/test/bigtest/interactors/package-search.js
@@ -9,8 +9,10 @@ import {
   interactor,
   value,
   text,
-  is
+  is,
 } from '@bigtest/interactor';
+
+import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
 
 import TagsAccordion from './tags-accordion';
 
@@ -41,6 +43,10 @@ import SearchBadge from './search-badge';
     '[data-test-search-form-type-switcher] a[class*=" primary--"]'
   ].join(','));
 
+  tagsFilterAccordion = new AccordionInteractor('#accordionTagFilter');
+  sortFilterAccordion = new AccordionInteractor('#filter-packages-sort');
+  selectionFilterAccordion = new AccordionInteractor('#filter-packages-selected');
+  typeFilterAccordion = new AccordionInteractor('#filter-packages-type');
   sortBy = value('[data-test-eholdings-search-filters="packages"] input[name="sort"]:checked');
   clickCloseButton = clickable('[data-test-eholdings-details-view-close-button]');
   hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
@@ -57,6 +63,10 @@ import SearchBadge from './search-badge';
 
   changeSearchType = action(function (searchType) {
     return this.click(`[data-test-search-type-button="${searchType}"]`);
+  });
+
+  toggleAccordion = action(function (accordionId) {
+    return this.click(accordionId);
   });
 
   clickFilter = action(function (name, val) {

--- a/test/bigtest/interactors/provider-search.js
+++ b/test/bigtest/interactors/provider-search.js
@@ -12,6 +12,8 @@ import {
   text
 } from '@bigtest/interactor';
 
+import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
+
 import TagsAccordion from './tags-accordion';
 
 import SearchBadge from './search-badge';
@@ -46,7 +48,8 @@ import SearchBadge from './search-badge';
   hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
   searchBadge = new SearchBadge('[data-test-eholdings-results-pane-search-badge]');
   tagsSection = new TagsAccordion('[data-test-eholdings-tag-filter]');
-
+  tagsFilterAccordion = new AccordionInteractor('#accordionTagFilter');
+  sortFilterAccordion = new AccordionInteractor('#filter-providers-sort');
   hasLoaded = computed(function () {
     return this.providerList().length > 0;
   })
@@ -54,6 +57,10 @@ import SearchBadge from './search-badge';
   changeSearchType = action(function (searchType) {
     return this.click(`[data-test-search-type-button="${searchType}"]`);
   })
+
+  toggleAccordion = action(function (accordionId) {
+    return this.click(accordionId);
+  });
 
   clickFilter = action(function (name, val) {
     return this.click(`[data-test-eholdings-search-filters="providers"] input[name="${name}"][value="${val}"]`);

--- a/test/bigtest/interactors/search-modal.js
+++ b/test/bigtest/interactors/search-modal.js
@@ -7,7 +7,10 @@ import {
   value,
   fillable,
   selectable,
+  collection,
 } from '@bigtest/interactor';
+
+import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
 
 import TagsAccordion from './tags-accordion';
 
@@ -24,6 +27,14 @@ export default @interactor class SearchModal {
   sortBy = value('[data-test-eholdings-search-filters="titles"] input[name="sort"]:checked');
   resetSortFilter = clickable('#filter-titles-sort button[icon="times-circle-solid"]');
   tagsSection = new TagsAccordion('[data-test-eholdings-tag-filter]');
+  sortFilterAccordion = new AccordionInteractor('#filter-packages-sort');
+  selectionFilterAccordion = new AccordionInteractor('#filter-packages-selected');
+  typeFilterAccordion = new AccordionInteractor('#filter-packages-type');
+  toggleAccordion = action(function (accordionId) {
+    return this.click(accordionId);
+  });
+
+  filterAccordions = collection('[class^="accordion--"]', AccordionInteractor);
 
   clickFilter = action(function (name, val) {
     return this.click(`[data-test-eholdings-search-filters] input[name="${name}"][value="${val}"]`);

--- a/test/bigtest/interactors/title-search.js
+++ b/test/bigtest/interactors/title-search.js
@@ -12,6 +12,8 @@ import {
   is
 } from '@bigtest/interactor';
 
+import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
+
 import TagsAccordion from './tags-accordion';
 import SearchBadge from './search-badge';
 
@@ -49,6 +51,10 @@ import SearchBadge from './search-badge';
   hasPreSearchPane = isPresent('[data-test-eholdings-pre-search-pane]');
   clickNewButton = clickable('[data-test-eholdings-search-new-button]');
   tagsSection = new TagsAccordion('[data-test-eholdings-tag-filter]');
+  tagsFilterAccordion = new AccordionInteractor('#accordionTagFilter');
+  sortFilterAccordion = new AccordionInteractor('#filter-titles-sort');
+  selectionFilterAccordion = new AccordionInteractor('#filter-titles-selected');
+  typeFilterAccordion = new AccordionInteractor('#filter-titles-type');
 
   hasLoaded = computed(function () {
     return this.titleList().length > 0;
@@ -61,6 +67,10 @@ import SearchBadge from './search-badge';
           top: firstItem.offsetHeight * readOffset
         });
       });
+  });
+
+  toggleAccordion = action(function (accordionId) {
+    return this.click(accordionId);
   });
 
   selectSearchField = action(function (searchfield) {

--- a/test/bigtest/tests/package-search-test.js
+++ b/test/bigtest/tests/package-search-test.js
@@ -38,6 +38,13 @@ describe('PackageSearch', () => {
     expect(PackageSearchPage.hasPreSearchPane).to.equal(true);
   });
 
+  it('filter accordions should be collapsed by default', () => {
+    expect(PackageSearchPage.tagsFilterAccordion.isOpen).to.be.false;
+    expect(PackageSearchPage.typeFilterAccordion.isOpen).to.be.false;
+    expect(PackageSearchPage.sortFilterAccordion.isOpen).to.be.false;
+    expect(PackageSearchPage.selectionFilterAccordion.isOpen).to.be.false;
+  });
+
   describe('searching for a package', () => {
     beforeEach(() => {
       return PackageSearchPage.search('Package');
@@ -224,8 +231,9 @@ describe('PackageSearch', () => {
     });
 
     describe('filtering by content type', () => {
-      beforeEach(() => {
-        return PackageSearchPage.clickFilter('type', 'ebook');
+      beforeEach(async () => {
+        await PackageSearchPage.toggleAccordion('#accordion-toggle-button-filter-packages-type');
+        await PackageSearchPage.clickFilter('type', 'ebook');
       });
 
       it('only shows results for ebook content types', () => {
@@ -278,8 +286,9 @@ describe('PackageSearch', () => {
     });
 
     describe('filtering by selection status', () => {
-      beforeEach(() => {
-        return PackageSearchPage.clickFilter('selected', 'true');
+      beforeEach(async () => {
+        await PackageSearchPage.toggleAccordion('#accordion-toggle-button-filter-packages-selected');
+        await PackageSearchPage.clickFilter('selected', 'true');
       });
 
       it('only shows results for selected packages', () => {
@@ -417,8 +426,9 @@ describe('PackageSearch', () => {
       });
 
       describe('then filtering by sort options', () => {
-        beforeEach(() => {
-          return PackageSearchPage.clickFilter('sort', 'name');
+        beforeEach(async () => {
+          await PackageSearchPage.toggleAccordion('#accordion-toggle-button-filter-packages-sort');
+          await PackageSearchPage.clickFilter('sort', 'name');
         });
 
         it('displays the packages sorted by package name', () => {

--- a/test/bigtest/tests/package-show-titles-search-test.js
+++ b/test/bigtest/tests/package-show-titles-search-test.js
@@ -115,11 +115,24 @@ describe('Package Show Title Search', () => {
       });
     });
 
+    describe('when the search modal is open', () => {
+      beforeEach(async () => {
+        await PackageShowPage.clickListSearch();
+      });
+
+      it('all filter accordions should be collapsed', () => {
+        PackageShowPage.searchModal.filterAccordions().forEach(accordion => {
+          expect(accordion.isOpen).to.be.false;
+        });
+      });
+    });
+
     describe('searching for a title with the selected filter', () => {
-      beforeEach(() => {
-        return PackageShowPage.clickListSearch()
-          .searchModal.clickFilter('selected', 'true')
-          .searchModal.clickSearch();
+      beforeEach(async () => {
+        await PackageShowPage.clickListSearch();
+        await PackageShowPage.searchModal.toggleAccordion('#accordion-toggle-button-filter-titles-selected');
+        await PackageShowPage.searchModal.clickFilter('selected', 'true');
+        await PackageShowPage.searchModal.clickSearch();
       });
 
       it('properly filters the results', () => {
@@ -128,10 +141,11 @@ describe('Package Show Title Search', () => {
     });
 
     describe('searching for a title with the publication type filter', () => {
-      beforeEach(() => {
-        return PackageShowPage.clickListSearch()
-          .searchModal.clickFilter('type', 'report')
-          .searchModal.clickSearch();
+      beforeEach(async () => {
+        await PackageShowPage.clickListSearch();
+        await PackageShowPage.searchModal.toggleAccordion('#accordion-toggle-button-filter-titles-type');
+        await PackageShowPage.searchModal.clickFilter('type', 'report');
+        await PackageShowPage.searchModal.clickSearch();
       });
 
       it('properly filters to one result', () => {
@@ -294,10 +308,11 @@ describe('Package Show Title Search', () => {
       });
     });
 
-    describe('when "name" sort oprion is chosen by user', () => {
-      beforeEach(() => {
-        return PackageShowPage.clickListSearch()
-          .searchModal.clickFilter('sort', 'name');
+    describe('when "name" sort option is chosen by user', () => {
+      beforeEach(async () => {
+        await PackageShowPage.clickListSearch();
+        await PackageShowPage.searchModal.toggleAccordion('#accordion-toggle-button-filter-titles-sort');
+        await PackageShowPage.searchModal.clickFilter('sort', 'name');
       });
       describe('search form', () => {
         it('should show "name" sort option', () => {

--- a/test/bigtest/tests/provider-search-test.js
+++ b/test/bigtest/tests/provider-search-test.js
@@ -38,6 +38,12 @@ describe('ProviderSearch', () => {
     expect(ProviderSearchPage.hasPreSearchPane).to.equal(true);
   });
 
+  it('filter accordions should be collapsed by default', () => {
+    expect(ProviderSearchPage.tagsFilterAccordion.isOpen).to.be.false;
+    expect(ProviderSearchPage.sortFilterAccordion.isOpen).to.be.false;
+  });
+
+
   describe('searching for a provider', () => {
     beforeEach(() => {
       return ProviderSearchPage.search('Provider');
@@ -284,8 +290,9 @@ describe('ProviderSearch', () => {
       });
 
       describe('then filtering by sort options', () => {
-        beforeEach(() => {
-          return ProviderSearchPage.clickFilter('sort', 'name');
+        beforeEach(async () => {
+          await ProviderSearchPage.toggleAccordion('#accordion-toggle-button-filter-providers-sort');
+          await ProviderSearchPage.clickFilter('sort', 'name');
         });
 
         it('displays the providers sorted by provider name', () => {
@@ -394,8 +401,9 @@ describe('ProviderSearch', () => {
     });
 
     describe('selecting a filter without a value in the search field', () => {
-      beforeEach(() => {
-        return ProviderSearchPage.clickFilter('sort', 'name');
+      beforeEach(async () => {
+        await ProviderSearchPage.toggleAccordion('#accordion-toggle-button-filter-providers-sort');
+        await ProviderSearchPage.clickFilter('sort', 'name');
       });
 
       it('should not perform an empty search', () => {

--- a/test/bigtest/tests/provider-show-package-search-test.js
+++ b/test/bigtest/tests/provider-show-package-search-test.js
@@ -86,8 +86,9 @@ describe('ProviderShow package search', () => {
     });
 
     describe('with filter change', () => {
-      beforeEach(() => {
-        return ProviderShowPage.searchModal.clickFilter('sort', 'name');
+      beforeEach(async () => {
+        await ProviderShowPage.searchModal.toggleAccordion('#accordion-toggle-button-filter-packages-sort');
+        await ProviderShowPage.searchModal.clickFilter('sort', 'name');
       });
 
       it('enables the search button', () => {
@@ -190,6 +191,18 @@ describe('ProviderShow package search', () => {
     });
   });
 
+  describe('when the search modal is open', () => {
+    beforeEach(async () => {
+      await ProviderShowPage.clickListSearch();
+    });
+
+    it('all filter accordions should be collapsed', () => {
+      ProviderShowPage.searchModal.filterAccordions().forEach(accordion => {
+        expect(accordion.isOpen).to.be.false;
+      });
+    });
+  });
+
   describe('filter package by search term', () => {
     beforeEach(() => {
       return ProviderShowPage.clickListSearch()
@@ -257,10 +270,11 @@ describe('ProviderShow package search', () => {
     });
 
     describe('then sorting by package name', () => {
-      beforeEach(() => {
-        return ProviderShowPage.clickListSearch()
-          .searchModal.clickFilter('sort', 'name')
-          .searchModal.clickSearch();
+      beforeEach(async () => {
+        await ProviderShowPage.clickListSearch();
+        await ProviderShowPage.searchModal.toggleAccordion('#accordion-toggle-button-filter-packages-sort');
+        await ProviderShowPage.searchModal.clickFilter('sort', 'name');
+        await ProviderShowPage.searchModal.clickSearch();
       });
 
       it('displays packages matching the search term ordered by name', () => {
@@ -288,10 +302,11 @@ describe('ProviderShow package search', () => {
     });
 
     describe('then filtering the packages by selection status', () => {
-      beforeEach(() => {
-        return ProviderShowPage.clickListSearch()
-          .searchModal.clickFilter('selected', 'true')
-          .searchModal.clickSearch();
+      beforeEach(async () => {
+        await ProviderShowPage.clickListSearch();
+        await ProviderShowPage.searchModal.toggleAccordion('#accordion-toggle-button-filter-packages-selected');
+        await ProviderShowPage.searchModal.clickFilter('selected', 'true');
+        await ProviderShowPage.searchModal.clickSearch();
       });
 
       it('displays selected packages matching the search term', () => {
@@ -305,10 +320,11 @@ describe('ProviderShow package search', () => {
     });
 
     describe('then filtering the packages by content type', () => {
-      beforeEach(() => {
-        return ProviderShowPage.clickListSearch()
-          .searchModal.clickFilter('type', 'ebook')
-          .searchModal.clickSearch();
+      beforeEach(async () => {
+        await ProviderShowPage.clickListSearch();
+        await ProviderShowPage.searchModal.toggleAccordion('#accordion-toggle-button-filter-packages-type');
+        await ProviderShowPage.searchModal.clickFilter('type', 'ebook');
+        await ProviderShowPage.searchModal.clickSearch();
       });
 
       it('displays packages matching the search term and content type', () => {
@@ -330,9 +346,11 @@ describe('ProviderShow package search', () => {
         });
 
       this.server.get(`providers/${largeProvider.id}/packages`,
-        { 'data':[],
-          'meta':{ 'totalResults': 10001 },
-          'jsonapi':{ 'version':'1.0' } }, 200);
+        {
+          'data': [],
+          'meta': { 'totalResults': 10001 },
+          'jsonapi': { 'version': '1.0' }
+        }, 200);
 
       this.visit(
         {

--- a/test/bigtest/tests/title-search-test.js
+++ b/test/bigtest/tests/title-search-test.js
@@ -75,6 +75,13 @@ describe('TitleSearch', () => {
     expect(TitleSearchPage.hasPreSearchPane).to.equal(true);
   });
 
+  it('filter accordions should be collapsed by default', () => {
+    expect(TitleSearchPage.tagsFilterAccordion.isOpen).to.be.false;
+    expect(TitleSearchPage.typeFilterAccordion.isOpen).to.be.false;
+    expect(TitleSearchPage.sortFilterAccordion.isOpen).to.be.false;
+    expect(TitleSearchPage.selectionFilterAccordion.isOpen).to.be.false;
+  });
+
   describe('searching for a title', () => {
     beforeEach(() => {
       return TitleSearchPage.search('Title');
@@ -225,8 +232,9 @@ describe('TitleSearch', () => {
     });
 
     describe('filtering by publication type', () => {
-      beforeEach(() => {
-        return TitleSearchPage.clickFilter('type', 'book');
+      beforeEach(async () => {
+        await TitleSearchPage.toggleAccordion('#accordion-toggle-button-filter-titles-type');
+        await TitleSearchPage.clickFilter('type', 'book');
       });
 
       it('only shows results for book publication types', () => {
@@ -277,8 +285,9 @@ describe('TitleSearch', () => {
     });
 
     describe('filtering by selection status', () => {
-      beforeEach(() => {
-        return TitleSearchPage.clickFilter('selected', 'true');
+      beforeEach(async () => {
+        await TitleSearchPage.toggleAccordion('#accordion-toggle-button-filter-titles-selected');
+        await TitleSearchPage.clickFilter('selected', 'true');
       });
 
       it('only shows results for selected titles', () => {
@@ -456,11 +465,11 @@ describe('TitleSearch', () => {
     });
 
     describe('selecting both a search field and a search filter', () => {
-      beforeEach(() => {
-        return TitleSearchPage
-          .selectSearchField('isxn')
-          .clickFilter('type', 'book')
-          .search('999-999');
+      beforeEach(async () => {
+        await TitleSearchPage.selectSearchField('isxn');
+        await TitleSearchPage.toggleAccordion('#accordion-toggle-button-filter-titles-type');
+        await TitleSearchPage.clickFilter('type', 'book');
+        await TitleSearchPage.search('999-999');
       });
       it('only shows results having both isxn and book pub type', () => {
         expect(TitleSearchPage.titleList()).to.have.lengthOf(1);
@@ -579,8 +588,9 @@ describe('TitleSearch', () => {
       });
 
       describe('when "name" sort option is chosen by user', () => {
-        beforeEach(() => {
-          return TitleSearchPage.clickFilter('sort', 'name');
+        beforeEach(async () => {
+          await TitleSearchPage.toggleAccordion('#accordion-toggle-button-filter-titles-sort');
+          await TitleSearchPage.clickFilter('sort', 'name');
         });
 
         describe('search form', () => {
@@ -700,8 +710,9 @@ describe('TitleSearch', () => {
     });
 
     describe('when selecting a filter without a value in the search field', () => {
-      beforeEach(() => {
-        return TitleSearchPage.clickFilter('sort', 'name');
+      beforeEach(async () => {
+        await TitleSearchPage.toggleAccordion('#accordion-toggle-button-filter-titles-sort');
+        await TitleSearchPage.clickFilter('sort', 'name');
       });
 
       describe('presearch pane', () => {


### PR DESCRIPTION
The purpose of this PR is to make all search filters throughout the application closed by default.
All necessary tests adjustments were done to reflect this change.