### PR TITLE
UIEH-956: Ability to unlink an agreement from package/resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fixed View Package > Find Title - Accordions missing some ARIA attributes. (UIEH-925)
 * Fix bug with `<Datepicker>` in Resource Edit Page. (UIEH-961)
 * Fix issue in agreements accordion with displaying start date. (UIEH-971)
+* Ability to unlink an agreement from package/resource. (UIEH-956)
 
 ## [4.0.1] (https://github.com/folio-org/ui-eholdings/tree/v4.0.0) (2020-07-08)
 

--- a/src/api/agreements.js
+++ b/src/api/agreements.js
@@ -50,7 +50,7 @@ export default {
       method,
       headers: getHeaders(method, okapi, url),
     };
-    console.log(params);
+
     return doRequest(url, params);
   },
   deleteAgreementLines: (okapi, agreement) => {

--- a/src/api/agreements.js
+++ b/src/api/agreements.js
@@ -41,5 +41,28 @@ export default {
     };
 
     return doRequest(url, params);
+  },
+  getAgreementLines: (okapi, agreementId, refId) => {
+    const method = 'GET';
+    const url = `${okapi.url}/erm/entitlements?filters=owner%3D${agreementId}&filters=reference%3D${refId}`;
+
+    const params = {
+      method,
+      headers: getHeaders(method, okapi, url),
+    };
+    console.log(params);
+    return doRequest(url, params);
+  },
+  deleteAgreementLines: (okapi, agreement) => {
+    const method = 'PUT';
+    const url = `${okapi.url}${API_URL}/${agreement.id}`;
+
+    const params = {
+      method,
+      headers: getHeaders(method, okapi, url),
+      body: JSON.stringify(agreement),
+    };
+
+    return doRequest(url, params);
   }
 };

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -26,12 +26,12 @@ const COLUMN_WIDTHS = {
 const propTypes = {
   agreements: PropTypes.shape({
     isLoading: PropTypes.bool.isRequired,
+    isUnassigned: PropTypes.bool.isRequired,
     items: PropTypes.arrayOf({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
       startDate: PropTypes.string.isRequired,
     }).isRequired,
-    isUnassigned: PropTypes.bool.isRequired,
   }).isRequired,
   unassignAgreement: PropTypes.func.isRequired,
 };
@@ -107,12 +107,12 @@ const AgreementsList = ({
     startDate: ({ startDate }) => startDate,
     status: ({ status }) => status,
     name: ({ name }) => name,
-    actions: ({ id }) => (
+    actions: agreement => (
       <IconButton
         icon="trash"
         onClick={e => {
           e.preventDefault();
-          unassignAgreement({ id });
+          unassignAgreement({ id: agreement.id });
         }}
         data-test-delete-agreement
       />

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -29,6 +29,7 @@ const propTypes = {
     items: PropTypes.arrayOf({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
+      startDate: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
   unassignAgreement: PropTypes.func.isRequired,
@@ -77,7 +78,7 @@ const AgreementsList = ({
     );
   };
 
-  const getResults = () => agreements.items.map(agreement => {
+  const contentData = agreements.items.map(agreement => {
     const {
       id,
       name,
@@ -124,7 +125,7 @@ const AgreementsList = ({
         id="agreements-list"
         interactive
         ariaLabel={formatMessage({ id: 'ui-eholdings.agreements' })}
-        contentData={getResults()}
+        contentData={contentData}
         visibleColumns={COLUMN_NAMES}
         columnMapping={columnsMap}
         columnWidths={COLUMN_WIDTHS}

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -100,7 +100,7 @@ const AgreementsList = ({
       ),
     };
   });
-  
+
   const formatter = {
     startDate: ({ startDate }) => startDate,
     status: ({ status }) => status,
@@ -120,19 +120,19 @@ const AgreementsList = ({
   return agreements.isLoading
     ? <Icon icon="spinner-ellipsis" />
     : (
-        <MultiColumnList
-          id="agreements-list"
-          interactive
-          ariaLabel={formatMessage({ id: 'ui-eholdings.agreements' })}
-          contentData={getResults()}
-          visibleColumns={COLUMN_NAMES}
-          columnMapping={columnsMap}
-          columnWidths={COLUMN_WIDTHS}
-          isEmptyMessage={<FormattedMessage id="ui-eholdings.agreements.notFound" />}
-          rowFormatter={rowFormatter}
-          formatter={formatter}
-        />
-      );
+      <MultiColumnList
+        id="agreements-list"
+        interactive
+        ariaLabel={formatMessage({ id: 'ui-eholdings.agreements' })}
+        contentData={getResults()}
+        visibleColumns={COLUMN_NAMES}
+        columnMapping={columnsMap}
+        columnWidths={COLUMN_WIDTHS}
+        isEmptyMessage={<FormattedMessage id="ui-eholdings.agreements.notFound" />}
+        rowFormatter={rowFormatter}
+        formatter={formatter}
+      />
+    );
 };
 
 AgreementsList.propTypes = propTypes;

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -17,10 +17,10 @@ import { TIME_ZONE } from '../../constants';
 
 const COLUMN_NAMES = ['startDate', 'status', 'name', 'actions'];
 const COLUMN_WIDTHS = {
-  startDate: '32%',
+  startDate: '31%',
   name: '32%',
-  status: '32%',
-  actions: '4%',
+  status: '31%',
+  actions: '6%',
 };
 
 const propTypes = {

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -17,10 +17,10 @@ import { TIME_ZONE } from '../../constants';
 
 const COLUMN_NAMES = ['startDate', 'status', 'name', 'actions'];
 const COLUMN_WIDTHS = {
-  startDate: '30%',
-  name: '30%',
-  status: '30%',
-  actions: '10%',
+  startDate: '32%',
+  name: '32%',
+  status: '32%',
+  actions: '4%',
 };
 
 const propTypes = {

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -31,6 +31,7 @@ const propTypes = {
       name: PropTypes.string.isRequired,
       startDate: PropTypes.string.isRequired,
     }).isRequired,
+    isUnassigned: PropTypes.bool.isRequired,
   }).isRequired,
   unassignAgreement: PropTypes.func.isRequired,
 };

--- a/src/features/agreements-accordion/agreements-accordion.js
+++ b/src/features/agreements-accordion/agreements-accordion.js
@@ -32,7 +32,16 @@ import styles from './agreements-accordion.css';
 
 class AgreementsAccordion extends Component {
   static propTypes = {
-    agreements: PropTypes.object.isRequired,
+    agreements: PropTypes.shape({
+      errors: PropTypes.array.isRequired,
+      isLoading: PropTypes.bool.isRequired,
+      isUnassigned: PropTypes.bool.isRequired,
+      items: PropTypes.arrayOf({
+        id: PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
+        startDate: PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired,
     attachAgreement: PropTypes.func.isRequired,
     getAgreements: PropTypes.func.isRequired,
     headerProps: PropTypes.object,
@@ -146,6 +155,16 @@ class AgreementsAccordion extends Component {
       headerProps,
       unassignAgreement,
     } = this.props;
+
+    const toasts = this.getToastErrors();
+
+    if (agreements.isUnassigned) {
+      toasts.push({
+        id: `success-agreement-unlink-${id}-${Date.now()}`,
+        message: <FormattedMessage id="ui-eholdings.agreements.unlink" />,
+        type: 'success'
+      });
+    }
 
     return (
       <>

--- a/src/features/agreements-accordion/agreements-accordion.js
+++ b/src/features/agreements-accordion/agreements-accordion.js
@@ -23,6 +23,7 @@ import {
   attachAgreement as attachAgreementAction,
   getAgreements as getAgreementsAction,
   unassignAgreement as unassignAgreementAction,
+  confirmUnassignAgreement as confirmUnassignAgreementAction,
 } from '../../redux/actions';
 
 import AgreementsList from '../../components/agreements-list';
@@ -43,6 +44,7 @@ class AgreementsAccordion extends Component {
       }).isRequired,
     }).isRequired,
     attachAgreement: PropTypes.func.isRequired,
+    confirmUnassignAgreement: PropTypes.func.isRequired,
     getAgreements: PropTypes.func.isRequired,
     headerProps: PropTypes.object,
     id: PropTypes.string.isRequired,
@@ -68,6 +70,17 @@ class AgreementsAccordion extends Component {
     }
   }
 
+  componentDidUpdate() {
+    const {
+      agreements: { isUnassigned },
+      confirmUnassignAgreement,
+    } = this.props;
+
+    if (isUnassigned) {
+      confirmUnassignAgreement();
+    }
+  }
+
   getAgreementsAccordionHeader = () => {
     return (
       <Headline
@@ -77,15 +90,6 @@ class AgreementsAccordion extends Component {
         <FormattedMessage id="ui-eholdings.agreements" />
       </Headline>
     );
-  }
-
-  getToastErrors() {
-    return this.props.agreements.errors.map((error) => {
-      return {
-        message: error.title,
-        type: 'error',
-      };
-    });
   }
 
   renderFindAgreementTrigger = (props) => {
@@ -146,6 +150,31 @@ class AgreementsAccordion extends Component {
     attachAgreement(new Agreement(agreementParams));
   };
 
+  get toasts() {
+    const {
+      id,
+      agreements: {
+        errors,
+        isUnassigned,
+      },
+    } = this.props;
+
+    const toasts = errors.map(error => ({
+      message: error.title,
+      type: 'error',
+    }));
+
+    if (isUnassigned) {
+      toasts.push({
+        id: `success-agreement-unlink-${id}-${Date.now()}`,
+        message: <FormattedMessage id="ui-eholdings.agreements.unlink" />,
+        type: 'success'
+      });
+    }
+
+    return toasts;
+  }
+
   render() {
     const {
       agreements,
@@ -155,16 +184,6 @@ class AgreementsAccordion extends Component {
       headerProps,
       unassignAgreement,
     } = this.props;
-
-    const toasts = this.getToastErrors();
-
-    if (agreements.isUnassigned) {
-      toasts.push({
-        id: `success-agreement-unlink-${id}-${Date.now()}`,
-        message: <FormattedMessage id="ui-eholdings.agreements.unlink" />,
-        type: 'success'
-      });
-    }
 
     return (
       <>
@@ -185,7 +204,7 @@ class AgreementsAccordion extends Component {
 
         <Toaster
           position="bottom"
-          toasts={toasts}
+          toasts={this.toasts}
         />
       </>
     );
@@ -199,5 +218,6 @@ export default connect(
     getAgreements: getAgreementsAction,
     attachAgreement: attachAgreementAction,
     unassignAgreement: unassignAgreementAction,
+    confirmUnassignAgreement: confirmUnassignAgreementAction,
   }
 )(AgreementsAccordion);

--- a/src/features/agreements-accordion/agreements-accordion.js
+++ b/src/features/agreements-accordion/agreements-accordion.js
@@ -185,7 +185,7 @@ class AgreementsAccordion extends Component {
 
         <Toaster
           position="bottom"
-          toasts={this.getToastErrors()}
+          toasts={toasts}
         />
       </>
     );

--- a/src/features/agreements-accordion/agreements-accordion.js
+++ b/src/features/agreements-accordion/agreements-accordion.js
@@ -44,6 +44,7 @@ class AgreementsAccordion extends Component {
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
     }).isRequired,
+    unassignAgreement: PropTypes.func.isRequired,
   }
 
   componentDidMount() {

--- a/src/features/agreements-accordion/agreements-accordion.js
+++ b/src/features/agreements-accordion/agreements-accordion.js
@@ -22,6 +22,7 @@ import { selectPropFromData } from '../../redux/selectors';
 import {
   attachAgreement as attachAgreementAction,
   getAgreements as getAgreementsAction,
+  unassignAgreement as unassignAgreementAction,
 } from '../../redux/actions';
 
 import AgreementsList from '../../components/agreements-list';
@@ -142,6 +143,7 @@ class AgreementsAccordion extends Component {
       id,
       onToggle,
       headerProps,
+      unassignAgreement,
     } = this.props;
 
     return (
@@ -155,7 +157,10 @@ class AgreementsAccordion extends Component {
           onToggle={onToggle}
           headerProps={headerProps}
         >
-          <AgreementsList agreements={agreements} />
+          <AgreementsList
+            agreements={agreements}
+            unassignAgreement={unassignAgreement}
+          />
         </Accordion>
 
         <Toaster
@@ -173,5 +178,6 @@ export default connect(
   }), {
     getAgreements: getAgreementsAction,
     attachAgreement: attachAgreementAction,
+    unassignAgreement: unassignAgreementAction,
   }
 )(AgreementsAccordion);

--- a/src/redux/actions/confirm-unassign-agreement.js
+++ b/src/redux/actions/confirm-unassign-agreement.js
@@ -1,0 +1,5 @@
+export const CONFIRM_UNASSIGN_AGREEMENT = 'CONFIRM_UNASSIGN_AGREEMENT';
+
+export const confirmUnassignAgreement = () => ({
+  type: CONFIRM_UNASSIGN_AGREEMENT,
+});

--- a/src/redux/actions/delete-agreement-lines-failure.js
+++ b/src/redux/actions/delete-agreement-lines-failure.js
@@ -1,0 +1,6 @@
+export const DELETE_AGREEMENT_LINES_FAILURE = 'DELETE_AGREEMENT_LINES_FAILURE';
+
+export const deleteAgreementLinesFailure = payload => ({
+  type: DELETE_AGREEMENT_LINES_FAILURE,
+  payload,
+});

--- a/src/redux/actions/delete-agreement-lines-success.js
+++ b/src/redux/actions/delete-agreement-lines-success.js
@@ -1,0 +1,5 @@
+export const DELETE_AGREEMENT_LINES_SUCCESS = 'DELETE_AGREEMENT_LINES_SUCCESS';
+
+export const deleteAgreementLinesSuccess = () => ({
+  type: DELETE_AGREEMENT_LINES_SUCCESS,
+});

--- a/src/redux/actions/get-agreement-lines-failure.js
+++ b/src/redux/actions/get-agreement-lines-failure.js
@@ -1,0 +1,6 @@
+export const GET_AGREEMENT_LINES_FAILURE = 'GET_AGREEMENT_LINES_FAILURE';
+
+export const getAgreementLinesFailure = payload => ({
+  type: GET_AGREEMENT_LINES_FAILURE,
+  payload,
+});

--- a/src/redux/actions/get-agreement-lines-succes.js
+++ b/src/redux/actions/get-agreement-lines-succes.js
@@ -1,0 +1,6 @@
+export const GET_AGREEMENT_LINES_SUCCESS = 'GET_AGREEMENT_LINES_SUCCESS';
+
+export const getAgreementLinesSuccess = payload => ({
+  type: GET_AGREEMENT_LINES_SUCCESS,
+  payload,
+});

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -61,3 +61,4 @@ export * from './get-agreement-lines-failure';
 export * from './get-agreement-lines-succes';
 export * from './delete-agreement-lines-success';
 export * from './delete-agreement-lines-failure';
+export * from './confirm-unassign-agreement';

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -56,3 +56,8 @@ export * from './get-proxy-types';
 export * from './get-proxy-types-success';
 export * from './get-proxy-types-failure';
 export * from './user-groups';
+export * from './unassign-agreement';
+export * from './get-agreement-lines-failure';
+export * from './get-agreement-lines-succes';
+export * from './delete-agreement-lines-success';
+export * from './delete-agreement-lines-failure';

--- a/src/redux/actions/unassign-agreement.js
+++ b/src/redux/actions/unassign-agreement.js
@@ -1,0 +1,6 @@
+export const UNASSIGN_AGREEMENT = 'UNASSIGN_AGREEMENT';
+
+export const unassignAgreement = payload => ({
+  type: UNASSIGN_AGREEMENT,
+  payload,
+});

--- a/src/redux/epics/delete-agreement-lines.js
+++ b/src/redux/epics/delete-agreement-lines.js
@@ -20,7 +20,7 @@ export default ({ agreementsApi }) => (action$, store) => {
 
       const items = payload.map(id => ({ id, _delete: true }));
 
-      const agreement = { 
+      const agreement = {
         ...unassignedAgreement,
         items,
       };

--- a/src/redux/epics/delete-agreement-lines.js
+++ b/src/redux/epics/delete-agreement-lines.js
@@ -1,0 +1,33 @@
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/catch';
+
+import {
+  deleteAgreementLinesSuccess,
+  deleteAgreementLinesFailure,
+  GET_AGREEMENT_LINES_SUCCESS,
+} from '../actions';
+
+export default ({ agreementsApi }) => (action$, store) => {
+  return action$
+    .filter(action => action.type === GET_AGREEMENT_LINES_SUCCESS)
+    .mergeMap(({ payload }) => {
+      const {
+        okapi,
+        eholdings: { data: { agreements: { unassignedAgreement } } },
+      } = store.getState();
+
+      const items = payload.map(id => ({ id, _delete: true }));
+
+      const agreement = { 
+        ...unassignedAgreement,
+        items,
+      };
+
+      return agreementsApi
+        .deleteAgreementLines(okapi, agreement)
+        .map(() => deleteAgreementLinesSuccess())
+        .catch(errors => Observable.of(deleteAgreementLinesFailure({ errors })));
+    });
+};

--- a/src/redux/epics/get-agreement-lines.js
+++ b/src/redux/epics/get-agreement-lines.js
@@ -1,0 +1,31 @@
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/catch';
+
+import {
+  UNASSIGN_AGREEMENT,
+  getAgreementLinesFailure,
+  getAgreementLinesSuccess,
+} from '../actions';
+
+export default ({ agreementsApi }) => (action$, store) => {
+  return action$
+    .filter(action => action.type === UNASSIGN_AGREEMENT)
+    .mergeMap(action => {
+      const { payload: { id: agreementId } } = action;
+      const {
+        okapi,
+        eholdings: { data: { agreements: { refId } } },
+      } = store.getState();
+
+      return agreementsApi
+        .getAgreementLines(okapi, agreementId, refId)
+        .map(agreementLines => {
+          const agreementLinesIds = agreementLines.map(({ id }) => id);
+
+          return getAgreementLinesSuccess(agreementLinesIds);
+        })
+        .catch(errors => Observable.of(getAgreementLinesFailure({ errors })));
+    });
+};

--- a/src/redux/epics/index.js
+++ b/src/redux/epics/index.js
@@ -18,3 +18,5 @@ export { default as createGetRootProxyEpic } from './get-root-proxy';
 export { default as createUpdateRootProxyEpic } from './update-root-proxy';
 export { default as createGetProxyTypesEpic } from './get-proxy-types';
 export { default as createGetUserGroupsEpic } from './get-user-groups';
+export { default as createGetAgreementLinesEpic } from './get-agreement-lines';
+export { default as createDeleteAgreementLinesEpic } from './delete-agreement-lines';

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -64,6 +64,8 @@ import {
   createUpdateRootProxyEpic,
   createGetProxyTypesEpic,
   createGetUserGroupsEpic,
+  createGetAgreementLinesEpic,
+  createDeleteAgreementLinesEpic,
 } from './epics';
 
 export const createResolver = (state) => {
@@ -103,6 +105,8 @@ export const epics = combineEpics(
   dataEpic,
   updateEntityTags,
   createGetAgreementsEpic({ agreementsApi }),
+  createGetAgreementLinesEpic({ agreementsApi }),
+  createDeleteAgreementLinesEpic({ agreementsApi }),
   createAttachAgreementEpic({ agreementsApi }),
   createGetCustomLabelsEpic({ customLabelsApi }),
   createUpdateCustomLabelsEpic({ customLabelsApi }),

--- a/src/redux/reducers/agreements.js
+++ b/src/redux/reducers/agreements.js
@@ -15,6 +15,7 @@ import { formatErrors } from '../helpers';
 const handleError = (state, { payload }) => ({
   ...state,
   isLoading: false,
+  isUnassigned: false,
   errors: formatErrors(payload.errors),
 });
 
@@ -27,6 +28,7 @@ const handlers = {
     return {
       ...state,
       isLoading: true,
+      isUnassigned: false,
       ...payload,
     };
   },
@@ -87,6 +89,7 @@ const handlers = {
       items: items.filter(item => item.id !== unassignedAgreement.id),
       unassignedAgreement: {},
       isLoading: false,
+      isUnassigned: true,
     };
   },
 };
@@ -96,6 +99,7 @@ const initialState = {
   items: [],
   errors: [],
   unassignedAgreement: {},
+  isUnassigned: false,
 };
 
 export default function agreements(state, action) {

--- a/src/redux/reducers/agreements.js
+++ b/src/redux/reducers/agreements.js
@@ -4,9 +4,20 @@ import {
   GET_AGREEMENTS_FAILURE,
   ATTACH_AGREEMENT_FAILURE,
   ADD_AGREEMENT,
+  UNASSIGN_AGREEMENT,
+  GET_AGREEMENT_LINES_FAILURE,
+  GET_AGREEMENT_LINES_SUCCESS,
+  DELETE_AGREEMENT_LINES_FAILURE,
+  DELETE_AGREEMENT_LINES_SUCCESS,
 } from '../actions';
 
 import { formatErrors } from '../helpers';
+
+const handleError = (state, { payload }) => ({
+  ...state,
+  isLoading: false,
+  errors: formatErrors(payload.errors),
+});
 
 const handlers = {
   [GET_AGREEMENTS]: (state, action) => {
@@ -31,24 +42,8 @@ const handlers = {
       items: [...payload.items],
     };
   },
-  [GET_AGREEMENTS_FAILURE]: (state, action) => {
-    const {
-      payload: { errors },
-    } = action;
-
-    return {
-      ...state,
-      isLoading: false,
-      errors: formatErrors(errors),
-    };
-  },
-  [ATTACH_AGREEMENT_FAILURE]: (state, action) => {
-    return {
-      ...state,
-      isLoading: false,
-      errors: formatErrors(action.payload.errors),
-    };
-  },
+  [GET_AGREEMENTS_FAILURE]: handleError,
+  [ATTACH_AGREEMENT_FAILURE]: handleError,
   [ADD_AGREEMENT]: (state, action) => {
     const {
       payload: agreement,
@@ -68,12 +63,40 @@ const handlers = {
         ],
       };
   },
+  [UNASSIGN_AGREEMENT]: (state, action) => {
+    const { payload: { id } } = action;
+    const { items } = state;
+
+    const unassignedAgreement = items.find(item => item.id === id) || {};
+
+    return {
+      ...state,
+      isLoading: true,
+      unassignedAgreement,
+    };
+  },
+  [GET_AGREEMENT_LINES_FAILURE]: handleError,
+  [DELETE_AGREEMENT_LINES_FAILURE]: handleError,
+  [DELETE_AGREEMENT_LINES_SUCCESS]: state => {
+    const {
+      items,
+      unassignedAgreement,
+    } = state;
+
+    return {
+      ...state,
+      items: items.filter(item => item.id !== unassignedAgreement.id),
+      unassignedAgreement: {},
+      isLoading: false,
+    }
+  }
 };
 
 const initialState = {
   isLoading: false,
   items: [],
   errors: [],
+  unassignedAgreement: {},
 };
 
 export default function agreements(state, action) {

--- a/src/redux/reducers/agreements.js
+++ b/src/redux/reducers/agreements.js
@@ -87,7 +87,7 @@ const handlers = {
       items: items.filter(item => item.id !== unassignedAgreement.id),
       unassignedAgreement: {},
       isLoading: false,
-    }
+    };
   },
 };
 

--- a/src/redux/reducers/agreements.js
+++ b/src/redux/reducers/agreements.js
@@ -6,7 +6,6 @@ import {
   ADD_AGREEMENT,
   UNASSIGN_AGREEMENT,
   GET_AGREEMENT_LINES_FAILURE,
-  GET_AGREEMENT_LINES_SUCCESS,
   DELETE_AGREEMENT_LINES_FAILURE,
   DELETE_AGREEMENT_LINES_SUCCESS,
 } from '../actions';
@@ -89,7 +88,7 @@ const handlers = {
       unassignedAgreement: {},
       isLoading: false,
     }
-  }
+  },
 };
 
 const initialState = {

--- a/src/redux/reducers/agreements.js
+++ b/src/redux/reducers/agreements.js
@@ -8,6 +8,7 @@ import {
   GET_AGREEMENT_LINES_FAILURE,
   DELETE_AGREEMENT_LINES_FAILURE,
   DELETE_AGREEMENT_LINES_SUCCESS,
+  CONFIRM_UNASSIGN_AGREEMENT,
 } from '../actions';
 
 import { formatErrors } from '../helpers';
@@ -28,7 +29,6 @@ const handlers = {
     return {
       ...state,
       isLoading: true,
-      isUnassigned: false,
       ...payload,
     };
   },
@@ -90,6 +90,12 @@ const handlers = {
       unassignedAgreement: {},
       isLoading: false,
       isUnassigned: true,
+    };
+  },
+  [CONFIRM_UNASSIGN_AGREEMENT]: state => {
+    return {
+      ...state,
+      isUnassigned: false,
     };
   },
 };

--- a/src/redux/reducers/agreements.js
+++ b/src/redux/reducers/agreements.js
@@ -72,7 +72,6 @@ const handlers = {
 
     return {
       ...state,
-      isLoading: true,
       unassignedAgreement,
     };
   },
@@ -88,7 +87,6 @@ const handlers = {
       ...state,
       items: items.filter(item => item.id !== unassignedAgreement.id),
       unassignedAgreement: {},
-      isLoading: false,
       isUnassigned: true,
     };
   },

--- a/test/bigtest/interactors/agreements-accordion.js
+++ b/test/bigtest/interactors/agreements-accordion.js
@@ -9,7 +9,9 @@ import {
 
 export default @interactor class {
   isExpanded = !!attribute('#accordion-toggle-button-packageShowAgreements', 'aria-expanded');
-  agreements = collection('[data-test-agreements-list-item]');
+  agreements = collection('[data-test-agreements-list-item]', {
+    clickTrashIcon: clickable('[data-test-delete-agreement]'),
+  });
   hasNewButton = isPresent('[data-test-new-button]');
   clickNewButton = clickable('[data-test-new-button]');
   clickSection = clickable('[class^=defaultCollapseButton]');

--- a/test/bigtest/interactors/agreements-accordion.js
+++ b/test/bigtest/interactors/agreements-accordion.js
@@ -12,6 +12,7 @@ export default @interactor class {
   agreements = collection('[data-test-agreements-list-item]', {
     clickTrashIcon: clickable('[data-test-delete-agreement]'),
   });
+
   hasNewButton = isPresent('[data-test-new-button]');
   clickNewButton = clickable('[data-test-new-button]');
   clickSection = clickable('[class^=defaultCollapseButton]');

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -7,6 +7,7 @@ import {
   includesWords,
   getMultiSelectValueFromQueryString,
 } from './helpers';
+import queryString from 'qs';
 
 // typical mirage config export
 export default function config() {
@@ -175,6 +176,7 @@ export default function config() {
     ]
   }));
 
+  // Agreements endpoints
   this.get('/erm/sas', [
     {
       id: '2c918098689ba8f70168a349f1160027',
@@ -278,6 +280,47 @@ export default function config() {
         'label': 'Active',
       },
     };
+  });
+
+  this.get('/erm/entitlements', (schema, request) => {
+    const [ ,owner, reference] = request.url.split('filters=');
+    const ownerId = owner.split('%3D')[1].slice(0, -1);
+    const referenceId = reference.split('%3D')[1];
+
+    return [{
+        id: "33fce77f-5e00-415e-a297-04b77319b84b",
+        tags:[],
+        owner: {
+          id: ownerId,
+          contacts: [],
+          tags: [],
+          startDate: '2019-01-01T00:01:00Z',
+          items: [],
+          historyLines: [],
+          name: "Test",
+          orgs: [],
+          agreementStatus: {
+            id: '2c918098689ba8f701689baa48e40011',
+            value: 'active',
+            label: 'Active',
+          },
+        },
+        resource: {
+          id: referenceId,
+          suppressFromDiscovery: false,
+          tags: [],
+        },
+        poLines: [],
+        suppressFromDiscovery: false,
+        customCoverage: false,
+        startDate: null,
+        endDate: null,
+        activeFrom: null,
+        activeTo: null,
+        contentUpdated: null,
+        haveAccess: true,
+        suppressFromDiscovery: false,
+      }];
   });
 
   // e-holdings endpoints

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -296,7 +296,7 @@ export default function config() {
         startDate: '2019-01-01T00:01:00Z',
         items: [],
         historyLines: [],
-        name: "Test",
+        name: 'Test',
         orgs: [],
         agreementStatus: {
           id: '2c918098689ba8f701689baa48e40011',

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -7,7 +7,6 @@ import {
   includesWords,
   getMultiSelectValueFromQueryString,
 } from './helpers';
-import queryString from 'qs';
 
 // typical mirage config export
 export default function config() {
@@ -283,44 +282,43 @@ export default function config() {
   });
 
   this.get('/erm/entitlements', (schema, request) => {
-    const [ ,owner, reference] = request.url.split('filters=');
+    const [, owner, reference] = request.url.split('filters=');
     const ownerId = owner.split('%3D')[1].slice(0, -1);
     const referenceId = reference.split('%3D')[1];
 
     return [{
-        id: "33fce77f-5e00-415e-a297-04b77319b84b",
-        tags:[],
-        owner: {
-          id: ownerId,
-          contacts: [],
-          tags: [],
-          startDate: '2019-01-01T00:01:00Z',
-          items: [],
-          historyLines: [],
-          name: "Test",
-          orgs: [],
-          agreementStatus: {
-            id: '2c918098689ba8f701689baa48e40011',
-            value: 'active',
-            label: 'Active',
-          },
+      id: "33fce77f-5e00-415e-a297-04b77319b84b",
+      tags:[],
+      owner: {
+        id: ownerId,
+        contacts: [],
+        tags: [],
+        startDate: '2019-01-01T00:01:00Z',
+        items: [],
+        historyLines: [],
+        name: "Test",
+        orgs: [],
+        agreementStatus: {
+          id: '2c918098689ba8f701689baa48e40011',
+          value: 'active',
+          label: 'Active',
         },
-        resource: {
-          id: referenceId,
-          suppressFromDiscovery: false,
-          tags: [],
-        },
-        poLines: [],
+      },
+      resource: {
+        id: referenceId,
         suppressFromDiscovery: false,
-        customCoverage: false,
-        startDate: null,
-        endDate: null,
-        activeFrom: null,
-        activeTo: null,
-        contentUpdated: null,
-        haveAccess: true,
-        suppressFromDiscovery: false,
-      }];
+        tags: [],
+      },
+      poLines: [],
+      suppressFromDiscovery: false,
+      customCoverage: false,
+      startDate: null,
+      endDate: null,
+      activeFrom: null,
+      activeTo: null,
+      contentUpdated: null,
+      haveAccess: true,
+    }];
   });
 
   // e-holdings endpoints

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -287,7 +287,7 @@ export default function config() {
     const referenceId = reference.split('%3D')[1];
 
     return [{
-      id: "33fce77f-5e00-415e-a297-04b77319b84b",
+      id: '33fce77f-5e00-415e-a297-04b77319b84b',
       tags:[],
       owner: {
         id: ownerId,

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -190,6 +190,17 @@ describe('ResourceShow', () => {
             expect(this.location.pathname).to.contain(itemDetailsUrl);
           });
         });
+
+        describe('when clicking on trash icon for first agreement', () => {
+          beforeEach(async () => {
+            await ResourcePage.agreementsSection.agreements(0).clickTrashIcon();
+          });
+
+          it('should remove first agreement from aggreements list', () => {
+            console.log(ResourcePage.agreementsSection.agreements(0));
+            expect(ResourcePage.agreementsSection.agreements().length).to.equal(2);
+          });
+        });
       });
 
       describe('when closed', () => {

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -197,7 +197,6 @@ describe('ResourceShow', () => {
           });
 
           it('should remove first agreement from aggreements list', () => {
-            console.log(ResourcePage.agreementsSection.agreements(0));
             expect(ResourcePage.agreementsSection.agreements().length).to.equal(2);
           });
         });

--- a/test/bigtest/tests/unit/actions/confirm-unassign-agreement-test.js
+++ b/test/bigtest/tests/unit/actions/confirm-unassign-agreement-test.js
@@ -1,0 +1,15 @@
+/* global describe, it */
+import { expect } from 'chai';
+
+import {
+  CONFIRM_UNASSIGN_AGREEMENT,
+  confirmUnassignAgreement,
+} from '../../../../../src/redux/actions/confirm-unassign-agreement';
+
+describe('(action) confirmUnassignAgreement', () => {
+  it('should create an action to confirm unassign agreement', () => {
+    const expectedAction = { type: CONFIRM_UNASSIGN_AGREEMENT };
+
+    expect(confirmUnassignAgreement()).to.deep.equal(expectedAction);
+  });
+});

--- a/test/bigtest/tests/unit/actions/delete-agreement-lines-failure-test.js
+++ b/test/bigtest/tests/unit/actions/delete-agreement-lines-failure-test.js
@@ -1,0 +1,19 @@
+/* global describe, it */
+import { expect } from 'chai';
+
+import {
+  DELETE_AGREEMENT_LINES_FAILURE,
+  deleteAgreementLinesFailure,
+} from '../../../../../src/redux/actions/delete-agreement-lines-failure';
+
+describe('(action) deleteAgreementLinesFailure', () => {
+  it('should create an action to handle delete agreement lines failure', () => {
+    const payload = 'payload';
+    const expectedAction = {
+      type: DELETE_AGREEMENT_LINES_FAILURE,
+      payload,
+    };
+
+    expect(deleteAgreementLinesFailure(payload)).to.deep.equal(expectedAction);
+  });
+});

--- a/test/bigtest/tests/unit/actions/delete-agreement-lines-success-test.js
+++ b/test/bigtest/tests/unit/actions/delete-agreement-lines-success-test.js
@@ -1,0 +1,15 @@
+/* global describe, it */
+import { expect } from 'chai';
+
+import {
+  DELETE_AGREEMENT_LINES_SUCCESS,
+  deleteAgreementLinesSuccess,
+} from '../../../../../src/redux/actions/delete-agreement-lines-success';
+
+describe('(action) deleteAgreementLinesSuccess', () => {
+  it('should create an action to handle delete agreement lines success', () => {
+    const expectedAction = { type: DELETE_AGREEMENT_LINES_SUCCESS };
+
+    expect(deleteAgreementLinesSuccess()).to.deep.equal(expectedAction);
+  });
+});

--- a/test/bigtest/tests/unit/actions/get-agreement-lines-failure-test.js
+++ b/test/bigtest/tests/unit/actions/get-agreement-lines-failure-test.js
@@ -1,0 +1,19 @@
+/* global describe, it */
+import { expect } from 'chai';
+
+import {
+  GET_AGREEMENT_LINES_FAILURE,
+  getAgreementLinesFailure,
+} from '../../../../../src/redux/actions/get-agreement-lines-failure';
+
+describe('(action) getAgreementLinesFailure', () => {
+  it('should create an action to handle get agreement lines failure', () => {
+    const payload = 'payload';
+    const expectedAction = {
+      type: GET_AGREEMENT_LINES_FAILURE,
+      payload,
+    };
+
+    expect(getAgreementLinesFailure(payload)).to.deep.equal(expectedAction);
+  });
+});

--- a/test/bigtest/tests/unit/actions/get-agreement-lines-success-test.js
+++ b/test/bigtest/tests/unit/actions/get-agreement-lines-success-test.js
@@ -1,0 +1,19 @@
+/* global describe, it */
+import { expect } from 'chai';
+
+import {
+  GET_AGREEMENT_LINES_SUCCESS,
+  getAgreementLinesSuccess,
+} from '../../../../../src/redux/actions/get-agreement-lines-succes';
+
+describe('(action) getAgreementLinesSuccess', () => {
+  it('should create an action to handle get agreement lines success', () => {
+    const payload = ['agreementLineId1', 'agreementLineId2'];
+    const expectedAction = {
+      type: GET_AGREEMENT_LINES_SUCCESS,
+      payload,
+    };
+
+    expect(getAgreementLinesSuccess(payload)).to.deep.equal(expectedAction);
+  });
+});

--- a/test/bigtest/tests/unit/actions/unassign-agreement-test.js
+++ b/test/bigtest/tests/unit/actions/unassign-agreement-test.js
@@ -1,0 +1,18 @@
+/* global describe, it */
+import { expect } from 'chai';
+
+import {
+  UNASSIGN_AGREEMENT,
+  unassignAgreement,
+} from '../../../../../src/redux/actions/unassign-agreement';
+
+describe('(action) unassignAgreement', () => {
+  it('should create an action to unassign agreement', () => {
+    const expectedAction = {
+      type: UNASSIGN_AGREEMENT,
+      payload: '1',
+    };
+
+    expect(unassignAgreement('1')).to.deep.equal(expectedAction);
+  });
+});

--- a/test/bigtest/tests/unit/epics/delete-agreement-lines-test.js
+++ b/test/bigtest/tests/unit/epics/delete-agreement-lines-test.js
@@ -42,7 +42,8 @@ describe('(epic) deleteAgreementLines', () => {
         }, {
           id: '1-2',
           _delete: true,
-      }],
+        },
+      ],
     };
 
     const dependencies = {

--- a/test/bigtest/tests/unit/epics/delete_agreement_lines-test.js
+++ b/test/bigtest/tests/unit/epics/delete_agreement_lines-test.js
@@ -1,0 +1,83 @@
+/* global describe, it, beforeEach */
+import { expect } from 'chai';
+import { TestScheduler } from 'rxjs/Rx';
+
+import { createDeleteAgreementLinesEpic } from '../../../../../src/redux/epics';
+import {
+  GET_AGREEMENT_LINES_SUCCESS,
+  DELETE_AGREEMENT_LINES_SUCCESS,
+  DELETE_AGREEMENT_LINES_FAILURE,
+} from '../../../../../src/redux/actions';
+
+describe('(epic) deleteAgreementLines', () => {
+  const state$ = {
+    getState: () => ({
+      okapi: {
+        url: 'https://folio-snapshot',
+        tenant: 'diku',
+        token: 'token',
+      },
+    }),
+  };
+
+  let testScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).deep.equal(expected);
+    });
+  });
+
+  it('should trigger an action to delete agreement lines', () => {
+    const action$ = testScheduler.createHotObservable('-a', {
+      a: { type: GET_AGREEMENT_LINES_SUCCESS },
+    });
+
+    const agreement = {
+      id: 1,
+      items: [
+        {
+          id: '1-1',
+          _delete: true,
+        }, {
+          id: '1-2',
+          _delete: true,
+      }],
+    };
+
+    const dependencies = {
+      agreementsApi: {
+        deleteAgreementLines: () => testScheduler.createColdObservable('--a', {
+          a: agreement,
+        }),
+      },
+    };
+
+    const output$ = createDeleteAgreementLinesEpic(dependencies)(action$, state$);
+
+    testScheduler.expectObservable(output$).toBe('---a', {
+      a: { type: DELETE_AGREEMENT_LINES_SUCCESS },
+    });
+  });
+
+  it('should handle errors', () => {
+    const action$ = testScheduler.createHotObservable('-a', {
+      a: { type: GET_AGREEMENT_LINES_SUCCESS },
+    });
+
+    const dependencies = {
+      agreementsApi: {
+        deleteAgreementLines: () => testScheduler.createColdObservable('--#', 'Error messages'),
+      },
+    };
+
+    const output$ = createDeleteAgreementLinesEpic(dependencies)(action$, state$);
+
+    testScheduler.expectObservable(output$).toBe('---a', {
+      a: {
+        type: DELETE_AGREEMENT_LINES_FAILURE,
+        payload: { errors: 'Error messages' },
+      },
+    });
+  });
+});

--- a/test/bigtest/tests/unit/epics/get-agreement-lines-test.js
+++ b/test/bigtest/tests/unit/epics/get-agreement-lines-test.js
@@ -1,0 +1,79 @@
+/* global describe, it, beforeEach */
+import { expect } from 'chai';
+import { TestScheduler } from 'rxjs/Rx';
+
+import { createGetAgreementLinesEpic } from '../../../../../src/redux/epics';
+import {
+  UNASSIGN_AGREEMENT,
+  GET_AGREEMENT_LINES_SUCCESS,
+  GET_AGREEMENT_LINES_FAILURE,
+} from '../../../../../src/redux/actions';
+
+describe('(epic) getAgreementLines', () => {
+  const state$ = {
+    getState: () => ({
+      okapi: {
+        url: 'https://folio-snapshot',
+        tenant: 'diku',
+        token: 'token',
+      },
+    }),
+  };
+
+  let testScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).deep.equal(expected);
+    });
+  });
+
+  it('should trigger an action to get agreement lines ids', () => {
+    const action$ = testScheduler.createHotObservable('-a', {
+      a: { type: UNASSIGN_AGREEMENT },
+    });
+
+    const agreementLines = [
+      { id: 1 },
+      { id: 2 },
+    ];
+
+    const dependencies = {
+      agreementsApi: {
+        getAgreementLines: () => testScheduler.createColdObservable('--a', {
+          a: agreementLines,
+        }),
+      },
+    };
+
+    const output$ = createGetAgreementLinesEpic(dependencies)(action$, state$);
+
+    testScheduler.expectObservable(output$).toBe('---a', {
+      a: {
+        type: GET_AGREEMENT_LINES_SUCCESS,
+        payload: agreementLines,
+      },
+    });
+  });
+
+  it('should handle errors', () => {
+    const action$ = testScheduler.createHotObservable('-a', {
+      a: { type: UNASSIGN_AGREEMENT },
+    });
+
+    const dependencies = {
+      agreementsApi: {
+        getAgreementLines: () => testScheduler.createColdObservable('--#', 'Error messages'),
+      },
+    };
+
+    const output$ = createGetAgreementLinesEpic(dependencies)(action$, state$);
+
+    testScheduler.expectObservable(output$).toBe('---a', {
+      a: {
+        type: GET_AGREEMENT_LINES_FAILURE,
+        payload: { errors: 'Error messages' },
+      },
+    });
+  });
+});

--- a/test/bigtest/tests/unit/reducers/agreements-test.js
+++ b/test/bigtest/tests/unit/reducers/agreements-test.js
@@ -173,6 +173,27 @@ describe('(reducer) agreements', () => {
     expect(agreements(actualState, action)).to.deep.equal(expectedState);
   });
 
+  it('should handle UNASSIGN_AGREEMENT whit not-existend id', () => {
+    const actualState = {
+      isLoading: false,
+      items: [
+        { id: 1 },
+        { id: 2 },
+      ],
+    };
+    const action = {
+      type: UNASSIGN_AGREEMENT,
+      payload: { id: 3 },
+    };
+    const expectedState = {
+      ...actualState,
+      isLoading: true,
+      unassignedAgreement: {},
+    };
+
+    expect(agreements(actualState, action)).to.deep.equal(expectedState);
+  });
+
   it('should handle GET_AGREEMENT_LINES_FAILURE', () => {
     const actualState = {
       isLoading: true,

--- a/test/bigtest/tests/unit/reducers/agreements-test.js
+++ b/test/bigtest/tests/unit/reducers/agreements-test.js
@@ -41,7 +41,6 @@ describe('(reducer) agreements', () => {
       items: 'items',
       isLoading: true,
       referenceId: '123',
-      isUnassigned: false,
     };
 
     expect(agreements(actualState, action)).to.deep.equal(expectedState);
@@ -155,7 +154,6 @@ describe('(reducer) agreements', () => {
 
   it('should handle UNASSIGN_AGREEMENT', () => {
     const actualState = {
-      isLoading: false,
       items: [
         { id: 1 },
         { id: 2 },
@@ -167,16 +165,14 @@ describe('(reducer) agreements', () => {
     };
     const expectedState = {
       ...actualState,
-      isLoading: true,
       unassignedAgreement: { id: 1 },
     };
 
     expect(agreements(actualState, action)).to.deep.equal(expectedState);
   });
 
-  it('should handle UNASSIGN_AGREEMENT whit not-existend id', () => {
+  it('should handle UNASSIGN_AGREEMENT with not-existend id', () => {
     const actualState = {
-      isLoading: false,
       items: [
         { id: 1 },
         { id: 2 },
@@ -188,7 +184,6 @@ describe('(reducer) agreements', () => {
     };
     const expectedState = {
       ...actualState,
-      isLoading: true,
       unassignedAgreement: {},
     };
 

--- a/test/bigtest/tests/unit/reducers/agreements-test.js
+++ b/test/bigtest/tests/unit/reducers/agreements-test.js
@@ -12,6 +12,7 @@ import {
   GET_AGREEMENT_LINES_FAILURE,
   DELETE_AGREEMENT_LINES_FAILURE,
   DELETE_AGREEMENT_LINES_SUCCESS,
+  CONFIRM_UNASSIGN_AGREEMENT,
 } from '../../../../../src/redux/actions';
 
 describe('(reducer) agreements', () => {
@@ -254,4 +255,20 @@ describe('(reducer) agreements', () => {
 
     expect(agreements(actualState, action)).to.deep.equal(expectedState);
   });
+
+  it('should handle CONFIRM_UNASSIGN_AGREEMENT', () => {
+    const actualState = {
+      isLoading: false,
+      items: [],
+      isUnassigned: true,
+    };
+    const action = { type: CONFIRM_UNASSIGN_AGREEMENT };
+    const expectedState = {
+      items: [],
+      isLoading: false,
+      isUnassigned: false,
+    };
+
+    expect(agreements(actualState, action)).to.deep.equal(expectedState);
+  })
 });

--- a/test/bigtest/tests/unit/reducers/agreements-test.js
+++ b/test/bigtest/tests/unit/reducers/agreements-test.js
@@ -8,6 +8,10 @@ import {
   GET_AGREEMENTS_FAILURE,
   ADD_AGREEMENT,
   ATTACH_AGREEMENT_FAILURE,
+  UNASSIGN_AGREEMENT,
+  GET_AGREEMENT_LINES_FAILURE,
+  DELETE_AGREEMENT_LINES_FAILURE,
+  DELETE_AGREEMENT_LINES_SUCCESS,
 } from '../../../../../src/redux/actions';
 
 describe('(reducer) agreements', () => {
@@ -16,6 +20,7 @@ describe('(reducer) agreements', () => {
       isLoading: false,
       items: [],
       errors: [],
+      unassignedAgreement: {},
     });
   });
 
@@ -138,6 +143,85 @@ describe('(reducer) agreements', () => {
         { id: 1, data: 'data1' },
         { id: 2, data: 'data2' },
       ],
+    };
+
+    expect(agreements(actualState, action)).to.deep.equal(expectedState);
+  });
+
+  it('should handle UNASSIGN_AGREEMENT', () => {
+    const actualState = {
+      isLoading: false,
+      items: [
+        { id: 1 },
+        { id: 2 },
+      ],
+    };
+    const action = {
+      type: UNASSIGN_AGREEMENT,
+      payload: { id: 1 },
+    };
+    const expectedState = {
+      ...actualState,
+      isLoading: true,
+      unassignedAgreement: { id: 1 },
+    };
+
+    expect(agreements(actualState, action)).to.deep.equal(expectedState);
+  });
+
+  it('should handle GET_AGREEMENT_LINES_FAILURE', () => {
+    const actualState = {
+      isLoading: true,
+    };
+    const action = {
+      type: GET_AGREEMENT_LINES_FAILURE,
+      payload: { errors: 'error' }
+    };
+    const expectedState = {
+      isLoading: false,
+      errors: [
+        { title: 'error' },
+      ],
+    };
+
+    expect(agreements(actualState, action)).to.deep.equal(expectedState);
+  });
+
+  it('should handle DELETE_AGREEMENT_LINES_FAILURE', () => {
+    const actualState = {
+      isLoading: true,
+    };
+    const action = {
+      type: DELETE_AGREEMENT_LINES_FAILURE,
+      payload: { errors: 'error' }
+    };
+    const expectedState = {
+      isLoading: false,
+      errors: [
+        { title: 'error' },
+      ],
+    };
+
+    expect(agreements(actualState, action)).to.deep.equal(expectedState);
+  });
+
+  it('should handle DELETE_AGREEMENT_LINES_SUCCESS', () => {
+    const actualState = {
+      isLoading: false,
+      items: [
+        { id: 1 },
+        { id: 2 },
+      ],
+      unassignedAgreement: { id: 1 },
+    };
+    const action = {
+      type: DELETE_AGREEMENT_LINES_SUCCESS,
+      payload: { id: 1 },
+    };
+    const expectedState = {
+      items: [{ id: 2 }],
+      isLoading: false,
+      unassignedAgreement: {},
     };
 
     expect(agreements(actualState, action)).to.deep.equal(expectedState);

--- a/test/bigtest/tests/unit/reducers/agreements-test.js
+++ b/test/bigtest/tests/unit/reducers/agreements-test.js
@@ -14,13 +14,14 @@ import {
   DELETE_AGREEMENT_LINES_SUCCESS,
 } from '../../../../../src/redux/actions';
 
-describe('(reducer) agreements', () => {
+describe.only('(reducer) agreements', () => {
   it('should return the initial state', () => {
     expect(agreements(undefined, {})).to.deep.equal({
       isLoading: false,
       items: [],
       errors: [],
       unassignedAgreement: {},
+      isUnassigned: false,
     });
   });
 
@@ -39,6 +40,7 @@ describe('(reducer) agreements', () => {
       items: 'items',
       isLoading: true,
       referenceId: '123',
+      isUnassigned: false,
     };
 
     expect(agreements(actualState, action)).to.deep.equal(expectedState);
@@ -75,6 +77,7 @@ describe('(reducer) agreements', () => {
     const expectedState = {
       items: 'items',
       isLoading: false,
+      isUnassigned: false,
       errors: [
         { title: 'error' },
       ],
@@ -93,6 +96,7 @@ describe('(reducer) agreements', () => {
     };
     const expectedState = {
       isLoading: false,
+      isUnassigned: false,
       errors: [
         { title: 'error' },
       ],
@@ -179,6 +183,7 @@ describe('(reducer) agreements', () => {
     };
     const expectedState = {
       isLoading: false,
+      isUnassigned: false,
       errors: [
         { title: 'error' },
       ],
@@ -197,6 +202,7 @@ describe('(reducer) agreements', () => {
     };
     const expectedState = {
       isLoading: false,
+      isUnassigned: false,
       errors: [
         { title: 'error' },
       ],
@@ -222,6 +228,7 @@ describe('(reducer) agreements', () => {
       items: [{ id: 2 }],
       isLoading: false,
       unassignedAgreement: {},
+      isUnassigned: true,
     };
 
     expect(agreements(actualState, action)).to.deep.equal(expectedState);

--- a/test/bigtest/tests/unit/reducers/agreements-test.js
+++ b/test/bigtest/tests/unit/reducers/agreements-test.js
@@ -14,7 +14,7 @@ import {
   DELETE_AGREEMENT_LINES_SUCCESS,
 } from '../../../../../src/redux/actions';
 
-describe.only('(reducer) agreements', () => {
+describe('(reducer) agreements', () => {
   it('should return the initial state', () => {
     expect(agreements(undefined, {})).to.deep.equal({
       isLoading: false,

--- a/test/bigtest/tests/unit/reducers/agreements-test.js
+++ b/test/bigtest/tests/unit/reducers/agreements-test.js
@@ -270,5 +270,5 @@ describe('(reducer) agreements', () => {
     };
 
     expect(agreements(actualState, action)).to.deep.equal(expectedState);
-  })
+  });
 });

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -7,6 +7,7 @@
     "status": "Status",
     "agreements": "Agreements",
     "agreements.notFound": "No agreements found",
+    "agreements.unlink": "Unlink agreement from this record.",
     "package.actionMenu.edit": "Edit",
     "package.addToHoldings": "Add to holdings",
     "package.addToken": "Add token",


### PR DESCRIPTION
### UIEH-956 Ability to unlink an agreement from package/resource

## Purpose
Ability to unlink an agreement from package/resource. For implementation, it is necessary to make two requests. First request needed to get agreement lines ids related to current agreement and package/resource. Second one to delete related agreement lines from agreement.

[Issue](https://issues.folio.org/browse/UIEH-956)

## Screenshots
![XewioYpzrp](https://user-images.githubusercontent.com/55701515/95331774-2356ee80-08b3-11eb-8adf-9f4c368d0d85.gif)
