### PR TITLE
UIEH-912: KB credentials do not display in alphabetical order by KB Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-eholdings
 
+## [4.0.1] (IN PROGRESS)
+
+* Fix KB credentials list shown not in alphabetical order. (UIEH-912)
+
 ## [4.0.0] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-06-11)
 
 * Pin `moment` at `~2.24.0`. Refs STRIPES-678.

--- a/src/routes/settings-route.js
+++ b/src/routes/settings-route.js
@@ -24,6 +24,10 @@ class SettingsRoute extends Component {
     this.props.getKbCredentials();
   }
 
+  sortKbCredentials = (kbCredentials) => {
+    return kbCredentials.sort((a, b) => a.attributes.name.localeCompare(b.attributes.name));
+  }
+
   render() {
     const { children, location, kbCredentials } = this.props;
 
@@ -32,7 +36,10 @@ class SettingsRoute extends Component {
         <FormattedMessage id="ui-eholdings.label.settings">
           {pageTitle => (
             <TitleManager page={pageTitle}>
-              <View location={location} kbCredentials={kbCredentials.items}>
+              <View
+                location={location}
+                kbCredentials={this.sortKbCredentials(kbCredentials.items)}
+              >
                 {children}
               </View>
             </TitleManager>

--- a/test/bigtest/interactors/settings.js
+++ b/test/bigtest/interactors/settings.js
@@ -3,6 +3,7 @@ import {
   isPresent,
   collection,
   clickable,
+  text,
 } from '@bigtest/interactor';
 
 import { hasClassBeginningWith } from './helpers';
@@ -14,6 +15,7 @@ import { hasClassBeginningWith } from './helpers';
 @interactor class ConfigurationInteractor {
   settingsLinks = collection('[data-test-nav-list-item]', NavListItem);
   clickHeading = clickable('[data-test-configuration-heading]');
+  name = text('[data-test-configuration-heading]');
 }
 
 @interactor class Settings {

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -804,7 +804,7 @@ export default function config() {
         'id': '1',
         'type': 'credentials',
         'attributes': {
-          'name': '111111111',
+          'name': 'Beta',
           'apiKey': '',
           'url': '',
           'customerId': ''
@@ -822,7 +822,7 @@ export default function config() {
         'id': '2',
         'type': 'credentials',
         'attributes': {
-          'name': '2222222',
+          'name': 'Alpha',
           'apiKey': 'XXXX',
           'url': 'YYYY',
           'customerId': 'ZZZZ'
@@ -840,7 +840,7 @@ export default function config() {
         'id': '3',
         'type': 'credentials',
         'attributes': {
-          'name': '333333333',
+          'name': 'Gamma',
           'apiKey': 'XXXX',
           'url': 'YYYY',
           'customerId': 'ZZZZ'

--- a/test/bigtest/tests/settings-test.js
+++ b/test/bigtest/tests/settings-test.js
@@ -8,7 +8,6 @@ import { expect } from 'chai';
 import setupApplication from '../helpers/setup-application';
 import Settings from '../interactors/settings';
 
-
 describe('Settings', () => {
   setupApplication();
 
@@ -44,13 +43,19 @@ describe('Settings', () => {
       expect(Settings.configurationNavigationList().length).to.equal(3);
     });
 
+    it('should display Knowledge Base configurations in alphabetical order', () => {
+      const names = Settings.configurationNavigationList().map(kbCredential => kbCredential.name);
+
+      expect(names).to.deep.equal(['Alpha', 'Beta', 'Gamma']);
+    });
+
     describe('when clicking on configuration heading', () => {
       beforeEach(async () => {
         await Settings.configurationNavigationList(0).clickHeading();
       });
 
       it('should redirect to Knowledge Base configuration page', function () {
-        expect(this.location.pathname).to.equal('/settings/eholdings/knowledge-base/1');
+        expect(this.location.pathname).to.equal('/settings/eholdings/knowledge-base/2');
       });
     });
 


### PR DESCRIPTION
## Purpose
- Sort KB credentials in alphabetical order by name in Settings > eHoldings

## Issue

[UIEH-912](https://issues.folio.org/browse/UIEH-912)