### PR TITLE
UIEH-1018: Add assign/unassign user from KB permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add label for contributor type narrator. (UIEH-977)
 * Remove request to '/status' in Settings > eHoldings. (UIEH-1012)
 * Fixed text wrapping for Custom Labels. (UIEH-985)
+* Add assign/unassign user from KB permissions. (UIEH-1018) 
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/package.json
+++ b/package.json
@@ -249,6 +249,7 @@
         "displayName": "Settings (eHoldings): Can assign/unassign a user from a KB",
         "visible": true,
         "subPermissions": [
+          "ui-eholdings.settings.enabled",
           "kb-ebsco.kb-credentials.users.all"
         ]
       }

--- a/package.json
+++ b/package.json
@@ -247,7 +247,10 @@
       {
         "permissionName": "ui-eholdings.settings.assignedUser",
         "displayName": "Settings (eHoldings): Can assign/unassign a user from a KB",
-        "visible": true
+        "visible": true,
+        "subPermissions": [
+          "kb-ebsco.kb-credentials.users.all"
+        ]
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -243,6 +243,11 @@
         "subPermissions": [
           "ui-eholdings.settings.custom-labels.view"
         ]
+      },
+      {
+        "permissionName": "ui-eholdings.settings.assignedUser",
+        "displayName": "Settings (eHoldings): Can assign/unassign a user from a KB",
+        "visible": true
       }
     ]
   }

--- a/src/components/settings/settings.js
+++ b/src/components/settings/settings.js
@@ -128,9 +128,12 @@ class Settings extends Component {
                 <FormattedMessage id="ui-eholdings.settings.accessStatusTypes" />
               </NavListItem>
             </IfPermission>
-            <NavListItem to={`/settings/eholdings/${configuration.id}/users`}>
-              <FormattedMessage id="ui-eholdings.settings.assignedUsers" />
-            </NavListItem>
+
+            <IfPermission perm="ui-eholdings.settings.assignedUser">
+              <NavListItem to={`/settings/eholdings/${configuration.id}/users`}>
+                <FormattedMessage id="ui-eholdings.settings.assignedUsers" />
+              </NavListItem>
+            </IfPermission>
           </div>
         </NavListSection>
       </NavList>

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -449,5 +449,6 @@
     "permission.settings.access-types.create-edit": "Settings (eholdings): Can create, edit, and view access status types",
     "permission.settings.access-types.view": "Settings (eholdings): Can view access status types",
     "permission.settings.custom-labels.all": "Settings (eholdings): Can create, edit, view, and delete custom labels",
-    "permission.settings.custom-labels.view": "Settings (eholdings): Can view custom labels"
+    "permission.settings.custom-labels.view": "Settings (eholdings): Can view custom labels",
+    "permission.settings.assignedUser": "Settings (eHoldings): Can assign/unassign a user from a KB"
   }


### PR DESCRIPTION
### UIEH-1018 New permission: Settings (eHoldings): Can assign/unassign a user from a KB

## Purpose
Add permissions for settings - assign/unassign user from knowledge base

Issue: [UIEH-1018](https://issues.folio.org/browse/UIEH-1018)
