### PR TITLE
UIEH-763: fix audiobook misspelling causing inabiliy to create a title

### DIFF
--- a/src/components/title/_fields/publication-type/publication-type-field.js
+++ b/src/components/title/_fields/publication-type/publication-type-field.js
@@ -13,7 +13,7 @@ export default function PublicationTypeField() {
         label={<FormattedMessage id="ui-eholdings.title.publicationType" />}
       >
         <FormattedMessage id="ui-eholdings.filter.pubType.audioBook">
-          {(message) => <option value="Audio Book">{message}</option>}
+          {(message) => <option value="Audiobook">{message}</option>}
         </FormattedMessage>
         <FormattedMessage id="ui-eholdings.filter.pubType.book">
           {(message) => <option value="Book">{message}</option>}

--- a/src/redux/title.js
+++ b/src/redux/title.js
@@ -19,17 +19,19 @@ class Title {
   // new title record payloads
   serialize() {
     const data = { id: this.id, type: this.type };
-    const { resources, ...attributes } = this.data.attributes;
+    const { resources } = this.data.attributes;
     const payload = { data };
-    const readOnlyAttributes = ['isTitleCustom', 'subjects'];
 
-    data.attributes = Object.keys(attributes).reduce((attrs, attr) => {
-      const isReadOnly = readOnlyAttributes.includes(attr);
-
-      if (isReadOnly) return attrs;
-
-      return Object.assign(attrs, { [attr]: this[attr] });
-    }, {});
+    data.attributes = {
+      contributors: this.contributors,
+      description: this.description,
+      edition: this.edition,
+      identifiers: this.identifiers,
+      isPeerReviewed: this.isPeerReviewed,
+      name: this.name,
+      publicationType: this.publicationType,
+      publisherName: this.publisherName,
+    };
 
     // when serializing a new title we need to include any new resources
     const isTitleNew = !this.id;

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -233,7 +233,7 @@
     "filter.contentType.print": "Print",
     "filter.contentType.onlineReference": "Online Reference",
     "filter.contentType.unknown": "Unknown",
-    "filter.pubType.audioBook": "Audio Book",
+    "filter.pubType.audioBook": "Audiobook",
     "filter.pubType.book": "Book",
     "filter.pubType.bookSeries": "Book Series",
     "filter.pubType.database": "Database",


### PR DESCRIPTION
There are 2 places in the application where "audio book" is used (should be single work):
1.  `<PublicationTypeField>`. Here  "Audio book" causes a bug because the value expected by the back-en is "Audiobook" 
2. `ui-eholdings.filter.pubType.audioBook` translation string

There are no tests or mirage configs which rely on publication type so no additional fixes are required 