### PR TITLE
UIEH-860: handle error when trying to delete access status type that doesn't exist

### DIFF
--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import {
@@ -40,6 +40,29 @@ const SettingsAccessStatusTypes = ({
     type: 'accessTypes',
     attributes,
   });
+
+  useEffect(() => {
+    const errorsLength = accessTypesData.errors.length;
+
+    if (errorsLength) {
+      const lastErrorTitle = accessTypesData.errors[errorsLength - 1].title;
+
+      if (lastErrorTitle.endsWith('not found')) {
+        setToasts(currentToasts => [
+          ...currentToasts,
+          {
+            id: `access-type-delete-failure-${Date.now()}`,
+            message: <FormattedMessage id="ui-eholdings.settings.accessStatusTypes.delete.error" />,
+            type: 'error',
+          }
+        ]);
+
+        setSelectedStatusType(null);
+        setShowConfirmDialog(false);
+      }
+    }
+  }, [accessTypesData.errors]);
+
 
   const formatter = {
     name: ({ attributes }) => (attributes?.name ?? <NoValue />),
@@ -228,6 +251,7 @@ const SettingsAccessStatusTypes = ({
 
 SettingsAccessStatusTypes.propTypes = {
   accessTypesData: PropTypes.shape({
+    errors: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)).isRequired,
     isDeleted: PropTypes.bool.isRequired,
     isLoading: PropTypes.bool.isRequired,
     items: PropTypes.arrayOf(accessStatusTypeDataShape),

--- a/src/redux/actions/delete-access-type-failure.js
+++ b/src/redux/actions/delete-access-type-failure.js
@@ -1,8 +1,11 @@
 export const DELETE_ACCESS_TYPE_FAILURE = 'DELETE_ACCESS_TYPE_FAILURE';
 
-export function deleteAccessTypeFailure({ errors }) {
+export function deleteAccessTypeFailure({ errors, accessTypeId }) {
   return {
     type: DELETE_ACCESS_TYPE_FAILURE,
-    payload: errors,
+    payload: {
+      errors,
+      accessTypeId,
+    },
   };
 }

--- a/src/redux/epics/delete-access-type.js
+++ b/src/redux/epics/delete-access-type.js
@@ -16,11 +16,14 @@ export default ({ accessTypesApi }) => (action$, store) => {
   return action$
     .filter(action => action.type === DELETE_ACCESS_TYPE)
     .mergeMap(action => {
-      const { payload: id } = action;
+      const { payload: accessTypeData } = action;
 
       return accessTypesApi
-        .deleteAccessType(state.okapi, id)
-        .map(() => deleteAccessTypeSuccess(id))
-        .catch(errors => Observable.of(deleteAccessTypeFailure({ errors })));
+        .deleteAccessType(state.okapi, accessTypeData)
+        .map(() => deleteAccessTypeSuccess(accessTypeData))
+        .catch(({ errors }) => Observable.of(deleteAccessTypeFailure({
+          errors,
+          accessTypeId: accessTypeData.id
+        })));
     });
 };

--- a/src/redux/reducers/accessTypes.js
+++ b/src/redux/reducers/accessTypes.js
@@ -82,10 +82,16 @@ const handlers = {
   },
 
   [DELETE_ACCESS_TYPE_FAILURE]: (state, action) => {
-    const { payload: { errors } } = action;
+    const { payload: { errors, accessTypeId } } = action;
+    const isAlreadyDeleted = errors[0].title.endsWith('not found');
 
     return {
       ...state,
+      items: {
+        data: isAlreadyDeleted
+          ? state.items.data.filter(accessType => accessType.id !== accessTypeId)
+          : state.items.data,
+      },
       isLoading: false,
       isDeleted: false,
       errors: formatErrors(errors),

--- a/test/bigtest/interactors/settings-access-status-types.js
+++ b/test/bigtest/interactors/settings-access-status-types.js
@@ -16,6 +16,7 @@ import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/i
   cancelStatusTypeDeleteButton = clickable('[data-test-confirmation-modal-cancel-button]');
   confirmStatusTypeDeleteButton = clickable('[data-test-confirmation-modal-confirm-button]');
   successText = text('[data-test-eholdings-toast="success"]');
+  errorText = text('[data-test-eholdings-toast="error"]');
 
   accessStatusTypesList = collection('[id^="editList-"] [data-row-index]', {
     clickDelete: clickable('[id^="clickable-delete-"]'),

--- a/test/bigtest/tests/settings-access-status-types-test.js
+++ b/test/bigtest/tests/settings-access-status-types-test.js
@@ -165,6 +165,31 @@ describe('With list of root proxies available to a customer', () => {
           expect(SettingsAccessStatusTypesPage.successText.includes(typeToDelete)).to.be.true;
         });
       });
+
+      describe('if access status type does not exist in the back-end', () => {
+        beforeEach(function () {
+          this.server.delete('/access-types/:id', {
+            errors: [{
+              title: 'not found'
+            }]
+          }, 404);
+        });
+
+        describe('when clicking on Delete', () => {
+          beforeEach(async () => {
+            await SettingsAccessStatusTypesPage.confirmStatusTypeDeleteButton();
+          });
+          it('should display correct error message', () => {
+            const expectedErrorText = 'This access status type has already been deleted.';
+
+            expect(SettingsAccessStatusTypesPage.errorText).to.be.equal(expectedErrorText);
+          });
+
+          it('should show list of access status types without first item', () => {
+            expect(SettingsAccessStatusTypesPage.accessStatusTypesList().length).to.be.equal(13);
+          });
+        });
+      });
     });
   });
 });

--- a/test/bigtest/tests/unit/actions/delete-access-type-failure-test.js
+++ b/test/bigtest/tests/unit/actions/delete-access-type-failure-test.js
@@ -9,11 +9,15 @@ import {
 describe('(action) deleteAccessTypeFailure', () => {
   it('should create an action to handle delete access type failure', () => {
     const errors = 'error';
+    const accessTypeId = '1';
     const expectedAction = {
       type: DELETE_ACCESS_TYPE_FAILURE,
-      payload: errors,
+      payload: {
+        errors,
+        accessTypeId,
+      },
     };
 
-    expect(deleteAccessTypeFailure({ errors })).to.deep.equal(expectedAction);
+    expect(deleteAccessTypeFailure({ errors, accessTypeId })).to.deep.equal(expectedAction);
   });
 });

--- a/test/bigtest/tests/unit/reducers/access-types-test.js
+++ b/test/bigtest/tests/unit/reducers/access-types-test.js
@@ -221,16 +221,47 @@ describe('(reducer) accessTypes', () => {
     expect(accessTypes(actualState, action)).to.deep.equal(expectedState);
   });
 
-  it('should handle DELETE_ACCESS_TYPE_FAILURE', () => {
-    const actualState = { isLoading: true };
+  it('should handle general case for DELETE_ACCESS_TYPE_FAILURE', () => {
+    const actualState = {
+      isLoading: true,
+      items: { data: [{ id: '1' }] }
+    };
+
     const action = {
       type: DELETE_ACCESS_TYPE_FAILURE,
-      payload: { errors: 'error' },
+      payload: {
+        errors: [{ title: 'random error' }],
+        accessTypeId: '1'
+      },
     };
     const expectedState = {
       isLoading: false,
-      errors: [{ title: 'error' }],
+      errors: [{ title: 'random error' }],
       isDeleted: false,
+      items: { data: [{ id: '1' }] },
+    };
+
+    expect(accessTypes(actualState, action)).to.deep.equal(expectedState);
+  });
+
+  it('should handle not found case for DELETE_ACCESS_TYPE_FAILURE', () => {
+    const actualState = {
+      isLoading: true,
+      items: { data: [{ id: '1' }] }
+    };
+
+    const action = {
+      type: DELETE_ACCESS_TYPE_FAILURE,
+      payload: {
+        errors: [{ title: 'not found' }],
+        accessTypeId: '1'
+      },
+    };
+    const expectedState = {
+      isLoading: false,
+      errors: [{ title: 'not found' }],
+      isDeleted: false,
+      items: { data: [] },
     };
 
     expect(accessTypes(actualState, action)).to.deep.equal(expectedState);

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -181,6 +181,7 @@
     "settings.accessStatusTypes.delete.cancel": "Cancel",
     "settings.accessStatusTypes.delete.confirm": "Delete",
     "settings.accessStatusTypes.delete.toast": "The access status type {name} has been deleted.",
+    "settings.accessStatusTypes.delete.error": "This access status type has already been deleted.",
 
     "proxy": "Proxy",
     "proxy.inherited": "Inherited - {proxy}",


### PR DESCRIPTION
## Purpose
To let users know if the access status type that they are trying to delete has already been deleted. Also, this access status type should be removed from the list on the page.

## Ticket
https://issues.folio.org/browse/UIEH-860

## Screen
![captured (2)](https://user-images.githubusercontent.com/43514877/81787231-6631b780-9509-11ea-95d6-bb1e5bfa3e34.gif)

