### PR TITLE
UIEH-1122 Settings > eholdings > KB configuration > Unable to change Knowledge base name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add tests on Jest+RTL for ProviderShow component. (UIEH-1093)
 * Search shortcut should redirect to eHoldings search page. (UIEH-1111)
 * Remove the Ordered through EBSCO option from filters. (UIEH-1118)
+* Fix unable to change Knowledge base name. (UIEH-1122) 
 
 ## [6.0.1] (https://github.com/folio-org/ui-eholdings/tree/v6.0.1) (2021-03-29)
 * Fix scroll wobble when page is zoomed out. (UIEH-1107)

--- a/src/redux/epics/patch-kb-credentials.js
+++ b/src/redux/epics/patch-kb-credentials.js
@@ -15,15 +15,13 @@ export default ({ knowledgeBaseApi }) => (action$, store) => {
     .mergeMap(({ payload }) => {
       return knowledgeBaseApi
         .editCredentials(store.getState().okapi, { data: payload.data }, payload.credentialId)
-        .map((response) => {
+        .map(() => {
           return patchKBCredentialsSuccess({
             // here we're using data that comes from the form but not the response
             // because the response sends api key in an encrypted format. this differs from the
             // actual value of the key in form.
             // this difference causes the form to become dirty right after the update
-            // But we still need the actual metadata from response so we're adding it here
             ...payload.data,
-            meta: response.data.meta,
           });
         })
         .catch(errors => Observable.of(patchKBCredentialsFailure({ errors })));

--- a/src/redux/reducers/kb-credentials.js
+++ b/src/redux/reducers/kb-credentials.js
@@ -157,7 +157,7 @@ const handlers = {
             ...credential.attributes,
             ...action.payload.attributes,
           },
-          meta: action.payload.meta,
+          meta: credential.meta,
         }
         : credential;
     }),


### PR DESCRIPTION
## Description
Fix unable to change Knowledge base name by removing reference to empty response

## Issues
[UIEH-1122](https://issues.folio.org/browse/UIEH-1122)
