### PR TITLE
UIEH-890: eHoldings app: Move permission names to translation file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Pin `moment` at `~2.24.0`. Refs STRIPES-678.
 * Add filtering of titles by Access Types. (UIEH-834)
 * Add validation for duplicated Access Types. (UIEH-878)
+* Add permission names to translations. (UIEH-890)
 
 ## [3.0.2] (https://github.com/folio-org/ui-eholdings/tree/v3.0.2) (2020-04-08)
 

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -390,6 +390,13 @@
     "notes.entityType.provider.pluralized": "{count} {count, plural, one {provider} other {providers}}",
     "notes.entityType.package.pluralized": "{count} {count, plural, one {package} other {packages}}",
     "notes.entityType.resource.pluralized": "{count} {count, plural, one {resource} other {resources}}",
-    "notes.entityType.title.pluralized": "{count} {count, plural, one {title} other {titles}}"
+    "notes.entityType.title.pluralized": "{count} {count, plural, one {title} other {titles}}",
 
+    "permission.module.eholdings.enabled": "UI: eHoldings module is enabled",
+    "permission.eholdings.enabled": "Settings (eHoldings): display list of settings pages",
+    "permission.settings.kb": "Settings (eHoldings): configure EBSCO RM API credentials",
+    "permission.settings.root-proxy": "Settings (eHoldings): configure root proxy setting",
+    "permission.package-title.select-unselect": "eHoldings: Can select/unselect packages and titles to/from your holdings",
+    "permission.records.edit": "eHoldings: Can edit providers, packages, titles detail records",
+    "permission.titles-packages.create-delete": "eHoldings: Can create and delete custom packages and titles"
   }


### PR DESCRIPTION
## Purpose
- Move permission display names to translation files to be picked up by `react-intl`