### PR TITLE
[UIEH-924] Package View - Invalid id and aria-labelledby attributes in Pane header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Add Tags label assigned to Title and Packages (UIEH-933, UIEH-934)
 * Pass aria-labelledby to MultiSelection component (UIEH-939)
 * Bumped `erm` interface version to `3.0`.
+* Fixed id and aria-labelledby attributes in Pane header. (UIEH-924)
 
 ## [4.0.1] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-07-08)
 

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -376,6 +376,7 @@ class DetailsView extends Component {
       hasFooter: !!footer,
     });
 
+    const paneTitleId = 'details-view-pane-title';
 
     return (
       <div data-test-eholdings-details-view={type}>
@@ -388,12 +389,18 @@ class DetailsView extends Component {
             footer={footer}
             firstMenu={this.renderFirstMenu()}
             paneTitle={
-              <span data-test-eholdings-details-view-pane-title>{paneTitle}</span>
+              <span
+                data-test-eholdings-details-view-pane-title
+                id={paneTitleId}
+              >
+                {paneTitle}
+              </span>
             }
             lastMenu={lastMenu}
             paneSub={
               <span data-test-eholdings-details-view-pane-sub>{paneSub}</span>
             }
+            aria-labelledby={paneTitleId}
           >
             <div
               ref={(n) => { this.$container = n; }}


### PR DESCRIPTION
[[UIEH-924]](https://issues.folio.org/browse/UIEH-924) Package View - Invalid id and aria-labelledby attributes in Pane header

## Purpose
Invalid ARIA attribute value: aria-labelledby="paneHeaderEBSCO Biotechnology Collection: India-pane-title"
