### PR TITLE
UIEH-925: View Package > Find Title - Accordions missing some ARIA attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fix issues in Title Record Filter packages Multi-select component. (UIEH-959)
 * Fixed Providers, Packages, Titles filter - accordions ARIA attributes. (UIEH-923)
 * Bumped `react-intl` version to `5.8.0`.
+* Fixed View Package > Find Title - Accordions missing some ARIA attributes. (UIEH-925)
 
 ## [4.0.1] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-07-08)
 

--- a/src/components/search-form/search-filters.js
+++ b/src/components/search-form/search-filters.js
@@ -36,6 +36,7 @@ export default function SearchFilters({
             displayClearButton={!!activeFilters[name] && activeFilters[name] !== defaultValue}
             onClearFilter={() => onUpdate({ ...activeFilters, [name]: undefined })}
             id={`filter-${searchType}-${name}`}
+            headerProps={{ role: 'tab' }}
           >
             <div
               role="radiogroup"

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -243,6 +243,7 @@ class SearchForm extends Component {
             displayClearButton={tagsList.length > 0}
             onClearFilter={() => this.props.onStandaloneFilterChange({ tags: undefined })}
             onToggle={this.toggleSection}
+            headerProps={{ role: 'tab' }}
           >
             {this.renderSearchByTagsCheckbox()}
             <FormattedMessage id="ui-eholdings.tags.filter">
@@ -307,6 +308,7 @@ class SearchForm extends Component {
             displayClearButton={accessTypesList.length}
             onClearFilter={() => this.props.onStandaloneFilterChange({ 'access-type': undefined })}
             onToggle={this.toggleSection}
+            headerProps={{ role: 'tab' }}
           >
             {this.renderSearchByAccessTypesCheckbox()}
             <FormattedMessage id="ui-eholdings.accessTypes.filter">


### PR DESCRIPTION
[UIEH-925](https://issues.folio.org/browse/UIEH-925): View Package > Find Title - Accordions missing some ARIA attributes

## Purpose
Accordions in search modal were missing `role="tab"` attributes.

Related PR - https://github.com/folio-org/stripes-components/pull/1402