### PR TITLE
UIEH-949: Resource View Page: Usage & Analysis accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 * Settings - Usage Consolidation - Currency. (UIEH-965)
 * Settings - Usage Consolidation - Start month for usage statistics. (UIEH-966)
 * Settings - Usage Consolidation - Usage consolidation ID. (UIEH-968)
+* Package Record: Display Usage & Analysis Accordion (UIEH-941)
 * Added Usage Consolidation Filters to Package Show page. (UIEH-942, UIEH-973)
+* Title+Package Record: Display Usage & Analysis Accordion. (UIEH-949)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -34,7 +34,7 @@ import ExternalLink from '../external-link/external-link';
 import IdentifiersList from '../identifiers-list';
 import ContributorsList from '../contributors-list';
 import CoverageDateList from '../coverage-date-list';
-import { AgreementsAccordion, CustomLabelsAccordion } from '../../features';
+import { AgreementsAccordion, CustomLabelsAccordion, UsageConsolidationAccordion } from '../../features';
 import {
   isBookPublicationType,
   isValidCoverageList,
@@ -79,6 +79,7 @@ class ResourceShow extends Component {
         resourceShowCoverageSettings: this.props.model.isSelected,
         resourceShowAgreements: true,
         resourceShowNotes: true,
+        resourceShowUsageConsolidation: false,
       },
     };
   }
@@ -607,6 +608,12 @@ class ResourceShow extends Component {
                 entityId={model.id}
                 pathToNoteCreate={paths.NOTE_CREATE}
                 pathToNoteDetails={paths.NOTES}
+              />
+
+              <UsageConsolidationAccordion
+                id="resourceShowUsageConsolidation"
+                isOpen={sections.resourceShowUsageConsolidation}
+                onToggle={this.handleSectionToggle}
               />
             </>
           )}

--- a/test/bigtest/interactors/resource-show.js
+++ b/test/bigtest/interactors/resource-show.js
@@ -19,6 +19,7 @@ import ResourceDropDownMenu from './resource-drop-down-menu';
 import NavigationModal from './navigation-modal';
 import ResourceShowDeselectionModal from './resource-show-deselection-modal';
 import UnassignAgreementModal from './unassign-agreement-modal';
+import ResourceUsageConsolidation from './resource-usage-consolidation';
 
 @interactor class ResourceShowPage {
   isLoaded = isPresent('[data-test-eholdings-details-view-name="resource"]');
@@ -122,6 +123,8 @@ import UnassignAgreementModal from './unassign-agreement-modal';
   });
 
   agreementsSection = new AgreementsAccordion('#resourceShowAgreements');
+
+  usageConsolidationSection = new ResourceUsageConsolidation();
 
   customLabelsAccordion = new AccordionInteractor('#resourceShowCustomLabels');
   customLabels = collection('[data-test-eholdings-resource-custom-label]', CustomLabel);

--- a/test/bigtest/interactors/resource-usage-consolidation.js
+++ b/test/bigtest/interactors/resource-usage-consolidation.js
@@ -1,0 +1,15 @@
+import {
+  interactor,
+  isPresent,
+} from '@bigtest/interactor';
+
+import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
+
+export default @interactor class ResourceUsageConsolidation {
+  accordion = new AccordionInteractor('#resourceShowUsageConsolidation');
+  isAccordionPresent = isPresent('#resourceShowUsageConsolidation');
+
+  whenLoaded() {
+    return this.when(() => this.isAccordionPresent).timeout(1000);
+  }
+}

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -250,6 +250,16 @@ describe('ResourceShow', () => {
       });
     });
 
+    describe('usage & analysis section', () => {
+      it('should display usage & analysis accordion', () => {
+        expect(ResourcePage.usageConsolidationSection.isAccordionPresent).to.be.true;
+      });
+
+      it('should display closed accordion by default', () => {
+        expect(ResourcePage.usageConsolidationSection.accordion.isOpen).to.be.false;
+      });
+    });
+
     describe('when token is not needed', () => {
       it('should not display "Add token" button', () => {
         expect(ResourcePage.hasAddTokenButton).to.be.false;
@@ -401,6 +411,17 @@ describe('ResourceShow', () => {
         expect(ResourcePage.toast.errorToastCount).to.equal(2);
         expect(ResourcePage.toast.totalToastCount).to.equal(2);
       });
+    });
+  });
+  
+  describe('visiting the resource page without Usage Consolidation Settings', () => {
+    beforeEach(function () {
+      this.server.get('/uc', 404);
+      this.visit(`/eholdings/resources/${resource.titleId}`);
+    });
+
+    it('should not show Usage Consolidation accordion', () => {
+      expect(ResourcePage.usageConsolidationSection.isAccordionPresent).to.be.false;
     });
   });
 

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -413,7 +413,7 @@ describe('ResourceShow', () => {
       });
     });
   });
-  
+
   describe('visiting the resource page without Usage Consolidation Settings', () => {
     beforeEach(function () {
       this.server.get('/uc', 404);


### PR DESCRIPTION
### UIEH-949 Title+Package (Resource) Record: Display Usage & Analysis Accordion

## Purpose
Add `UsageConsolidationAccordion` on Title+Package (Resource) page

[Issue](https://issues.folio.org/browse/UIEH-949)

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/99578471-92148500-29e5-11eb-8219-0a1354901aa7.png)
