### PR TITLE
UIEH-897: fix DetailsView scrolling issues

### DIFF
--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -161,7 +161,7 @@ class DetailsView extends Component {
       const height = e.currentTarget.offsetHeight;
       const scrollHeight = e.currentTarget.scrollHeight;
       // these will be equal when scrolled all the way down
-      const bottomedOut = Math.ceil(top + height) === scrollHeight;
+      const bottomedOut = Math.abs(scrollHeight - (top + height)) < 1;
 
       // if bottoming out, enable isSticky
       if (bottomedOut && !isSticky) {


### PR DESCRIPTION
## Purpose
To fix scrolling issues in the `DetailsView` component

## Approach
The component decides whether it should disable or enable scrolling of the page container and the packages/titles list depending on the `scrollTop` property. Sometimes its value has a decimal point which results in the condition always evaluating to `false`. This depends on the height of the viewport.

To fix this, I check if values don't differ by more than 1 pixel, instead of checking if they are the equal. Rounding the numbers won't work because we can't know if we need to round up or down in every specific case.