### PR TITLE
UIEH-758: fix mirage handler for GET titles with tags filter

### DIFF
--- a/test/bigtest/interactors/resource-show.js
+++ b/test/bigtest/interactors/resource-show.js
@@ -57,7 +57,7 @@ import Toast from './toast';
   hasContentType = isPresent('[data-test-eholdings-resource-show-content-type]');
   hasErrors = isPresent('[data-test-eholdings-details-view-error="resource"]');
   isResourceSelected = text('[data-test-eholdings-resource-show-selected] div');
-  isLoading = isPresent('[data-test-eholdings-resource-show-selected] [class*=icon---][class*=iconSpinner]');
+  isLoading = isPresent('[data-test-eholdings-resource-show-selected] [class*=icon---] [class*=icon-spinner]');
   hasBackButton = isPresent('[data-test-eholdings-details-view-back-button]');
   hasCollapseAllButton = isPresent('[data-test-eholdings-details-view-collapse-all-button]');
   collapseAllButtonText = text('[data-test-eholdings-details-view-collapse-all-button]');

--- a/test/bigtest/interactors/selection-status.js
+++ b/test/bigtest/interactors/selection-status.js
@@ -14,6 +14,6 @@ export default @interactor class PackageSelectionStatus {
     return this.selectionText === 'Selected';
   });
 
-  isSelecting = isPresent('[data-test-eholdings-package-details-selected] [class*=icon---][class*=iconSpinner]');
+  isSelecting = isPresent('[data-test-eholdings-package-details-selected] [class*=icon---] [class*=icon-spinner]');
   hasAddButton = isPresent('[data-test-eholdings-package-add-to-holdings-button]');
 }

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -475,7 +475,9 @@ export default function config() {
     let filtered = true;
 
     if (tags) {
-      return tags.split(',').some(item => title.tags.tagList.includes(item));
+      return tags.split(',').some(item => {
+        return title.resources.models.some((resource => resource.tags.tagList.includes(item)));
+      });
     }
 
     if (name) {

--- a/test/bigtest/tests/title-search-test.js
+++ b/test/bigtest/tests/title-search-test.js
@@ -775,10 +775,14 @@ describe('TitleSearch', () => {
         tagList: allTags.slice(0)
       }).toJSON();
 
-      this.server.create('title', {
+      const title = this.server.create('title', 'withPackages', {
         name: 'Test Urgent Tag',
-        tags: urgentTag
       });
+
+      const taggedResource = title.resources.models[0];
+
+      taggedResource.tags = urgentTag;
+      taggedResource.save();
     });
 
     it('displays tags accordion as closed', () => {


### PR DESCRIPTION
## Purpose 
The mirage handler of `GET   /titles ` request containing tags filter works incorrectly. It searches for tags inside titles, however, titles don't have tags. We should make it search for tags inside the titles' resources.

## Approach
* Fix the `this.get('/titles', ....)` handler. Now it searches for tags inside titles' resources
* Adjust test preparation steps (i.e. beforeEach). Now we don't create a title with a list of tags. Instead, we create a title whose resources contain tags
* [not related to the ticket] fix some failing tests which are not tied code which was changed during the work on the story. Supposedly, the started failing because of some stripes-components updates. 