### PR TITLE
Support erm interface v2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "okapiInterfaces": {
       "eholdings": "2.0",
       "tags": "1.0",
-      "erm": "1.0"
+      "erm": "1.0 2.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Purpose
`mod-agreements` needs to update the version on the `erm` interface to 2.0 because of the breaking changes to the API to [_set_ agreement dates/periods](https://issues.folio.org/browse/ERM-466). eHoldings needs to support the new interface version for the nightly builds to build.

## Approach
The breaking change is only to the process of editing the start, end or cancellation date of an agreement. eHoldings does none of these so a simple bump to the version in `okapiInterfaces` is all that's needed.

Note that as of this PR being opened, `mod-agreements` has not yet been updated with the new interface version. I'm opening this PR ahead of time so that this can be merged before then.