### PR TITLE
UIEH-1003: Edit Package/Resource record: Field labels text size is too small

### DIFF
--- a/src/components/fieldset-styles.css
+++ b/src/components/fieldset-styles.css
@@ -1,0 +1,10 @@
+@import "@folio/stripes-components/lib/variables";
+
+.fieldset {
+  margin-bottom: var(--control-margin-bottom);
+}
+
+.label {
+  font-size: 1.05rem; /* like Label component font-size from `stripes-components` */
+  margin-bottom: 0;
+}

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -39,7 +39,7 @@ import AccessTypeEditSection from '../../access-type-edit-section';
 import { accessTypesReduxStateShape } from '../../../constants';
 
 import styles from './managed-package-edit.css';
-import componentsStyles from '../../styles.css';
+import fieldsetStyles from '../../fieldset-styles.css';
 
 const focusOnErrors = createFocusDecorator();
 
@@ -380,11 +380,13 @@ class ManagedPackageEdit extends Component {
                           >
                             <div className={styles['visibility-radios']}>
                               {initialValues.isVisible !== null ? (
-                                <fieldset data-test-eholdings-package-visibility-field>
+                                <fieldset
+                                  data-test-eholdings-package-visibility-field
+                                  className={fieldsetStyles.fieldset}
+                                >
                                   <Headline
                                     tag="legend"
-                                    margin="x-large"
-                                    className={componentsStyles.labelFontSize}
+                                    className={fieldsetStyles.label}
                                   >
                                     <FormattedMessage id="ui-eholdings.package.visibility" />
                                   </Headline>
@@ -425,11 +427,13 @@ class ManagedPackageEdit extends Component {
                             </div>
                             <div className={styles['title-management-radios']}>
                               {initialValues.allowKbToAddTitles !== null ? (
-                                <fieldset data-test-eholdings-allow-kb-to-add-titles-radios>
+                                <fieldset
+                                  data-test-eholdings-allow-kb-to-add-titles-radios
+                                  className={fieldsetStyles.fieldset}
+                                >
                                   <Headline
                                     tag="legend"
-                                    margin="x-large"
-                                    className={componentsStyles.labelFontSize}
+                                    className={fieldsetStyles.label}
                                   >
                                     <FormattedMessage id="ui-eholdings.package.packageAllowToAddTitles" />
                                   </Headline>

--- a/src/components/resource/_fields/visibility/visibility-field.js
+++ b/src/components/resource/_fields/visibility/visibility-field.js
@@ -4,7 +4,7 @@ import { Field } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 import { Headline, RadioButton } from '@folio/stripes/components';
 
-import componentsStyles from '../../../styles.css';
+import fieldsetStyles from '../../../fieldset-styles.css';
 
 class VisibilityField extends Component {
   static propTypes = {
@@ -21,11 +21,11 @@ class VisibilityField extends Component {
     return (
       <fieldset
         data-test-eholdings-resource-visibility-field
+        className={fieldsetStyles.fieldset}
       >
         <Headline
           tag="legend"
-          margin="x-large"
-          className={componentsStyles.labelFontSize}
+          className={fieldsetStyles.label}
         >
           <FormattedMessage id="ui-eholdings.label.showToPatrons" />
         </Headline>

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -4,8 +4,3 @@
 .marginRightHalf {
   margin-right: 0.5rem;
 }
-
-/* like `Label` component `font-size` from `stripes-components` */
-.labelFontSize {
-  font-size: 1.05rem;
-}


### PR DESCRIPTION
## Description
-  Edit Package/Resource record: Field labels text size is too small

## Issue
[UIEH-1003](https://issues.folio.org/browse/UIEH-1003)

## Screenshots
![image](https://user-images.githubusercontent.com/24813219/101915308-1cf43400-3bce-11eb-8f75-1683f649228e.png)



