### PR TITLE
UIEH-998: Settings > eholdings > Usage Consolidation setting is misspelled 

### DIFF
--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -229,7 +229,7 @@
     "settings.usageConsolidation.id": "Usage consolidation ID",
     "settings.usageConsolidation.id.validation.empty": "Please enter a Usage Consolidation ID.",
     "settings.usageConsolidation.id.validation.invalid": "Invalid Usage Consolidation ID. Please enter a valid ID.",
-    "settings.usageConsolidation.startMonth": "Start month for usage stastistics",
+    "settings.usageConsolidation.startMonth": "Start month for usage statistics",
     "settings.usageConsolidation.currency": "Currency",
     "settings.usageConsolidation.currency.default": "Select a currency",
     "settings.usageConsolidation.currency.validation": "Select a currency",


### PR DESCRIPTION
## Description
- Fix spelling error in Usage Consolidation month field label

## Issue
[UIEH-998](https://issues.folio.org/browse/UIEH-998)