### PR TITLE
UIEH-831: implement access types for packages

### DIFF
--- a/src/components/access-type-display/access-type-display.js
+++ b/src/components/access-type-display/access-type-display.js
@@ -16,7 +16,7 @@ function AccessTypeDisplay({ accessTypeId, accessStatusTypes }) {
     .find(accessType => accessType.id === accessTypeId)?.name || '';
 
   return (
-    <KeyValue label={<FormattedMessage id="ui-eholdings.settings.accessStatusTypes" />}>
+    <KeyValue label={<FormattedMessage id="ui-eholdings.settings.accessStatusTypes.type" />}>
       <div data-test-eholdings-details-access-type>
         {accessTypeId
           ? selectedAccessType

--- a/src/components/access-type-edit-section/access-type-edit-section.js
+++ b/src/components/access-type-edit-section/access-type-edit-section.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { Icon } from '@folio/stripes/components';
 
@@ -8,13 +7,10 @@ import {
   getAccessTypeIdsAndNames,
 } from '../utilities';
 
+import { accessTypesReduxStateShape } from '../../constants';
+
 const propTypes = {
-  accessStatusTypes: PropTypes.shape({
-    isLoading: PropTypes.bool.isRequired,
-    items: PropTypes.shape({
-      data: PropTypes.array.isRequired,
-    }).isRequired,
-  }).isRequired,
+  accessStatusTypes: accessTypesReduxStateShape.isRequired,
 };
 
 const AccessStatusTypeEditSection = ({ accessStatusTypes }) => {

--- a/src/components/access-type-edit-section/access-type-edit-section.js
+++ b/src/components/access-type-edit-section/access-type-edit-section.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Icon } from '@folio/stripes/components';
+
+import AccessTypeField from '../access-type-select';
+import {
+  getAccessTypeIdsAndNames,
+} from '../utilities';
+
+const propTypes = {
+  accessStatusTypes: PropTypes.shape({
+    isLoading: PropTypes.bool.isRequired,
+    items: PropTypes.shape({
+      data: PropTypes.array.isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+const AccessStatusTypeEditSection = ({ accessStatusTypes }) => {
+  if (!accessStatusTypes?.items?.data?.length) {
+    return null;
+  }
+
+  const formattedAccessTypes = getAccessTypeIdsAndNames(accessStatusTypes.items.data);
+
+  return accessStatusTypes.isLoading
+    ? <Icon icon="spinner-ellipsis" />
+    : (
+      <div data-test-eholdings-access-types-select>
+        <AccessTypeField accessStatusTypes={formattedAccessTypes} />
+      </div>
+    );
+};
+
+AccessStatusTypeEditSection.propTypes = propTypes;
+
+export default AccessStatusTypeEditSection;

--- a/src/components/access-type-edit-section/index.js
+++ b/src/components/access-type-edit-section/index.js
@@ -1,0 +1,1 @@
+export { default } from './access-type-edit-section';

--- a/src/components/access-type-select/access-type-select-field.js
+++ b/src/components/access-type-select/access-type-select-field.js
@@ -39,7 +39,7 @@ function AccessTypeSelectField({ accessStatusTypes }) {
         id="eholdings-access-type-id"
         name="accessTypeId"
         component={Select}
-        label={<FormattedMessage id="ui-eholdings.settings.accessStatusTypes" />}
+        label={<FormattedMessage id="ui-eholdings.settings.accessStatusTypes.type" />}
       >
         {options}
       </Field>

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -22,6 +22,8 @@ import AccessTypeEditSection from '../../access-type-edit-section';
 
 import Toaster from '../../toaster';
 
+import { accessTypesReduxStateShape } from '../../../constants';
+
 import styles from './package-create.css';
 
 const initialValues = {
@@ -35,12 +37,7 @@ const paneTitle = <FormattedMessage id="ui-eholdings.package.create.custom" />;
 
 export default class PackageCreate extends Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
     removeCreateRequests: PropTypes.func.isRequired,

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -11,14 +11,19 @@ import {
   Pane,
   Paneset,
   PaneFooter,
+  Icon,
 } from '@folio/stripes/components';
 
+import AccessTypeField from '../../access-type-select';
 import DetailsViewSection from '../../details-view-section';
 import NameField from '../_fields/name';
 import CoverageFields from '../_fields/custom-coverage';
 import ContentTypeField from '../_fields/content-type';
 import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
+
+import { getAccessTypeIdsAndNames } from '../../utilities';
+
 import styles from './package-create.css';
 
 const initialValues = {
@@ -32,6 +37,12 @@ const paneTitle = <FormattedMessage id="ui-eholdings.package.create.custom" />;
 
 export default class PackageCreate extends Component {
   static propTypes = {
+    accessStatusTypes: PropTypes.shape({
+      isLoading: PropTypes.bool.isRequired,
+      items: PropTypes.shape({
+        data: PropTypes.array.isRequired,
+      }).isRequired,
+    }).isRequired,
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
     removeCreateRequests: PropTypes.func.isRequired,
@@ -99,10 +110,27 @@ export default class PackageCreate extends Component {
       : null;
   }
 
+  renderAccessTypeSelectField = () => {
+    const { accessStatusTypes } = this.props;
+
+    if (!accessStatusTypes?.items?.data?.length) {
+      return null;
+    }
+
+    const formattedAccessTypes = getAccessTypeIdsAndNames(accessStatusTypes.items.data);
+
+    return (
+      <div data-test-eholdings-access-types-select>
+        <AccessTypeField accessStatusTypes={formattedAccessTypes} />
+      </div>
+    );
+  }
+
   render() {
     const {
       request,
       onSubmit,
+      accessStatusTypes,
     } = this.props;
 
     return (
@@ -137,6 +165,10 @@ export default class PackageCreate extends Component {
                   >
                     <NameField />
                     <ContentTypeField />
+                    {accessStatusTypes.isLoading
+                      ? <Icon icon="spinner-ellipsis" />
+                      : this.renderAccessTypeSelectField()
+                    }
                   </DetailsViewSection>
                   <DetailsViewSection
                     label={<FormattedMessage id="ui-eholdings.label.coverageSettings" />}

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -11,18 +11,16 @@ import {
   Pane,
   Paneset,
   PaneFooter,
-  Icon,
 } from '@folio/stripes/components';
 
-import AccessTypeField from '../../access-type-select';
 import DetailsViewSection from '../../details-view-section';
 import NameField from '../_fields/name';
 import CoverageFields from '../_fields/custom-coverage';
 import ContentTypeField from '../_fields/content-type';
 import NavigationModal from '../../navigation-modal';
-import Toaster from '../../toaster';
+import AccessTypeEditSection from '../../access-type-edit-section';
 
-import { getAccessTypeIdsAndNames } from '../../utilities';
+import Toaster from '../../toaster';
 
 import styles from './package-create.css';
 
@@ -110,22 +108,6 @@ export default class PackageCreate extends Component {
       : null;
   }
 
-  renderAccessTypeSelectField = () => {
-    const { accessStatusTypes } = this.props;
-
-    if (!accessStatusTypes?.items?.data?.length) {
-      return null;
-    }
-
-    const formattedAccessTypes = getAccessTypeIdsAndNames(accessStatusTypes.items.data);
-
-    return (
-      <div data-test-eholdings-access-types-select>
-        <AccessTypeField accessStatusTypes={formattedAccessTypes} />
-      </div>
-    );
-  }
-
   render() {
     const {
       request,
@@ -165,10 +147,7 @@ export default class PackageCreate extends Component {
                   >
                     <NameField />
                     <ContentTypeField />
-                    {accessStatusTypes.isLoading
-                      ? <Icon icon="spinner-ellipsis" />
-                      : this.renderAccessTypeSelectField()
-                    }
+                    <AccessTypeEditSection accessStatusTypes={accessStatusTypes} />
                   </DetailsViewSection>
                   <DetailsViewSection
                     label={<FormattedMessage id="ui-eholdings.label.coverageSettings" />}

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -37,6 +37,8 @@ import SelectionStatus from '../selection-status';
 import ProxySelectField from '../../proxy-select';
 import AccessTypeEditSection from '../../access-type-edit-section';
 
+import { accessTypesReduxStateShape } from '../../../constants';
+
 import styles from './custom-package-edit.css';
 
 const focusOnErrors = createFocusDecorator();
@@ -66,12 +68,7 @@ class CustomPackageEdit extends Component {
   }
 
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     addPackageToHoldings: PropTypes.func.isRequired,
     model: PropTypes.object.isRequired,
     onCancel: PropTypes.func.isRequired,

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -302,9 +302,7 @@ class CustomPackageEdit extends Component {
                       onToggle={this.toggleSection}
                     >
                       {packageSelected
-                        ? (
-                          <NameField />
-                        )
+                        ? <NameField />
                         : (
                           <KeyValue label={<FormattedMessage id="ui-eholdings.package.name" />}>
                             <div data-test-eholdings-package-readonly-name-field>
@@ -314,9 +312,7 @@ class CustomPackageEdit extends Component {
                         )}
 
                       {packageSelected
-                        ? (
-                          <ContentTypeField />
-                        )
+                        ? <ContentTypeField />
                         : (
                           <KeyValue label={<FormattedMessage id="ui-eholdings.package.contentType" />}>
                             <div data-test-eholdings-package-details-readonly-content-type>

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -24,7 +24,6 @@ import {
 import {
   processErrors,
   getAccessTypeId,
-  getAccessTypeIdsAndNames,
 } from '../../utilities';
 
 
@@ -36,7 +35,8 @@ import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 import SelectionStatus from '../selection-status';
 import ProxySelectField from '../../proxy-select';
-import AccessTypeField from '../../access-type-select';
+import AccessTypeEditSection from '../../access-type-edit-section';
+
 import styles from './custom-package-edit.css';
 
 const focusOnErrors = createFocusDecorator();
@@ -247,22 +247,6 @@ class CustomPackageEdit extends Component {
     );
   }
 
-  renderAccessTypeSelectField = () => {
-    const { accessStatusTypes } = this.props;
-
-    if (!accessStatusTypes?.items?.data?.length) {
-      return null;
-    }
-
-    const formattedAccessTypes = getAccessTypeIdsAndNames(accessStatusTypes.items.data);
-
-    return (
-      <div data-test-eholdings-access-types-select>
-        <AccessTypeField accessStatusTypes={formattedAccessTypes} />
-      </div>
-    );
-  }
-
   render() {
     const {
       model,
@@ -343,10 +327,7 @@ class CustomPackageEdit extends Component {
                             </div>
                           </KeyValue>
                         )}
-                      {accessStatusTypes.isLoading
-                        ? <Icon icon="spinner-ellipsis" />
-                        : this.renderAccessTypeSelectField()
-                      }
+                      <AccessTypeEditSection accessStatusTypes={accessStatusTypes} />
                     </Accordion>
 
                     <Accordion

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -21,7 +21,12 @@ import {
   PaneFooter,
 } from '@folio/stripes/components';
 
-import { processErrors } from '../../utilities';
+import {
+  processErrors,
+  getAccessTypeId,
+  getAccessTypeIdsAndNames,
+} from '../../utilities';
+
 
 import DetailsView from '../../details-view';
 import NameField from '../_fields/name';
@@ -31,6 +36,7 @@ import NavigationModal from '../../navigation-modal';
 import Toaster from '../../toaster';
 import SelectionStatus from '../selection-status';
 import ProxySelectField from '../../proxy-select';
+import AccessTypeField from '../../access-type-select';
 import styles from './custom-package-edit.css';
 
 const focusOnErrors = createFocusDecorator();
@@ -55,10 +61,17 @@ class CustomPackageEdit extends Component {
       }],
       proxyId: proxy.id,
       isVisible: !visibilityData.isHidden,
+      accessTypeId: getAccessTypeId(model),
     };
   }
 
   static propTypes = {
+    accessStatusTypes: PropTypes.shape({
+      isLoading: PropTypes.bool.isRequired,
+      items: PropTypes.shape({
+        data: PropTypes.array.isRequired,
+      }).isRequired,
+    }).isRequired,
     addPackageToHoldings: PropTypes.func.isRequired,
     model: PropTypes.object.isRequired,
     onCancel: PropTypes.func.isRequired,
@@ -234,12 +247,29 @@ class CustomPackageEdit extends Component {
     );
   }
 
+  renderAccessTypeSelectField = () => {
+    const { accessStatusTypes } = this.props;
+
+    if (!accessStatusTypes?.items?.data?.length) {
+      return null;
+    }
+
+    const formattedAccessTypes = getAccessTypeIdsAndNames(accessStatusTypes.items.data);
+
+    return (
+      <div data-test-eholdings-access-types-select>
+        <AccessTypeField accessStatusTypes={formattedAccessTypes} />
+      </div>
+    );
+  }
+
   render() {
     const {
       model,
       proxyTypes,
       provider,
       onCancel,
+      accessStatusTypes,
     } = this.props;
 
     const {
@@ -290,25 +320,33 @@ class CustomPackageEdit extends Component {
                       id="packageInfo"
                       onToggle={this.toggleSection}
                     >
-                      {packageSelected ? (
-                        <NameField />
-                      ) : (
-                        <KeyValue label={<FormattedMessage id="ui-eholdings.package.name" />}>
-                          <div data-test-eholdings-package-readonly-name-field>
-                            {model.name}
-                          </div>
-                        </KeyValue>
-                      )}
+                      {packageSelected
+                        ? (
+                          <NameField />
+                        )
+                        : (
+                          <KeyValue label={<FormattedMessage id="ui-eholdings.package.name" />}>
+                            <div data-test-eholdings-package-readonly-name-field>
+                              {model.name}
+                            </div>
+                          </KeyValue>
+                        )}
 
-                      {packageSelected ? (
-                        <ContentTypeField />
-                      ) : (
-                        <KeyValue label={<FormattedMessage id="ui-eholdings.package.contentType" />}>
-                          <div data-test-eholdings-package-details-readonly-content-type>
-                            {model.contentType}
-                          </div>
-                        </KeyValue>
-                      )}
+                      {packageSelected
+                        ? (
+                          <ContentTypeField />
+                        )
+                        : (
+                          <KeyValue label={<FormattedMessage id="ui-eholdings.package.contentType" />}>
+                            <div data-test-eholdings-package-details-readonly-content-type>
+                              {model.contentType}
+                            </div>
+                          </KeyValue>
+                        )}
+                      {accessStatusTypes.isLoading
+                        ? <Icon icon="spinner-ellipsis" />
+                        : this.renderAccessTypeSelectField()
+                      }
                     </Accordion>
 
                     <Accordion

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -34,6 +34,8 @@ import ProxySelectField from '../../proxy-select';
 import TokenField from '../../token';
 import AccessTypeEditSection from '../../access-type-edit-section';
 
+import { accessTypesReduxStateShape } from '../../../constants';
+
 import styles from './managed-package-edit.css';
 
 const focusOnErrors = createFocusDecorator();
@@ -64,12 +66,7 @@ class ManagedPackageEdit extends Component {
   }
 
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     addPackageToHoldings: PropTypes.func.isRequired,
     model: PropTypes.object.isRequired,
     onCancel: PropTypes.func.isRequired,

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -23,7 +23,6 @@ import {
 import {
   processErrors,
   getAccessTypeId,
-  getAccessTypeIdsAndNames,
 } from '../../utilities';
 
 import DetailsView from '../../details-view';
@@ -33,7 +32,7 @@ import Toaster from '../../toaster';
 import SelectionStatus from '../selection-status';
 import ProxySelectField from '../../proxy-select';
 import TokenField from '../../token';
-import AccessTypeField from '../../access-type-select';
+import AccessTypeEditSection from '../../access-type-edit-section';
 
 import styles from './managed-package-edit.css';
 
@@ -298,22 +297,6 @@ class ManagedPackageEdit extends Component {
     );
   }
 
-  renderAccessTypeSelectField = () => {
-    const { accessStatusTypes } = this.props;
-
-    if (!accessStatusTypes?.items?.data?.length) {
-      return null;
-    }
-
-    const formattedAccessTypes = getAccessTypeIdsAndNames(accessStatusTypes.items.data);
-
-    return (
-      <div data-test-eholdings-access-types-select>
-        <AccessTypeField accessStatusTypes={formattedAccessTypes} />
-      </div>
-    );
-  }
-
   render() {
     const {
       model,
@@ -467,10 +450,7 @@ class ManagedPackageEdit extends Component {
                             ) : (
                               <Icon icon="spinner-ellipsis" />
                             )}
-                            {accessStatusTypes.isLoading
-                              ? <Icon icon="spinner-ellipsis" />
-                              : this.renderAccessTypeSelectField()
-                            }
+                            <AccessTypeEditSection accessStatusTypes={accessStatusTypes} />
                             {supportsProviderTokens && (
                               <fieldset>
                                 <Headline tag="legend">

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -20,7 +20,11 @@ import {
   PaneFooter,
 } from '@folio/stripes/components';
 
-import { processErrors } from '../../utilities';
+import {
+  processErrors,
+  getAccessTypeId,
+  getAccessTypeIdsAndNames,
+} from '../../utilities';
 
 import DetailsView from '../../details-view';
 import CoverageFields from '../_fields/custom-coverage';
@@ -29,6 +33,8 @@ import Toaster from '../../toaster';
 import SelectionStatus from '../selection-status';
 import ProxySelectField from '../../proxy-select';
 import TokenField from '../../token';
+import AccessTypeField from '../../access-type-select';
+
 import styles from './managed-package-edit.css';
 
 const focusOnErrors = createFocusDecorator();
@@ -54,10 +60,17 @@ class ManagedPackageEdit extends Component {
       packageTokenValue: packageToken.value,
       isVisible: !visibilityData.isHidden,
       allowKbToAddTitles,
+      accessTypeId: getAccessTypeId(model),
     };
   }
 
   static propTypes = {
+    accessStatusTypes: PropTypes.shape({
+      isLoading: PropTypes.bool.isRequired,
+      items: PropTypes.shape({
+        data: PropTypes.array.isRequired,
+      }).isRequired,
+    }).isRequired,
     addPackageToHoldings: PropTypes.func.isRequired,
     model: PropTypes.object.isRequired,
     onCancel: PropTypes.func.isRequired,
@@ -285,12 +298,29 @@ class ManagedPackageEdit extends Component {
     );
   }
 
+  renderAccessTypeSelectField = () => {
+    const { accessStatusTypes } = this.props;
+
+    if (!accessStatusTypes?.items?.data?.length) {
+      return null;
+    }
+
+    const formattedAccessTypes = getAccessTypeIdsAndNames(accessStatusTypes.items.data);
+
+    return (
+      <div data-test-eholdings-access-types-select>
+        <AccessTypeField accessStatusTypes={formattedAccessTypes} />
+      </div>
+    );
+  }
+
   render() {
     const {
       model,
       proxyTypes,
       provider,
       onCancel,
+      accessStatusTypes,
     } = this.props;
 
     const {
@@ -437,6 +467,10 @@ class ManagedPackageEdit extends Component {
                             ) : (
                               <Icon icon="spinner-ellipsis" />
                             )}
+                            {accessStatusTypes.isLoading
+                              ? <Icon icon="spinner-ellipsis" />
+                              : this.renderAccessTypeSelectField()
+                            }
                             {supportsProviderTokens && (
                               <fieldset>
                                 <Headline tag="legend">

--- a/src/components/package/package-edit.js
+++ b/src/components/package/package-edit.js
@@ -6,14 +6,11 @@ import { Icon } from '@folio/stripes-components';
 import ManagedPackageEdit from './edit-managed';
 import CustomPackageEdit from './edit-custom';
 
+import { accessTypesReduxStateShape } from '../../constants';
+
 export default class PackageEdit extends React.Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     model: PropTypes.object.isRequired,
     provider: PropTypes.object.isRequired,
   };

--- a/src/components/package/package-edit.js
+++ b/src/components/package/package-edit.js
@@ -8,8 +8,14 @@ import CustomPackageEdit from './edit-custom';
 
 export default class PackageEdit extends React.Component {
   static propTypes = {
+    accessStatusTypes: PropTypes.shape({
+      isLoading: PropTypes.bool.isRequired,
+      items: PropTypes.shape({
+        data: PropTypes.array.isRequired,
+      }).isRequired,
+    }).isRequired,
     model: PropTypes.object.isRequired,
-    provider: PropTypes.object.isRequired
+    provider: PropTypes.object.isRequired,
   };
 
   renderRequestErrorMessage() {
@@ -39,6 +45,7 @@ export default class PackageEdit extends React.Component {
     const {
       model,
       provider,
+      accessStatusTypes,
       ...props
     } = this.props;
 
@@ -50,6 +57,7 @@ export default class PackageEdit extends React.Component {
       <View
         model={model}
         provider={provider}
+        accessStatusTypes={accessStatusTypes}
         {...props}
       />
     );

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -34,7 +34,11 @@ import {
   DOMAIN_NAME,
   paths,
 } from '../../../constants';
-import { processErrors } from '../../utilities';
+import {
+  processErrors,
+  getAccessTypeId,
+  getAccessTypeIdsAndNames,
+} from '../../utilities';
 import DetailsView from '../../details-view';
 import QueryList from '../../query-list';
 import InternalLink from '../../internal-link';
@@ -46,12 +50,19 @@ import KeyValueColumns from '../../key-value-columns';
 import ProxyDisplay from '../../proxy-display';
 import TokenDisplay from '../../token-display';
 import TagsAccordion from '../../tags';
+import AccessType from '../../access-type-display';
 import { AgreementsAccordion } from '../../../features';
 
 const ITEM_HEIGHT = 53;
 
 class PackageShow extends Component {
   static propTypes = {
+    accessStatusTypes: PropTypes.shape({
+      isLoading: PropTypes.bool.isRequired,
+      items: PropTypes.shape({
+        data: PropTypes.array.isRequired,
+      }).isRequired,
+    }).isRequired,
     addPackageToHoldings: PropTypes.func.isRequired,
     fetchPackageTitles: PropTypes.func.isRequired,
     isDestroyed: PropTypes.bool,
@@ -178,11 +189,30 @@ class PackageShow extends Component {
     );
   };
 
+  renderAccessTypeDisplay() {
+    const { model, accessStatusTypes } = this.props;
+
+    if (!accessStatusTypes?.items?.data?.length) {
+      return null;
+    }
+
+    const formattedAccessTypes = getAccessTypeIdsAndNames(accessStatusTypes.items.data);
+
+    return (
+      <AccessType
+        accessTypeId={getAccessTypeId(model)}
+        accessStatusTypes={formattedAccessTypes}
+      />
+    );
+  }
+
+
   renderPackageSettings() {
     const {
       model,
       proxyTypes,
       provider,
+      accessStatusTypes,
     } = this.props;
 
     const {
@@ -194,6 +224,7 @@ class PackageShow extends Component {
     const hasProviderToken = hasIn('providerToken.prompt', provider);
     const hasPackageToken = hasIn('packageToken.prompt', model);
     const isProxyAvailable = hasProxy && proxyTypes.request.isResolved && model.isLoaded && provider.isLoaded;
+    const haveAccessTypesLoaded = !accessStatusTypes?.isLoading && !model.isLoading;
 
     return (
       <div>
@@ -240,6 +271,18 @@ class PackageShow extends Component {
               />
             )
             : <Icon icon="spinner-ellipsis" />
+        }
+        {
+          <div data-test-eholdings-access-type>
+            {haveAccessTypesLoaded
+              ? this.renderAccessTypeDisplay()
+              : (
+                <Icon icon="spinner-ellipsis" />
+              )}
+          </div>
+        }
+        {
+
         }
         {
           hasProviderToken && (

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -276,13 +276,9 @@ class PackageShow extends Component {
           <div data-test-eholdings-access-type>
             {haveAccessTypesLoaded
               ? this.renderAccessTypeDisplay()
-              : (
-                <Icon icon="spinner-ellipsis" />
-              )}
+              : <Icon icon="spinner-ellipsis" />
+            }
           </div>
-        }
-        {
-
         }
         {
           hasProviderToken && (

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -33,6 +33,7 @@ import {
   listTypes,
   DOMAIN_NAME,
   paths,
+  accessTypesReduxStateShape,
 } from '../../../constants';
 import {
   processErrors,
@@ -57,12 +58,7 @@ const ITEM_HEIGHT = 53;
 
 class PackageShow extends Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     addPackageToHoldings: PropTypes.func.isRequired,
     fetchPackageTitles: PropTypes.func.isRequired,
     isDestroyed: PropTypes.bool,

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -32,7 +32,7 @@ import { CustomLabelsEditSection } from '../../custom-labels-section';
 import DetailsView from '../../details-view';
 import NavigationModal from '../../navigation-modal';
 import ProxySelectField from '../../proxy-select';
-import AccessTypeSelectField from '../../access-type-select';
+import AccessTypeEditSection from '../../access-type-edit-section';
 import Toaster from '../../toaster';
 
 import {
@@ -40,7 +40,6 @@ import {
   isBookPublicationType,
   getUserDefinedFields,
   getAccessTypeId,
-  getAccessTypeIdsAndNames,
 } from '../../utilities';
 
 import { CustomLabelsAccordion } from '../../../features';
@@ -228,24 +227,6 @@ class ResourceEditCustomTitle extends Component {
     );
   };
 
-  renderAccessTypeSelectField = () => {
-    const { accessStatusTypes } = this.props;
-
-    if (!accessStatusTypes?.items?.data?.length) {
-      return null;
-    }
-
-    const formattedAccessTypes = getAccessTypeIdsAndNames(accessStatusTypes.items.data);
-
-    return (
-      <div data-test-eholdings-access-types-select>
-        <AccessTypeSelectField
-          accessStatusTypes={formattedAccessTypes}
-        />
-      </div>
-    );
-  }
-
   getActionMenu = () => {
     const { stripes } = this.props;
 
@@ -395,11 +376,7 @@ class ResourceEditCustomTitle extends Component {
                             )}
                           </div>
                           <CustomUrlFields />
-                          {accessStatusTypes?.isLoading
-                            ? (
-                              <Icon icon="spinner-ellipsis" />
-                            )
-                            : this.renderAccessTypeSelectField()}
+                          <AccessTypeEditSection accessStatusTypes={accessStatusTypes} />
                         </>
                       ) : (
                         <p data-test-eholdings-resource-edit-settings-message>

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -47,6 +47,7 @@ import { CustomLabelsAccordion } from '../../../features';
 import {
   historyActions,
   coverageStatementExistenceStatuses,
+  accessTypesReduxStateShape,
 } from '../../../constants';
 
 
@@ -54,12 +55,7 @@ const focusOnErrors = createFocusDecorator();
 
 class ResourceEditCustomTitle extends Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     model: PropTypes.object.isRequired,
     onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -46,18 +46,14 @@ import { CustomLabelsAccordion } from '../../../features';
 import {
   historyActions,
   coverageStatementExistenceStatuses,
+  accessTypesReduxStateShape,
 } from '../../../constants';
 
 const focusOnErrors = createFocusDecorator();
 
 class ResourceEditManagedTitle extends Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     model: PropTypes.object.isRequired,
     onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -28,7 +28,6 @@ import {
   isBookPublicationType,
   getUserDefinedFields,
   getAccessTypeId,
-  getAccessTypeIdsAndNames,
 } from '../../utilities';
 
 import CoverageStatementFields, { coverageStatementDecorator } from '../_fields/coverage-statement';
@@ -36,7 +35,7 @@ import VisibilityField from '../_fields/visibility';
 import Toaster from '../../toaster';
 import CustomEmbargoFields, { getEmbargoInitial } from '../_fields/custom-embargo';
 import NavigationModal from '../../navigation-modal';
-import AccessTypeSelectField from '../../access-type-select';
+import AccessTypeEditSection from '../../access-type-edit-section';
 import ProxySelectField from '../../proxy-select';
 import CoverageFields from '../_fields/resource-coverage-fields';
 import CoverageDateList from '../../coverage-date-list';
@@ -213,24 +212,6 @@ class ResourceEditManagedTitle extends Component {
     );
   };
 
-  renderAccessTypeSelectField = () => {
-    const { accessStatusTypes } = this.props;
-
-    if (!accessStatusTypes?.items?.data?.length) {
-      return null;
-    }
-
-    const formattedAccessTypes = getAccessTypeIdsAndNames(accessStatusTypes.items.data);
-
-    return (
-      <div data-test-eholdings-access-types-select>
-        <AccessTypeSelectField
-          accessStatusTypes={formattedAccessTypes}
-        />
-      </div>
-    );
-  }
-
   getActionMenu = () => {
     const { stripes } = this.props;
     const hasSelectPermission = stripes.hasPerm('ui-eholdings.package-title.select-unselect');
@@ -395,11 +376,7 @@ class ResourceEditManagedTitle extends Component {
                                 <ProxySelectField proxyTypes={proxyTypes} inheritedProxyId={model.package.proxy.id} />
                               </div>
                             ))}
-                          {accessStatusTypes?.isLoading
-                            ? (
-                              <Icon icon="spinner-ellipsis" />
-                            )
-                            : this.renderAccessTypeSelectField()}
+                          <AccessTypeEditSection accessStatusTypes={accessStatusTypes} />
                         </div>
                       </Accordion>
                     )}

--- a/src/components/resource/resource-edit.js
+++ b/src/components/resource/resource-edit.js
@@ -6,14 +6,11 @@ import { Icon } from '@folio/stripes-components';
 import ManagedResourceEdit from './edit-managed-title';
 import CustomResourceEdit from './edit-custom-title';
 
+import { accessTypesReduxStateShape } from '../../constants';
+
 export default class ResourceEdit extends Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     model: PropTypes.object.isRequired,
     onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -26,6 +26,7 @@ import {
   entityTypes,
   paths,
   DOMAIN_NAME,
+  accessTypesReduxStateShape,
 } from '../../constants';
 import DetailsView from '../details-view';
 import InternalLink from '../internal-link';
@@ -51,12 +52,7 @@ import { CustomLabelsShowSection } from '../custom-labels-section';
 
 class ResourceShow extends Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     isFreshlySaved: PropTypes.bool,
     model: PropTypes.object.isRequired,
     onEdit: PropTypes.func.isRequired,

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -223,6 +223,7 @@ const SettingsAccessStatusTypes = ({
 SettingsAccessStatusTypes.propTypes = {
   accessTypesData: PropTypes.shape({
     isDeleted: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
     items: PropTypes.arrayOf(PropTypes.shape({
       attributes: PropTypes.shape({
         description: PropTypes.string,

--- a/src/constants/accessTypesReduxStateShape.js
+++ b/src/constants/accessTypesReduxStateShape.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.shape({
+  isDeleted: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  items: PropTypes.shape({
+    data: PropTypes.arrayOf(PropTypes.shape({
+      attributes: PropTypes.shape({
+        description: PropTypes.string,
+        name: PropTypes.string.isRequired,
+      }).isRequired,
+      creator: PropTypes.objectOf(PropTypes.string),
+      id: PropTypes.string.isRequired,
+      metadata: PropTypes.shape({
+        createdByUserId: PropTypes.string.isRequired,
+        createdByUsername: PropTypes.string.isRequired,
+        createdDate: PropTypes.string.isRequired,
+        updatedByUserId: PropTypes.string,
+        updatedDate: PropTypes.string,
+      }),
+      type: PropTypes.string.isRequired,
+      updater: PropTypes.objectOf(PropTypes.string),
+    })),
+  }).isRequired,
+});

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -10,3 +10,4 @@ export { default as entityTypeTranslationKeys } from './entityTypeTranslationKey
 export { default as entityTypePluralizedTranslationKeys } from './entityTypePluralizedTranslationKeys';
 export { default as paths } from './paths';
 export { default as accessTypes } from './accessTypes';
+export { default as accessTypesReduxStateShape } from './accessTypesReduxStateShape';

--- a/src/redux/package.js
+++ b/src/redux/package.js
@@ -16,6 +16,7 @@ class Package {
   packageType = '';
   proxy = {};
   packageToken = {};
+  accessTypeId = null;
   tags = {
     tagList: []
   };
@@ -44,6 +45,7 @@ class Package {
         proxy: this.proxy,
         packageToken: this.packageToken,
         isFullPackage: this.isSelected && !this.isPartiallySelected,
+        accessTypeId: this.accessTypeId,
       };
     }
 

--- a/src/routes/package-create.js
+++ b/src/routes/package-create.js
@@ -13,14 +13,11 @@ import Package from '../redux/package';
 
 import View from '../components/package/create';
 
+import { accessTypesReduxStateShape } from '../constants';
+
 class PackageCreateRoute extends Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     createPackage: PropTypes.func.isRequired,
     createRequest: PropTypes.object.isRequired,
     getAccessTypes: PropTypes.func.isRequired,

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -12,12 +12,23 @@ import { ProxyType } from '../redux/application';
 import Package from '../redux/package';
 import Provider from '../redux/provider';
 import Resource from '../redux/resource';
+import { selectPropFromData } from '../redux/selectors';
+import { getAccessTypes as getAccessTypesAction } from '../redux/actions';
 
 import View from '../components/package/package-edit';
 
+import { accessTypes } from '../constants';
+
 class PackageEditRoute extends Component {
   static propTypes = {
+    accessStatusTypes: PropTypes.shape({
+      isLoading: PropTypes.bool.isRequired,
+      items: PropTypes.shape({
+        data: PropTypes.array.isRequired,
+      }).isRequired,
+    }).isRequired,
     destroyPackage: PropTypes.func.isRequired,
+    getAccessTypes: PropTypes.func.isRequired,
     getPackage: PropTypes.func.isRequired,
     getProvider: PropTypes.func.isRequired,
     getProxyTypes: PropTypes.func.isRequired,
@@ -40,6 +51,7 @@ class PackageEditRoute extends Component {
     props.getPackage(packageId);
     props.getProxyTypes();
     props.getProvider(providerId);
+    props.getAccessTypes();
   }
 
   componentDidUpdate(prevProps) {
@@ -72,7 +84,7 @@ class PackageEditRoute extends Component {
 
     if (packageId !== oldMatch.params.packageId) {
       getPackage(packageId);
-    // if an update just resolved, unfetch the package titles
+      // if an update just resolved, unfetch the package titles
     } else if (next.update.isResolved && old.update.isPending) {
       unloadResources(next.resources);
     }
@@ -117,6 +129,7 @@ class PackageEditRoute extends Component {
       model.visibilityData.isHidden = false;
       model.customCoverage = {};
       model.allowKbToAddTitles = false;
+      model.accessTypeId = null;
       updatePackage(model);
     } else if (values.isSelected && !values.customCoverages) {
       model.isSelected = true;
@@ -169,6 +182,10 @@ class PackageEditRoute extends Component {
         this.providerEditSubmitted(values);
       }
 
+      model.accessTypeId = values.accessTypeId !== accessTypes.ACCESS_TYPE_NONE_ID
+        ? values.accessTypeId
+        : null;
+
       updatePackage(model);
     }
   };
@@ -207,6 +224,7 @@ class PackageEditRoute extends Component {
       model,
       proxyTypes,
       provider,
+      accessStatusTypes,
     } = this.props;
 
     return (
@@ -220,6 +238,7 @@ class PackageEditRoute extends Component {
               onSubmit={this.packageEditSubmitted}
               onCancel={this.handleCancel}
               addPackageToHoldings={this.addPackageToHoldings}
+              accessStatusTypes={accessStatusTypes}
             />
           </TitleManager>
         )}
@@ -229,17 +248,20 @@ class PackageEditRoute extends Component {
 }
 
 export default connect(
-  ({ eholdings: { data } }, { match }) => {
+  (store, { match }) => {
+    const { eholdings: { data } } = store;
     const resolver = createResolver(data);
     const model = resolver.find('packages', match.params.packageId);
     return {
       model,
       proxyTypes: resolver.query('proxyTypes'),
       provider: resolver.find('providers', model.providerId),
-      resolver
+      resolver,
+      accessStatusTypes: selectPropFromData(store, 'accessStatusTypes'),
     };
-  }, {
-    getPackage: id => Package.find(id),
+  },
+  {
+    getPackage: id => Package.find(id, { include: ['accessType'] }),
     getProxyTypes: () => ProxyType.query(),
     getProvider: id => Provider.find(id),
     unloadResources: collection => Resource.unload(collection),
@@ -247,5 +269,6 @@ export default connect(
     updatePackage: model => Package.save(model),
     destroyPackage: model => Package.destroy(model),
     removeUpdateRequests: () => Package.removeRequests('update'),
+    getAccessTypes: getAccessTypesAction,
   }
 )(PackageEditRoute);

--- a/src/routes/package-edit.js
+++ b/src/routes/package-edit.js
@@ -17,16 +17,14 @@ import { getAccessTypes as getAccessTypesAction } from '../redux/actions';
 
 import View from '../components/package/package-edit';
 
-import { accessTypes } from '../constants';
+import {
+  accessTypes,
+  accessTypesReduxStateShape,
+} from '../constants';
 
 class PackageEditRoute extends Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     destroyPackage: PropTypes.func.isRequired,
     getAccessTypes: PropTypes.func.isRequired,
     getPackage: PropTypes.func.isRequired,

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -17,19 +17,17 @@ import { selectPropFromData } from '../redux/selectors';
 import { getAccessTypes as getAccessTypesAction } from '../redux/actions';
 import Tag from '../redux/tag';
 import { transformQueryParams } from '../components/utilities';
-import { listTypes } from '../constants';
+import {
+  listTypes,
+  accessTypesReduxStateShape,
+} from '../constants';
 
 import View from '../components/package/show';
 import SearchModal from '../components/search-modal';
 
 class PackageShowRoute extends Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.arrayOf(PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     destroyPackage: PropTypes.func.isRequired,
     getAccessTypes: PropTypes.func.isRequired,
     getPackage: PropTypes.func.isRequired,

--- a/src/routes/resource-edit.js
+++ b/src/routes/resource-edit.js
@@ -12,18 +12,16 @@ import { ProxyType } from '../redux/application';
 import Resource from '../redux/resource';
 
 import View from '../components/resource/resource-edit';
-import { accessTypes } from '../constants';
+import {
+  accessTypes,
+  accessTypesReduxStateShape,
+} from '../constants';
 import { getAccessTypes as getAccessTypesAction } from '../redux/actions';
 import { selectPropFromData } from '../redux/selectors';
 
 class ResourceEditRoute extends Component {
   static propTypes = {
-    accessStatusTypes: PropTypes.shape({
-      isLoading: PropTypes.bool.isRequired,
-      items: PropTypes.shape({
-        data: PropTypes.array.isRequired,
-      }).isRequired,
-    }).isRequired,
+    accessStatusTypes: accessTypesReduxStateShape.isRequired,
     destroyResource: PropTypes.func.isRequired,
     getAccessTypes: PropTypes.func.isRequired,
     getProxyTypes: PropTypes.func.isRequired,

--- a/src/routes/resource-show.js
+++ b/src/routes/resource-show.js
@@ -13,9 +13,11 @@ import Tag from '../redux/tag';
 import { getAccessTypes as getAccessTypesAction } from '../redux/actions';
 import { selectPropFromData } from '../redux/selectors';
 
+import { accessTypesReduxStateShape } from '../constants';
+
 class ResourceShowRoute extends Component {
   static propTypes = {
-    accessTypes: PropTypes.object.isRequired,
+    accessTypes: accessTypesReduxStateShape.isRequired,
     destroyResource: PropTypes.func.isRequired,
     getAccessTypes: PropTypes.func.isRequired,
     getProxyTypes: PropTypes.func.isRequired,

--- a/test/bigtest/interactors/package-edit.js
+++ b/test/bigtest/interactors/package-edit.js
@@ -49,6 +49,10 @@ import SectionToggleButton from './section-toggle-button';
   isHiddenMessagePresent = isPresent('[data-test-eholdings-package-details-is-hidden-reason]');
   isVisibilityFieldPresent = isPresent('[data-test-eholdings-package-visibility-field]');
   isVisibleToPatrons = property('[data-test-eholdings-package-visibility-field] input[value="true"]', 'checked');
+  hasAccessTypeSelect = isPresent('[data-test-eholdings-access-type-select-field] select');
+  accessTypeSelectValue = value('[data-test-eholdings-access-type-select-field] select');
+  chooseAccessType = selectable('[data-test-eholdings-access-type-select-field] select');
+
   toggleIsVisible() {
     const isVisible = (!this.isVisibleToPatrons).toString();
     return this.click(`[data-test-eholdings-package-visibility-field] input[value="${isVisible}"]`);

--- a/test/bigtest/interactors/package-show.js
+++ b/test/bigtest/interactors/package-show.js
@@ -68,6 +68,8 @@ import PackageModal from './package-modal';
   actionsDropDown = ActionsDropDown;
   dropDownMenu = new PackageDropDownMenu();
   searchModalBadge = new SearchBadge('[data-test-eholdings-search-modal-badge]');
+  isAccessTypeSectionPresent = isPresent('[data-test-eholdings-details-access-type]');
+  accessType = text('[data-test-eholdings-details-access-type]');
 
   detailPaneMouseWheel = triggerable('[data-test-eholdings-detail-pane-contents]', 'wheel', {
     bubbles: true,

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -426,6 +426,7 @@ export default function config() {
       contentType,
       proxy,
       packageToken,
+      accessTypeId,
     } = body.data.attributes;
 
     const selectedCount = isSelected ? matchingResources.length : 0;
@@ -441,6 +442,7 @@ export default function config() {
     matchingPackage.update('contentType', contentType);
     matchingPackage.update('proxy', proxy);
     matchingPackage.update('packageToken', packageToken);
+    matchingPackage.update('accessTypeId', accessTypeId);
 
     return matchingPackage;
   });

--- a/test/bigtest/network/factories/package.js
+++ b/test/bigtest/network/factories/package.js
@@ -50,6 +50,20 @@ export default Factory.extend({
     }
   }),
 
+  withAccessType: trait({
+    afterCreate(packageObj, server) {
+      const accessTypes = server.schema.accessTypes.all();
+      const randomAccessTypeIndex = faker.random.number({
+        min: 0,
+        max: accessTypes.length - 1
+      });
+
+      const randomAccessType = accessTypes.models[randomAccessTypeIndex];
+
+      packageObj.update('accessTypeId', randomAccessType.id);
+    },
+  }),
+
   withProvider: trait({
     afterCreate(packageObj, server) {
       const provider = server.create('provider');
@@ -154,7 +168,7 @@ export default Factory.extend({
         factName: '[[mysiteid]]',
         prompt: '/test1/',
         helpText,
-        value:'testing package token'
+        value: 'testing package token'
       });
       packageObj.update('packageToken', token.toJSON());
       packageObj.save();

--- a/test/bigtest/network/models/access-type.js
+++ b/test/bigtest/network/models/access-type.js
@@ -2,4 +2,5 @@ import { Model, hasMany } from '@bigtest/mirage';
 
 export default Model.extend({
   resources: hasMany(),
+  packages: hasMany(),
 });

--- a/test/bigtest/network/models/package.js
+++ b/test/bigtest/network/models/package.js
@@ -2,5 +2,6 @@ import { Model, belongsTo, hasMany } from '@bigtest/mirage';
 
 export default Model.extend({
   resources: hasMany(),
-  provider: belongsTo()
+  provider: belongsTo(),
+  accessType: belongsTo(),
 });

--- a/test/bigtest/network/scenarios/default.js
+++ b/test/bigtest/network/scenarios/default.js
@@ -11,31 +11,6 @@ export default function defaultScenario(server) {
     });
   }
 
-  const customProvider = server.create('provider', {
-    name: 'Atlanta A&T Library',
-    packagesSelected: 1,
-    packagesTotal: 1
-  });
-
-  const customPackage = server.create('package', {
-    provider: customProvider,
-    name: 'Atlanta A&T Drumming Books',
-    contentType: 'AggregatedFullText',
-    isSelected: true,
-    isCustom: true,
-    selectedCount: 1,
-    titleCount: 1
-  });
-
-  const customTitle = server.create('title', {
-    name: 'Single, Double, and Triple Paradiddles',
-    isTitleCustom: true,
-    isPeerReviewed: false,
-    isSelected: true,
-    description: '',
-    edition: ''
-  });
-
   server.createList('access-type', 14);
 
   createProvider('Economist Intelligence Unit', [

--- a/test/bigtest/tests/custom-package-edit-access-type-test.js
+++ b/test/bigtest/tests/custom-package-edit-access-type-test.js
@@ -1,0 +1,76 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import PackageEditPage from '../interactors/package-edit';
+import PackageShowPage from '../interactors/package-show';
+
+import { accessTypes } from '../../../src/constants';
+
+describe('Custom package edit access types flow', () => {
+  setupApplication();
+
+  let testPackage;
+
+  beforeEach(function () {
+    testPackage = this.server.create('package', 'withTitles', 'withProvider', {
+      isCustom: true,
+      isSelected: true,
+    });
+
+    this.server.create('access-type', {
+      name: 'Trial',
+    });
+  });
+
+  describe('when access status types were not set in settings', () => {
+    beforeEach(function () {
+      this.server.get('/access-types', () => []);
+      this.visit(`/eholdings/packages/${testPackage.id}/edit`);
+    });
+
+    it('should not render access type select', () => {
+      expect(PackageEditPage.hasAccessTypeSelect).to.be.false;
+    });
+  });
+
+  describe('when access status types were set in settings', () => {
+    describe('and package does not have access status type selected', () => {
+      beforeEach(function () {
+        this.visit(`/eholdings/packages/${testPackage.id}/edit`);
+      });
+
+      it('should have unselected option as default value', () => {
+        expect(PackageEditPage.accessTypeSelectValue).to.equal(accessTypes.ACCESS_TYPE_NONE_ID);
+      });
+
+      describe('and an access status type was selected', () => {
+        beforeEach(async () => {
+          await PackageEditPage.chooseAccessType('Trial');
+        });
+
+        it('should enable save action button', () => {
+          expect(PackageEditPage.isSaveDisabled).to.be.false;
+        });
+
+        describe('and save button was clicked', () => {
+          beforeEach(async () => {
+            await PackageEditPage.clickSave();
+          });
+
+          it('should redirect to the package show page', () => {
+            expect(PackageEditPage.$root).to.exist;
+          });
+
+          it('should show newly saved access status type', () => {
+            expect(PackageShowPage.accessType).to.equal('Trial');
+          });
+
+          it('should show a success toast message', () => {
+            expect(PackageShowPage.toast.successText).to.equal('Package saved.');
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/bigtest/tests/managed-package-edit-access-type-test.js
+++ b/test/bigtest/tests/managed-package-edit-access-type-test.js
@@ -1,0 +1,76 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import PackageEditPage from '../interactors/package-edit';
+import PackageShowPage from '../interactors/package-show';
+
+import { accessTypes } from '../../../src/constants';
+
+describe('Managed package edit access types flow', () => {
+  setupApplication();
+
+  let testPackage;
+
+  beforeEach(function () {
+    testPackage = this.server.create('package', 'withTitles', 'withProvider', {
+      isCustom: false,
+      isSelected: true,
+    });
+
+    this.server.create('access-type', {
+      name: 'Trial',
+    });
+  });
+
+  describe('when access status types were not set in settings', () => {
+    beforeEach(function () {
+      this.server.get('/access-types', () => []);
+      this.visit(`/eholdings/packages/${testPackage.id}/edit`);
+    });
+
+    it('should not render access type select', () => {
+      expect(PackageEditPage.hasAccessTypeSelect).to.be.false;
+    });
+  });
+
+  describe('when access status types were set in settings', () => {
+    describe('and package does not have access status type selected', () => {
+      beforeEach(function () {
+        this.visit(`/eholdings/packages/${testPackage.id}/edit`);
+      });
+
+      it('should have unselected option as default value', () => {
+        expect(PackageEditPage.accessTypeSelectValue).to.equal(accessTypes.ACCESS_TYPE_NONE_ID);
+      });
+
+      describe('and an access status type was selected', () => {
+        beforeEach(async () => {
+          await PackageEditPage.chooseAccessType('Trial');
+        });
+
+        it('should enable save action button', () => {
+          expect(PackageEditPage.isSaveDisabled).to.be.false;
+        });
+
+        describe('and save button was clicked', () => {
+          beforeEach(async () => {
+            await PackageEditPage.clickSave();
+          });
+
+          it('should redirect to the package show page', () => {
+            expect(PackageEditPage.$root).to.exist;
+          });
+
+          it('should show newly saved access status type', () => {
+            expect(PackageShowPage.accessType).to.equal('Trial');
+          });
+
+          it('should show a success toast message', () => {
+            expect(PackageShowPage.toast.successText).to.equal('Package saved.');
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -10,6 +10,7 @@ describe('PackageShow', () => {
   let provider;
   let providerPackage;
   let resources;
+  let accessType;
 
   beforeEach(function () {
     provider = this.server.create('provider', {
@@ -22,10 +23,14 @@ describe('PackageShow', () => {
       contentType: 'E-Book',
       isSelected: false,
       titleCount: 5,
-      packageType: 'Complete'
+      packageType: 'Complete',
     });
 
     resources = this.server.schema.where('resource', { packageId: providerPackage.id }).models;
+
+    accessType = this.server.create('access-type', {
+      name: 'Trial',
+    });
   });
 
   describe('visiting the package details page', () => {
@@ -87,6 +92,44 @@ describe('PackageShow', () => {
 
     it('should display a back (close) button', () => {
       expect(PackageShowPage.hasBackButton).to.be.true;
+    });
+
+    describe('when there is no access status types configured', () => {
+      beforeEach(function () {
+        this.server.get('/access-types', () => []);
+        this.visit(`/eholdings/packages/${providerPackage.id}`);
+      });
+
+      it('should not render access status type section', () => {
+        expect(PackageShowPage.isAccessTypeSectionPresent).to.be.false;
+      });
+    });
+
+    describe('when there are access status types configured', () => {
+      beforeEach(async function () {
+        providerPackage.update('isSelected', true);
+        this.visit(`/eholdings/packages/${providerPackage.id}`);
+      });
+
+      describe('and package has access status type unassigned', () => {
+        it('should display the access type dash', () => {
+          expect(PackageShowPage.accessType).to.equal('-');
+        });
+      });
+
+      describe('and package has access status type assigned', () => {
+        beforeEach(function () {
+          const testPackage = this.server.create('package', 'withTitles', 'withProvider', {
+            accessType,
+          });
+          providerPackage.save();
+          this.visit(`/eholdings/packages/${testPackage.id}`);
+        });
+
+        it('displays the access type name', () => {
+          expect(PackageShowPage.accessType).to.equal('Trial');
+        });
+      });
     });
 
     describe('agreements section', () => {


### PR DESCRIPTION
In this PR, I added the possibility to assign an access status type to a package, as well as to see which access type is assigned to a package. 

## Approach
* Implement access status types functionality on package pages
* Add corresponding tests 