### PR TITLE
UIEH-1003: Edit Package/Resource record: Field labels text size is too small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added Usage Consolidation Summary table to Resource Show page. (UIEH-952)
 * Title Record: Display Holdings summary table. (UIEH-999)
 * Add info popover for Usage Consolidation Accordion. (UIEH-993)
+* Edit Package/Resource record: Field labels text size is too small. (UIEH-1003)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -39,6 +39,7 @@ import AccessTypeEditSection from '../../access-type-edit-section';
 import { accessTypesReduxStateShape } from '../../../constants';
 
 import styles from './managed-package-edit.css';
+import componentsStyles from '../../styles.css';
 
 const focusOnErrors = createFocusDecorator();
 
@@ -380,7 +381,11 @@ class ManagedPackageEdit extends Component {
                             <div className={styles['visibility-radios']}>
                               {initialValues.isVisible !== null ? (
                                 <fieldset data-test-eholdings-package-visibility-field>
-                                  <Headline tag="legend" size="small" margin="x-large">
+                                  <Headline
+                                    tag="legend"
+                                    margin="x-large"
+                                    className={componentsStyles.labelFontSize}
+                                  >
                                     <FormattedMessage id="ui-eholdings.package.visibility" />
                                   </Headline>
 
@@ -421,7 +426,11 @@ class ManagedPackageEdit extends Component {
                             <div className={styles['title-management-radios']}>
                               {initialValues.allowKbToAddTitles !== null ? (
                                 <fieldset data-test-eholdings-allow-kb-to-add-titles-radios>
-                                  <Headline tag="legend" size="small" margin="x-large">
+                                  <Headline
+                                    tag="legend"
+                                    margin="x-large"
+                                    className={componentsStyles.labelFontSize}
+                                  >
                                     <FormattedMessage id="ui-eholdings.package.packageAllowToAddTitles" />
                                   </Headline>
 

--- a/src/components/resource/_fields/visibility/visibility-field.js
+++ b/src/components/resource/_fields/visibility/visibility-field.js
@@ -4,6 +4,8 @@ import { Field } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 import { Headline, RadioButton } from '@folio/stripes/components';
 
+import componentsStyles from '../../../styles.css';
+
 class VisibilityField extends Component {
   static propTypes = {
     disabled: PropTypes.oneOfType([
@@ -20,7 +22,11 @@ class VisibilityField extends Component {
       <fieldset
         data-test-eholdings-resource-visibility-field
       >
-        <Headline tag="legend" size="small" margin="x-large">
+        <Headline
+          tag="legend"
+          margin="x-large"
+          className={componentsStyles.labelFontSize}
+        >
           <FormattedMessage id="ui-eholdings.label.showToPatrons" />
         </Headline>
 

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -1,6 +1,11 @@
 /* This file is for importing shared styles without using the `:global` scope */
 
-/* like `marginTopHalf` or `marginBottomHalf` from stripes-components */
+/* like `marginTopHalf` or `marginBottomHalf` from `stripes-components` */
 .marginRightHalf {
   margin-right: 0.5rem;
+}
+
+/* like `Label` component `font-size` from `stripes-components` */
+.labelFontSize {
+  font-size: 1.05rem;
 }


### PR DESCRIPTION
## Description
-  Edit Package/Resource record: Field labels text size is too small

## Issue
[UIEH-1003](https://issues.folio.org/browse/UIEH-1003)

## Screenshots
![image](https://user-images.githubusercontent.com/24813219/101751249-bc36ff80-3ad8-11eb-9ffa-72da5b1ebc38.png)


