### PR TITLE
UIEH-864: Fix Access status types settings permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-eholdings
 
+## [4.0.1] (IN PROGRESS)
+
+* Fix missing Access Status Types on records when missing Settings permissions. (UIEH-864)
+
 ## [4.0.0] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-06-11)
 
 * Pin `moment` at `~2.24.0`. Refs STRIPES-678.

--- a/package.json
+++ b/package.json
@@ -171,9 +171,7 @@
         "displayName": "Settings (eholdings): Can view access status types",
         "visible": true,
         "subPermissions": [
-          "settings.eholdings.enabled",
-          "kb-ebsco.kb-credentials.access-types.collection.get",
-          "kb-ebsco.kb-credentials.access-types.item.get"
+          "settings.eholdings.enabled"
         ]
       },
       {


### PR DESCRIPTION
## Purpose
- Remove Access Types `collection.get` and `item.get` permissions from Settings permissions, so that everyone has view permissions in eHoldings records. To see Settings related permission set (`Settings (eholdings): Can view access status types`) is still required.