### PR TITLE
UIEH-977: Add label for contributor type narrator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix routing issues when visiting Note Edit page. (UIEH-991)
 * Add permission for button New Settings (eHoldings): Can create, edit, and view knowledge base credentials. (UIEH-992)
 * Title Record: Add a Selection Status filter to Search within Packages modal. (UIEH-978)
+* Add label for contributor type narrator. (UIEH-977)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -424,6 +424,7 @@
     "contributorType.author": "{count, plural, one {Author} other {Authors}}",
     "contributorType.illustrator": "{count, plural, one {Illustrator} other {Illustrators}}",
     "contributorType.editor": "{count, plural, one {Editor} other {Editors}}",
+    "contributorType.narrator": "{count, plural, one {Narrator} other {Narrators}}",
     "listType.packages": "Packages",
     "listType.titles": "Titles",
 


### PR DESCRIPTION
## Description
- Add label for contributor type narrator.

## Issue
[UIEH-977](https://issues.folio.org/browse/UIEH-977)

## Screenshots
![image](https://user-images.githubusercontent.com/24813219/101923617-4fa32a00-3bd8-11eb-8582-fe446ae614c6.png)



