### PR TITLE
UIEH-960: Package/Title pages experience wobbly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 * Add custom labels settings permissions. (UIEH-865)
 * Add possibility to filter packages on the title page. (UIEH-928)
 * New/Edit Custom title: update Name required error message. (UIEH-958)
-* Add Tags label assigned to Title and Packages (UIEH-933, UIEH-934)
+* Add Tags label assigned to Title and Packages. (UIEH-933, UIEH-934)
+* Fix Package/Title view page wobbles when scrolling. (UIEH-960)
 
 ## [4.0.1] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-07-08)
 

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -122,8 +122,8 @@ class DetailsView extends Component {
    */
   handleLayout = () => {
     if (this.$container && this.$sticky && this.$list) {
-      const stickyHeight = this.$sticky.offsetHeight;
-      const containerHeight = this.$container.offsetHeight;
+      const stickyHeight = Math.floor(this.$sticky.getBoundingClientRect().height);
+      const containerHeight = Math.floor(this.$container.getBoundingClientRect().height);
 
       this.shouldHandleScroll = stickyHeight >= containerHeight;
 


### PR DESCRIPTION
## Purpose
- Fix calculation of scrollable list height to be more precise

## Issue
[UIEH-960](https://issues.folio.org/browse/UIEH-960)