### PR TITLE
UIEH-900: Settings > eholdings > Assigned Users > Attempting to add a user to a second set of credentials results in a length loading indicator

### DIFF
--- a/src/routes/settings-assigned-users-route.js
+++ b/src/routes/settings-assigned-users-route.js
@@ -145,9 +145,12 @@ const SettingsAssignedUsersRoute = ({
     }
   };
 
+  const assignedUsersLoaded = assignedUsers.hasLoaded || assignedUsers.hasFailed;
+  const userGroupsLoaded = userGroups.hasLoaded || userGroups.hasFailed;
+
   return (
     <>
-      {!assignedUsers.isLoading && !userGroups.isLoading
+      {assignedUsersLoaded && userGroupsLoaded
         ? (
           <View
             requestIsPending={assignedUsers.isLoading}

--- a/src/routes/settings-assigned-users-route.js
+++ b/src/routes/settings-assigned-users-route.js
@@ -147,7 +147,7 @@ const SettingsAssignedUsersRoute = ({
 
   return (
     <>
-      {assignedUsers.hasLoaded && userGroups.hasLoaded
+      {!assignedUsers.isLoading && !userGroups.isLoading
         ? (
           <View
             requestIsPending={assignedUsers.isLoading}


### PR DESCRIPTION
## Purpose
Fix infinite spinner when assigning a user to KB has failed
