### PR TITLE
UIEH-1104: Update permission for eholdings module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Fix Package/Title/Provider scroll disappearing when an accordion is collapsed. (UIEH-1026)
 * Add FOLIO keyboard shortcuts to eholdings. (UIEH-979)
 * Fix cannot create a custom title. (UIEH-1103)
+* Update permission name for eholdings module. (UIEH-1104)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "permissionSets": [
       {
         "permissionName": "module.eholdings.enabled",
-        "displayName": "UI: eHoldings module is enabled",
+        "displayName": "eHoldings: Can view providers, packages, titles detail records",
         "visible": false,
         "subPermissions": [
           "kb-ebsco.all",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -514,7 +514,7 @@
     "notes.entityType.resource.pluralized": "{count} {count, plural, one {resource} other {resources}}",
     "notes.entityType.title.pluralized": "{count} {count, plural, one {title} other {titles}}",
 
-    "permission.app.enabled": "UI: eHoldings module is enabled",
+    "permission.app.enabled": "eHoldings: Can view providers, packages, titles detail records",
     "permission.settings.enabled": "Settings (eHoldings): display list of settings pages",
     "permission.settings.kb": "Settings (eHoldings): Can create, edit, and view knowledge base credentials",
     "permission.settings.kb.delete": "Settings (eHoldings): Can delete knowledge base credentials",


### PR DESCRIPTION
### UIEH-1104 Change [ UI: eHoldings module is enabled] permission TO [eHoldings: Can view providers, packages, titles detail records]

## Purpose
Issue: [UIEH-1104](https://issues.folio.org/browse/UIEH-1104)