### PR TITLE
UIEH-815: When you access the app the focus should be in the Search box

### DIFF
--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -30,7 +30,6 @@ export default class SearchPaneset extends Component {
     filterCount: PropTypes.number,
     hideFilters: PropTypes.bool,
     isLoading: PropTypes.bool,
-    location: PropTypes.object,
     resultsLabel: PropTypes.node,
     resultsType: PropTypes.string,
     resultsView: PropTypes.node,

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -48,11 +48,6 @@ export default class SearchPaneset extends Component {
   // used to focus the pane title when a new search happens
   $title = React.createRef(); // eslint-disable-line react/sort-comp
 
-  componentDidUpdate(prevProps) {
-    const isNewSearch = prevProps.location.search !== this.props.location.search;
-    const isSameSearchType = prevProps.resultsType === this.props.resultsType;
-  }
-
   toggleFilters = () => {
     this.props.updateFilters(hideFilters => !hideFilters);
   };

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -48,21 +48,9 @@ export default class SearchPaneset extends Component {
   // used to focus the pane title when a new search happens
   $title = React.createRef(); // eslint-disable-line react/sort-comp
 
-  // focus the pane title if we mounted with existing search results
-  componentDidMount() {
-    if (this.props.resultsView && this.$title.current) {
-      this.$title.current.focus();
-    }
-  }
-
   componentDidUpdate(prevProps) {
     const isNewSearch = prevProps.location.search !== this.props.location.search;
     const isSameSearchType = prevProps.resultsType === this.props.resultsType;
-
-    // focus the pane title when a new search happens within the same search type
-    if (isNewSearch && isSameSearchType && this.$title.current) {
-      this.$title.current.focus();
-    }
   }
 
   toggleFilters = () => {

--- a/src/components/search-paneset/search-paneset.js
+++ b/src/components/search-paneset/search-paneset.js
@@ -30,7 +30,7 @@ export default class SearchPaneset extends Component {
     filterCount: PropTypes.number,
     hideFilters: PropTypes.bool,
     isLoading: PropTypes.bool,
-    location: PropTypes.object.isRequired,
+    location: PropTypes.object,
     resultsLabel: PropTypes.node,
     resultsType: PropTypes.string,
     resultsView: PropTypes.node,


### PR DESCRIPTION

## Purpose
Initially there were focus set to the app header after the search complete.
When changing the app and returning back the search was not focused.

This behaviour was changed and the focus is set to search in all the cases.
