### PR TITLE
UIEH-841: Settings > eholdings > Access Status Types CRUD sort order should be name

### DIFF
--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -5,6 +5,9 @@ import {
   FormattedMessage,
   FormattedDate,
 } from 'react-intl';
+import {
+  sortBy
+} from 'lodash';
 
 import { IntlConsumer } from '@folio/stripes/core';
 import {
@@ -25,6 +28,7 @@ const SettingsAccessStatusTypes = ({
   onUpdate,
   confirmDelete,
 }) => {
+  debugger;
   const MAX_ACCESS_STATUS_TYPES_COUNT = 15;
 
   const [isConfirmDialogShown, setShowConfirmDialog] = useState(false);
@@ -124,6 +128,8 @@ const SettingsAccessStatusTypes = ({
     return null;
   };
 
+  const getSortedItems = () => sortBy(accessTypesData?.items || [], [(item) => item.attributes.name]);
+
   if (accessTypesData.isDeleted && !!selectedStatusType) {
     // access status type delete successful
     confirmDelete();
@@ -176,7 +182,7 @@ const SettingsAccessStatusTypes = ({
               lastUpdated: intl.formatMessage({ id: 'ui-eholdings.settings.accessStatusTypes.lastUpdated' }),
               records: intl.formatMessage({ id: 'ui-eholdings.settings.accessStatusTypes.records' }),
             }}
-            contentData={accessTypesData?.items || []}
+            contentData={getSortedItems()}
             createButtonLabel={intl.formatMessage({ id: 'ui-eholdings.new' })}
             fieldComponents={{
               name: item => renderField(item, nameValidation),

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -28,7 +28,6 @@ const SettingsAccessStatusTypes = ({
   onUpdate,
   confirmDelete,
 }) => {
-  debugger;
   const MAX_ACCESS_STATUS_TYPES_COUNT = 15;
 
   const [isConfirmDialogShown, setShowConfirmDialog] = useState(false);

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -127,9 +127,7 @@ const SettingsAccessStatusTypes = ({
     return null;
   };
 
-  const getSortedItems = () => {
-    return sortBy(accessTypesData?.items || [], [(item) => item.attributes.name.toLowerCase()]);
-  };
+  const sortedItems = sortBy(accessTypesData?.items || [], [(item) => item.attributes.name.toLowerCase()]);
 
   if (accessTypesData.isDeleted && !!selectedStatusType) {
     // access status type delete successful
@@ -183,7 +181,7 @@ const SettingsAccessStatusTypes = ({
               lastUpdated: intl.formatMessage({ id: 'ui-eholdings.settings.accessStatusTypes.lastUpdated' }),
               records: intl.formatMessage({ id: 'ui-eholdings.settings.accessStatusTypes.records' }),
             }}
-            contentData={getSortedItems()}
+            contentData={sortedItems}
             createButtonLabel={intl.formatMessage({ id: 'ui-eholdings.new' })}
             fieldComponents={{
               name: item => renderField(item, nameValidation),

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -127,7 +127,9 @@ const SettingsAccessStatusTypes = ({
     return null;
   };
 
-  const getSortedItems = () => sortBy(accessTypesData?.items || [], [(item) => item.attributes.name]);
+  const getSortedItems = () => {
+    return sortBy(accessTypesData?.items || [], [(item) => item.attributes.name.toLowerCase()])
+  };
 
   if (accessTypesData.isDeleted && !!selectedStatusType) {
     // access status type delete successful

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -128,7 +128,7 @@ const SettingsAccessStatusTypes = ({
   };
 
   const getSortedItems = () => {
-    return sortBy(accessTypesData?.items || [], [(item) => item.attributes.name.toLowerCase()])
+    return sortBy(accessTypesData?.items || [], [(item) => item.attributes.name.toLowerCase()]);
   };
 
   if (accessTypesData.isDeleted && !!selectedStatusType) {


### PR DESCRIPTION

## Purpose
In this PR the sorting for the access statuses was added according to https://issues.folio.org/browse/UIEH-841