### PR TITLE
UIEH-793: fix bigtest imports

### DIFF
--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -1,4 +1,4 @@
-import { setupStripesCore } from '@folio/stripes/core/test';
+import setupStripesCore from '@folio/stripes-core/test/bigtest/helpers/setup-application';
 import mirageOptions from '../network';
 
 export default function setupApplication({

--- a/test/bigtest/network/boot.js
+++ b/test/bigtest/network/boot.js
@@ -1,4 +1,4 @@
-import { startMirage } from '@folio/stripes/core/test';
+import startMirage from '@folio/stripes-core/test/bigtest/network/start';
 import mirageOptions from '.';
 
 /**


### PR DESCRIPTION
The [guide](https://github.com/folio-org/stripes/blob/master/doc/stripes-framework.md#upgrading-to-v26) on how to migrate to stripes 2.6 is misleading.

Changing
`import startMirage from '@folio/stripes-core/test/bigtest/network/start';`
to
`import { startMirage } from '@folio/stripes/core/test';`
results in an application not working in mirage mode.

The reason is that `stripes-core` does not export what `stripes` is trying to import:
  [stripes/core/test/index.js](https://github.com/folio-org/stripes/blob/master/core/test/index.js)  has  `export { default } from '@folio/stripes-core/test';`
but [stripes-core/test/index.js](https://github.com/folio-org/stripes-core/blob/master/test/index.js)  has no default export