### PR TITLE
UIEH-1041: Fix error message for costperuse in record

### DIFF
--- a/src/features/usage-consolidation-accordion/no-cost-per-use-available.js
+++ b/src/features/usage-consolidation-accordion/no-cost-per-use-available.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+const propTypes = {
+  entityType: PropTypes.string.isRequired,
+  year: PropTypes.number.isRequired,
+};
+
+const NoCostPerUseAvailable = ({
+  entityType,
+  year,
+}) => (
+  <div data-test-usage-consolidation-error>
+    <FormattedMessage
+      id={`ui-eholdings.usageConsolidation.summary.${entityType}.noData`}
+      values={{ year }}
+    />
+  </div>
+);
+
+NoCostPerUseAvailable.propTypes = propTypes;
+
+export default NoCostPerUseAvailable;

--- a/src/features/usage-consolidation-accordion/summary-table/summary-table.js
+++ b/src/features/usage-consolidation-accordion/summary-table/summary-table.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  FormattedMessage,
   useIntl,
 } from 'react-intl';
 
@@ -25,7 +24,6 @@ const propTypes = {
   noCostPerUseAvailable: PropTypes.bool.isRequired,
   onExportTitles: PropTypes.func,
   onViewTitles: PropTypes.func,
-  year: PropTypes.number.isRequired,
 };
 
 const SummaryTable = ({
@@ -39,7 +37,6 @@ const SummaryTable = ({
   onExportTitles,
   isExportDisabled,
   noCostPerUseAvailable,
-  year,
   ...rest
 }) => {
   const intl = useIntl();
@@ -55,21 +52,15 @@ const SummaryTable = ({
     ? rest.contentData || [data?.attributes?.analysis]
     : [];
 
-  const emptyMessage = (
-    <div data-test-usage-consolidation-error>
-      <FormattedMessage
-        id={`ui-eholdings.usageConsolidation.summary.${entityType}.noData`}
-        values={{ year }}
-      />
-    </div>
-  );
+  if (!contentData.length) {
+    return null;
+  }
 
   return (
     <KeyValue>
       <MultiColumnList
         id={id}
         contentData={contentData}
-        isEmptyMessage={emptyMessage}
         {...getSummaryTableColumnProperties(intl, {
           currency,
           metricType,

--- a/src/features/usage-consolidation-accordion/usage-consolidation-content-package.js
+++ b/src/features/usage-consolidation-accordion/usage-consolidation-content-package.js
@@ -11,6 +11,7 @@ import {
   Icon,
 } from '@folio/stripes/components';
 
+import NoCostPerUseAvailable from './no-cost-per-use-available';
 import SummaryTable from './summary-table';
 import { DEFAULT_SUMMARY_TABLE_COLUMNS } from './summary-table/column-properties';
 import TitlesTable from './titles-table';
@@ -163,7 +164,12 @@ const UsageConsolidationContentPackage = ({
     },
   };
 
-  return (
+  return noCostPerUseAvailable ? (
+    <NoCostPerUseAvailable
+      entityType={entityTypes.PACKAGE}
+      year={year}
+    />
+  ) : (
     <>
       <SummaryTable
         id="packageUsageConsolidationSummary"
@@ -176,7 +182,6 @@ const UsageConsolidationContentPackage = ({
         isExportDisabled={isExportDisabled}
         metricType={metricType}
         noCostPerUseAvailable={noCostPerUseAvailable}
-        year={year}
       />
       <TitlesTable
         costPerUseData={costPerUseData}

--- a/src/features/usage-consolidation-accordion/usage-consolidation-content-resource.js
+++ b/src/features/usage-consolidation-accordion/usage-consolidation-content-resource.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import FullTextRequestUsageTable from './full-text-request-usage-table';
 import SummaryTable from './summary-table';
+import NoCostPerUseAvailable from './no-cost-per-use-available';
 import {
   costPerUse as costPerUseShape,
   entityTypes,
@@ -55,7 +56,14 @@ const UsageConsolidationContentResource = ({
     columnMapping: { cost: 'ui-eholdings.usageConsolidation.summary.resourceCost' },
   };
 
-  return (
+  const isPlatformsDataEmpty = !data.attributes?.usage?.platforms.length;
+
+  return noCostPerUseAvailable && isPlatformsDataEmpty ? (
+    <NoCostPerUseAvailable
+      entityType={entityTypes.RESOURCE}
+      year={year}
+    />
+  ) : (
     <>
       <SummaryTable
         id="resourceUsageConsolidationSummary"

--- a/src/features/usage-consolidation-accordion/usage-consolidation-content-title.js
+++ b/src/features/usage-consolidation-accordion/usage-consolidation-content-title.js
@@ -13,6 +13,7 @@ import {
 
 import FullTextRequestUsageTable from './full-text-request-usage-table';
 import SummaryTable from './summary-table';
+import NoCostPerUseAvailable from './no-cost-per-use-available';
 import {
   formatCoverageYear,
   formatCoverageFullDate,
@@ -163,7 +164,14 @@ const UsageConsolidationContentTitle = ({
     formatter,
   };
 
-  return (
+  const isPlatformsDataEmpty = !data.attributes?.usage?.platforms.length;
+
+  return noCostPerUseAvailable && isPlatformsDataEmpty ? (
+    <NoCostPerUseAvailable
+      entityType={entityTypes.TITLE}
+      year={year}
+    />
+  ) : (
     <>
       <SummaryTable
         id="titleUsageConsolidationSummary"

--- a/test/bigtest/tests/title-usage-consolidation-test.js
+++ b/test/bigtest/tests/title-usage-consolidation-test.js
@@ -322,16 +322,11 @@ describe('TitleShowUsageConsolidation', () => {
         'type': 'titleCostPerUse',
         'attributes': {
           'usage': {
-            'platforms': [{
-              'name': 'Wiley Online Library',
-              'isPublisherPlatform' : true,
-              'counts': [2, 6, 0, 3, 6, 2, 1, 2, null, null, null, null],
-              'total': 22
-            }],
+            'platforms': [],
             'totals': {
               'publisher': {
-                'counts': [2, 6, 0, 3, 6, 2, 1, 2, null, null, null, null],
-                'total': 22
+                'counts': [],
+                'total': 0,
               }
             }
           },


### PR DESCRIPTION
### UIEH-1041: Resource record: Summary and Full Text requests tables do not display

## Purpose
Fix of this [PR](https://github.com/folio-org/ui-eholdings/pull/1272)
Now if no costPerUse data available it should show full text request usage table if usage data present

Issue: [UIEH-1041](https://issues.folio.org/browse/UIEH-57)

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/109151933-7acafd80-7773-11eb-9bc8-4788f08df0ca.png)
