### PR TITLE
UIEH-918: eHoldings app: Incorrect x-okapi-token sent to /access-types after re-login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.0.1] (IN PROGRESS)
 
 * Fix KB credentials list shown not in alphabetical order. (UIEH-912)
+* Fix incorrect x-okapi-token sent after re-logging in eHoldings. (UIEH-918)
 
 ## [4.0.0] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-06-11)
 

--- a/src/redux/epics/attach-access-type.js
+++ b/src/redux/epics/attach-access-type.js
@@ -11,16 +11,13 @@ import {
 } from '../actions';
 
 export default ({ accessTypesApi }) => (action$, store) => {
-  const { getState } = store;
-  const state = getState();
-
   return action$
     .filter(action => action.type === ATTACH_ACCESS_TYPE)
     .mergeMap(action => {
       const { payload: { accessType, credentialId } } = action;
 
       return accessTypesApi
-        .attachAccessType(state.okapi, { data: accessType }, credentialId)
+        .attachAccessType(store.getState().okapi, { data: accessType }, credentialId)
         .map(response => {
           attachAccessTypeSuccess();
           return addAccessType(response);

--- a/src/redux/epics/attach-agreement.js
+++ b/src/redux/epics/attach-agreement.js
@@ -15,12 +15,6 @@ import {
 } from './common';
 
 export default ({ agreementsApi }) => (action$, store) => {
-  const {
-    getState,
-  } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === ATTACH_AGREEMENT)
     .mergeMap(action => {
@@ -29,7 +23,7 @@ export default ({ agreementsApi }) => (action$, store) => {
       } = action;
 
       return agreementsApi
-        .attachAgreement(state.okapi, agreement)
+        .attachAgreement(store.getState().okapi, agreement)
         .map((currentAgreement) => {
           attachAgreementSuccess();
           return addAgreement(pickAgreementProps(currentAgreement));

--- a/src/redux/epics/delete-access-type.js
+++ b/src/redux/epics/delete-access-type.js
@@ -10,16 +10,13 @@ import {
 } from '../actions';
 
 export default ({ accessTypesApi }) => (action$, store) => {
-  const { getState } = store;
-  const state = getState();
-
   return action$
     .filter(action => action.type === DELETE_ACCESS_TYPE)
     .mergeMap(action => {
       const { payload: { accessType, credentialId } } = action;
 
       return accessTypesApi
-        .deleteAccessType(state.okapi, accessType, credentialId)
+        .deleteAccessType(store.getState().okapi, accessType, credentialId)
         .map(() => deleteAccessTypeSuccess(accessType.id))
         .catch(({ errors }) => Observable.of(deleteAccessTypeFailure({
           errors,

--- a/src/redux/epics/delete-kb-credentials-user.js
+++ b/src/redux/epics/delete-kb-credentials-user.js
@@ -10,17 +10,13 @@ import {
 } from '../actions';
 
 export default ({ kbCredentialsUsersApi }) => (action$, store) => {
-  const { getState } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === DELETE_KB_CREDENTIALS_USER)
     .mergeMap(({ payload }) => {
       const { credentialsId, userId } = payload;
 
       return kbCredentialsUsersApi
-        .unassignUser(state.okapi, credentialsId, userId)
+        .unassignUser(store.getState().okapi, credentialsId, userId)
         .map(() => deleteKBCredentialsUserSuccess(userId))
         .catch(errors => Observable.of(deleteKBCredentialsUserFailure({ errors })));
     });

--- a/src/redux/epics/delete-kb-credentials.js
+++ b/src/redux/epics/delete-kb-credentials.js
@@ -10,16 +10,13 @@ import {
 } from '../actions';
 
 export default ({ knowledgeBaseApi }) => (action$, store) => {
-  const { getState } = store;
-  const state = getState();
-
   return action$
     .filter(action => action.type === DELETE_KB_CREDENTIALS)
     .mergeMap(action => {
       const { payload: { id } } = action;
 
       return knowledgeBaseApi
-        .deleteCredentials(state.okapi, id)
+        .deleteCredentials(store.getState().okapi, id)
         .map(() => deleteKBCredentialsSuccess(id))
         .catch(errors => Observable.of(deleteKBCredentialsFailure({ errors })));
     });

--- a/src/redux/epics/get-access-types.js
+++ b/src/redux/epics/get-access-types.js
@@ -10,13 +10,10 @@ import {
 } from '../actions';
 
 export default ({ accessTypesApi }) => (action$, store) => {
-  const { getState } = store;
-  const state = getState();
-
   return action$
     .filter(action => action.type === GET_ACCESS_TYPES)
     .mergeMap(({ payload: credentialId }) => accessTypesApi
-      .getAll(state.okapi, credentialId)
+      .getAll(store.getState().okapi, credentialId)
       .map(response => getAccessTypesSuccess(response))
       .catch(errors => Observable.of(getAccessTypesFailure({ errors }))));
 };

--- a/src/redux/epics/get-agreements.js
+++ b/src/redux/epics/get-agreements.js
@@ -10,12 +10,6 @@ import {
 } from '../actions';
 
 export default ({ agreementsApi }) => (action$, store) => {
-  const {
-    getState,
-  } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === GET_AGREEMENTS)
     .mergeMap(action => {
@@ -26,7 +20,7 @@ export default ({ agreementsApi }) => (action$, store) => {
       } = action;
 
       return agreementsApi
-        .getAll(state.okapi, refId)
+        .getAll(store.getState().okapi, refId)
         .map(response => getAgreementsSuccess(response))
         .catch(errors => Observable.of(getAgreementsFailure({ errors })));
     });

--- a/src/redux/epics/get-custom-labels.js
+++ b/src/redux/epics/get-custom-labels.js
@@ -10,12 +10,6 @@ import {
 } from '../actions';
 
 export default ({ customLabelsApi }) => (action$, store) => {
-  const {
-    getState,
-  } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === GET_CUSTOM_LABELS)
     .mergeMap(action => {
@@ -24,7 +18,7 @@ export default ({ customLabelsApi }) => (action$, store) => {
       } = action;
 
       return customLabelsApi
-        .getAll(state.okapi, credentialId)
+        .getAll(store.getState().okapi, credentialId)
         .map(response => getCustomLabelsSuccess(response))
         .catch(errors => Observable.of(getCustomLabelsFailure({ errors })));
     });

--- a/src/redux/epics/get-kb-credentials-users.js
+++ b/src/redux/epics/get-kb-credentials-users.js
@@ -10,14 +10,10 @@ import {
 } from '../actions';
 
 export default ({ kbCredentialsUsersApi }) => (action$, store) => {
-  const { getState } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === GET_KB_CREDENTIALS_USERS)
     .mergeMap(({ payload: { credentialsId } }) => kbCredentialsUsersApi
-      .getCollection(state.okapi, credentialsId)
+      .getCollection(store.getState().okapi, credentialsId)
       .map(getKBCredentialsUsersSuccess)
       .catch(errors => Observable.of(getKBCredentialsUsersFailure({ errors }))));
 };

--- a/src/redux/epics/get-kb-credentials.js
+++ b/src/redux/epics/get-kb-credentials.js
@@ -10,14 +10,10 @@ import {
 } from '../actions';
 
 export default ({ knowledgeBaseApi }) => (action$, store) => {
-  const { getState } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === GET_KB_CREDENTIALS)
     .mergeMap(() => knowledgeBaseApi
-      .getCollection(state.okapi)
+      .getCollection(store.getState().okapi)
       .map(getKbCredentialsSuccess)
       .catch(errors => Observable.of(getKbCredentialsFailure({ errors }))));
 };

--- a/src/redux/epics/get-proxy-types.js
+++ b/src/redux/epics/get-proxy-types.js
@@ -10,17 +10,13 @@ import {
 } from '../actions';
 
 export default ({ proxyTypesApi }) => (action$, store) => {
-  const { getState } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === GET_PROXY_TYPES)
     .mergeMap(action => {
       const { payload: credentialId } = action;
 
       return proxyTypesApi
-        .getAll(state.okapi, credentialId)
+        .getAll(store.getState().okapi, credentialId)
         .map(getProxyTypesSuccess)
         .catch(errors => Observable.of(getProxyTypesFailure({ errors })));
     });

--- a/src/redux/epics/get-root-proxy.js
+++ b/src/redux/epics/get-root-proxy.js
@@ -10,12 +10,6 @@ import {
 } from '../actions';
 
 export default ({ rootProxyApi }) => (action$, store) => {
-  const {
-    getState,
-  } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === GET_ROOT_PROXY)
     .mergeMap(action => {
@@ -24,7 +18,7 @@ export default ({ rootProxyApi }) => (action$, store) => {
       } = action;
 
       return rootProxyApi
-        .get(state.okapi, credentialId)
+        .get(store.getState().okapi, credentialId)
         .map(response => getRootProxySuccess(response))
         .catch(errors => Observable.of(getRootProxyFailure({ errors })));
     });

--- a/src/redux/epics/get-user-groups.js
+++ b/src/redux/epics/get-user-groups.js
@@ -10,14 +10,10 @@ import {
 } from '../actions';
 
 export default ({ userGroupsApi }) => (action$, store) => {
-  const { getState } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === GET_USER_GROUPS)
     .mergeMap(() => userGroupsApi
-      .getAll(state.okapi)
+      .getAll(store.getState().okapi)
       .map(getUserGroupsSuccess)
       .catch(errors => Observable.of(getUserGroupsFailure({ errors }))));
 };

--- a/src/redux/epics/post-kb-credentials-user.js
+++ b/src/redux/epics/post-kb-credentials-user.js
@@ -10,17 +10,13 @@ import {
 } from '../actions';
 
 export default ({ kbCredentialsUsersApi }) => (action$, store) => {
-  const { getState } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === POST_KB_CREDENTIALS_USER)
     .mergeMap(({ payload }) => {
       const { credentialsId, userData } = payload;
 
       return kbCredentialsUsersApi
-        .assignUser(state.okapi, credentialsId, userData)
+        .assignUser(store.getState().okapi, credentialsId, userData)
         .map(postKBCredentialsUserSuccess)
         .catch(errors => Observable.of(postKBCredentialsUserFailure({ errors })));
     });

--- a/src/redux/epics/post-kb-credentials.js
+++ b/src/redux/epics/post-kb-credentials.js
@@ -10,14 +10,11 @@ import {
 } from '../actions';
 
 export default ({ knowledgeBaseApi }) => (action$, store) => {
-  const { getState } = store;
-  const state = getState();
-
   return action$
     .filter(action => action.type === POST_KB_CREDENTIALS)
     .mergeMap(({ payload }) => {
       return knowledgeBaseApi
-        .createCredentials(state.okapi, payload)
+        .createCredentials(store.getState().okapi, payload)
         .map(postKBCredentialsSuccess)
         .catch(errors => Observable.of(postKBCredentialsFailure({ errors })));
     });

--- a/src/redux/epics/put-kb-credentials.js
+++ b/src/redux/epics/put-kb-credentials.js
@@ -10,14 +10,11 @@ import {
 } from '../actions';
 
 export default ({ knowledgeBaseApi }) => (action$, store) => {
-  const { getState } = store;
-  const state = getState();
-
   return action$
     .filter(action => action.type === PUT_KB_CREDENTIALS)
     .mergeMap(({ payload }) => {
       return knowledgeBaseApi
-        .editCredentials(state.okapi, { data: payload.data }, payload.credentialId)
+        .editCredentials(store.getState().okapi, { data: payload.data }, payload.credentialId)
         .map(() => putKBCredentialsSuccess(payload.data))
         .catch(errors => Observable.of(putKBCredentialsFailure({ errors })));
     });

--- a/src/redux/epics/update-access-type.js
+++ b/src/redux/epics/update-access-type.js
@@ -10,16 +10,13 @@ import {
 } from '../actions';
 
 export default ({ accessTypesApi }) => (action$, store) => {
-  const { getState } = store;
-  const state = getState();
-
   return action$
     .filter(action => action.type === UPDATE_ACCESS_TYPE)
     .mergeMap(action => {
       const { payload: { accessType, credentialId } } = action;
 
       return accessTypesApi
-        .updateAccessType(state.okapi, accessType, credentialId)
+        .updateAccessType(store.getState().okapi, accessType, credentialId)
         .map(() => updateAccessTypeSuccess(accessType))
         .catch(errors => Observable.of(updateAccessTypeFailure({ errors })));
     });

--- a/src/redux/epics/update-custom-labels.js
+++ b/src/redux/epics/update-custom-labels.js
@@ -10,12 +10,6 @@ import {
 } from '../actions';
 
 export default ({ customLabelsApi }) => (action$, store) => {
-  const {
-    getState,
-  } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === UPDATE_CUSTOM_LABELS)
     .mergeMap(action => {
@@ -24,7 +18,7 @@ export default ({ customLabelsApi }) => (action$, store) => {
       } = action;
 
       return customLabelsApi
-        .updateCustomLabels(state.okapi, customLabels, credentialId)
+        .updateCustomLabels(store.getState().okapi, customLabels, credentialId)
         .map(updateCustomLabelsSuccess)
         .catch(errors => Observable.of(updateCustomLabelsFailure({ errors })));
     });

--- a/src/redux/epics/update-root-proxy.js
+++ b/src/redux/epics/update-root-proxy.js
@@ -10,12 +10,6 @@ import {
 } from '../actions';
 
 export default ({ rootProxyApi }) => (action$, store) => {
-  const {
-    getState,
-  } = store;
-
-  const state = getState();
-
   return action$
     .filter(action => action.type === UPDATE_ROOT_PROXY)
     .mergeMap(action => {
@@ -24,7 +18,7 @@ export default ({ rootProxyApi }) => (action$, store) => {
       } = action;
 
       return rootProxyApi
-        .updateRootProxy(state.okapi, rootProxy, credentialId)
+        .updateRootProxy(store.getState().okapi, rootProxy, credentialId)
         .map(() => updateRootProxySuccess(rootProxy))
         .catch(errors => Observable.of(updateRootProxyFailure({ errors })));
     });


### PR DESCRIPTION
## Description

In Settings > eHoldings after re-logging with another user incorrect x-okapi-token was being send with each request.
This is caused by a mistake in writing of epics, which would retrieve okapi token from store only one time per epic, and then use old token with each request. This meant that when you logged in the first time, the epic would get the token from store and (unintentionally) cache it in a closure. After re-logging a fresh token would be saved to a store, but not in epics.