### PR TITLE
UIEH-923: Providers, Packages, Titles filter - accordions do not have correct ARIA attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Pass aria-labelledby to MultiSelection component (UIEH-939)
 * Bumped `erm` interface version to `3.0`.
 * Fixed id and aria-labelledby attributes in Pane header. (UIEH-924)
+* Fixed Providers, Packages, Titles filter - accordions ARIA attributes. (UIEH-923)
 
 ## [4.0.1] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Add Tags label assigned to Title and Packages (UIEH-933, UIEH-934)
 * Pass aria-labelledby to MultiSelection component (UIEH-939)
 * Bumped `erm` interface version to `3.0`.
+* Fixed id and aria-labelledby attributes in Pane header. (UIEH-924)
 
 ## [4.0.1] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-07-08)
 

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -331,6 +331,9 @@ class DetailsView extends Component {
                     id={listSectionId}
                     onToggle={onListToggle}
                     listType={listType}
+                    headerProps={{
+                      role: 'tab'
+                    }}
                   >
                     {renderList(isSticky)}
                   </Accordion>

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -376,6 +376,7 @@ class DetailsView extends Component {
       hasFooter: !!footer,
     });
 
+    const paneTitleId = 'details-view-pane-title';
 
     return (
       <div data-test-eholdings-details-view={type}>
@@ -388,12 +389,18 @@ class DetailsView extends Component {
             footer={footer}
             firstMenu={this.renderFirstMenu()}
             paneTitle={
-              <span data-test-eholdings-details-view-pane-title>{paneTitle}</span>
+              <span
+                data-test-eholdings-details-view-pane-title
+                id={paneTitleId}
+              >
+                {paneTitle}
+              </span>
             }
             lastMenu={lastMenu}
             paneSub={
               <span data-test-eholdings-details-view-pane-sub>{paneSub}</span>
             }
+            aria-labelledby={paneTitleId}
           >
             <div
               ref={(n) => { this.$container = n; }}

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -331,9 +331,7 @@ class DetailsView extends Component {
                     id={listSectionId}
                     onToggle={onListToggle}
                     listType={listType}
-                    headerProps={{
-                      role: 'tab'
-                    }}
+                    headerProps={{ role: 'tab' }}
                   >
                     {renderList(isSticky)}
                   </Accordion>

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -324,9 +324,7 @@ class PackageShow extends Component {
       packageSelected,
     } = this.state;
 
-    const headerProps = {
-      role: 'tab'
-    };
+    const headerProps = { role: 'tab' };
 
     return (
       <>

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -324,6 +324,10 @@ class PackageShow extends Component {
       packageSelected,
     } = this.state;
 
+    const headerProps = {
+      role: 'tab'
+    };
+
     return (
       <>
         <TagsAccordion
@@ -347,6 +351,7 @@ class PackageShow extends Component {
           open={sections.packageShowHoldingStatus}
           id="packageShowHoldingStatus"
           onToggle={this.handleSectionToggle}
+          headerProps={headerProps}
         >
           <SelectionStatus
             model={model}
@@ -366,6 +371,7 @@ class PackageShow extends Component {
           open={sections.packageShowInformation}
           id="packageShowInformation"
           onToggle={this.handleSectionToggle}
+          headerProps={headerProps}
         >
           <KeyValueColumns>
             <div>
@@ -426,6 +432,7 @@ class PackageShow extends Component {
           open={sections.packageShowSettings}
           id="packageShowSettings"
           onToggle={this.handleSectionToggle}
+          headerProps={headerProps}
         >
           {
             packageSelected
@@ -447,6 +454,7 @@ class PackageShow extends Component {
           open={sections.packageShowCoverageSettings}
           id="packageShowCoverageSettings"
           onToggle={this.handleSectionToggle}
+          headerProps={headerProps}
         >
           {
             packageSelected
@@ -498,6 +506,7 @@ class PackageShow extends Component {
           refType={entityAuthorityTypes.PACKAGE}
           isOpen={sections.packageShowAgreements}
           onToggle={this.handleSectionToggle}
+          headerProps={headerProps}
         />
 
         <NotesSmartAccordion
@@ -510,6 +519,7 @@ class PackageShow extends Component {
           entityId={model.id}
           pathToNoteCreate={paths.NOTE_CREATE}
           pathToNoteDetails={paths.NOTES}
+          headerProps={headerProps}
         />
       </>
     );

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -337,6 +337,7 @@ class PackageShow extends Component {
           open={sections.packageShowTags}
           tagsModel={tagsModel}
           updateFolioTags={updateFolioTags}
+          headerProps={headerProps}
         />
 
         <Accordion

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -167,9 +167,7 @@ class ProviderShow extends Component {
     const hasProxy = hasIn('proxy.id', model);
     const hasToken = hasIn('providerToken.prompt', model);
     const hasProviderSettings = hasProxy || hasToken;
-    const headerProps = {
-      role: 'tab'
-    };
+    const headerProps = { role: 'tab' };
 
     return (
       <>

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -167,6 +167,9 @@ class ProviderShow extends Component {
     const hasProxy = hasIn('proxy.id', model);
     const hasToken = hasIn('providerToken.prompt', model);
     const hasProviderSettings = hasProxy || hasToken;
+    const headerProps = {
+      role: 'tab'
+    };
 
     return (
       <>
@@ -191,6 +194,7 @@ class ProviderShow extends Component {
           open={sections.providerShowProviderInformation}
           id="providerShowProviderInformation"
           onToggle={this.handleSectionToggle}
+          headerProps={headerProps}
         >
           <KeyValue label={<FormattedMessage id="ui-eholdings.provider.packagesSelected" />}>
             <div data-test-eholdings-provider-details-packages-selected>
@@ -219,6 +223,7 @@ class ProviderShow extends Component {
               open={sections.providerShowProviderSettings}
               id="providerShowProviderSettings"
               onToggle={this.handleSectionToggle}
+              headerProps={headerProps}
             >
               {hasProxy && this.renderProxy()}
               {hasToken && this.renderToken()}
@@ -236,6 +241,7 @@ class ProviderShow extends Component {
           entityId={model.id}
           pathToNoteCreate={paths.NOTE_CREATE}
           pathToNoteDetails={paths.NOTES}
+          headerProps={headerProps}
         />
       </>
     );

--- a/src/components/provider/show/provider-show.js
+++ b/src/components/provider/show/provider-show.js
@@ -180,6 +180,7 @@ class ProviderShow extends Component {
           open={sections.providerShowTags}
           tagsModel={tagsModel}
           updateFolioTags={updateFolioTags}
+          headerProps={headerProps}
         />
 
         <Accordion

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -256,9 +256,7 @@ class ResourceShow extends Component {
         type: 'success'
       });
     }
-    const headerProps = {
-      role: 'tab'
-    };
+    const headerProps = { role: 'tab' };
 
     return (
       <>

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -256,6 +256,9 @@ class ResourceShow extends Component {
         type: 'success'
       });
     }
+    const headerProps = {
+      role: 'tab'
+    };
 
     return (
       <>
@@ -278,6 +281,7 @@ class ResourceShow extends Component {
                 open={sections.resourceShowTags}
                 tagsModel={tagsModel}
                 updateFolioTags={updateFolioTags}
+                headerProps={headerProps}
               />
 
               <Accordion
@@ -285,6 +289,7 @@ class ResourceShow extends Component {
                 open={sections.resourceShowHoldingStatus}
                 id="resourceShowHoldingStatus"
                 onToggle={this.handleSectionToggle}
+                headerProps={headerProps}
               >
                 <label
                   data-test-eholdings-resource-show-selected
@@ -332,6 +337,7 @@ class ResourceShow extends Component {
                 open={sections.resourceShowInformation}
                 id="resourceShowInformation"
                 onToggle={this.handleSectionToggle}
+                headerProps={headerProps}
               >
                 <KeyValueColumns>
                   <div>
@@ -444,6 +450,7 @@ class ResourceShow extends Component {
                   onToggle={this.handleSectionToggle}
                   section={CustomLabelsShowSection}
                   userDefinedFields={userDefinedFields}
+                  headerProps={headerProps}
                 />}
 
               <Accordion
@@ -451,6 +458,7 @@ class ResourceShow extends Component {
                 open={sections.resourceShowSettings}
                 id="resourceShowSettings"
                 onToggle={this.handleSectionToggle}
+                headerProps={headerProps}
               >
                 <KeyValue label={<FormattedMessage id="ui-eholdings.label.showToPatrons" />}>
                   <div data-test-eholdings-resource-show-visibility>
@@ -511,6 +519,7 @@ class ResourceShow extends Component {
                 open={sections.resourceShowCoverageSettings}
                 id="resourceShowCoverageSettings"
                 onToggle={this.handleSectionToggle}
+                headerProps={headerProps}
               >
 
                 {hasManagedCoverages && !hasCustomCoverages && (
@@ -592,6 +601,7 @@ class ResourceShow extends Component {
                 refType={entityAuthorityTypes.RESOURCE}
                 isOpen={sections.resourceShowAgreements}
                 onToggle={this.handleSectionToggle}
+                headerProps={headerProps}
               />
 
               <NotesSmartAccordion
@@ -604,6 +614,7 @@ class ResourceShow extends Component {
                 entityId={model.id}
                 pathToNoteCreate={paths.NOTE_CREATE}
                 pathToNoteDetails={paths.NOTES}
+                headerProps={headerProps}
               />
             </>
           )}

--- a/src/components/tags/tags-accordion.js
+++ b/src/components/tags/tags-accordion.js
@@ -39,7 +39,7 @@ class TagsAccordion extends React.Component {
       updateFolioTags,
       updateEntityTags,
       entityTags,
-      headerProps
+      headerProps,
     } = this.props;
 
     return (

--- a/src/components/tags/tags-accordion.js
+++ b/src/components/tags/tags-accordion.js
@@ -19,6 +19,7 @@ import { updateEntityTags as updateEntityTagsAction } from '../../redux/actions'
 class TagsAccordion extends React.Component {
   static propTypes = {
     entityTags: PropTypes.arrayOf(PropTypes.string),
+    headerProps: PropTypes.object,
     id: PropTypes.string.isRequired,
     model: PropTypes.object.isRequired,
     onToggle: PropTypes.func.isRequired,
@@ -38,6 +39,7 @@ class TagsAccordion extends React.Component {
       updateFolioTags,
       updateEntityTags,
       entityTags,
+      headerProps
     } = this.props;
 
     return (
@@ -60,9 +62,7 @@ class TagsAccordion extends React.Component {
             </span>
           </Badge>
         }
-        headerProps={{
-          role: 'tab'
-        }}
+        headerProps={headerProps}
       >
         {(!tagsModel.request.isResolved || model.isLoading)
           ? <Icon icon="spinner-ellipsis" />

--- a/src/components/tags/tags-accordion.js
+++ b/src/components/tags/tags-accordion.js
@@ -60,6 +60,9 @@ class TagsAccordion extends React.Component {
             </span>
           </Badge>
         }
+        headerProps={{
+          role: 'tab'
+        }}
       >
         {(!tagsModel.request.isResolved || model.isLoading)
           ? <Icon icon="spinner-ellipsis" />

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -215,6 +215,9 @@ class TitleShow extends Component {
     };
     let submit;
     const submitAddToCustomPackage = (event) => submit(event);
+    const headerProps = {
+      role: 'tab'
+    };
 
     return (
       <>
@@ -243,6 +246,7 @@ class TitleShow extends Component {
               open={sections.titleShowTitleInformation}
               id="titleShowTitleInformation"
               onToggle={this.handleSectionToggle}
+              headerProps={headerProps}
             >
               <KeyValueColumns>
                 <div>

--- a/src/components/title/show/title-show.js
+++ b/src/components/title/show/title-show.js
@@ -215,9 +215,7 @@ class TitleShow extends Component {
     };
     let submit;
     const submitAddToCustomPackage = (event) => submit(event);
-    const headerProps = {
-      role: 'tab'
-    };
+    const headerProps = { role: 'tab' };
 
     return (
       <>

--- a/src/features/agreements-accordion/agreements-accordion.js
+++ b/src/features/agreements-accordion/agreements-accordion.js
@@ -34,6 +34,7 @@ class AgreementsAccordion extends Component {
     agreements: PropTypes.object.isRequired,
     attachAgreement: PropTypes.func.isRequired,
     getAgreements: PropTypes.func.isRequired,
+    headerProps: PropTypes.object,
     id: PropTypes.string.isRequired,
     isOpen: PropTypes.bool,
     onToggle: PropTypes.func,
@@ -140,6 +141,7 @@ class AgreementsAccordion extends Component {
       isOpen,
       id,
       onToggle,
+      headerProps,
     } = this.props;
 
     return (
@@ -151,6 +153,7 @@ class AgreementsAccordion extends Component {
           displayWhenOpen={this.getAgreementsAccordionButtons()}
           displayWhenClosed={this.renderBadge()}
           onToggle={onToggle}
+          headerProps={headerProps}
         >
           <AgreementsList agreements={agreements} />
         </Accordion>

--- a/src/features/custom-labels-accordion/custom-labels-accordion.js
+++ b/src/features/custom-labels-accordion/custom-labels-accordion.js
@@ -22,6 +22,7 @@ class CustomLabelsAccordion extends Component {
       }),
     }).isRequired,
     getCustomLabels: PropTypes.func.isRequired,
+    headerProps: PropTypes.object,
     id: PropTypes.string.isRequired,
     isOpen: PropTypes.bool,
     onToggle: PropTypes.func.isRequired,
@@ -67,6 +68,7 @@ class CustomLabelsAccordion extends Component {
       onToggle,
       section: Section,
       userDefinedFields,
+      headerProps,
     } = this.props;
 
     const data = get(customLabels, ['items', 'data'], []);
@@ -79,6 +81,7 @@ class CustomLabelsAccordion extends Component {
             label={this.getCustomLabelsAccordionHeader()}
             open={isOpen}
             onToggle={onToggle}
+            headerProps={headerProps}
           >
             <Section
               customLabels={data}


### PR DESCRIPTION
[UIEH-923](https://issues.folio.org/browse/UIEH-923): Providers, Packages, Titles filter - accordions do not have correct ARIA attributes

## Purpose
Element with a `tablist` role missed children with a `tab` role.

Related PR's

- Added additional props to `DefaultAcordionHeader` 
  https://github.com/folio-org/stripes-components/pull/1397

- Added headerProps property to `NotesSmartAccordion`
  https://github.com/folio-org/stripes-smart-components/pull/922