### PR TITLE
UIEH-878: Settings > Access Status Types > Able to create duplicate access status types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Pin `moment` at `~2.24.0`. Refs STRIPES-678.
 * Add filtering of titles by Access Types. (UIEH-834)
+* Add validation for duplicated Access Types. (UIEH-878)
 
 ## [3.0.2] (https://github.com/folio-org/ui-eholdings/tree/v3.0.2) (2020-04-08)
 

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -115,6 +115,10 @@ const SettingsAccessStatusTypes = ({
       />;
     }
 
+    if (value && accessTypesData.items.find(accessType => accessType.attributes.name === value)) {
+      return <FormattedMessage id="ui-eholdings.settings.accessStatusTypes.validation.duplicate" />;
+    }
+
     return null;
   };
 

--- a/test/bigtest/network/helpers.js
+++ b/test/bigtest/network/helpers.js
@@ -170,7 +170,16 @@ export function nestedResourceRouteFor(foreignKey, resourceType, filter = () => 
 export function getAccessTypesFromFilterQuery(query = '') {
   const parsedQuery = queryString.parse(query, { ignoreQueryPrefix: true });
 
-  const accessTypes = parsedQuery.filter['access-type'];
+  const { filter } = parsedQuery;
+  if (!filter) {
+    return [];
+  }
+
+  const accessTypes = filter['access-type'];
+  if (!accessTypes) {
+    return [];
+  }
+
   if (Array.isArray(accessTypes)) {
     return accessTypes;
   } else {

--- a/test/bigtest/tests/settings-access-status-types-test.js
+++ b/test/bigtest/tests/settings-access-status-types-test.js
@@ -57,6 +57,16 @@ describe('With list of root proxies available to a customer', () => {
         });
       });
 
+      describe('fill access status type name field with duplicate value', () => {
+        beforeEach(async () => {
+          await SettingsAccessStatusTypesPage.accessStatusTypesList(0).nameField.fillAndBlur('my custom type 1');
+        });
+
+        it('should show validation error message', () => {
+          expect(SettingsAccessStatusTypesPage.accessStatusTypesList(0).validationErrorMessage).to.be.equal('Duplicate type. Please revise.');
+        });
+      });
+
       describe('fill description field with unvalid string length', () => {
         beforeEach(async () => {
           await SettingsAccessStatusTypesPage.accessStatusTypesList(0).descriptionField.fillAndBlur((new Array(151)).fill('a').join(''));

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -175,6 +175,7 @@
     "settings.accessStatusTypes.lastUpdated.data": "{date} by {name}",
     "settings.accessStatusTypes.records": "# of records",
     "settings.accessStatusTypes.validation": "Exceeded {limit}. Please revise.",
+    "settings.accessStatusTypes.validation.duplicate": "Duplicate type. Please revise.",
     "settings.accessStatusTypes.delete": "Delete Access status type",
     "settings.accessStatusTypes.delete.description": "Are you sure you want to delete the access status type {name}?",
     "settings.accessStatusTypes.delete.cancel": "Cancel",


### PR DESCRIPTION
## Purpose
- Add validation for duplicated Access Types

## Issue

[UIEH-878](https://issues.folio.org/browse/UIEH-878)

## Coverage

![image](https://user-images.githubusercontent.com/19309423/81282049-575b8880-9063-11ea-98c0-66b6731ca9d6.png)
