### PR TITLE
UIEH-853: Retain search within filtered list for provider and package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Fix Unsaved Changes Modal not appearing after changing selected status. (UIEH-854)
 * Fix need to click 'X' twice to return after changing selected status and visiting Edit page. (UIEH-854)
 * Fix Proxy selection is set to None when package has Inherited proxy. (UIEH-854)
+* Retain search within packages search and filter selections on the Provider record (UIEH-847)
+* Retain search within titles search and filter selections on the Package record (UIEH-853)
 
 ## [3.0.0] (https://github.com/folio-org/ui-eholdings/tree/v3.0.0) (2020-03-13)
 

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -52,9 +52,12 @@ class PackageShowRoute extends Component {
 
   constructor(props) {
     super(props);
+
+    const { filterTitles } = queryString.parse(props.location.search.substring(1));
+
     this.state = {
       queryId: 0,
-      pkgSearchParams: {},
+      pkgSearchParams: filterTitles ? { q: filterTitles } : {},
     };
     const { packageId } = props.match.params;
     const [providerId] = packageId.split('-');
@@ -180,6 +183,17 @@ class PackageShowRoute extends Component {
   }
 
   searchTitles = (pkgSearchParams) => {
+    const { location, history } = this.props;
+    const qs = queryString.parse(location.search, { ignoreQueryPrefix: true });
+    const search = queryString.stringify({ ...qs, filterTitles: pkgSearchParams.q });
+
+    if (pkgSearchParams?.q) {
+      history.replace({
+        ...location,
+        search
+      }, { eholdings: true });
+    }
+
     this.setState(({ queryId }) => ({
       pkgSearchParams,
       queryId: (queryId + 1)
@@ -255,6 +269,7 @@ class PackageShowRoute extends Component {
             history.location.state &&
             history.location.state.isDestroyed
           }
+          searchParams={pkgSearchParams}
           searchModal={
             <SearchModal
               key={queryId}

--- a/src/routes/package-show.js
+++ b/src/routes/package-show.js
@@ -269,7 +269,6 @@ class PackageShowRoute extends Component {
             history.location.state &&
             history.location.state.isDestroyed
           }
-          searchParams={pkgSearchParams}
           searchModal={
             <SearchModal
               key={queryId}

--- a/src/routes/provider-show.js
+++ b/src/routes/provider-show.js
@@ -35,8 +35,11 @@ class ProviderShowRoute extends Component {
 
   constructor(props) {
     super(props);
+
+    const { filterPackages } = queryString.parse(props.location.search);
+
     this.state = {
-      pkgSearchParams: {},
+      pkgSearchParams: filterPackages ? { q: filterPackages } : {},
       queryId: 0,
     };
     const { providerId } = props.match.params;
@@ -71,6 +74,17 @@ class ProviderShowRoute extends Component {
   }
 
   searchPackages = (pkgSearchParams) => {
+    const { location, history } = this.props;
+    const qs = queryString.parse(location.search, { ignoreQueryPrefix: true });
+    const search = queryString.stringify({ ...qs, filterPackages: pkgSearchParams.q });
+
+    if (pkgSearchParams?.q) {
+      history.replace({
+        ...location,
+        search
+      }, { eholdings: true });
+    }
+
     this.setState(({ queryId }) => ({
       pkgSearchParams,
       queryId: (queryId + 1)


### PR DESCRIPTION

## Purpose
Add functionality for retaining search filters after moving on previous page

## Approach
Update query string with filter query for titles on Package View Page and for packages on Provider View Page

### Issue
[UIEH-853](https://issues.folio.org/browse/UIEH-853)
[UIEH-847](https://issues.folio.org/browse/UIEH-847)

## Screenshots

### Provider page
![Qyfpxsntjj](https://user-images.githubusercontent.com/55701515/78008110-ea5c2100-7347-11ea-8ba0-5538d3bde36b.gif)

### Package page
![t0enxtFNMf](https://user-images.githubusercontent.com/55701515/78008477-6191b500-7348-11ea-8f47-654e8f9ec789.gif)
