### PR TITLE
UIEH-961: Fix bug with Datepicker on Resource Edit Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fixed Providers, Packages, Titles filter - accordions ARIA attributes. (UIEH-923)
 * Bumped `react-intl` version to `5.8.0`.
 * Fixed View Package > Find Title - Accordions missing some ARIA attributes. (UIEH-925)
+* Fix bug with `<Datepicker>` in Resource Edit Page. (UIEH-961)
 
 ## [4.0.1] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-07-08)
 

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -16,7 +16,15 @@ import {
   Col,
   Row,
 } from '@folio/stripes/components';
-
+import {
+  formatDate,
+  parseDate,
+} from '../../../utilities';
+import {
+  DATE_FORMAT,
+  BACKEND_DATE_STANDARD,
+  TIME_ZOME,
+} from '../../../../constants';
 
 class PackageCoverageFields extends Component {
   static propTypes = {
@@ -58,8 +66,6 @@ class PackageCoverageFields extends Component {
   }
 
   renderField = (dateRange) => {
-    const formatField = value => (value ? moment.utc(value) : '');
-
     return (
       <Row>
         <Col
@@ -69,12 +75,22 @@ class PackageCoverageFields extends Component {
         >
           <Field
             name={`${dateRange}.beginCoverage`}
-            type="text"
-            component={Datepicker}
-            label={<FormattedMessage id="ui-eholdings.date.startDate" />}
-            format={formatField}
             validate={this.validateCoverageDate}
-            timeZone="UTC"
+            timeZone={TIME_ZOME}
+            render={({ input, meta }) => (
+              <Datepicker
+                dateFormat={DATE_FORMAT}
+                parse={parseDate}
+                format={formatDate}
+                backendDateStandard={BACKEND_DATE_STANDARD}
+                error={meta.error}
+                id="begin-coverage"
+                input={input}
+                label={<FormattedMessage id="ui-eholdings.date.startDate" />}
+                useInput
+                usePortal
+              />
+            )}
           />
         </Col>
         <Col
@@ -84,12 +100,22 @@ class PackageCoverageFields extends Component {
         >
           <Field
             name={`${dateRange}.endCoverage`}
-            type="text"
-            component={Datepicker}
-            label={<FormattedMessage id="ui-eholdings.date.endDate" />}
-            format={formatField}
             validate={this.validateCoverageDate}
-            timeZone="UTC"
+            timeZone={TIME_ZOME}
+            render={({ input, meta }) => (
+              <Datepicker
+                dateFormat={DATE_FORMAT}
+                parse={parseDate}
+                format={formatDate}
+                backendDateStandard={BACKEND_DATE_STANDARD}
+                error={meta.error}
+                id="begin-coverage"
+                input={input}
+                label={<FormattedMessage id="ui-eholdings.date.endDate" />}
+                useInput
+                usePortal
+              />
+            )}
           />
         </Col>
       </Row>

--- a/src/components/resource/_fields/resource-coverage-fields/resource-coverage-fields.js
+++ b/src/components/resource/_fields/resource-coverage-fields/resource-coverage-fields.js
@@ -8,7 +8,6 @@ import {
   injectIntl,
 } from 'react-intl';
 
-import moment from 'moment';
 import isEqual from 'lodash/isEqual';
 import has from 'lodash/has';
 

--- a/src/components/resource/_fields/resource-coverage-fields/resource-coverage-fields.js
+++ b/src/components/resource/_fields/resource-coverage-fields/resource-coverage-fields.js
@@ -28,6 +28,8 @@ import { isBookPublicationType } from '../../../utilities';
 import styles from './resource-coverage-fields.css';
 
 const COVERAGE_STATEMENT_ON_STATUS = 'on';
+const BACKEND_DATE_STANDARD = 'YYYY-MM-DD';
+const DATE_FORMAT = 'MM/DD/YYYY';
 
 class ResourceCoverageFields extends Component {
   static propTypes = {
@@ -75,6 +77,8 @@ class ResourceCoverageFields extends Component {
       ? moment.utc(value)
       : '';
   }
+
+  parseDate = value => value;
 
   renderManagedCoverageFields = (formData) => {
     const { model } = this.props;
@@ -155,12 +159,20 @@ class ResourceCoverageFields extends Component {
         >
           <Field
             name={`${dateRange}.beginCoverage`}
-            type="text"
-            component={Datepicker}
-            label={<FormattedMessage id="ui-eholdings.date.startDate" />}
-            id="begin-coverage"
-            format={this.formatDate}
-            timeZone="UTC"
+            render={({ input, meta }) => (
+              <Datepicker
+                dateFormat={DATE_FORMAT}
+                parse={this.parseDate}
+                format={this.formatDate}
+                backendDateStandard={BACKEND_DATE_STANDARD}
+                error={meta.error}
+                id="begin-coverage"
+                input={input}
+                label={<FormattedMessage id="ui-eholdings.date.startDate" />}
+                useInput
+                usePortal
+              />
+            )}
           />
         </Col>
         <Col
@@ -170,12 +182,20 @@ class ResourceCoverageFields extends Component {
         >
           <Field
             name={`${dateRange}.endCoverage`}
-            type="text"
-            component={Datepicker}
-            label={<FormattedMessage id="ui-eholdings.date.endDate" />}
-            id="end-coverage"
-            format={this.formatDate}
-            timeZone="UTC"
+            render={({ input, meta }) => (
+              <Datepicker
+                dateFormat={DATE_FORMAT}
+                parse={this.parseDate}
+                format={this.formatDate}
+                backendDateStandard={BACKEND_DATE_STANDARD}
+                error={meta.error}
+                id="end-coverage"
+                input={input}
+                label={<FormattedMessage id="ui-eholdings.date.endDate" />}
+                useInput
+                usePortal
+              />
+            )}
           />
         </Col>
       </Row>

--- a/src/components/resource/_fields/resource-coverage-fields/resource-coverage-fields.js
+++ b/src/components/resource/_fields/resource-coverage-fields/resource-coverage-fields.js
@@ -23,13 +23,20 @@ import {
 import CoverageDateList from '../../../coverage-date-list';
 
 import validateDateRange from '../validate-date-range';
-import { isBookPublicationType } from '../../../utilities';
+import {
+  isBookPublicationType,
+  parseDate,
+  formatDate,
+} from '../../../utilities';
+import {
+  DATE_FORMAT,
+  BACKEND_DATE_STANDARD,
+  TIME_ZOME,
+} from '../../../../constants';
 
 import styles from './resource-coverage-fields.css';
 
 const COVERAGE_STATEMENT_ON_STATUS = 'on';
-const BACKEND_DATE_STANDARD = 'YYYY-MM-DD';
-const DATE_FORMAT = 'MM/DD/YYYY';
 
 class ResourceCoverageFields extends Component {
   static propTypes = {
@@ -71,14 +78,6 @@ class ResourceCoverageFields extends Component {
       />
     );
   }
-
-  formatDate(value) {
-    return value
-      ? moment.utc(value)
-      : '';
-  }
-
-  parseDate = value => value;
 
   renderManagedCoverageFields = (formData) => {
     const { model } = this.props;
@@ -159,11 +158,12 @@ class ResourceCoverageFields extends Component {
         >
           <Field
             name={`${dateRange}.beginCoverage`}
+            timeZone={TIME_ZOME}
             render={({ input, meta }) => (
               <Datepicker
                 dateFormat={DATE_FORMAT}
-                parse={this.parseDate}
-                format={this.formatDate}
+                parse={parseDate}
+                format={formatDate}
                 backendDateStandard={BACKEND_DATE_STANDARD}
                 error={meta.error}
                 id="begin-coverage"
@@ -182,11 +182,12 @@ class ResourceCoverageFields extends Component {
         >
           <Field
             name={`${dateRange}.endCoverage`}
+            timeZone={TIME_ZOME}
             render={({ input, meta }) => (
               <Datepicker
                 dateFormat={DATE_FORMAT}
-                parse={this.parseDate}
-                format={this.formatDate}
+                parse={parseDate}
+                format={formatDate}
                 backendDateStandard={BACKEND_DATE_STANDARD}
                 error={meta.error}
                 id="end-coverage"

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -224,3 +224,7 @@ export const getFullName = user => {
 
   return `${lastName}${firstName ? ', ' : ' '}${firstName}${middleName ? ' ' : ''}${middleName}`;
 };
+
+export const parseDate = value => value;
+
+export const formatDate = value => (value ? moment.utc(value) : '');

--- a/src/constants/backendDateStandard.js
+++ b/src/constants/backendDateStandard.js
@@ -1,0 +1,3 @@
+const BACKEND_DATE_STANDARD = 'YYYY-MM-DD';
+
+export default BACKEND_DATE_STANDARD;

--- a/src/constants/dateFormat.js
+++ b/src/constants/dateFormat.js
@@ -1,0 +1,3 @@
+const DATE_FORMAT = 'MM/DD/YYYY';
+
+export default DATE_FORMAT;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -15,4 +15,7 @@ export { default as KbCredentials } from './kbCredentialsReduxStateShape';
 export { default as KbCredentialsUsers } from './kbCredentialsUsersReduxStateShape';
 export { default as rootProxy } from './rootProxyReduxStateShape';
 export { default as httpResponseCodes } from './httpResponseCodes';
+export { default as DATE_FORMAT } from './dateFormat';
+export { default as BACKEND_DATE_STANDARD } from './backendDateStandard';
+export { default as TIME_ZOME } from './timeZone';
 export * from './filterConfigs';

--- a/src/constants/timeZone.js
+++ b/src/constants/timeZone.js
@@ -1,0 +1,3 @@
+const TIME_ZONE = 'UTC';
+
+export default TIME_ZONE;


### PR DESCRIPTION
 ### New/Edit Resource: Unable to edit custom coverage dates - by using input box only

## Purpose
After refactoring the `<Datepicker>` component in `stripes-components`, the `<Datepicker>` in the `ui-eholdings` ceased to function correctly for data entry via the input. This problem is inherent in the `<Datepicker>` used with `react-final-form`. The problematic place is the prop `format`, which, when the value changes, aggressively replaces it with a valid value from the store.

[UIEH-961](https://issues.folio.org/browse/UIEH-961)

## Approach

The solution to this problem was to rewrite the component call as in example from `<Datepicker>` documentation for use with the `react-final-form`. The main props for `<Datepicker>` in this situation are `dateFormat` which helps to keep correct date format in the input and `backendFormatStandard` which allows you to store data in the required format for the backend.

#### TODOS and Open Questions
Possibly, in future, it needs validation error messages under input if user sets wrong value. Needs to discuss it with PO

## Screenshots
![YI2QYWn8pL](https://user-images.githubusercontent.com/55701515/93995677-ffb38480-fd99-11ea-8eab-cc5e829d18ef.gif)

