### PR TITLE
UIEH-992: Add support for Settings (eHoldings): Can create, edit, and view knowledge base credentials.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Increase Settings Custom Labels display label max length to 200. (UIEH-985)
 * Increase Custom Labels value max length to 500. (UIEH-985)
 * Fix routing issues when visiting Note Edit page. (UIEH-991)
+* Add permission for button New Settings (eHoldings): Can create, edit, and view knowledge base credentials. (UIEH-992)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -138,7 +138,16 @@ class Settings extends Component {
   }
 
   renderLastMenu() {
-    const { location: { pathname } } = this.props;
+    const {
+      location: {
+        pathname,
+      },
+      stripes,
+    } = this.props;
+
+    if (!stripes.hasPerm('ui-eholdings.settings.kb')) {
+      return null;
+    }
 
     return (
       <Button

--- a/src/routes/settings-knowledge-base.js
+++ b/src/routes/settings-knowledge-base.js
@@ -3,14 +3,16 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import {
-  TitleManager,
-  CalloutContext,
-} from '@folio/stripes/core';
-import {
   FormattedMessage,
   injectIntl,
 } from 'react-intl';
 import { cloneDeep } from 'lodash';
+
+import {
+  TitleManager,
+  CalloutContext,
+  withStripes,
+} from '@folio/stripes/core';
 
 import {
   postKBCredentials as postKBCredentialsAction,
@@ -38,6 +40,9 @@ class SettingsKnowledgeBaseRoute extends Component {
     match: PropTypes.object.isRequired,
     patchKBCredentials: PropTypes.func.isRequired,
     postKBCredentials: PropTypes.func.isRequired,
+    stripes: PropTypes.shape({
+      hasPerm: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
   state = {
@@ -164,7 +169,13 @@ class SettingsKnowledgeBaseRoute extends Component {
     const {
       kbCredentials,
       intl,
+      stripes,
+      history,
     } = this.props;
+
+    if (!stripes.hasPerm('ui-eholdings.settings.kb')) {
+      history.push('/settings/eholdings');
+    }
 
     return (
       <CalloutContext.Consumer>
@@ -206,4 +217,4 @@ export default connect(
     confirmPatchKBCredentials: confirmPatchKBCredentialsAction,
     confirmPostKBCredentials: confirmPostKBCredentialsAction,
   }
-)(injectIntl(SettingsKnowledgeBaseRoute));
+)(injectIntl(withStripes(SettingsKnowledgeBaseRoute)));


### PR DESCRIPTION
## Description
-  Add support for Settings (eHoldings): Can create, edit, and view knowledge base credentials.

## Issue
[UIEH-992](https://issues.folio.org/browse/UIEH-992)

## Screenshots
![image](https://user-images.githubusercontent.com/24813219/101765802-8438b800-3aea-11eb-8bf1-2c6224bc2222.png)
