### PR TITLE
Modify pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "yarn lint"
+      "pre-push": "yarn lint >&2"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## Purpose
When testing out some changes to BigTest interactors (related to https://issues.folio.org/browse/UIEH-612), I switched my local copy of `ui-eholdings` to use a GitHub-hosted branch of `@bigtest/interactor`, instead of the version published on NPM.

When I tried to push my changed `ui-eholdings` branch to the `frontside-folio` fork with [Git Tower](https://www.git-tower.com), I received an ambiguous error.

I finally traced my inability to push to the pre-push hooks added with https://github.com/folio-org/ui-eholdings/pull/766. Tower was not displaying the ESLint errors caused by my pointing a scoped package to an unpublished branch.

## Approach
Make sure the errors get printed to STDERR: https://www.git-tower.com/help/mac/faq-and-tips/faq/hook-scripts

### For Future Consideration
I'm generally not in favor of pre-commit or pre-push hooks. Its utility might need reconsideration.
#### Pros of the pre-push lint hook
- Cuts down on CI runs.
- Catches lint errors earlier than CI if a developer didn't catch the errors in their editor.

#### Cons of the pre-push lint hook
- CI runs are cheap.
- Poor integration with Git GUIs.
- If I have any unstaged changes in my branch that don't pass `yarn lint`, I can't push.
- I have to run the 30 seconds or so of linting locally before pushing changes, when it's just going to run `yarn lint` again when I push to the CI server.
- The most efficient time to catch lint errors is while editing a file. Everyone should have ESLint plugins configured for their editor (VS Code, Atom, Emacs, Vim, etc.) so they catch problems as early as possible. Developers should rarely have to run `yarn lint` locally.

## Screenshot
### Before
<img width="482" alt="Screen Shot 2019-07-03 at 9 58 47 AM" src="https://user-images.githubusercontent.com/230597/60606762-8a692780-9d81-11e9-8b99-eb2fa32d6806.png">

### After
<img width="481" alt="Screen Shot 2019-07-03 at 9 59 34 AM" src="https://user-images.githubusercontent.com/230597/60606788-95bc5300-9d81-11e9-9adb-279b424519a3.png">