### PR TITLE
UIEH-993: Add info popover for Usage Consolidation Accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Settings: Usage Consolidation: Permissions. (UIEH-938)
 * Added Usage Consolidation Summary table to Resource Show page. (UIEH-952)
 * Title Record: Display Holdings summary table. (UIEH-999)
+* Add info popover for Usage Consolidation Accordion. (UIEH-993)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/src/features/usage-consolidation-accordion/usage-consolidation-accordion.css
+++ b/src/features/usage-consolidation-accordion/usage-consolidation-accordion.css
@@ -1,0 +1,4 @@
+.accordion-usage-consolidation-header {
+  display: flex;
+  padding-top: 5px;
+}

--- a/src/features/usage-consolidation-accordion/usage-consolidation-accordion.js
+++ b/src/features/usage-consolidation-accordion/usage-consolidation-accordion.js
@@ -11,6 +11,7 @@ import { useStripes } from '@folio/stripes/core';
 import {
   Accordion,
   Headline,
+  InfoPopover,
 } from '@folio/stripes/components';
 
 import Toaster from '../../components/toaster';
@@ -25,6 +26,8 @@ import {
   entityTypes,
   costPerUse,
 } from '../../constants';
+
+import styles from './usage-consolidation-accordion.css';
 
 const propTypes = {
   costPerUseData: costPerUse.CostPerUseReduxStateShape.isRequired,
@@ -76,13 +79,38 @@ const UsageConsolidationAccordion = ({
     }));
   };
 
+  const renderInfoPopover = () => {
+    return (
+      // eslint-disable-next-line jsx-a11y/interactive-supports-focus, jsx-a11y/click-events-have-key-events
+      <span
+        role="button"
+        onClick={(e) => {
+          // We don't need to open / close the accordion by clicking on the info icon
+          e.stopPropagation();
+        }}
+      >
+        <InfoPopover
+          allowAnchorClick
+          hideOnButtonClick
+          iconSize="medium"
+          content={<FormattedMessage id="ui-eholdings.usageConsolidation.infoPopover.content" />}
+          buttonLabel={<FormattedMessage id="ui-eholdings.usageConsolidation.infoPopover.buttonLabel" />}
+          buttonHref="https://wiki.folio.org/display/FOLIOtips/Usage+Consolidation"
+          buttonTarget="_blank"
+        />
+      </span>
+    );
+  };
+
   const getUsageConsolidationAccordionHeader = () => {
     return (
       <Headline
         size="large"
         tag="h3"
+        className={styles['accordion-usage-consolidation-header']}
       >
         <FormattedMessage id="ui-eholdings.usageConsolidation" />
+        {renderInfoPopover()}
       </Headline>
     );
   };

--- a/test/bigtest/index.js
+++ b/test/bigtest/index.js
@@ -7,4 +7,5 @@ turnOffWarnings();
 // require all modules ending in "-test" from the current directory and
 // all subdirectories
 const requireTest = require.context('./tests/', true, /-test/);
+
 requireTest.keys().forEach(requireTest);

--- a/test/bigtest/interactors/package-usage-consolidation.js
+++ b/test/bigtest/interactors/package-usage-consolidation.js
@@ -6,12 +6,15 @@ import {
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
 
 import UsageConsolidationFilters from './usage-consolidation-filters';
+import UsageConsolidationInfoPopover from './usage-consolidation-info-popover';
 import UsageConsolidationContent from './usage-consolidation-content-package';
 
 export default @interactor class PackageUsageConsolidation {
   accordion = new AccordionInteractor('#packageShowUsageConsolidation');
   isAccordionPresent = isPresent('#packageShowUsageConsolidation');
+
   filters = new UsageConsolidationFilters();
+  infoPopover = new UsageConsolidationInfoPopover();
   content = new UsageConsolidationContent();
 
   whenLoaded() {

--- a/test/bigtest/interactors/resource-usage-consolidation.js
+++ b/test/bigtest/interactors/resource-usage-consolidation.js
@@ -6,6 +6,7 @@ import {
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
 
 import UsageConsolidationFilters from './usage-consolidation-filters';
+import UsageConsolidationInfoPopover from './usage-consolidation-info-popover';
 import UsageConsolidationContent from './usage-consolidation-content-resource';
 
 export default @interactor class ResourceUsageConsolidation {
@@ -13,6 +14,7 @@ export default @interactor class ResourceUsageConsolidation {
   isAccordionPresent = isPresent('#resourceShowUsageConsolidation');
 
   filters = new UsageConsolidationFilters();
+  infoPopover = new UsageConsolidationInfoPopover();
   content = new UsageConsolidationContent();
 
   whenLoaded() {

--- a/test/bigtest/interactors/title-usage-consolidation.js
+++ b/test/bigtest/interactors/title-usage-consolidation.js
@@ -6,6 +6,7 @@ import {
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
 
 import UsageConsolidationFilters from './usage-consolidation-filters';
+import UsageConsolidationInfoPopover from './usage-consolidation-info-popover';
 import UsageConsolidationContent from './usage-consolidation-content-title';
 
 export default @interactor class TitleUsageConsolidation {
@@ -13,6 +14,7 @@ export default @interactor class TitleUsageConsolidation {
   isAccordionPresent = isPresent('#titleShowUsageConsolidation');
 
   filters = new UsageConsolidationFilters();
+  infoPopover = new UsageConsolidationInfoPopover();
   content = new UsageConsolidationContent();
 
   whenLoaded() {

--- a/test/bigtest/interactors/usage-consolidation-info-popover.js
+++ b/test/bigtest/interactors/usage-consolidation-info-popover.js
@@ -1,0 +1,28 @@
+import {
+  isPresent,
+  interactor,
+  text,
+} from '@bigtest/interactor';
+
+import IconButtonInteractor from '@folio/stripes-components/lib/IconButton/tests/interactor';
+import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
+
+@interactor class UsageConsolidationInfoPopover {
+  triggerButton = new IconButtonInteractor('[data-test-info-popover-trigger]');
+  button = new ButtonInteractor('[data-test-info-popover-button]');
+  content = text('[data-test-info-popover-content]');
+
+  isTriggerButtonLoaded = isPresent('[data-test-info-popover-trigger]');
+
+  whenTriggerButtonLoaded() {
+    return this.when(() => this.isTriggerButtonLoaded);
+  }
+
+  isPopoverLoaded = isPresent('[data-test-popover-overlay]');
+
+  whenPopoverLoaded() {
+    return this.when(() => this.isPopoverLoaded);
+  }
+}
+
+export default UsageConsolidationInfoPopover;

--- a/test/bigtest/tests/package-usage-consolidation-test.js
+++ b/test/bigtest/tests/package-usage-consolidation-test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 
 import setupApplication, { axe } from '../helpers/setup-application';
 import PackageShowPage from '../interactors/package-show';
+// import usageConsolidationInfoPopoverTests from './usage-consolidation-info-popover';
 
 describe('PackageShowUsageConsolidation', () => {
   setupApplication();
@@ -61,6 +62,9 @@ describe('PackageShowUsageConsolidation', () => {
     it('should show accordion collapsed by default', () => {
       expect(PackageShowPage.usageConsolidation.accordion.isOpen).to.be.false;
     });
+
+    // TODO:: uncomment current tests after folio/stripes 5.1.0 will be available
+    // usageConsolidationInfoPopoverTests(PackageShowPage.usageConsolidation.infoPopover);
 
     describe('when clicking on accordion header', () => {
       beforeEach(async () => {

--- a/test/bigtest/tests/resource-show-test.js
+++ b/test/bigtest/tests/resource-show-test.js
@@ -5,6 +5,7 @@ import setupApplication, { axe } from '../helpers/setup-application';
 import ResourcePage from '../interactors/resource-show';
 import PackageEditPage from '../interactors/package-edit';
 import { entityAuthorityTypes } from '../../../src/constants';
+// import usageConsolidationInfoPopoverTests from './usage-consolidation-info-popover';
 
 describe('ResourceShow', () => {
   setupApplication();
@@ -304,6 +305,9 @@ describe('ResourceShow', () => {
           expect(ResourcePage.usageConsolidationSection.content.summaryTable.rows(0).cells(2).content).to.equal('$0.04 (USD)');
         });
       });
+
+      // TODO:: uncomment current tests after folio/stripes 5.1.0 will be available
+      // usageConsolidationInfoPopoverTests(ResourcePage.usageConsolidationSection.infoPopover);
     });
 
     describe('when token is not needed', () => {

--- a/test/bigtest/tests/title-show-test.js
+++ b/test/bigtest/tests/title-show-test.js
@@ -3,6 +3,7 @@ import { describe, beforeEach, it } from '@bigtest/mocha';
 
 import setupApplication, { axe } from '../helpers/setup-application';
 import TitleShowPage from '../interactors/title-show';
+// import usageConsolidationInfoPopoverTests from './usage-consolidation-info-popover';
 
 describe('TitleShow', () => {
   setupApplication();
@@ -170,6 +171,9 @@ describe('TitleShow', () => {
       it('should display correct value for platform filter', () => {
         expect(TitleShowPage.usageConsolidationSection.filters.platformTypeDropdown.value).to.equal('publisher');
       });
+
+      // TODO:: uncomment current tests after folio/stripes 5.1.0 will be available
+      // usageConsolidationInfoPopoverTests(TitleShowPage.usageConsolidationSection.infoPopover);
     });
   });
 

--- a/test/bigtest/tests/usage-consolidation-info-popover.js
+++ b/test/bigtest/tests/usage-consolidation-info-popover.js
@@ -1,0 +1,34 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+const usageConsolidationInfoPopoverTests = (interactor) => {
+  describe('Usage consolidation info popover', () => {
+    beforeEach(async () => {
+      await interactor.whenTriggerButtonLoaded();
+      await interactor.triggerButton.click();
+      await interactor.whenPopoverLoaded();
+    });
+
+    it('should display correct content text', () => {
+      expect(interactor.content).to.equal('Access to cost and usage information for the packages and titles that are a part of your library\'s holdings.');
+    });
+
+    it('should be presented info popover button', () => {
+      expect(interactor.button.isPresent).to.be.true;
+    });
+
+    it('should display correct info popover button label', () => {
+      expect(interactor.button.text).to.equal('Learn more');
+    });
+
+    it('should display correct info popover button href', () => {
+      expect(interactor.button.href).to.equal('https://wiki.folio.org/display/FOLIOtips/Usage+Consolidation');
+    });
+  });
+};
+
+export default usageConsolidationInfoPopoverTests;

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -30,6 +30,8 @@
     "usageConsolidation.summary.actions": "Actions",
     "usageConsolidation.summary.actions.export": "Export",
     "usageConsolidation.summary.embargo": "full text delay:",
+    "usageConsolidation.infoPopover.content": "Access to cost and usage information for the packages and titles that are a part of your library's holdings.",
+    "usageConsolidation.infoPopover.buttonLabel": "Learn more",
     "package.actionMenu.edit": "Edit",
     "package.addToHoldings": "Add to holdings",
     "package.addToken": "Add token",


### PR DESCRIPTION
## Description
-  Add info popover for Usage Consolidation Accordion

## Issue
[UIEH-993](https://issues.folio.org/browse/UIEH-993)

## Screenshots
![image](https://user-images.githubusercontent.com/24813219/100593935-b5063980-3301-11eb-9dad-24c2db747250.png)
