### PR TITLE
UIEH-823: Removed edit icon from resource show page

### DIFF
--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -15,7 +15,6 @@ import {
   Accordion,
   Button,
   Headline,
-  IconButton,
   Icon,
   KeyValue,
   Modal,
@@ -137,6 +136,7 @@ class ResourceShow extends Component {
         {canEdit &&
           <Button
             buttonStyle="dropdownItem fullWidth"
+            data-test-eholdings-resource-edit-link
             onClick={onEdit}
           >
             <FormattedMessage id="ui-eholdings.actionMenu.edit" />
@@ -175,36 +175,6 @@ class ResourceShow extends Component {
             <FormattedMessage id="ui-eholdings.resource.actionMenu.addHolding" />
           </Button>
         )
-    );
-  }
-
-  renderLastMenu() {
-    const {
-      model: { name },
-      onEdit,
-    } = this.props;
-    const { resourceSelected } = this.state;
-
-    if (!resourceSelected) return null;
-
-    return (
-      <IfPermission perm="ui-eholdings.records.edit">
-        <FormattedMessage
-          id="ui-eholdings.label.editLink"
-          values={{
-            name,
-          }}
-        >
-          {ariaLabel => (
-            <IconButton
-              data-test-eholdings-resource-edit-link
-              icon="edit"
-              ariaLabel={ariaLabel}
-              onClick={onEdit}
-            />
-          )}
-        </FormattedMessage>
-      </IfPermission>
     );
   }
 
@@ -273,7 +243,6 @@ class ResourceShow extends Component {
           actionMenu={this.getActionMenu()}
           sections={sections}
           handleExpandAll={this.handleExpandAll}
-          lastMenu={this.renderLastMenu()}
           bodyContent={(
             <>
               <TagsAccordion

--- a/test/bigtest/interactors/resource-drop-down-menu.js
+++ b/test/bigtest/interactors/resource-drop-down-menu.js
@@ -4,6 +4,7 @@ import {
 } from '@bigtest/interactor';
 
 export default @interactor class ResourceDropDownMenu {
+  clickEdit = clickable('[data-test-eholdings-resource-edit-link]');
   clickRemoveFromHoldings = clickable('[data-test-eholdings-remove-resource-from-holdings]');
   clickAddToHoldings = clickable('[data-test-eholdings-add-resource-to-holdings]');
 }

--- a/test/bigtest/interactors/resource-show.js
+++ b/test/bigtest/interactors/resource-show.js
@@ -1,4 +1,5 @@
 import {
+  action,
   clickable,
   collection,
   computed,
@@ -78,7 +79,12 @@ import ResourceShowDeselectionModal from './resource-show-deselection-modal';
     return this.isResourceHidden ? this.resourceVisibilityLabel.replace(/^No(\s\((.*)\))?$/, '$2') : '';
   });
 
-  clickEditButton = clickable('[data-test-eholdings-resource-edit-link]');
+  clickEditButton= action(function () {
+    return this
+      .actionsDropDown.clickDropDownButton()
+      .dropDownMenu.clickEdit();
+  });
+
   peerReviewedStatus = text('[data-test-eholdings-peer-reviewed-field]');
 
   toast = Toast;


### PR DESCRIPTION

## Purpose
Due to  this PR https://github.com/folio-org/stripes-components/pull/1112
The purpose of this PR is to:

- Remove the edit icon from the resource show page
- Adopt the test

## Screenshots
![Screenshot 2020-02-18 at 14 17 09](https://user-images.githubusercontent.com/15856488/74735874-3a7c9980-525a-11ea-98ff-c2b23d6714b3.png)
