### PR TITLE
UIEH-1009 Fix Usage Consolidation currency setting not updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Edit Package/Resource record: Field labels text size is too small. (UIEH-1003)
 * Add Full text request usage table to Resource/Title Show page. (UIEH-953, UIEH-997)
 * Add Usage Consolidation Titles table to Package Show page. (UIEH-948)
+* Fix Usage Consolidation currency setting not updating. (UIEH-1009)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/package.json
+++ b/package.json
@@ -263,7 +263,8 @@
         "visible": true,
         "subPermissions": [
           "ui-eholdings.settings.enabled",
-          "kb-ebsco.kb-credentials.uc.item.get"
+          "kb-ebsco.kb-credentials.uc.item.get",
+          "kb-ebsco.currencies.collection.get"
         ]
       },
       {

--- a/src/routes/settings-usage-consolidation-route.js
+++ b/src/routes/settings-usage-consolidation-route.js
@@ -79,7 +79,7 @@ const SettingsUsageConsolidationRoute = ({
     } = params;
 
     const attributes = {
-      currency: 'USD',
+      currency: updatedData.currency,
       platformType: updatedData.platformType,
       startMonth: updatedData.startMonth,
     };


### PR DESCRIPTION
## Description
- Using actual form data instead of hardcoded 'USD' currency
- Added backend permission `kb-ebsco.currencies.collection.get` to get a list of currencies
