### PR TITLE
UIEH-928: add possibility to filter packages on the title page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Changed asterisk to red and added accessibility label on Create/Edit Custom Package > Name. (UIEH-919)
 * Changed asterisk to red and added accessibility label on Create/Edit Custom Title > Name and Package. (UIEH-920)
 * Add custom labels settings permissions. (UIEH-865)
+* Add possibility to filter packages on the title page. (UIEH-928)
 
 ## [4.0.1] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-07-08)
 

--- a/src/components/title/show/package-filter-modal/index.js
+++ b/src/components/title/show/package-filter-modal/index.js
@@ -1,0 +1,1 @@
+export { default } from './package-filter-modal';

--- a/src/components/title/show/package-filter-modal/package-filter-modal.css
+++ b/src/components/title/show/package-filter-modal/package-filter-modal.css
@@ -1,0 +1,3 @@
+.content {
+  min-height: 20rem;
+}

--- a/src/components/title/show/package-filter-modal/package-filter-modal.js
+++ b/src/components/title/show/package-filter-modal/package-filter-modal.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Modal,
+  Button,
+  ModalFooter,
+  MultiSelection,
+} from '@folio/stripes/components';
+
+import useModalToggle from './use-modal-toggle';
+import usePackageFilterSelectOptions from './use-package-filter-select-options';
+import SearchBadge from '../../../search-modal/search-badge';
+
+import css from './package-filter-modal.css';
+
+const propTypes = {
+  allPackages: PropTypes.array.isRequired,
+  filterCount: PropTypes.number.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  selectedPackages: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.string,
+  })).isRequired,
+};
+
+const PackageFilterModal = ({
+  allPackages,
+  selectedPackages,
+  onSubmit,
+  filterCount,
+}) => {
+  const {
+    isOpen,
+    toggleModal,
+  } = useModalToggle();
+
+  const {
+    allOptions,
+    selectedOptions,
+    setSelectedOptions,
+  } = usePackageFilterSelectOptions(allPackages, selectedPackages);
+
+  const handleFilterChange = value => {
+    setSelectedOptions(value);
+  };
+
+  const handleReset = () => {
+    onSubmit([]);
+    setSelectedOptions([]);
+    toggleModal();
+  };
+
+  const handleSubmit = () => {
+    const newSelectedPackages = allPackages.filter(({ id: packageId }) => selectedOptions.some((({ value: optionId }) => packageId === optionId)));
+
+    onSubmit(newSelectedPackages);
+    toggleModal();
+  };
+
+  const renderModal = () => {
+    const footer = (
+      <ModalFooter>
+        <Button
+          buttonStyle="primary"
+          onClick={handleSubmit}
+        >
+          <FormattedMessage id="ui-eholdings.filter.search" />
+        </Button>
+        <Button onClick={handleReset}>
+          <FormattedMessage id="ui-eholdings.filter.resetAll" />
+        </Button>
+      </ModalFooter>
+    );
+
+    return (
+      <Modal
+        open
+        closeOnBackgroundClick
+        dismissible
+        size="small"
+        contentClass={css.content}
+        label={<FormattedMessage id="ui-eholdings.filter.filterType.packages" />}
+        footer={footer}
+        onClose={toggleModal}
+      >
+        <MultiSelection
+          label={<FormattedMessage id="ui-eholdings.label.packages" />}
+          dataOptions={allOptions}
+          onChange={handleFilterChange}
+          value={selectedOptions}
+        />
+      </Modal>
+    );
+  };
+
+  return (
+    <>
+      <SearchBadge
+        onClick={toggleModal}
+        filterCount={filterCount}
+      />
+      {isOpen && renderModal()}
+    </>
+  );
+};
+
+PackageFilterModal.propTypes = propTypes;
+
+export default PackageFilterModal;

--- a/src/components/title/show/package-filter-modal/package-filter-modal.js
+++ b/src/components/title/show/package-filter-modal/package-filter-modal.js
@@ -64,11 +64,15 @@ const PackageFilterModal = ({
       <ModalFooter>
         <Button
           buttonStyle="primary"
+          data-test-package-selection-modal-submit
           onClick={handleSubmit}
         >
           <FormattedMessage id="ui-eholdings.filter.search" />
         </Button>
-        <Button onClick={handleReset}>
+        <Button
+          onClick={handleReset}
+          data-test-package-selection-modal-reset-all
+        >
           <FormattedMessage id="ui-eholdings.filter.resetAll" />
         </Button>
       </ModalFooter>
@@ -84,12 +88,15 @@ const PackageFilterModal = ({
         label={<FormattedMessage id="ui-eholdings.filter.filterType.packages" />}
         footer={footer}
         onClose={toggleModal}
+        id="package-filter-modal"
       >
         <MultiSelection
           label={<FormattedMessage id="ui-eholdings.label.packages" />}
           dataOptions={allOptions}
           onChange={handleFilterChange}
           value={selectedOptions}
+          data-test-package-filter-select
+          id="packageFilterSelect"
         />
       </Modal>
     );

--- a/src/components/title/show/package-filter-modal/use-modal-toggle.js
+++ b/src/components/title/show/package-filter-modal/use-modal-toggle.js
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+
+const useModalToggle = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleModal = () => { setIsOpen(open => !open); };
+
+  return { isOpen, toggleModal };
+};
+
+export default useModalToggle;

--- a/src/components/title/show/package-filter-modal/use-package-filter-select-options.js
+++ b/src/components/title/show/package-filter-modal/use-package-filter-select-options.js
@@ -1,0 +1,16 @@
+import { useState, useMemo } from 'react';
+
+const getOptionsFromPackageList = packages => packages.map(({ id, packageName }) => ({ value: id, label: packageName }));
+
+const usePackageFilterSelectOptions = (allPackages, selectedPackages) => {
+  const [selectedOptions, setSelectedOptions] = useState(() => getOptionsFromPackageList(selectedPackages));
+  const allOptions = useMemo(() => getOptionsFromPackageList(allPackages), [allPackages]);
+
+  return {
+    allOptions,
+    selectedOptions,
+    setSelectedOptions,
+  };
+};
+
+export default usePackageFilterSelectOptions;

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -233,7 +233,7 @@ class TitleShow extends Component {
               allPackages={model.resources.records}
               selectedPackages={filteredPackages}
               onSubmit={this.handlePackageFilterChange}
-              filterCount={packageFilterApplied ? 1 : 0}
+              filterCount={packageFilterApplied ? 1 : 0} // todo: implement actual filter counting to avoid hardcoding
             />)
           }
           bodyContent={(

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -91,7 +91,6 @@ class TitleShow extends Component {
       model,
     } = this.props;
 
-
     const { filteredPackages: filteredPackagesIds } = qs.parse(location.search, {
       ignoreQueryPrefix: true,
     });
@@ -120,7 +119,6 @@ class TitleShow extends Component {
     });
     history.replace({ search: newSearch }, { eholdings: true });
   }
-
 
   get lastMenu() {
     const {

--- a/test/bigtest/interactors/package-filter-modal.js
+++ b/test/bigtest/interactors/package-filter-modal.js
@@ -1,0 +1,18 @@
+import {
+  interactor,
+  clickable,
+  text,
+  property,
+  isPresent,
+} from '@bigtest/interactor';
+
+import MultiSelectInteractor from '@folio/stripes-components/lib/MultiSelection/tests/interactor';
+
+@interactor class PackageFilterModal {
+  clickResetAll = clickable('[data-test-package-selection-modal-reset-all]');
+  clickSearch = clickable('[data-test-package-selection-modal-submit]');
+  packageMultiSelect = new MultiSelectInteractor('#packageFilterSelect');
+  modalIsDisplayed = isPresent('#package-filter-modal');
+}
+
+export default new PackageFilterModal();

--- a/test/bigtest/interactors/package-filter-modal.js
+++ b/test/bigtest/interactors/package-filter-modal.js
@@ -1,8 +1,6 @@
 import {
   interactor,
   clickable,
-  text,
-  property,
   isPresent,
 } from '@bigtest/interactor';
 

--- a/test/bigtest/interactors/title-show.js
+++ b/test/bigtest/interactors/title-show.js
@@ -21,6 +21,7 @@ import AddToCustomPackageModal from './add-to-custom-package-modal';
     return this.when(() => this.isLoaded);
   }
 
+  clickSearchBadge = clickable('[data-test-eholdings-search-filters="icon"]')
   paneTitle = text('[data-test-eholdings-details-view-pane-title]');
   titleName = text('[data-test-eholdings-details-view-name="title"]');
   nameHasFocus = is('[data-test-eholdings-details-view-name="title"]', ':focus');

--- a/test/bigtest/tests/title-show-package-filter-test.js
+++ b/test/bigtest/tests/title-show-package-filter-test.js
@@ -5,10 +5,9 @@ import setupApplication from '../helpers/setup-application';
 import TitleShowPage from '../interactors/title-show';
 import PackageFilterModal from '../interactors/package-filter-modal';
 
-describe.only('TitleShow package filter flow', () => {
+describe('TitleShow package filter flow', () => {
   setupApplication();
-  let title,
-    resources;
+  let title;
 
   beforeEach(function () {
     title = this.server.create('title', 'withPackages', {
@@ -39,8 +38,6 @@ describe.only('TitleShow package filter flow', () => {
     ].map(m => m.toJSON());
 
     title.save();
-
-    resources = title.resources.models;
   });
 
   describe('when the title show page is opened', () => {

--- a/test/bigtest/tests/title-show-package-filter-test.js
+++ b/test/bigtest/tests/title-show-package-filter-test.js
@@ -1,0 +1,113 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+
+import setupApplication from '../helpers/setup-application';
+import TitleShowPage from '../interactors/title-show';
+import PackageFilterModal from '../interactors/package-filter-modal';
+
+describe.only('TitleShow package filter flow', () => {
+  setupApplication();
+  let title,
+    resources;
+
+  beforeEach(function () {
+    title = this.server.create('title', 'withPackages', {
+      name: 'Cool Title',
+      edition: 'Cool Edition',
+      publisherName: 'Cool Publisher',
+      publicationType: 'Website'
+    });
+
+    title.subjects = [
+      this.server.create('subject', { subject: 'Cool Subject 1' }),
+      this.server.create('subject', { subject: 'Cool Subject 2' }),
+      this.server.create('subject', { subject: 'Cool Subject 3' })
+    ].map(m => m.toJSON());
+
+    title.identifiers = [
+      this.server.create('identifier', { type: 'ISBN', subtype: 'Print', id: '978-0547928210' }),
+      this.server.create('identifier', { type: 'ISBN', subtype: 'Print', id: '978-0547928203' }),
+      this.server.create('identifier', { type: 'ISBN', subtype: 'Online', id: '978-0547928197' }),
+      this.server.create('identifier', { type: 'ISBN', subtype: 'Empty', id: '978-0547928227' }),
+      this.server.create('identifier', { type: 'Mid', subtype: 'someothersubtype', id: 'someothertypeofid' })
+    ].map(m => m.toJSON());
+
+    title.contributors = [
+      this.server.create('contributor', { type: 'author', contributor: 'Writer, Sally' }),
+      this.server.create('contributor', { type: 'author', contributor: 'Wordsmith, Jane' }),
+      this.server.create('contributor', { type: 'illustrator', contributor: 'Artist, John' })
+    ].map(m => m.toJSON());
+
+    title.save();
+
+    resources = title.resources.models;
+  });
+
+  describe('when the title show page is opened', () => {
+    beforeEach(function () {
+      this.visit(`/eholdings/titles/${title.id}`);
+    });
+
+    describe('and the package filter modal is opened', () => {
+      beforeEach(async () => {
+        await TitleShowPage.clickSearchBadge();
+      });
+
+      it('should display the package filter modal', () => {
+        expect(PackageFilterModal.modalIsDisplayed).to.be.true;
+      });
+
+      it('the package filter select should be empty by default', () => {
+        expect(PackageFilterModal.packageMultiSelect.values()).to.deep.equal([]);
+      });
+
+      describe('and one package was selected', () => {
+        beforeEach(async () => {
+          await PackageFilterModal.packageMultiSelect.options(0).clickOption();
+        });
+
+        describe('and reset all was clicked', () => {
+          beforeEach(async () => {
+            await PackageFilterModal.clickResetAll();
+          });
+
+          it('should close the modal', () => {
+            expect(PackageFilterModal.modalIsDisplayed).to.be.false;
+          });
+
+          it('should display all of the packages that the titles has', () => {
+            expect(TitleShowPage.packageList().length).to.equal(title.resources.length);
+          });
+        });
+
+        describe('and search button was clicked', () => {
+          beforeEach(async () => {
+            await PackageFilterModal.clickSearch();
+          });
+
+          it('should close the modal', () => {
+            expect(PackageFilterModal.modalIsDisplayed).to.be.false;
+          });
+
+          it('should display one package in the package list', () => {
+            expect(TitleShowPage.packageList().length).to.equal(1);
+          });
+
+          it('should contain the package filter in the url', function () {
+            expect(this.location.search).to.equal(`?filteredPackages%5B0%5D=${title.resources.models[0].id}`);
+          });
+        });
+      });
+    });
+  });
+
+  describe('when the URL contains package filter', () => {
+    beforeEach(function () {
+      this.visit(`/eholdings/titles/${title.id}?filteredPackages%5B0%5D=${title.resources.models[0].id}`);
+    });
+
+    it('the package list should contain one package', () => {
+      expect(TitleShowPage.packageList().length).to.equal(1);
+    });
+  });
+});

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -304,6 +304,7 @@
     "filter.pubType.website": "Website",
     "filter.pubType.unspecified": "Unspecified",
     "filter.resetAll": "Reset all",
+    "filter.search": "Search",
     "filter.filterType": "Filter {listType}",
     "filter.filterType.packages": "Filter packages",
     "filter.filterType.titles": "Filter titles",


### PR DESCRIPTION
This PR implements the functionality of filtering packages on the title page
[Ticket](https://issues.folio.org/browse/UIEH-928)

## Screen 
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/43514877/91554902-aaba5500-e938-11ea-9400-33d8451f4c1c.png">

## Tests
<img width="693" alt="image" src="https://user-images.githubusercontent.com/43514877/91559551-f83ac000-e940-11ea-898b-b0ff9ecd184f.png">
