### PR TITLE
UIEH-991: Routing issues when clicking Edit on Notes List Accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [5.1.0] (IN PROGRESS)
 
 * Increase Settings Custom Labels display label max length to 200. (UIEH-985)
+* Fix routing issues when visiting Note Edit page. (UIEH-991)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/src/routes/note-edit.js
+++ b/src/routes/note-edit.js
@@ -24,19 +24,7 @@ export default class NoteEditRoute extends Component {
   };
 
   goToNoteView = () => {
-    const {
-      match,
-      history,
-      location,
-    } = this.props;
-
-    const { id } = match.params;
-    const noteViewUrl = `/eholdings/notes/${id}`;
-
-    history.replace({
-      pathname: noteViewUrl,
-      state: location.state,
-    });
+    this.props.history.goBack();
   }
 
   render() {

--- a/src/routes/note-view.js
+++ b/src/routes/note-view.js
@@ -29,7 +29,7 @@ class NoteViewRoute extends Component {
       match,
     } = this.props;
 
-    history.replace({
+    history.push({
       pathname: `/eholdings/notes/${match.params.noteId}/edit/`,
       state: location.state,
     });


### PR DESCRIPTION
# Purpose
Fix routing issues when visiting Note Edit page:

1. when on Package View page and after clicking on 'Edit' in Notes Accordion and clicking 'X' - should return to Package View page
2. when on Note View page and after licking on 'Edit' in dropdown menu and clicking 'X' - should return to Note View page

# Issue
[UIEH-991](https://issues.folio.org/browse/UIEH-991)