### PR TITLE
[UIEH-920] Create/Edit Custom Title > Name and Package required field does not display as a red asterisk NOR is it read by a screenreader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fixed no Provider/Package/Title results message. (UIEH-905)
 * Change holdings status button label. (UIEH-935)
 * Changed asterisk to red and added accessibility label on Create/Edit Custom Package > Name. (UIEH-919)
+* Changed asterisk to red and added accessibility label on Create/Edit Custom Title > Name and Package. (UIEH-920)
 
 ## [4.0.1] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-07-08)
 

--- a/src/components/title/_fields/name/title-name-field.js
+++ b/src/components/title/_fields/name/title-name-field.js
@@ -27,9 +27,10 @@ function TitleNameField() {
             name="name"
             type="text"
             component={TextField}
-            label={<FormattedMessage id="ui-eholdings.label.name.isRequired" />}
+            label={<FormattedMessage id="ui-eholdings.label.name" />}
             validate={validate}
             ariaLabel={ariaLabel}
+            required
           />
         )}
       </FormattedMessage>

--- a/src/components/title/_fields/package-select/package-select-field.js
+++ b/src/components/title/_fields/package-select/package-select-field.js
@@ -15,9 +15,10 @@ function PackageSelectField({ options }) {
       <Field
         name="packageId"
         component={Select}
-        label={<FormattedMessage id="ui-eholdings.title.package.isRequired" />}
+        label={<FormattedMessage id="ui-eholdings.label.package" />}
         validate={validate}
         onBlur={null} // preventing validation that is in onBlur
+        required
       >
         {options.length ? (
           <FormattedMessage id="ui-eholdings.title.chooseAPackage">

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -137,6 +137,7 @@ export default class TitleCreate extends Component {
                   paneTitle={paneTitle}
                   firstMenu={this.renderFirstMenu()}
                   footer={this.getFooter(pristine, reset)}
+                  noValidate
                 >
                   <div className={styles['title-create-form-container']}>
                     <DetailsViewSection


### PR DESCRIPTION
[[UIEH-920]](https://issues.folio.org/browse/UIEH-920) Create/Edit Custom Title > Name and Package required field does not display as a red asterisk NOR is it read by a screenreader
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Create/Edit Custom Title >

Name and Package required field does not display as a red asterisk
NOR is it read by a screenreader

