### PR TITLE
UIEH-796: Retrieve up to 100k of requested tags instead of 10

### DIFF
--- a/src/redux/tag.js
+++ b/src/redux/tag.js
@@ -14,6 +14,6 @@ class Tag {
 }
 export default model({
   type: 'tags',
-  path: '/tags'
+  path: '/tags?limit=100000'
 
 })(Tag);


### PR DESCRIPTION

## Purpose

Currently tags retrieved for the search filter limited only to 10.

The purpose of this PR is to increase the number of retrieved tags to up to 100k