### PR TITLE
UIEH-911: Remove headlines from Root Proxy and KB settings pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Change filter by Tags request format. (UIEH-922)
 * Add package selection confirmation modal. (UIEH-907)
 * Add possibility to delete KB credentials. (UIEH-909)
+* Remove headlines from Root Proxy and KB settings pages. (UIEH-911)
 
 ## [4.0.0] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-06-11)
 

--- a/src/components/settings/settings-knowledge-base/settings-knowledge-base.js
+++ b/src/components/settings/settings-knowledge-base/settings-knowledge-base.js
@@ -11,7 +11,6 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
-  Headline,
   Icon,
   TextField,
   Select,
@@ -257,12 +256,6 @@ class SettingsKnowledgeBase extends Component {
               </Button>
             )}
           >
-            {!isCreateMode && (
-              <Headline size="xx-large" tag="h3">
-                <FormattedMessage id="ui-eholdings.settings.kb.rmApiCreds" />
-              </Headline>
-            )}
-
             {kbCredentials.isLoading
               ? <Icon icon="spinner-ellipsis" />
               : (

--- a/src/components/settings/settings-root-proxy/settings-root-proxy.js
+++ b/src/components/settings/settings-root-proxy/settings-root-proxy.js
@@ -2,10 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Form } from 'react-final-form';
 import createFocusDecorator from 'final-form-focus';
-import {
-  Headline,
-  Icon,
-} from '@folio/stripes/components';
+import { Icon } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 
 import SettingsForm from '../settings-form';
@@ -74,10 +71,6 @@ export default class SettingsRootProxy extends Component {
             title={<FormattedMessage id="ui-eholdings.settings.rootProxy" />}
             toasts={this.state.toasts}
           >
-            <Headline size="xx-large" tag="h3">
-              <FormattedMessage id="ui-eholdings.settings.rootProxy.setting" />
-            </Headline>
-
             {proxyTypes.isLoading ? (
               <Icon icon="spinner-ellipsis" />
             ) : (


### PR DESCRIPTION
## Description
Layout updates:
- remove headline on KB settings page
- remove headline on Root Proxy settings page

## Issue
[UIEH-911](https://issues.folio.org/browse/UIEH-911)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://user-images.githubusercontent.com/55701515/89764515-32146580-dafd-11ea-8102-89c0bbcd10c6.png)

![image](https://user-images.githubusercontent.com/55701515/89764529-3a6ca080-dafd-11ea-8325-9f587189315d.png)

