### PR TITLE
UIEH-829: Fix view of Action button on package view page header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.2.0](IN PROGRESS)
 
 * Update eslint to v6.2.1 (UIEH-818)
+* Fix view of Action button on package view page header (UIEH-829)
 
 ## [2.1.0](https://github.com/folio-org/ui-eholdings/tree/v2.1.0) (2019-12-04)
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -560,30 +560,27 @@ class PackageShow extends Component {
     const {
       model: { name },
       onEdit,
-      stripes,
     } = this.props;
     const { packageSelected } = this.state;
-    const hasEditPermissions = stripes.hasPerm('ui-eholdings.records.edit');
-    const canEdit = packageSelected && hasEditPermissions;
 
-    if (!canEdit) return null;
-
-    return (
-      <FormattedMessage
-        id="ui-eholdings.label.editLink"
-        values={{
-          name,
-        }}
-      >
-        {ariaLabel => (
-          <IconButton
-            data-test-eholdings-package-edit-link
-            icon="edit"
-            ariaLabel={ariaLabel}
-            onClick={onEdit}
-          />
-        )}
-      </FormattedMessage>
+    return packageSelected && (
+      <IfPermission perm="ui-eholdings.records.edit">
+        <FormattedMessage
+          id="ui-eholdings.label.editLink"
+          values={{
+            name,
+          }}
+        >
+          {ariaLabel => (
+            <IconButton
+              data-test-eholdings-package-edit-link
+              icon="edit"
+              ariaLabel={ariaLabel}
+              onClick={onEdit}
+            />
+          )}
+        </FormattedMessage>
+      </IfPermission>
     );
   }
 

--- a/test/bigtest/interactors/actions-drop-down.js
+++ b/test/bigtest/interactors/actions-drop-down.js
@@ -4,7 +4,9 @@ import {
   attribute,
 } from '@bigtest/interactor';
 
-export default @interactor class DropDown {
+@interactor class ActionsDropDown {
   clickDropDownButton = clickable('button');
   isExpanded = attribute('button', 'aria-expanded');
 }
+
+export default new ActionsDropDown('[data-pane-header-actions-dropdown]');

--- a/test/bigtest/interactors/package-edit.js
+++ b/test/bigtest/interactors/package-edit.js
@@ -22,7 +22,7 @@ import Datepicker from './datepicker';
 import PackageSelectionStatus from './selection-status';
 import NavigationModal from './navigation-modal';
 import PackageModal from './package-modal';
-import DropDown from './drop-down';
+import ActionsDropDown from './actions-drop-down';
 import PackageDropDownMenu from './package-drop-down-menu';
 import SectionToggleButton from './section-toggle-button';
 
@@ -75,7 +75,7 @@ import SectionToggleButton from './section-toggle-button';
   hasReadOnlyContentTypeFieldPresent = isPresent('[data-test-eholdings-package-details-readonly-content-type]');
   proxySelectValue = value('[data-test-eholdings-package-proxy-select-field] select');
   chooseProxy = selectable('[data-test-eholdings-package-proxy-select-field] select');
-  dropDown = new DropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  actionsDropDown = ActionsDropDown;
   dropDownMenu = new PackageDropDownMenu();
   sectionToggleButton = new SectionToggleButton();
   holdingStatusSectionAccordion = new AccordionInteractor('#packageHoldingStatus');
@@ -123,20 +123,20 @@ import SectionToggleButton from './section-toggle-button';
 
   selectPackage() {
     return this
-      .dropDown.clickDropDownButton()
+      .actionsDropDown.clickDropDownButton()
       .dropDownMenu.addToHoldings.click();
   }
 
   deselectAndConfirmPackage() {
     return this
-      .dropDown.clickDropDownButton()
+      .actionsDropDown.clickDropDownButton()
       .dropDownMenu.removeFromHoldings.click()
       .modal.confirmDeselection();
   }
 
   deselectAndCancelPackage() {
     return this
-      .dropDown.clickDropDownButton()
+      .actionsDropDown.clickDropDownButton()
       .dropDownMenu.removeFromHoldings.click()
       .modal.cancelDeselection();
   }

--- a/test/bigtest/interactors/package-show.js
+++ b/test/bigtest/interactors/package-show.js
@@ -23,7 +23,7 @@ import Toast from './toast';
 import SearchModal from './search-modal';
 import SearchBadge from './search-badge';
 import PackageSelectionStatus from './selection-status';
-import DropDown from './drop-down';
+import ActionsDropDown from './actions-drop-down';
 import PackageDropDownMenu from './package-drop-down-menu';
 import PackageModal from './package-modal';
 
@@ -66,7 +66,7 @@ import PackageModal from './package-modal';
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button]');
   detailsPaneContentScrollHeight = property('[data-test-eholdings-detail-pane-contents]', 'scrollHeight');
   clickEditButton = clickable('[data-test-eholdings-package-edit-link]');
-  dropDown= new DropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  actionsDropDown = ActionsDropDown;
   dropDownMenu = new PackageDropDownMenu();
   searchModalBadge = new SearchBadge('[data-test-eholdings-search-modal-badge]');
 
@@ -134,20 +134,20 @@ import PackageModal from './package-modal';
 
   selectPackage() {
     return this
-      .dropDown.clickDropDownButton()
+      .actionsDropDown.clickDropDownButton()
       .dropDownMenu.addToHoldings.click();
   }
 
   deselectAndConfirmPackage() {
     return this
-      .dropDown.clickDropDownButton()
+      .actionsDropDown.clickDropDownButton()
       .dropDownMenu.removeFromHoldings.click()
       .modal.confirmDeselection();
   }
 
   deselectAndCancelPackage() {
     return this
-      .dropDown.clickDropDownButton()
+      .actionsDropDown.clickDropDownButton()
       .dropDownMenu.removeFromHoldings.click()
       .modal.cancelDeselection();
   }

--- a/test/bigtest/interactors/resource-edit.js
+++ b/test/bigtest/interactors/resource-edit.js
@@ -21,7 +21,7 @@ import { hasClassBeginningWith } from './helpers';
 import Toast from './toast';
 import Datepicker from './datepicker';
 import NavigationModal from './navigation-modal';
-import DropDown from './drop-down';
+import ActionsDropDown from './actions-drop-down';
 import ResourceEditModal from './resource-edit-modal';
 import ResourceDropDownMenu from './resource-drop-down-menu';
 import CustomLabelsFields from './custom-labels-fields';
@@ -147,7 +147,7 @@ import ResourceEditToggleSectionButton from './resource-edit-toggle-section-butt
   proxySelectValue = value('[data-test-eholdings-resource-proxy-select] select');
   chooseProxy = selectable('[data-test-eholdings-resource-proxy-select] select');
 
-  dropDown = new DropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  actionsDropDown = ActionsDropDown;
   dropDownMenu = new ResourceDropDownMenu();
 }
 

--- a/test/bigtest/interactors/resource-show.js
+++ b/test/bigtest/interactors/resource-show.js
@@ -13,7 +13,7 @@ import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tes
 import AgreementsAccordion from './agreements-accordion';
 import CustomLabel from './custom-label';
 import Toast from './toast';
-import DropDown from './drop-down';
+import ActionsDropDown from './actions-drop-down';
 import ResourceDropDownMenu from './resource-drop-down-menu';
 import NavigationModal from './navigation-modal';
 import ResourceShowDeselectionModal from './resource-show-deselection-modal';
@@ -57,7 +57,7 @@ import ResourceShowDeselectionModal from './resource-show-deselection-modal';
   clickPackage = clickable('[data-test-eholdings-resource-show-package-name] a');
   clickAddToHoldingsButton = clickable('[data-test-eholdings-resource-add-to-holdings-button]');
   isAddToHoldingsButtonDisabled = property('[data-test-eholdings-resource-add-to-holdings-button]', 'disabled');
-  dropDown= new DropDown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  actionsDropDown= ActionsDropDown;
   dropDownMenu = new ResourceDropDownMenu();
   deselectionModal = new ResourceShowDeselectionModal('#eholdings-resource-deselection-confirmation-modal');
   navigationModal = NavigationModal;

--- a/test/bigtest/tests/custom-package-edit-selection-test.js
+++ b/test/bigtest/tests/custom-package-edit-selection-test.js
@@ -49,7 +49,7 @@ describe('CustomPackageEditSelection', () => {
     describe('deleting the custom package', () => {
       beforeEach(() => {
         return PackageEditPage
-          .dropDown.clickDropDownButton()
+          .actionsDropDown.clickDropDownButton()
           .dropDownMenu.removeFromHoldings.click();
       });
 
@@ -272,7 +272,7 @@ describe('CustomPackageEditSelection', () => {
     describe('deselecting the package', () => {
       beforeEach(() => {
         return PackageEditPage
-          .dropDown.clickDropDownButton()
+          .actionsDropDown.clickDropDownButton()
           .dropDownMenu.removeFromHoldings.click();
       });
 

--- a/test/bigtest/tests/custom-package-show-selection-test.js
+++ b/test/bigtest/tests/custom-package-show-selection-test.js
@@ -43,7 +43,7 @@ describe('CustomPackageShowSelection', () => {
     describe('deselecting a custom package', () => {
       beforeEach(() => {
         return PackageShowPage
-          .dropDown.clickDropDownButton()
+          .actionsDropDown.clickDropDownButton()
           .dropDownMenu.removeFromHoldings.click();
       });
 
@@ -93,7 +93,7 @@ describe('CustomPackageShowSelection', () => {
         }, 500);
 
         return PackageShowPage
-          .dropDown.clickDropDownButton()
+          .actionsDropDown.clickDropDownButton()
           .dropDownMenu.removeFromHoldings.click();
       });
 

--- a/test/bigtest/tests/custom-resource-edit-selection-test.js
+++ b/test/bigtest/tests/custom-resource-edit-selection-test.js
@@ -62,7 +62,7 @@ describe('CustomResourceHoldingSelection', () => {
           this.visit(`/eholdings/resources/${resource.titleId}/edit`);
 
           await ResourceEditPage
-            .dropDown.clickDropDownButton()
+            .actionsDropDown.clickDropDownButton()
             .dropDownMenu.clickRemoveFromHoldings();
         });
 
@@ -79,7 +79,7 @@ describe('CustomResourceHoldingSelection', () => {
           this.visit(`/eholdings/resources/${resource.titleId}/edit`);
 
           await ResourceEditPage
-            .dropDown.clickDropDownButton()
+            .actionsDropDown.clickDropDownButton()
             .dropDownMenu.clickRemoveFromHoldings();
         });
 
@@ -114,7 +114,7 @@ describe('CustomResourceHoldingSelection', () => {
           });
 
           await ResourceEditPage
-            .dropDown.clickDropDownButton()
+            .actionsDropDown.clickDropDownButton()
             .dropDownMenu.clickRemoveFromHoldings();
           await ResourceEditPage.modal.confirmDeselection();
         });
@@ -160,7 +160,7 @@ describe('CustomResourceHoldingSelection', () => {
       describe('canceling the save and discontinue deselection', () => {
         beforeEach(async () => {
           await ResourceEditPage
-            .dropDown.clickDropDownButton()
+            .actionsDropDown.clickDropDownButton()
             .dropDownMenu.clickRemoveFromHoldings();
           await ResourceEditPage.modal.cancelDeselection();
         });
@@ -181,7 +181,7 @@ describe('CustomResourceHoldingSelection', () => {
         }, 500);
 
         return ResourceEditPage
-          .dropDown.clickDropDownButton()
+          .actionsDropDown.clickDropDownButton()
           .dropDownMenu.clickRemoveFromHoldings();
       });
 

--- a/test/bigtest/tests/package-selection-test.js
+++ b/test/bigtest/tests/package-selection-test.js
@@ -71,7 +71,7 @@ describe('PackageSelection', () => {
           // the `when` here
           return PackageShowPage
             .when(() => !PackageShowPage.isSelecting)
-            .dropDown.clickDropDownButton()
+            .actionsDropDown.clickDropDownButton()
             .dropDownMenu.removeFromHoldings.click();
         });
 

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -210,7 +210,7 @@ describe('PackageShow', () => {
 
     describe('inspecting the menu', () => {
       beforeEach(() => {
-        return PackageShowPage.dropDown.clickDropDownButton();
+        return PackageShowPage.actionsDropDown.clickDropDownButton();
       });
 
       it('has menu item to add all remaining titles from this packages', () => {

--- a/test/bigtest/tests/resource-deselection-test.js
+++ b/test/bigtest/tests/resource-deselection-test.js
@@ -87,7 +87,7 @@ describe('ResourceDeselection', () => {
 
       describe('deselecting', () => {
         beforeEach(async () => {
-          await ResourcePage.dropDown.clickDropDownButton();
+          await ResourcePage.actionsDropDown.clickDropDownButton();
           await ResourcePage.dropDownMenu.clickRemoveFromHoldings();
         });
 

--- a/test/bigtest/tests/resource-edit-deselection-test.js
+++ b/test/bigtest/tests/resource-edit-deselection-test.js
@@ -48,7 +48,7 @@ describe('ResourceEditDeselection', () => {
     describe('deselecting the resource', () => {
       beforeEach(() => {
         return ResourceShowPage
-          .dropDown.clickDropDownButton()
+          .actionsDropDown.clickDropDownButton()
           .dropDownMenu.clickRemoveFromHoldings();
       });
 

--- a/test/bigtest/tests/resource-edit-managed-title-in-custom-package-test.js
+++ b/test/bigtest/tests/resource-edit-managed-title-in-custom-package-test.js
@@ -61,7 +61,7 @@ describe('ResourceEditManagedTitleInCustomPackage', () => {
     describe('removing a managed resource', () => {
       beforeEach(() => {
         return ResourcePage
-          .dropDown.clickDropDownButton()
+          .actionsDropDown.clickDropDownButton()
           .dropDownMenu.clickRemoveFromHoldings();
       });
 
@@ -108,7 +108,7 @@ describe('ResourceEditManagedTitleInCustomPackage', () => {
         }, 500);
 
         return ResourcePage
-          .dropDown.clickDropDownButton()
+          .actionsDropDown.clickDropDownButton()
           .dropDownMenu.clickRemoveFromHoldings();
       });
 

--- a/test/bigtest/tests/resource-embargo-test.js
+++ b/test/bigtest/tests/resource-embargo-test.js
@@ -146,7 +146,7 @@ describe('ResourceEmbargo', () => {
     describe('removing the title package via drop down', () => {
       beforeEach(() => {
         return ResourceShowPage
-          .dropDown.clickDropDownButton()
+          .actionsDropDown.clickDropDownButton()
           .dropDownMenu.clickRemoveFromHoldings();
       });
 

--- a/test/bigtest/tests/resource-selection-test.js
+++ b/test/bigtest/tests/resource-selection-test.js
@@ -51,12 +51,12 @@ describe('ResourceSelection', () => {
         await ResourcePage.whenLoaded();
         this.server.block();
         await ResourcePage
-          .dropDown.clickDropDownButton()
+          .actionsDropDown.clickDropDownButton()
           .dropDownMenu.clickAddToHoldings();
       });
 
       it('closes the drop down', () => {
-        expect(ResourcePage.dropDown.isExpanded).to.equal('false');
+        expect(ResourcePage.actionsDropDown.isExpanded).to.equal('false');
       });
 
       it('indicates it is working to get to desired state', () => {


### PR DESCRIPTION
## Purpose
- Make it possible to edit selected packages
- Fix related tests to actions drop down button

## Approach
The problem was that the last menu use to check permission `stripes.hasPerm()` instead of component `<IfPermission>`. After PR - [STCOM-553](https://github.com/folio-org/stripes-components/pull/1112) this option doesn't work correctly.

## Link
https://issues.folio.org/browse/UIEH-829

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/73747415-10a67b80-4760-11ea-8e4f-124cc2ae25a1.png)
