### PR TITLE
UIEH-1010: Display toast notification for Settings Usage Consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Package Show page | Export Titles. (UIEH-946)
 * Display Usage data metric selection for Total usage on Summary table. (UIEH-994)
 * Remove Actions button dropdown from Title/Resource Summary Table. (UIEH-1014)
+* Settings - Usage Consolidation: Display a successful toast notification. (UIEH-1010)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/src/components/settings/settings-usage-consolidation/settings-usage-consolidation.js
+++ b/src/components/settings/settings-usage-consolidation/settings-usage-consolidation.js
@@ -1,4 +1,7 @@
-import React from 'react';
+import React, {
+  useEffect,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import {
   Form,
@@ -43,9 +46,20 @@ const SettingsUsageConsolidation = ({
   usageConsolidation,
   updateUsageConsolidation: onSubmit,
 }) => {
+  const [toasts, setToasts] = useState([]);
   const stripes = useStripes();
   const disabled = !stripes.hasPerm('ui-eholdings.settings.usage-consolidation.create-edit');
   const { formatMessage } = useIntl();
+
+  useEffect(() => {
+    if (usageConsolidation.hasSaved) {
+      setToasts([...toasts, {
+        id: `settings-uc-${Date.now()}`,
+        message: <FormattedMessage id="ui-eholdings.settings.usageConsolidation.saved" />,
+        type: 'success',
+      }]);
+    }
+  }, [usageConsolidation.hasSaved]);
 
   const usageConsolidationIdLabel = formatMessage({ id: 'ui-eholdings.settings.usageConsolidation.id' });
   const usageConsolidationStartMonthLabel = formatMessage({ id: 'ui-eholdings.settings.usageConsolidation.startMonth' });
@@ -120,7 +134,7 @@ const SettingsUsageConsolidation = ({
           id="usage-consolidation-form"
           formState={formState}
           title={<FormattedMessage id="ui-eholdings.settings.usageConsolidation" />}
-          toasts={[]}
+          toasts={toasts}
         >
           <Field
             id="eholdings-settings-usage-consolidation-id"

--- a/src/components/settings/settings-usage-consolidation/settings-usage-consolidation.js
+++ b/src/components/settings/settings-usage-consolidation/settings-usage-consolidation.js
@@ -53,7 +53,7 @@ const SettingsUsageConsolidation = ({
 
   useEffect(() => {
     if (usageConsolidation.hasSaved) {
-      setToasts([...toasts, {
+      setToasts(t => [...t, {
         id: `settings-uc-${Date.now()}`,
         message: <FormattedMessage id="ui-eholdings.settings.usageConsolidation.saved" />,
         type: 'success',

--- a/src/redux/reducers/usageConsolidation.js
+++ b/src/redux/reducers/usageConsolidation.js
@@ -15,6 +15,7 @@ const handleError = (state, { payload }) => ({
   isLoading: false,
   isLoaded: false,
   isFailed: true,
+  hasSaved: false,
   errors: formatErrors(payload.errors),
 });
 
@@ -24,6 +25,7 @@ const handlers = {
     isLoading: true,
     isLoaded: false,
     isFailed: false,
+    hasSaved: false,
     data: {},
     errors: [],
   }),
@@ -35,6 +37,7 @@ const handlers = {
       isLoading: false,
       isLoaded: true,
       isFailed: false,
+      hasSaved: false,
       data: attributes,
     };
   },
@@ -48,6 +51,7 @@ const handlers = {
       isLoading: false,
       isLoaded: true,
       isFailed: false,
+      hasSaved: true,
     };
   },
   [PATCH_USAGE_CONSOLIDATION_SUCCESS]: (state, { payload }) => {
@@ -60,6 +64,7 @@ const handlers = {
       isLoading: false,
       isLoaded: true,
       isFailed: false,
+      hasSaved: true,
     };
   },
   [CLEAR_USAGE_CONSOLIDATION_ERRORS]: state => ({
@@ -72,6 +77,7 @@ const initialState = {
   isLoading: false,
   isLoaded: false,
   isFailed: false,
+  hasSaved: false,
   data: {},
   errors: [],
 };

--- a/test/bigtest/tests/unit/reducers/usage-consolidation-test.js
+++ b/test/bigtest/tests/unit/reducers/usage-consolidation-test.js
@@ -12,7 +12,7 @@ import {
   POST_USAGE_CONSOLIDATION_SUCCESS,
 } from '../../../../../src/redux/actions';
 
-describe.only('(reducer) usageConsolidation', () => {
+describe('(reducer) usageConsolidation', () => {
   it('should return the initial state', () => {
     expect(usageConsolidation(undefined, {})).to.deep.equal({
       data: {},

--- a/test/bigtest/tests/unit/reducers/usage-consolidation-test.js
+++ b/test/bigtest/tests/unit/reducers/usage-consolidation-test.js
@@ -12,7 +12,7 @@ import {
   POST_USAGE_CONSOLIDATION_SUCCESS,
 } from '../../../../../src/redux/actions';
 
-describe('(reducer) usageConsolidation', () => {
+describe.only('(reducer) usageConsolidation', () => {
   it('should return the initial state', () => {
     expect(usageConsolidation(undefined, {})).to.deep.equal({
       data: {},
@@ -20,6 +20,7 @@ describe('(reducer) usageConsolidation', () => {
       isLoading: false,
       isLoaded: false,
       isFailed: false,
+      hasSaved: false,
     });
   });
 
@@ -36,6 +37,7 @@ describe('(reducer) usageConsolidation', () => {
       isLoading: true,
       isLoaded: false,
       isFailed: false,
+      hasSaved: false,
     };
 
     expect(usageConsolidation(actualState, action)).to.deep.equal(expectedState);
@@ -56,6 +58,7 @@ describe('(reducer) usageConsolidation', () => {
       isLoading: false,
       isLoaded: false,
       isFailed: true,
+      hasSaved: false,
       errors: [{ title: 'error' }],
     };
 
@@ -77,6 +80,7 @@ describe('(reducer) usageConsolidation', () => {
       isLoading: false,
       isLoaded: false,
       isFailed: true,
+      hasSaved: false,
       errors: [{ title: 'error' }],
     };
 
@@ -98,6 +102,7 @@ describe('(reducer) usageConsolidation', () => {
       isLoading: false,
       isLoaded: true,
       isFailed: false,
+      hasSaved: true,
       errors: [],
     };
 
@@ -119,6 +124,7 @@ describe('(reducer) usageConsolidation', () => {
       isLoading: false,
       isLoaded: false,
       isFailed: true,
+      hasSaved: false,
       errors: [{ title: 'error' }],
     };
 
@@ -140,6 +146,7 @@ describe('(reducer) usageConsolidation', () => {
       isLoading: false,
       isLoaded: true,
       isFailed: false,
+      hasSaved: true,
       errors: [],
     };
 
@@ -152,6 +159,7 @@ describe('(reducer) usageConsolidation', () => {
       isLoading: false,
       isLoaded: false,
       isFailed: true,
+      hasSaved: false,
       errors: [{ title: 'error' }],
     };
     const action = {
@@ -162,6 +170,7 @@ describe('(reducer) usageConsolidation', () => {
       isLoading: false,
       isLoaded: false,
       isFailed: true,
+      hasSaved: false,
       errors: [],
     };
 

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -273,6 +273,7 @@
     "settings.usageConsolidation.id": "Usage consolidation ID",
     "settings.usageConsolidation.id.validation.empty": "Please enter a Usage Consolidation ID.",
     "settings.usageConsolidation.id.validation.invalid": "Invalid Usage Consolidation ID. Please enter a valid ID.",
+    "settings.usageConsolidation.saved": "Usage Consolidation settings are updated.",
     "settings.usageConsolidation.startMonth": "Start month for usage statistics",
     "settings.usageConsolidation.currency": "Currency",
     "settings.usageConsolidation.currency.default": "Select a currency",


### PR DESCRIPTION
### UIEH-1010 Settings > eholdings > Usage Consolidation | Display a successful toast notification

## Purpose

Add toast notification for Settings Usage Consolidation page when usage consolidation ID would be updated. Also updated `usage-consolidation` reducer for it and tests.

#### Issue [UIEH-1010](https://issues.folio.org/browse/UIEH-1010)

## Screenshots
![2eAzzkB9S0](https://user-images.githubusercontent.com/55701515/104012137-fbc83880-51b7-11eb-9dcb-300d6fa7efb1.gif)

