### PR TITLE
UIEH-757 restore eHoldings to settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-eholdings
 
+## 1.9.0 (IN PROGRESS)
+
+* Restore eHoldings to the settings menu (UIEH-757, UITEN-35)
+
 ## [1.8.0](https://github.com/folio-org/ui-eholdings/tree/v1.8.0) (2019-07-24)
 [Full Changelog](https://github.com/folio-org/ui-eholdings/compare/v1.5.0...v1.8.0)
 * Make search filters collapsed by default(UIEH-737)

--- a/package.json
+++ b/package.json
@@ -99,11 +99,18 @@
         ]
       },
       {
+        "permissionName": "settings.eholdings.enabled",
+        "displayName": "Settings (eHoldings): display list of settings pages",
+        "subPermissions": [
+          "settings.enabled"
+        ]
+      },
+      {
         "permissionName": "ui-eholdings.settings.kb",
         "displayName": "Settings (eHoldings): configure EBSCO RM API credentials",
         "visible": true,
         "subPermissions": [
-          "settings.enabled"
+          "settings.eholdings.enabled"
         ]
       },
       {
@@ -111,7 +118,7 @@
         "displayName": "Settings (eHoldings): configure root proxy setting",
         "visible": true,
         "subPermissions": [
-          "settings.enabled"
+          "settings.eholdings.enabled"
         ]
       },
       {


### PR DESCRIPTION
## Purpose

stripes-core uses `settings.${module}.enabled` to determine whether a
module should be listed on the settings page. Unfortunately, it was
removed in #840 because I didn't realize that requirement.

## Approach

Here, `settings.${module}.enabled` is being restored BUT without `visible: true` because we do not want to grant this permission to anybody; we want granular, per-item permissions as UITEN-35 indicates.

Fixes UIEH-757; refs UITEN-35