### PR TITLE
UIEH-822: View Package Record: Remove Edit/Pencil icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix view of Action button on package view page header (UIEH-829)
 * Remove Actions dropdown from view provider record page. (UIEH-821)
 * Remove Actions dropdown from view custom title record page. (UIEH-824)
+* Remove Edit/Pencil icon from view package record page (UIEH-822)
 
 ## [2.1.0](https://github.com/folio-org/ui-eholdings/tree/v2.1.0) (2019-12-04)
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -556,34 +556,6 @@ class PackageShow extends Component {
     );
   }
 
-  renderLastMenu() {
-    const {
-      model: { name },
-      onEdit,
-    } = this.props;
-    const { packageSelected } = this.state;
-
-    return packageSelected && (
-      <IfPermission perm="ui-eholdings.records.edit">
-        <FormattedMessage
-          id="ui-eholdings.label.editLink"
-          values={{
-            name,
-          }}
-        >
-          {ariaLabel => (
-            <IconButton
-              data-test-eholdings-package-edit-link
-              icon="edit"
-              ariaLabel={ariaLabel}
-              onClick={onEdit}
-            />
-          )}
-        </FormattedMessage>
-      </IfPermission>
-    );
-  }
-
   render() {
     const {
       model,
@@ -661,7 +633,6 @@ class PackageShow extends Component {
           handleExpandAll={this.handleExpandAll}
           searchModal={searchModal}
           bodyContent={this.getBodyContent()}
-          lastMenu={this.renderLastMenu()}
           listType={listTypes.TITLES}
           listSectionId="packageShowTitles"
           onListToggle={this.handleSectionToggle}

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -169,6 +169,7 @@ class PackageShow extends Component {
           <Button
             buttonStyle="dropdownItem fullWidth"
             onClick={onEdit}
+            data-test-eholdings-package-edit-link
           >
             <FormattedMessage id="ui-eholdings.actionMenu.edit" />
           </Button>}

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -22,7 +22,6 @@ import {
   Button,
   Headline,
   Icon,
-  IconButton,
   KeyValue,
   Modal,
   ModalFooter,

--- a/test/bigtest/interactors/package-drop-down-menu.js
+++ b/test/bigtest/interactors/package-drop-down-menu.js
@@ -1,9 +1,11 @@
 import {
   interactor,
-  Interactor
+  Interactor,
+  clickable,
 } from '@bigtest/interactor';
 
 export default @interactor class PackageDropDownMenu {
+  clickEdit = clickable('[data-test-eholdings-package-edit-link]');
   addToHoldings = new Interactor('[data-test-eholdings-package-add-to-holdings-action]');
   removeFromHoldings = new Interactor('[data-test-eholdings-package-remove-from-holdings-action]');
 }

--- a/test/bigtest/interactors/package-show.js
+++ b/test/bigtest/interactors/package-show.js
@@ -65,7 +65,6 @@ import PackageModal from './package-modal';
   clickCollapseAllButton = clickable('[data-test-eholdings-details-view-collapse-all-button] button');
   clickBackButton = clickable('[data-test-eholdings-details-view-back-button]');
   detailsPaneContentScrollHeight = property('[data-test-eholdings-detail-pane-contents]', 'scrollHeight');
-  clickEditButton = clickable('[data-test-eholdings-package-edit-link]');
   actionsDropDown = ActionsDropDown;
   dropDownMenu = new PackageDropDownMenu();
   searchModalBadge = new SearchBadge('[data-test-eholdings-search-modal-badge]');
@@ -110,6 +109,12 @@ import PackageModal from './package-modal';
           top: firstItem.offsetHeight * readOffset
         });
       });
+  });
+
+  clickEditButton = action(function () {
+    return this
+      .actionsDropDown.clickDropDownButton()
+      .dropDownMenu.clickEdit();
   });
 
   titleContainerHeight = property('[data-test-eholdings-details-view-list="package"]', 'offsetHeight');

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -279,16 +279,6 @@ describe('PackageShow', () => {
     it('displays package proxy value', () => {
       expect(PackageShowPage.proxyValue).to.equal('microstates');
     });
-
-    describe('when clicking Edit button', () => {
-      beforeEach(async () => {
-        await PackageShowPage.clickEditButton();
-      });
-
-      it('displays Package Edit page', function () {
-        expect(this.location.pathname).to.equal(`/eholdings/packages/${providerPackage.id}/edit`);
-      });
-    });
   });
 
   describe('visiting a managed package details page with an inherited proxy', () => {

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -244,6 +244,16 @@ describe('PackageShow', () => {
     it('displays package proxy value', () => {
       expect(PackageShowPage.proxyValue).to.equal('microstates');
     });
+
+    describe('when clicking Edit button', () => {
+      beforeEach(async () => {
+        await PackageShowPage.clickEditButton();
+      });
+
+      it('displays Package Edit page', function () {
+        expect(this.location.pathname).to.equal(`/eholdings/packages/${providerPackage.id}/edit`);
+      });
+    });
   });
 
   describe('viewing a custom package details page', () => {
@@ -268,6 +278,16 @@ describe('PackageShow', () => {
 
     it('displays package proxy value', () => {
       expect(PackageShowPage.proxyValue).to.equal('microstates');
+    });
+
+    describe('when clicking Edit button', () => {
+      beforeEach(async () => {
+        await PackageShowPage.clickEditButton();
+      });
+
+      it('displays Package Edit page', function () {
+        expect(this.location.pathname).to.equal(`/eholdings/packages/${providerPackage.id}/edit`);
+      });
     });
   });
 


### PR DESCRIPTION
## Purpose

- Update pane header after [PR](https://github.com/folio-org/stripes-components/pull/1112), since buttons with the same functions are duplicated
- Remove Edit/Pencil icon

## Link

https://issues.folio.org/browse/UIEH-822

## Screenshots

![screen1](https://user-images.githubusercontent.com/19309423/74819823-a5d17480-5309-11ea-9b00-534b4100277c.png)

## Test Coverage

![image](https://user-images.githubusercontent.com/19309423/74747687-ff856080-526f-11ea-9e65-cd4b7df5c468.png)

