### PR TITLE
UIEH-970: eholdings App: Consume {{FormattedDate}} and {{FormattedTime}} via stripes-component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [6.1.0] (IN PROGRESS)
 * Fix scroll wobble when page is zoomed out. (UIEH-1107)
 * Add tests coverage for keyboard shortcuts to eholdings. (UIEH-1043)
+* eholdings App: Consume {{FormattedDate}} and {{FormattedTime}} via stripes-component. (UIEH-970)
 
 ## [6.0.0] (https://github.com/folio-org/ui-eholdings/tree/v6.0.0) (2021-03-17)
 * Settings - Usage Consolidation - Currency. (UIEH-965)

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
   FormattedMessage,

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -1,8 +1,6 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
   FormattedMessage,
-  FormattedDate,
   useIntl,
 } from 'react-intl';
 import { Link } from 'react-router-dom';
@@ -12,6 +10,7 @@ import {
   Icon,
   IconButton,
   Tooltip,
+  FormattedDate,
 } from '@folio/stripes/components';
 
 import { TIME_ZONE } from '../../constants';

--- a/src/components/package/show/components/coverage-settings/coverage-settings.js
+++ b/src/components/package/show/components/coverage-settings/coverage-settings.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
   FormattedMessage,

--- a/src/components/package/show/components/coverage-settings/coverage-settings.js
+++ b/src/components/package/show/components/coverage-settings/coverage-settings.js
@@ -1,14 +1,13 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
   FormattedMessage,
-  FormattedDate,
 } from 'react-intl';
 
 import {
   Accordion,
   Headline,
   KeyValue,
+  FormattedDate,
 } from '@folio/stripes/components';
 
 const propTypes = {

--- a/src/components/resource/_fields/validate-date-range.js
+++ b/src/components/resource/_fields/validate-date-range.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   FormattedMessage,
 } from 'react-intl';

--- a/src/components/resource/_fields/validate-date-range.js
+++ b/src/components/resource/_fields/validate-date-range.js
@@ -1,10 +1,10 @@
-import React from 'react';
 import {
   FormattedMessage,
-  FormattedDate,
 } from 'react-intl';
-
 import moment from 'moment';
+
+import { FormattedDate } from '@folio/stripes/components';
+
 
 /**
    * Validator to ensure begin date is present and entered dates are valid

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import {
   FormattedMessage,
-  FormattedDate,
   useIntl,
 } from 'react-intl';
 import {
@@ -18,8 +17,11 @@ import {
   NoValue,
   TextField,
   ConfirmationModal,
+  FormattedDate,
 } from '@folio/stripes/components';
-import { EditableList } from '@folio/stripes/smart-components';
+import {
+  EditableList,
+} from '@folio/stripes/smart-components';
 
 import Toaster from '../../toaster';
 

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import moment from 'moment';
 import queryString from 'qs';
 import {

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import moment from 'moment';
 import queryString from 'qs';
 import {
@@ -6,9 +5,10 @@ import {
   pickBy,
 } from 'lodash';
 import {
-  FormattedDate,
   FormattedMessage,
 } from 'react-intl';
+
+import { FormattedDate } from '@folio/stripes/components';
 
 import { searchTypes } from '../constants';
 


### PR DESCRIPTION
## Description
* eholdings App: Consume {{FormattedDate}} and {{FormattedTime}} via stripes-component. (UIEH-970)

## Issues
[UIEH-970](https://issues.folio.org/browse/UIEH-970)
