### PR TITLE
[UIEH-939] Pass aria-labelledby to MultiSelection component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add possibility to filter packages on the title page. (UIEH-928)
 * New/Edit Custom title: update Name required error message. (UIEH-958)
 * Add Tags label assigned to Title and Packages (UIEH-933, UIEH-934)
+* Pass aria-labelledby to MultiSelection component (UIEH-939)
 
 ## [4.0.1] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-07-08)
 

--- a/src/components/tags/tags.js
+++ b/src/components/tags/tags.js
@@ -22,6 +22,7 @@ export default class Tags extends React.Component {
     super(props);
     this.onChange = this.onChange.bind(this);
     this.filterItems = this.filterItems.bind(this);
+    this.labelId = 'multiselection-details-tags-label';
   }
 
   onAdd(tags) {
@@ -183,6 +184,9 @@ export default class Tags extends React.Component {
 
     return (
       <div data-test-eholdings-details-tags>
+        <span className="sr-only" id={this.labelId}>
+          <FormattedMessage id="stripes-smart-components.enterATag" />
+        </span>
         <FormattedMessage id="stripes-smart-components.enterATag">
           {placeholder => (
             <FormattedMessage id="stripes-smart-components.tagsTextArea">
@@ -190,6 +194,7 @@ export default class Tags extends React.Component {
                 <MultiSelection
                   placeholder={placeholder}
                   aria-label={ariaLabel}
+                  ariaLabelledBy={this.labelId}
                   actions={actions}
                   filter={this.filterItems}
                   emptyMessage=" "

--- a/src/components/title/show/package-filter-modal/package-filter-modal.js
+++ b/src/components/title/show/package-filter-modal/package-filter-modal.js
@@ -7,6 +7,7 @@ import {
   Button,
   ModalFooter,
   MultiSelection,
+  Label,
 } from '@folio/stripes/components';
 
 import useModalToggle from './use-modal-toggle';
@@ -78,6 +79,8 @@ const PackageFilterModal = ({
       </ModalFooter>
     );
 
+    const labelId = 'package-filter-modal-multiselection';
+
     return (
       <Modal
         open
@@ -90,13 +93,17 @@ const PackageFilterModal = ({
         onClose={toggleModal}
         id="package-filter-modal"
       >
+        <Label id={labelId}>
+          <FormattedMessage id="ui-eholdings.label.packages" />
+        </Label>
         <MultiSelection
-          label={<FormattedMessage id="ui-eholdings.label.packages" />}
           dataOptions={allOptions}
           onChange={handleFilterChange}
           value={selectedOptions}
           data-test-package-filter-select
           id="packageFilterSelect"
+          ariaLabelledBy={labelId}
+          aria-label={<FormattedMessage id="ui-eholdings.label.packages" />}
         />
       </Modal>
     );

--- a/src/components/title/show/package-filter-modal/package-filter-modal.js
+++ b/src/components/title/show/package-filter-modal/package-filter-modal.js
@@ -79,7 +79,7 @@ const PackageFilterModal = ({
       </ModalFooter>
     );
 
-    const labelId = 'package-filter-modal-multiselection';
+    const labelId = 'package-filter-modal-multiselection-label';
 
     return (
       <Modal


### PR DESCRIPTION
[[UIEH-939]](https://issues.folio.org/browse/UIEH-939) Pass aria-labelledby to MultiSelection component

## Purpose
Need to find places in ui-eholdings where we're using MultiSelection component and pass aria-labelledby prop that either:

References an already existing element on the page
References an element that has to be created, which has text for screen reader and .sr-only class
