### PR TITLE
UIEH-1008: Make Coverage Accordion in Resource Page be always expanded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add label for contributor type narrator. (UIEH-977)
 * Remove request to '/status' in Settings > eHoldings. (UIEH-1012)
 * Fixed text wrapping for Custom Labels. (UIEH-985)
+* Make Coverage Accordion in Resource Page be always expanded. (UIEH-1008)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -76,7 +76,7 @@ class ResourceShow extends Component {
         resourceShowInformation: true,
         resourceShowCustomLabels: true,
         resourceShowSettings: true,
-        resourceShowCoverageSettings: this.props.model.isSelected,
+        resourceShowCoverageSettings: true,
         resourceShowAgreements: true,
         resourceShowNotes: true,
       },


### PR DESCRIPTION
### UIEH-57 Focus should move to Results list pane header after search is conducted

## Purpose
Previous requirements were that when package isn't selected, coverage accordion was collapsed, now it is always expanded.

Issue: [UIEH-1008](https://issues.folio.org/browse/UIEH-1008)

## Screenshots
![qrfKn7keR5](https://user-images.githubusercontent.com/55701515/104312471-5545a580-54df-11eb-99e8-4368e7a324a7.gif)

