### PR TITLE
UIEH-868: Hide delete button when access type is used in records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add permission names to translations. (UIEH-890)
 * Update react-intl to v4
 * Update `stripes` to `v4`
+* Hide delete button when access type is used in records. (UIEH-868)
 
 ## [3.0.2] (https://github.com/folio-org/ui-eholdings/tree/v3.0.2) (2020-04-08)
 

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -58,7 +58,7 @@ const SettingsAccessStatusTypes = ({
       ) : <NoValue />;
     },
     // records will be done after MODKBEKBJ-378
-    records: () => <NoValue />
+    records: ({ usageNumber }) => usageNumber || <NoValue />
   };
 
   // eslint-disable-next-line react/prop-types
@@ -200,6 +200,7 @@ const SettingsAccessStatusTypes = ({
             onUpdate={onUpdate}
             readOnlyFields={['lastUpdated', 'records']}
             visibleFields={['name', 'description', 'lastUpdated', 'records']}
+            actionSuppression={{ delete: accessType => accessType.usageNumber, edit: () => false }}
           />
         )}
       </IntlConsumer>


### PR DESCRIPTION
## Description

- Show count of records where access type is used
- Hide delete button when access type is used in records

## Issue
[UIEH-868](https://issues.folio.org/browse/UIEH-868)

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/81720836-9d5f8480-9487-11ea-9fce-529558da003f.png)

