### PR TITLE
Make filtering by multiple access types possible

### DIFF
--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -507,7 +507,15 @@ export function epic(action$, { getState }) {
       // if we're querying a set of records, data.params are the
       // parameters needed in the request URL
       if (type === actionTypes.QUERY && Object.keys(data.params).length !== 0) {
-        url = `${url}?${qs.stringify(data.params)}`;
+        if (data?.params?.filter?.['access-type']) {
+          const accessTypesParams = data.params.filter['access-type']
+            .split(',')
+            .reduce((acc, accessType, index) => `${acc}${index ? '&' : ''}filter[access-type]=${accessType}`, '');
+
+          url = `${url}?${accessTypesParams}`;
+        } else {
+          url = `${url}?${qs.stringify(data.params)}`;
+        }
       }
 
       // if we need to include additional resources in the response,


### PR DESCRIPTION
## Purpose
To make filtering packages by multiple access status types available. Currently, if multiple access status types are selected, then an empty response is received because the request query string is built in the wrong way.

## Approach
The logic of building request query string for access types is different from how the query string is built in all other cases. Query strings are created deep inside the data layer of the app, so it's not possible to just specify them in components. That's why I chose to handle the creation of query string for access status type filter as a special case in the `redux/data.js`.