### PR TITLE
UIEH-1123: Fix error message for Usage consolidation usage id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add tests on Jest+RTL for ProviderShow component. (UIEH-1093)
 * Search shortcut should redirect to eHoldings search page. (UIEH-1111)
 * Remove the Ordered through EBSCO option from filters. (UIEH-1118)
+* Fix error message for Usage consolidation usage id. (UIEH-1123)
 
 ## [6.0.1] (https://github.com/folio-org/ui-eholdings/tree/v6.0.1) (2021-03-29)
 * Fix scroll wobble when page is zoomed out. (UIEH-1107)

--- a/src/components/settings/settings-usage-consolidation/settings-usage-consolidation.js
+++ b/src/components/settings/settings-usage-consolidation/settings-usage-consolidation.js
@@ -35,7 +35,7 @@ const propTypes = {
   usageConsolidation: ucReduxStateShape.UsageConsolidationReduxStateShape.isRequired,
 };
 
-const INVALID_CUSTOMER_KEY_ERROR_MESSAGE = 'Invalid UC Credentials';
+const INVALID_CUSTOMER_KEY_ERROR_MESSAGE = 'Invalid UC API Credentials';
 
 const SettingsUsageConsolidation = ({
   clearUsageConsolidationErrors,


### PR DESCRIPTION
### UIEH-1123 Settings > eholdings > Usage Consolidation

## Purpose
Backend error message was changed. It needs to be updated on UI side too.

Issue:  [UIEH-1123](https://issues.folio.org/browse/UIEH-1123)
