### PR TITLE
UITEN-35 use granular permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-eholdings
 
+## 1.8.0 (IN PROGRESS)
+
+* Use granular permissions for settings items (UITEN-35)
+
 ## [1.7.0](https://github.com/folio-org/ui-eholdings/tree/v1.7.0) (2019-06-11)
 [Full Changelog](https://github.com/folio-org/ui-eholdings/compare/v1.5.0...v1.7.0)
 

--- a/package.json
+++ b/package.json
@@ -99,9 +99,20 @@
         ]
       },
       {
-        "permissionName": "settings.eholdings.enabled",
-        "displayName": "Settings (eHoldings): display list of settings pages",
-        "visible": true
+        "permissionName": "ui-eholdings.settings.kb",
+        "displayName": "Settings (eHoldings): configure EBSCO RM API credentials",
+        "visible": true,
+        "subPermissions": [
+          "settings.enabled"
+        ]
+      },
+      {
+        "permissionName": "ui-eholdings.settings.root-proxy",
+        "displayName": "Settings (eHoldings): configure root proxy setting",
+        "visible": true,
+        "subPermissions": [
+          "settings.enabled"
+        ]
       },
       {
         "permissionName": "ui-eholdings.package-title.select-unselect",

--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -43,13 +43,13 @@ class Settings extends Component {
             <NavListSection
               activeLink={pathname}
             >
-              <IfPermission perm="module.eholdings.enabled">
+              <IfPermission perm="ui-eholdings.settings.kb">
                 <NavListItem to="/settings/eholdings/knowledge-base">
                   <FormattedMessage id="ui-eholdings.settings.kb" />
                 </NavListItem>
               </IfPermission>
 
-              <IfPermission perm="module.eholdings.enabled">
+              <IfPermission perm="ui-eholdings.settings.root-proxy">
                 <NavListItem to="/settings/eholdings/root-proxy">
                   <FormattedMessage id="ui-eholdings.settings.rootProxy" />
                 </NavListItem>


### PR DESCRIPTION
##  Purpose

Instead of a single setting to determine visibility of settings items,
use per-item permissions. Details at [UITEN-35](https://issues.folio.org/browse/UITEN-35)

## Approach

* Add granular settings permissions in `package.json`
* Use these settings where links to settings pages are rendered
* Remove the generic (and unused) "display list of settings pages" permission

#### TODOS

Note that this doesn't actually enforce the permission on the route itself; all it does it prevent displaying the link to the route. That _should_ be added but I wasn't sure of the preferred way to do it. 
