### PR TITLE
UIEH-769: Remove tags from resource/package/provider PUT payload

### DIFF
--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -391,7 +391,7 @@ class BaseModel {
     };
 
     for (const attr of Object.keys(this.data.attributes)) {
-      data.attributes[attr] = this[attr];
+      if (attr !== 'tags') data.attributes[attr] = this[attr];
     }
 
     return { data };

--- a/src/redux/resource.js
+++ b/src/redux/resource.js
@@ -70,7 +70,6 @@ class Resource {
         isTitleCustom: this.isTitleCustom,
         isPeerReviewed: this.isPeerReviewed,
         description: this.description,
-        tags: this.tags,
       };
     }
 


### PR DESCRIPTION
## Purpose
In this PR we get rid of the `tags` in the PUT payload for the resources/package/provider requets

This clean-up is needed as we currently update tags with separate endpoints.