### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "babel-polyfill": "^6.26.0",
     "chai": "^4.0.2",
     "eslint": "^5.5.0",
-    "fake-xml-http-request": "2.0.0",
     "husky": "^1.3.1",
     "lodash": "^4.17.4",
     "mocha": "^5.2.0",
@@ -68,9 +67,6 @@
     "react-router-prop-types": "^1.0.4",
     "redux-actions": "^2.2.1",
     "redux-observable": "^0.15.0"
-  },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^2.6.0",


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.