### PR TITLE
UIEH-862: package show title list ui updates

### DIFF
--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -54,7 +54,7 @@ import TagsAccordion from '../../tags';
 import AccessType from '../../access-type-display';
 import { AgreementsAccordion } from '../../../features';
 
-const ITEM_HEIGHT = 53;
+const ITEM_HEIGHT = 62;
 
 class PackageShow extends Component {
   static propTypes = {

--- a/src/components/title-list-item/title-list-item.css
+++ b/src/components/title-list-item/title-list-item.css
@@ -24,6 +24,23 @@
       color: #fff;
     }
   }
+
+  & .selection-status {
+    &.not-selected img {
+      filter: grayscale(1);
+    }
+  }
+
+  & .itemMetadata {
+    display: flex;
+    padding-top: var(--gutter-static-one-third);
+    font-size: var(--font-size-medium);
+    color: var(--color-text);
+
+    & > span {
+      padding-right: var(--gutter-static);
+    }
+  }
 }
 
 .skeleton {

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -2,13 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { FormattedMessage } from 'react-intl';
-import { Headline } from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes/core';
+import {
+  Headline,
+  Icon,
+} from '@folio/stripes/components';
 
 import shouldFocus from '../should-focus';
 import styles from './title-list-item.css';
 import InternalLink from '../internal-link';
 import IdentifiersList from '../identifiers-list';
 import ContributorsList from '../contributors-list';
+import { APP_ICON_NAME } from '../../constants';
 
 const cx = classNames.bind(styles);
 const CONTRIBUTORS_LIMIT = 3;
@@ -28,6 +33,7 @@ function TitleListItem({
   const hasPublisherOrType = showPublisherAndType && (item?.publicationType || item?.publisherName);
   const hasIdentifiers = item?.identifiers?.length > 0 && showIdentifiers;
   const showPublisherContributorSeparator = hasPublisherOrType && hasContributors;
+
   return !item
     ? (
       <div
@@ -98,20 +104,28 @@ function TitleListItem({
         )}
 
         {showSelected && (
-          <div>
-            <span data-test-eholdings-title-list-item-title-selected>
-              {item.isSelected
-                ? <FormattedMessage id="ui-eholdings.selected" />
-                : <FormattedMessage id="ui-eholdings.notSelected" />}
-            </span>
-
+          <div className={cx('itemMetadata')}>
+            <AppIcon
+              app={APP_ICON_NAME}
+              iconKey='selectedPackage'
+              size='small'
+              className={cx('item', 'selection-status', {
+                'not-selected': !item.isSelected,
+              })}
+            >
+              <span data-test-eholdings-title-list-item-title-selected>
+                {item.isSelected
+                  ? <FormattedMessage id="ui-eholdings.selected" />
+                  : <FormattedMessage id="ui-eholdings.notSelected" />
+                }
+              </span>
+            </AppIcon>
             {item.visibilityData.isHidden && (
-              <span>
-                &nbsp;&bull;&nbsp;
+              <Icon icon="eye-closed">
                 <span data-test-eholdings-title-list-item-title-hidden>
                   <FormattedMessage id="ui-eholdings.hidden" />
                 </span>
-              </span>
+              </Icon>
             )}
           </div>
         )}

--- a/test/bigtest/interactors/package-show.js
+++ b/test/bigtest/interactors/package-show.js
@@ -92,7 +92,7 @@ import PackageModal from './package-modal';
     isSelected: computed(function () {
       return this.isSelectedLabel === 'Selected';
     }),
-    isHiddenLabel: text('[data-test-eholdings-title-list-item-title-hidden]'),
+    hiddenIndicatorDisplayed: isPresent('[data-test-eholdings-title-list-item-title-hidden]'),
     clickToTitle: clickable()
   });
 

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -91,6 +91,10 @@ describe('PackageShow', () => {
       expect(PackageShowPage.titleList(0).isSelectedLabel).to.equal((resources[0].isSelected ? 'Selected' : 'Not selected'));
     });
 
+    it('displays whether the first title is hidden', () => {
+      expect(PackageShowPage.titleList(0).hiddenIndicatorDisplayed).to.equal((resources[0].visibilityData.isHidden));
+    });
+
     it('should display a back (close) button', () => {
       expect(PackageShowPage.hasBackButton).to.be.true;
     });


### PR DESCRIPTION
## Purpose 
To show icons next to selection status and visibility status indicators on the titles list on the package show page

## Screenshot
![image](https://user-images.githubusercontent.com/43514877/81934633-f2baa380-95f7-11ea-8311-6b179a4a95ea.png)
