### PR TITLE
UIEH-1109: display Holdings Summary heading for title record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Update permission name for eholdings module. (UIEH-1104)
 * Provider: Re-order accordions display. (UIEH-1044)
 * Package Record | Change accordion order. (UIEH-1045)
+* Display Holdings Summary Heading for Title record. (UIEH-1109)
 
 ## [5.0.0] (https://github.com/folio-org/ui-eholdings/tree/v5.0.0) (2020-10-15)
 

--- a/src/features/usage-consolidation-accordion/summary-table/summary-table.js
+++ b/src/features/usage-consolidation-accordion/summary-table/summary-table.js
@@ -10,7 +10,10 @@ import {
 } from '@folio/stripes/components';
 
 import { getSummaryTableColumnProperties } from './column-properties';
-import { costPerUse as costPerUseShape } from '../../../constants';
+import {
+  costPerUse as costPerUseShape,
+  entityTypes,
+} from '../../../constants';
 
 const propTypes = {
   contentData: PropTypes.array,
@@ -56,8 +59,12 @@ const SummaryTable = ({
     return null;
   }
 
+  const label = entityType === entityTypes.TITLE
+    ? intl.formatMessage({ id: 'ui-eholdings.usageConsolidation.holdingsSummary' })
+    : null;
+
   return (
-    <KeyValue>
+    <KeyValue label={label}>
       <MultiColumnList
         id={id}
         contentData={contentData}

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -16,6 +16,7 @@
     "usageConsolidation.filters.year": "Year",
     "usageConsolidation.filters.platformType": "Platform",
     "usageConsolidation.filters.view": "View",
+    "usageConsolidation.holdingsSummary": "Holdings Summary",
     "usageConsolidation.summary.packageName": "Package",
     "usageConsolidation.summary.coverage": "Coverage",
     "usageConsolidation.summary.titleCost": "Cost",


### PR DESCRIPTION
### UIEH-1109 Title Record: Usage Consolidation: Display Holdings Summary Heading

## Purpose
Add label for Holdings Summary table in Title Record Page

Issue: [UIEH-1109](https://issues.folio.org/browse/UIEH-1109)

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/111276328-e6e8a500-863f-11eb-8ff3-0c3dd62a4b93.png)
