### PR TITLE
UIEH-854: Edit Package Record | Proxy selection is not honored and Unsaved Changes modal does not display when you edit a record for the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix Unsaved Changes Modal not appearing after changing selected status. (UIEH-854)
 * Fix need to click 'X' twice to return after changing selected status and visiting Edit page. (UIEH-854)
+* Fix Proxy selection is set to None when package has Inherited proxy. (UIEH-854)
 
 ## [3.0.0] (https://github.com/folio-org/ui-eholdings/tree/v3.0.0) (2020-03-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-eholdings
 
+## [3.1.0] (IN PROGRESS)
+
+* Fix Unsaved Changes Modal not appearing after changing selected status. (UIEH-854)
+* Fix need to click 'X' twice to return after changing selected status and visiting Edit page. (UIEH-854)
+
 ## [3.0.0] (https://github.com/folio-org/ui-eholdings/tree/v3.0.0) (2020-03-13)
 
 * Add display custom labels on view resource page (UIEH-805)

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -93,7 +93,6 @@ class CustomPackageEdit extends Component {
     const {
       isSelected,
       destroy,
-      proxy,
     } = nextProps.model;
     const { proxyTypes, provider } = nextProps;
 

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -24,6 +24,8 @@ import {
 import {
   processErrors,
   getAccessTypeId,
+  getProxyTypesRecords,
+  getProxyTypeById,
 } from '../../utilities';
 
 
@@ -54,8 +56,8 @@ class CustomPackageEdit extends Component {
       visibilityData,
     } = model;
 
-    const proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
-    const matchingProxy = Object.values(proxyTypesRecords).find(proxyType => proxyType.id.toLowerCase() === proxy.id);
+    const proxyTypesRecords = getProxyTypesRecords(proxyTypes);
+    const matchingProxy = getProxyTypeById(proxyTypesRecords, proxy.id);
 
     return {
       name,

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -91,7 +91,7 @@ class CustomPackageEdit extends Component {
 
   static getDerivedStateFromProps(nextProps, prevState) {
     let stateUpdates = {};
-    const { initialValues, proxyTypesLoaded } = prevState;
+    const { initialValues, wasProxyTypesLoaded } = prevState;
     const {
       isSelected,
       destroy,
@@ -108,10 +108,10 @@ class CustomPackageEdit extends Component {
       };
     }
 
-    if (isProxyTypesLoaded && !proxyTypesLoaded) {
+    if (isProxyTypesLoaded && !wasProxyTypesLoaded) {
       stateUpdates = {
         initialValues: CustomPackageEdit.getInitialValues(nextProps.model, proxyTypes),
-        proxyTypesLoaded: true,
+        wasProxyTypesLoaded: true,
       };
     }
 
@@ -128,7 +128,7 @@ class CustomPackageEdit extends Component {
       showSelectionModal: false,
       allowFormToSubmit: false,
       packageSelected: this.props.model.isSelected,
-      proxyTypesLoaded: this.props.proxyTypes.request.isResolved,
+      wasProxyTypesLoaded: this.props.proxyTypes.request.isResolved,
       formValues: {},
       initialValues: CustomPackageEdit.getInitialValues(this.props.model, this.props.proxyTypes),
       sections: {

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -70,6 +70,10 @@ class CustomPackageEdit extends Component {
     };
   }
 
+  static isProxyTypesLoaded(proxyTypes, provider) {
+    return proxyTypes.request.isResolved && provider.data.isLoaded;
+  }
+
   static propTypes = {
     accessStatusTypes: accessTypesReduxStateShape.isRequired,
     addPackageToHoldings: PropTypes.func.isRequired,
@@ -83,13 +87,9 @@ class CustomPackageEdit extends Component {
     }),
   };
 
-  static isProxyTypesLoaded (proxyTypes, provider) {
-    return proxyTypes.request.isResolved && provider.data.isLoaded;
-  }
-
   static getDerivedStateFromProps(nextProps, prevState) {
     let stateUpdates = {};
-    const { initialValues } = prevState;
+    const { initialValues, proxyTypesLoaded } = prevState;
     const {
       isSelected,
       destroy,
@@ -107,7 +107,7 @@ class CustomPackageEdit extends Component {
       };
     }
 
-    if (isProxyTypesLoaded) {
+    if (isProxyTypesLoaded && !proxyTypesLoaded) {
       stateUpdates = {
         initialValues: CustomPackageEdit.getInitialValues(nextProps.model, proxyTypes),
         proxyTypesLoaded: true,

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -68,6 +68,10 @@ class ManagedPackageEdit extends Component {
     };
   }
 
+  static isProxyTypesLoaded(proxyTypes, provider) {
+    return proxyTypes.request.isResolved && provider.data.isLoaded;
+  }
+
   static propTypes = {
     accessStatusTypes: accessTypesReduxStateShape.isRequired,
     addPackageToHoldings: PropTypes.func.isRequired,
@@ -81,13 +85,9 @@ class ManagedPackageEdit extends Component {
     }),
   };
 
-  static isProxyTypesLoaded (proxyTypes, provider) {
-    return proxyTypes.request.isResolved && provider.data.isLoaded;
-  }
-
   static getDerivedStateFromProps(nextProps, prevState) {
     let stateUpdates = {};
-    const { initialValues } = prevState;
+    const { initialValues, proxyTypesLoaded } = prevState;
     const {
       model: {
         isSelected,
@@ -108,7 +108,7 @@ class ManagedPackageEdit extends Component {
       };
     }
 
-    if (isProxyTypesLoaded) {
+    if (isProxyTypesLoaded && !proxyTypesLoaded) {
       stateUpdates = {
         initialValues: ManagedPackageEdit.getInitialValues(nextProps.model, nextProps.provider, proxyTypes),
         proxyTypesLoaded: true,

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -89,7 +89,7 @@ class ManagedPackageEdit extends Component {
 
   static getDerivedStateFromProps(nextProps, prevState) {
     let stateUpdates = {};
-    const { initialValues, proxyTypesLoaded } = prevState;
+    const { initialValues, wasProxyTypesLoaded } = prevState;
     const {
       model: {
         isSelected,
@@ -110,10 +110,10 @@ class ManagedPackageEdit extends Component {
       };
     }
 
-    if (isProxyTypesLoaded && !proxyTypesLoaded) {
+    if (isProxyTypesLoaded && !wasProxyTypesLoaded) {
       stateUpdates = {
         initialValues: ManagedPackageEdit.getInitialValues(nextProps.model, nextProps.provider, proxyTypes),
-        proxyTypesLoaded: true,
+        wasProxyTypesLoaded: true,
       };
     }
 
@@ -130,7 +130,7 @@ class ManagedPackageEdit extends Component {
       showSelectionModal: false,
       allowFormToSubmit: false,
       packageSelected: this.props.model.isSelected,
-      proxyTypesLoaded: this.props.proxyTypes.request.isResolved,
+      wasProxyTypesLoaded: this.props.proxyTypes.request.isResolved,
       formValues: {},
       initialValues: ManagedPackageEdit.getInitialValues(this.props.model, this.props.provider, this.props.proxyTypes),
       sections: {

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -23,6 +23,8 @@ import {
 import {
   processErrors,
   getAccessTypeId,
+  getProxyTypesRecords,
+  getProxyTypeById,
 } from '../../utilities';
 
 import DetailsView from '../../details-view';
@@ -51,8 +53,8 @@ class ManagedPackageEdit extends Component {
       allowKbToAddTitles,
     } = model;
 
-    const proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
-    const matchingProxy = Object.values(proxyTypesRecords).find(proxyType => proxyType.id.toLowerCase() === proxy.id);
+    const proxyTypesRecords = getProxyTypesRecords(proxyTypes);
+    const matchingProxy = getProxyTypeById(proxyTypesRecords, proxy.id);
 
     return {
       isSelected,

--- a/src/components/proxy-select/proxy-select-field.js
+++ b/src/components/proxy-select/proxy-select-field.js
@@ -5,8 +5,10 @@ import { FormattedMessage } from 'react-intl';
 
 import { Select } from '@folio/stripes/components';
 
+import { getProxyTypesRecords } from '../utilities';
+
 function ProxySelectField({ proxyTypes, inheritedProxyId }) {
-  const proxyTypesRecords = proxyTypes.resolver.state.proxyTypes.records;
+  const proxyTypesRecords = getProxyTypesRecords(proxyTypes);
 
   const checkIfInherited = proxyTypeId => (inheritedProxyId && inheritedProxyId.toLowerCase() === proxyTypeId.toLowerCase());
 

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -124,6 +124,18 @@ export const getAccessTypeIdsAndNames = accessTypes => accessTypes.map(accessTyp
 }));
 
 /**
+ * Getter helper to get object with shape { proxyId: proxyType }
+ * @param {Object} proxyTypes - proxyTypes object returned by resolver
+ */
+export const getProxyTypesRecords = proxyTypes => proxyTypes?.resolver?.state?.proxyTypes?.records || {};
+
+/**
+ * Getter helper to get proxy type by id, ignoring case
+ * @param {Object} proxyTypesRecords - proxy types object with shape { proxyId: proxyType }
+ */
+export const getProxyTypeById = (proxyTypesRecords, id) => Object.values(proxyTypesRecords).find(proxyType => proxyType.id.toLowerCase() === id);
+
+/**
  *
  * @param {Object} entityModel - entity model that has tags attibute as tags:{taglist:[]}
  */

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -49,8 +49,6 @@ class ResourceShowRoute extends Component {
 
   componentDidUpdate(prevProps) {
     const wasUpdated = !this.props.model.update.isPending && prevProps.model.update.isPending && (!this.props.model.update.errors.length > 0);
-    const { changedAttributes } = this.props.model.update;
-    const isSelectedUpdated = changedAttributes?.isSelected?.prev !== changedAttributes?.isSelected?.next;
 
     const { match, getResource, history, location } = this.props;
     const { id } = match.params;
@@ -61,10 +59,8 @@ class ResourceShowRoute extends Component {
         { eholdings: true, isDestroyed: true });
     }
 
-    // no need to open View Resource page after adding/removing from holdings
-    // since we're already on it
-    if (wasUpdated && !isSelectedUpdated) {
-      history.push({
+    if (wasUpdated) {
+      history.replace({
         pathname: `/eholdings/resources/${this.props.model.id}`,
         search: location.search,
         state: { eholdings: true, isFreshlySaved: true }

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -49,6 +49,9 @@ class ResourceShowRoute extends Component {
 
   componentDidUpdate(prevProps) {
     const wasUpdated = !this.props.model.update.isPending && prevProps.model.update.isPending && (!this.props.model.update.errors.length > 0);
+    const { changedAttributes } = this.props.model.update;
+    const isSelectedUpdated = changedAttributes?.isSelected?.prev !== changedAttributes?.isSelected?.next;
+
     const { match, getResource, history, location } = this.props;
     const { id } = match.params;
 
@@ -58,7 +61,9 @@ class ResourceShowRoute extends Component {
         { eholdings: true, isDestroyed: true });
     }
 
-    if (wasUpdated) {
+    // no need to open View Resource page after adding/removing from holdings
+    // since we're already on it
+    if (wasUpdated && !isSelectedUpdated) {
       history.push({
         pathname: `/eholdings/resources/${this.props.model.id}`,
         search: location.search,

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -312,7 +312,16 @@ export default function config() {
           name: 'microstates',
           urlMask: 'https://github.com/microstates',
         }
-      }
+      },
+      {
+        id: 'EZproxy',
+        type: 'proxyTypes',
+        attributes: {
+          id: 'EZproxy',
+          name: 'EZproxy',
+          urlMask: 'https://github.com/ezproxy',
+        }
+      },
     ]
   });
 

--- a/test/bigtest/network/factories/proxy.js
+++ b/test/bigtest/network/factories/proxy.js
@@ -4,7 +4,8 @@ export default Factory.extend({
   id: () => faker.random.arrayElement([
     '<n>',
     'bigTestJS',
-    'microstates'
+    'microstates',
+    'EZproxy',
   ]),
   inherited: true
 });

--- a/test/bigtest/tests/custom-package-edit-proxy-test.js
+++ b/test/bigtest/tests/custom-package-edit-proxy-test.js
@@ -33,6 +33,21 @@ describe('CustomPackageEditProxy', () => {
       expect(PackageEditPage.proxySelectValue).to.equal('microstates');
     });
 
+    describe('when inherited proxy id has different casing', () => {
+      beforeEach(function () {
+        const proxy = this.server.create('proxy', {
+          id: 'ezproxy',
+        });
+
+        providerPackage.update('proxy', proxy.toJSON());
+        this.visit(`/eholdings/packages/${providerPackage.id}/edit`);
+      });
+
+      it('has a select containing the current proxy value', () => {
+        expect(PackageEditPage.proxySelectValue).to.equal('EZproxy');
+      });
+    });
+
     describe('selecting a new proxy value', () => {
       beforeEach(() => {
         return PackageEditPage.chooseProxy('Inherited - bigTestJS');

--- a/test/bigtest/tests/managed-package-edit-proxy-test.js
+++ b/test/bigtest/tests/managed-package-edit-proxy-test.js
@@ -42,7 +42,9 @@ describe('ManagedPackageEditProxy', () => {
         this.visit(`/eholdings/packages/${providerPackage.id}/edit`);
       });
 
-      it('has a select containing the current proxy value')
+      it('has a select containing the current proxy value', () => {
+        expect(PackageEditPage.proxySelectValue).to.equal('EZproxy');
+      });
     });
 
     describe('selecting a new proxy value', () => {

--- a/test/bigtest/tests/managed-package-edit-proxy-test.js
+++ b/test/bigtest/tests/managed-package-edit-proxy-test.js
@@ -32,6 +32,19 @@ describe('ManagedPackageEditProxy', () => {
       expect(PackageEditPage.proxySelectValue).to.equal('microstates');
     });
 
+    describe('when inherited proxy id has different casing', () => {
+      beforeEach(function () {
+        const proxy = this.server.create('proxy', {
+          id: 'ezproxy',
+        });
+
+        providerPackage.update('proxy', proxy.toJSON());
+        this.visit(`/eholdings/packages/${providerPackage.id}/edit`);
+      });
+
+      it('has a select containing the current proxy value')
+    });
+
     describe('selecting a new proxy value', () => {
       beforeEach(() => {
         return PackageEditPage.chooseProxy('Inherited - bigTestJS');

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 
 import setupApplication from '../helpers/setup-application';
 import PackageShowPage from '../interactors/package-show';
+import PackageEditPage from '../interactors/package-edit';
 import { entityAuthorityTypes } from '../../../src/constants';
 
 describe('PackageShow', () => {
@@ -523,6 +524,21 @@ describe('PackageShow', () => {
 
     it('should display the back button in UI', () => {
       expect(PackageShowPage.hasBackButton).to.be.true;
+    });
+  });
+
+  describe('toggling is selected successfully', () => {
+    beforeEach(async function () {
+      this.visit(`/eholdings/packages/${providerPackage.id}`);
+
+      await PackageShowPage.selectPackage();
+      await PackageShowPage.clickEditButton();
+      await PackageEditPage.chooseProxy('microstates');
+      return PackageEditPage.clickBackButton();
+    });
+
+    it('shows a navigation confirmation modal', () => {
+      expect(PackageEditPage.navigationModal.$root).to.exist;
     });
   });
 

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -295,6 +295,16 @@ describe('ResourceShow', () => {
       expect(ResourcePage.hasBackButton).to.be.true;
     });
 
+    describe('toggling is selected successfully', () => {
+      beforeEach(() => {
+        return ResourcePage.clickAddToHoldingsButton();
+      });
+
+      it('should not redirect to Resource Show page', function () {
+        expect(this.location.state?.isFreshlySaved).to.not.be.true;
+      });
+    });
+
     describe('toggling is selected with errors', () => {
       beforeEach(function () {
         this.server.put('/resources/:id', {

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -300,8 +300,14 @@ describe('ResourceShow', () => {
         return ResourcePage.clickAddToHoldingsButton();
       });
 
-      it('should not redirect to Resource Show page', function () {
-        expect(this.location.state?.isFreshlySaved).to.not.be.true;
+      describe('and clicking Back button', () => {
+        beforeEach(() => {
+          return ResourcePage.clickBackButton();
+        });
+
+        it('should not return to same page', function () {
+          expect(this.location.pathname).to.not.equal(`/eholdings/resources/${resource.id}`);
+        });
       });
     });
 


### PR DESCRIPTION
## Purpose

- Fix Unsaved Changes Modal not appearing after changing selected status of package.
- Fix need to click 'X' twice to return after changing selected status of resource and visiting Edit page.

## Issue

[UIEH-854](https://issues.folio.org/browse/UIEH-854)

## Coverage

![image](https://user-images.githubusercontent.com/19309423/77556175-d08e8a00-6ec0-11ea-8123-d91eaf800737.png)

