### PR TITLE
UIEH-803: lock react-final-form 6.3.0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "impagination": "^1.0.0-alpha.3",
     "inflected": "^2.0.3",
     "prop-types": "^15.6.2",
-    "react-final-form": "^6.3.0",
+    "react-final-form": "6.3.0",
     "react-final-form-arrays": "^3.1.0",
     "react-hot-loader": "^4.3.12",
     "react-intl": "^2.4.0",


### PR DESCRIPTION
https://issues.folio.org/browse/UIEH-803

## Purpose
react-final-form versions greater 6.3.0 breaks the work of the Eholdings forms

## Approach
Lock react-final-form 6.3.0 version.
