### PR TITLE
UIEH-915: Fix permission error in devtools console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix filter by Access Types request incorrectly formatted. (UIEH-917)
 * Fix routing issues. (UIEH-916)
 * Added possibility to change KB Name. (UIEH-898)
+* Fix permission error in devtools console. (UIEH-915)
 
 ## [4.0.0] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-06-11)
 

--- a/package.json
+++ b/package.json
@@ -102,19 +102,34 @@
       {
         "permissionName": "module.eholdings.enabled",
         "displayName": "UI: eHoldings module is enabled",
-        "visible": true,
+        "visible": false,
         "subPermissions": [
           "kb-ebsco.all",
           "tags.all"
         ]
       },
       {
+        "permissionName": "ui-eholdings.app.enabled",
+        "subPermissions": [
+          "module.eholdings.enabled"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "settings.eholdings.enabled",
         "displayName": "Settings (eHoldings): display list of settings pages",
+        "visible": false,
         "subPermissions": [
           "module.eholdings.enabled",
           "settings.enabled"
         ]
+      },
+      {
+        "permissionName": "ui-eholdings.settings.enabled",
+        "subPermissions": [
+          "settings.eholdings.enabled"
+        ],
+        "visible": true
       },
       {
         "permissionName": "ui-eholdings.settings.kb",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -415,8 +415,8 @@
     "notes.entityType.resource.pluralized": "{count} {count, plural, one {resource} other {resources}}",
     "notes.entityType.title.pluralized": "{count} {count, plural, one {title} other {titles}}",
 
-    "permission.module.eholdings.enabled": "UI: eHoldings module is enabled",
-    "permission.eholdings.enabled": "Settings (eHoldings): display list of settings pages",
+    "permission.app.enabled": "UI: eHoldings module is enabled",
+    "permission.settings.enabled": "Settings (eHoldings): display list of settings pages",
     "permission.settings.kb": "Settings (eHoldings): configure EBSCO RM API credentials",
     "permission.settings.root-proxy": "Settings (eHoldings): configure root proxy setting",
     "permission.package-title.select-unselect": "eHoldings: Can select/unselect packages and titles to/from your holdings",


### PR DESCRIPTION
Add translations for permission names in the scope of the [UIEH-915](https://issues.folio.org/browse/UIEH-915).