### PR TITLE
UIIH-907: implement package selection confirmation modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added possibility to change KB Name. (UIEH-898)
 * Fix permission error in devtools console. (UIEH-915)
 * Change filter by Tags request format. (UIEH-922)
+* Add package selection confirmation modal. (UIIH-907)
 
 ## [4.0.0] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-06-11)
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -746,7 +746,6 @@ class PackageShow extends Component {
         >
           {modalMessage.body}
         </Modal>
-
         {showSelectionConfirmationModal && this.renderSelectionConfirmationModal()}
         <NavigationModal when={isCoverageEditable} />
       </div>

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -606,6 +606,7 @@ class PackageShow extends Component {
     const footer = (
       <ModalFooter>
         <Button
+          data-test-confirm-package-selection
           buttonStyle="primary"
           onClick={() => {
             addPackageToHoldings();
@@ -614,7 +615,10 @@ class PackageShow extends Component {
         >
           <FormattedMessage id="ui-eholdings.selectPackage.confirmationModal.confirmationButtonText" />
         </Button>
-        <Button onClick={this.toggleSelectionConfirmationModal}>
+        <Button
+          data-test-cancel-package-selection
+          onClick={this.toggleSelectionConfirmationModal}
+        >
           <FormattedMessage id="ui-eholdings.cancel" />
         </Button>
       </ModalFooter>
@@ -626,6 +630,7 @@ class PackageShow extends Component {
         label={<FormattedMessage id="ui-eholdings.selectPackage.confirmationModal.label" />}
         footer={footer}
         size="small"
+        id="package-selection-confirmation-modal"
       >
         <SafeHTMLMessage id="ui-eholdings.selectPackage.confirmationModal.message" />
       </Modal>

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -600,7 +600,6 @@ class PackageShow extends Component {
   }
 
   renderSelectionConfirmationModal() {
-    const { showSelectionConfirmationModal } = this.state;
     const { addPackageToHoldings } = this.props;
 
     const footer = (
@@ -626,7 +625,7 @@ class PackageShow extends Component {
 
     return (
       <Modal
-        open={showSelectionConfirmationModal}
+        open
         label={<FormattedMessage id="ui-eholdings.selectPackage.confirmationModal.label" />}
         footer={footer}
         size="small"
@@ -649,7 +648,8 @@ class PackageShow extends Component {
     const {
       showDeselectionModal,
       isCoverageEditable,
-      sections
+      sections,
+      showSelectionConfirmationModal,
     } = this.state;
 
     const modalMessage = model.isCustom ?
@@ -747,7 +747,7 @@ class PackageShow extends Component {
           {modalMessage.body}
         </Modal>
 
-        {this.renderSelectionConfirmationModal()}
+        {showSelectionConfirmationModal && this.renderSelectionConfirmationModal()}
         <NavigationModal when={isCoverageEditable} />
       </div>
     );

--- a/test/bigtest/interactors/package-selection-modal.js
+++ b/test/bigtest/interactors/package-selection-modal.js
@@ -1,0 +1,9 @@
+import {
+  interactor,
+  clickable,
+} from '@bigtest/interactor';
+
+export default @interactor class PackageSelectionModal {
+  confirmPackageSelection = clickable('[data-test-confirm-package-selection]');
+  cancelPackageSelection = clickable('[data-test-cancel-package-selection]');
+}

--- a/test/bigtest/interactors/package-show.js
+++ b/test/bigtest/interactors/package-show.js
@@ -27,6 +27,7 @@ import PackageSelectionStatus from './selection-status';
 import ActionsDropDown from './actions-drop-down';
 import PackageDropDownMenu from './package-drop-down-menu';
 import PackageModal from './package-modal';
+import PackageSelectionModal from './package-selection-modal';
 
 @interactor class PackageShowPage {
   isLoaded = isPresent('[data-test-eholdings-details-view-name="package"]');
@@ -140,6 +141,8 @@ import PackageModal from './package-modal';
 
   tagsSection = new TagsAccordion('[data-test-eholdings-tag-filter]');
   accessTypesSection = new AccessTypesAccordion('[data-test-eholdings-access-types-filter]');
+
+  selectionConfirmationModal = new PackageSelectionModal();
 
   selectPackage() {
     return this

--- a/test/bigtest/interactors/package-show.js
+++ b/test/bigtest/interactors/package-show.js
@@ -141,7 +141,6 @@ import PackageSelectionModal from './package-selection-modal';
 
   tagsSection = new TagsAccordion('[data-test-eholdings-tag-filter]');
   accessTypesSection = new AccessTypesAccordion('[data-test-eholdings-access-types-filter]');
-
   selectionConfirmationModal = new PackageSelectionModal();
 
   selectPackage() {

--- a/test/bigtest/tests/package-add-new-titles-test.js
+++ b/test/bigtest/tests/package-add-new-titles-test.js
@@ -86,8 +86,9 @@ describe('PackageShowAllowKbToAddTitles', () => {
     });
 
     describe('selecting a package', () => {
-      beforeEach(() => {
-        return PackageShowPage.whenLoaded().selectPackage();
+      beforeEach(async () => {
+        await PackageShowPage.whenLoaded().selectPackage();
+        await PackageShowPage.selectionConfirmationModal.confirmPackageSelection();
       });
 
       it('reflects the desired state (Selected)', () => {

--- a/test/bigtest/tests/package-selection-test.js
+++ b/test/bigtest/tests/package-selection-test.js
@@ -31,95 +31,114 @@ describe('PackageSelection', () => {
       this.visit(`/eholdings/packages/${providerPackage.id}`);
     });
 
-    describe('successfully selecting a package title to add to my holdings', () => {
+    describe('when the package selection modal is open', () => {
       beforeEach(async function () {
         await PackageShowPage.whenLoaded();
-        this.server.block();
         await PackageShowPage.selectPackage();
-        await PackageShowPage.selectionConfirmationModal.confirmPackageSelection();
       });
 
-      it.skip('indicates it is working to get to desired state', () => {
-        expect(PackageShowPage.selectionStatus.isSelecting).to.equal(true);
+      it('should display selection confirmation modal', () => {
+        expect(PackageShowPage.selectionConfirmationModal.isPresent).to.be.true;
       });
 
-      describe('when the request succeeds', () => {
-        beforeEach(function () {
-          this.server.unblock();
+      describe('and package selection is canceled', () => {
+        beforeEach(async () => {
+          await PackageShowPage.selectionConfirmationModal.cancelPackageSelection();
         });
 
-        it('reflect the desired state was set', () => {
-          expect(PackageShowPage.selectionStatus.isSelected).to.equal(true);
-        });
-
-        it('indicates it is no longer working', () => {
-          expect(PackageShowPage.selectionStatus.isSelecting).to.equal(false);
-        });
-
-        it('should show the package titles are all selected', () => {
-          expect(PackageShowPage.allTitlesSelected).to.equal(true);
-        });
-
-        it('updates the selected title count', () => {
-          expect(PackageShowPage.numTitlesSelected).to.equal(`${providerPackage.titleCount}`);
+        it('should say that the package is still not selected', () => {
+          expect(PackageShowPage.selectionStatus.isSelected).to.equal(false);
         });
       });
 
-      describe('and deselecting the package', () => {
-        beforeEach(function () {
-          this.server.unblock();
-          // many thanks to elrick for catching the need for
-          // the `when` here
-          return PackageShowPage
-            .when(() => !PackageShowPage.isSelecting)
-            .actionsDropDown.clickDropDownButton()
-            .dropDownMenu.removeFromHoldings.click();
+      describe('and package selection is confirmed', () => {
+        beforeEach(async function () {
+          await PackageShowPage.selectionConfirmationModal.confirmPackageSelection();
+          this.server.block();
         });
 
-        describe('canceling the deselection', () => {
-          beforeEach(() => {
-            return PackageShowPage.modal.cancelDeselection();
+        it.skip('indicates it is working to get to desired state', () => {
+          expect(PackageShowPage.selectionStatus.isSelecting).to.equal(true);
+        });
+
+        describe('when the request succeeds', () => {
+          beforeEach(async function () {
+            this.server.unblock();
           });
 
-          it('does not show a loading indicator', () => {
+          it('reflect the desired state was set', () => {
+            expect(PackageShowPage.selectionStatus.isSelected).to.equal(true);
+          });
+
+          it('indicates it is no longer working', () => {
             expect(PackageShowPage.selectionStatus.isSelecting).to.equal(false);
           });
 
-          it('remains selected', () => {
-            expect(PackageShowPage.selectionStatus.isSelected).to.equal(true);
+          it('should show the package titles are all selected', () => {
+            expect(PackageShowPage.allTitlesSelected).to.equal(true);
+          });
+
+          it('updates the selected title count', () => {
+            expect(PackageShowPage.numTitlesSelected).to.equal(`${providerPackage.titleCount}`);
           });
         });
 
-        describe('confirming the deselection', () => {
+        describe('and deselecting the package', () => {
           beforeEach(function () {
-            this.server.block();
-            return PackageShowPage.modal.confirmDeselection();
+            this.server.unblock();
+            // many thanks to elrick for catching the need for
+            // the `when` here
+            return PackageShowPage
+              .when(() => !PackageShowPage.isSelecting)
+              .actionsDropDown.clickDropDownButton()
+              .dropDownMenu.removeFromHoldings.click();
           });
 
-
-          describe('when the request succeeds', () => {
-            beforeEach(function () {
-              this.server.unblock();
+          describe('canceling the deselection', () => {
+            beforeEach(() => {
+              return PackageShowPage.modal.cancelDeselection();
             });
 
-            it('reflect the desired state was set', () => {
-              expect(PackageShowPage.selectionStatus.isSelected).to.equal(false);
-            });
-
-            it('indicates it is no longer working', () => {
+            it('does not show a loading indicator', () => {
               expect(PackageShowPage.selectionStatus.isSelecting).to.equal(false);
             });
 
-            it('should show the package titles are not all selected', () => {
-              expect(PackageShowPage.allTitlesSelected).to.equal(false);
+            it('remains selected', () => {
+              expect(PackageShowPage.selectionStatus.isSelected).to.equal(true);
+            });
+          });
+
+          describe('confirming the deselection', () => {
+            beforeEach(function () {
+              this.server.block();
+              return PackageShowPage.modal.confirmDeselection();
             });
 
-            it('updates the selected title count', () => {
-              expect(PackageShowPage.numTitlesSelected).to.equal(`${providerPackage.titleCount}`);
-            });
 
-            it('removes custom coverage', () => {
-              expect(PackageShowPage.hasCustomCoverage).to.equal(false);
+            describe('when the request succeeds', () => {
+              beforeEach(function () {
+                this.server.unblock();
+              });
+
+              it('reflect the desired state was set', () => {
+                expect(PackageShowPage.selectionStatus.isSelected).to.equal(false);
+              });
+
+              it('indicates it is no longer working', () => {
+                expect(PackageShowPage.selectionStatus.isSelecting).to.equal(false);
+              });
+
+              it('should show the package titles are not all selected', () => {
+                expect(PackageShowPage.allTitlesSelected).to.equal(false);
+              });
+
+              it('updates the selected title count', () => {
+                expect(PackageShowPage.numTitlesSelected).to.equal(`${providerPackage.titleCount}`);
+              });
+
+              it('removes custom coverage', () => {
+                expect(PackageShowPage.hasCustomCoverage).to.equal(false);
+              });
             });
           });
         });

--- a/test/bigtest/tests/package-selection-test.js
+++ b/test/bigtest/tests/package-selection-test.js
@@ -36,6 +36,7 @@ describe('PackageSelection', () => {
         await PackageShowPage.whenLoaded();
         this.server.block();
         await PackageShowPage.selectPackage();
+        await PackageShowPage.selectionConfirmationModal.confirmPackageSelection();
       });
 
       it.skip('indicates it is working to get to desired state', () => {
@@ -140,6 +141,7 @@ describe('PackageSelection', () => {
         await PackageShowPage.whenLoaded();
         this.server.block();
         await PackageShowPage.selectPackage();
+        await PackageShowPage.selectionConfirmationModal.confirmPackageSelection();
       });
 
       it.skip('indicates it is working to get to desired state', () => {

--- a/test/bigtest/tests/package-show-test.js
+++ b/test/bigtest/tests/package-show-test.js
@@ -249,7 +249,7 @@ describe('PackageShow', () => {
     });
 
     it('has a button to add all of the remaining titles by selecting the entire package directly in the detail record', () => {
-      expect(PackageShowPage.selectionStatus.buttonText).to.equal('Add all to holdings');
+      expect(PackageShowPage.selectionStatus.buttonText).to.equal('Add all titles to holdings');
     });
 
     it('does not display tags accordion', () => {
@@ -262,7 +262,7 @@ describe('PackageShow', () => {
       });
 
       it('has menu item to add all remaining titles from this packages', () => {
-        expect(PackageShowPage.dropDownMenu.addToHoldings.text).to.equal('Add all to holdings');
+        expect(PackageShowPage.dropDownMenu.addToHoldings.text).to.equal('Add all titles to holdings');
       });
 
       it('has menu item to remove the entire package from holdings just like a completely selected packages', () => {
@@ -579,6 +579,7 @@ describe('PackageShow', () => {
       this.visit(`/eholdings/packages/${providerPackage.id}`);
 
       await PackageShowPage.selectPackage();
+      await PackageShowPage.selectionConfirmationModal.confirmPackageSelection();
       await PackageShowPage.clickEditButton();
       await PackageEditPage.chooseProxy('microstates');
       return PackageEditPage.clickBackButton();

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -319,7 +319,7 @@
 
     "validate.errors.edition.value": "Invalid value.",
     "validate.errors.edition.length": "Value exceeds the 250 character limit.",
-    
+
     "validate.errors.settings.kb.name": "Field required. Please revise.",
     "validate.errors.settings.kb.name.length": "255 character limit has been exceeded. Please revise.",
     "validate.errors.settings.customerId": "Customer ID cannot be blank",
@@ -380,8 +380,11 @@
     "selected": "Selected",
     "selectedCount": "Selected: {count}",
     "notSelected": "Not selected",
-    "addToHoldings": "Add to holdings",
-    "addAllToHoldings": "Add all to holdings",
+    "addToHoldings": "Add package to holdings",
+    "addAllToHoldings": "Add all titles to holdings",
+    "selectPackage.confirmationModal.label": "Add all titles in a package to holdings",
+    "selectPackage.confirmationModal.message": "Selecting this action will <strong>add all titles</strong> in this package to your holdings. To continue this action, select <strong>Add package (all titles) to holdings</strong>.",
+    "selectPackage.confirmationModal.confirmationButtonText": "Add package (all titles) to holdings",
     "saving": "Saving",
     "submit": "Submit",
     "save": "Save",


### PR DESCRIPTION
With these changes, when a user wants to select a package, they will be asked to confirm this action:
![image](https://user-images.githubusercontent.com/43514877/88656791-879e4a80-d0d9-11ea-9b15-c8c775d9858c.png)

Also, the selection button content was changed from Add to holdings to Add package to holdings (when there are no titles selected) and from Add all to holdings to Add all titles to holdings (when there is at least one title selected):
![image](https://user-images.githubusercontent.com/43514877/88657235-45293d80-d0da-11ea-92e0-df98a071c563.png)


![image](https://user-images.githubusercontent.com/43514877/88657501-b23cd300-d0da-11ea-879e-d10a0b72f5e7.png)

