### PR TITLE
UIEH-782: Disallow to create more than 1 date coverage range

### DIFF
--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -97,7 +97,7 @@ class PackageCoverageFields extends Component {
   }
 
   renderRepeatableField = ({ fields, name, meta: { initial } }) => {
-    const hasAddButton = fields.length === 0 || (fields.length === 1 && !initial[0]);
+    const hasAddButton = fields.length === 0;
     const hasEmptyMessage = initial.length > 0 && initial[0].beginCoverage;
     const addLabel = hasAddButton
       ? <FormattedMessage id="ui-eholdings.package.coverage.addDateRange" />

--- a/test/bigtest/tests/package-create-test.js
+++ b/test/bigtest/tests/package-create-test.js
@@ -74,6 +74,18 @@ describe('PackageCreate', () => {
       });
     });
 
+    describe('adding custom coverage', () => {
+      beforeEach(async () => {
+        await PackageCreatePage
+          .fillName('My Package')
+          .addCoverage();
+      });
+
+      it('does not display "Add date range" button when there is 1 date range row', () => {
+        expect(PackageCreatePage.hasAddCoverageButton).to.be.false;
+      });
+    });
+
     describe('creating a new package with custom coverages', () => {
       beforeEach(() => {
         return PackageCreatePage


### PR DESCRIPTION
https://issues.folio.org/browse/UIEH-782

## Purpose
Disallow to create more than 1 date range for custom coverage on UI.

## Approach
- Remove outdated condition
- Cover the case with a test

## Screenshots
![2019-09-09 15 45 03](https://user-images.githubusercontent.com/43621626/64532129-993bff80-d319-11e9-8b6c-645044337105.gif)
