### PR TITLE
UIEH-1051: Add tests for DescriptionField, EditionField, TitleNameField, PackageSelectField components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [6.2.0] (IN PROGRESS)
 * Fix import paths. (UIEH-1133)
+* Add tests for DescriptionField, EditionField, TitleNameField, PackageSelectField components. (UIEH-1051)
 
 ## [6.1.0] (https://github.com/folio-org/ui-eholdings/tree/v6.1.0) (2021-06-04)
 * Add tests coverage for keyboard shortcuts to eholdings. (UIEH-1043)

--- a/src/components/custom-url-fields/custom-url-fields.js
+++ b/src/components/custom-url-fields/custom-url-fields.js
@@ -1,9 +1,15 @@
 import { Field } from 'react-final-form';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 
 import { TextField } from '@folio/stripes/components';
 
 const CustomUrlFields = (props) => {
+  const intl = useIntl();
+  const label = intl.formatMessage({ id: 'ui-eholdings.customUrl' });
+
   const validate = (value) => {
     let errors;
 
@@ -23,7 +29,8 @@ const CustomUrlFields = (props) => {
       <Field
         name="customUrl"
         component={TextField}
-        label={<FormattedMessage id="ui-eholdings.customUrl" />}
+        label={label}
+        ariaLabel={label}
         validate={validate}
         data-testid="custom-url-field"
         {...props}

--- a/src/components/title/_fields/description/description-field.js
+++ b/src/components/title/_fields/description/description-field.js
@@ -1,7 +1,10 @@
 import { Field } from 'react-final-form';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 
 import { TextArea } from '@folio/stripes/components';
-import { FormattedMessage } from 'react-intl';
 
 const MAX_CHARACTER_LENGTH = 400;
 
@@ -13,20 +16,22 @@ function validate(value) {
     /> : undefined;
 }
 
-export default function DescriptionField() {
+const DescriptionField = () => {
+  const intl = useIntl();
+  const label = intl.formatMessage({ id: 'ui-eholdings.title.description' });
+
   return (
     <div data-test-eholdings-description-textarea>
-      <FormattedMessage id="ui-eholdings.title.description">
-        {(ariaLabel) => (
-          <Field
-            name="description"
-            component={TextArea}
-            label={ariaLabel}
-            validate={validate}
-            aria-label={ariaLabel}
-          />
-        )}
-      </FormattedMessage>
+      <Field
+        name="description"
+        component={TextArea}
+        label={label}
+        validate={validate}
+        aria-label={label}
+        data-testid="description-field"
+      />
     </div>
   );
-}
+};
+
+export default DescriptionField;

--- a/src/components/title/_fields/description/description-field.test.js
+++ b/src/components/title/_fields/description/description-field.test.js
@@ -1,0 +1,36 @@
+import { Form } from 'react-final-form';
+import {
+  render,
+  fireEvent,
+} from '@testing-library/react';
+
+import DescriptionField from './description-field';
+
+describe('Given DescriptionField', () => {
+  const renderDescriptionField = () => render(
+    <Form
+      onSubmit={() => {}}
+      render={() => <DescriptionField />}
+    />
+  );
+
+  it('should render description field', () => {
+    const { getByTestId } = renderDescriptionField();
+
+    expect(getByTestId('description-field')).toBeDefined();
+  });
+
+  describe('when fill input with more that 400 characters', () => {
+    it('should show validation error', () => {
+      const {
+        getByText,
+        getByTestId,
+      } = renderDescriptionField();
+
+      fireEvent.change(getByTestId('description-field'), { target: { value: new Array(401).fill('a').join('') } });
+      fireEvent.blur(getByTestId('description-field'));
+
+      expect(getByText('ui-eholdings.validate.errors.title.description.length')).toBeDefined();
+    });
+  });
+});

--- a/src/components/title/_fields/edition/edition-field.js
+++ b/src/components/title/_fields/edition/edition-field.js
@@ -1,7 +1,12 @@
 import { Field } from 'react-final-form';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 
 import { TextField } from '@folio/stripes/components';
-import { FormattedMessage } from 'react-intl';
+
+const MAX_CHARACTER_LENGTH = 250;
 
 function validate(value) {
   let errors;
@@ -10,27 +15,29 @@ function validate(value) {
     errors = <FormattedMessage id="ui-eholdings.validate.errors.edition.value" />;
   }
 
-  if (value && value.length > 250) {
+  if (value && value.length > MAX_CHARACTER_LENGTH) {
     errors = <FormattedMessage id="ui-eholdings.validate.errors.edition.length" />;
   }
 
   return errors;
 }
 
-export default function EditionField() {
+const EditionField = () => {
+  const intl = useIntl();
+  const label = intl.formatMessage({ id: 'ui-eholdings.title.edition' });
+
   return (
     <div data-test-eholdings-edition-field>
-      <FormattedMessage id="ui-eholdings.title.edition">
-        {(fieldName) => (
-          <Field
-            name="edition"
-            component={TextField}
-            label={fieldName}
-            validate={validate}
-            ariaLabel={fieldName}
-          />
-        )}
-      </FormattedMessage>
+      <Field
+        name="edition"
+        component={TextField}
+        label={label}
+        validate={validate}
+        ariaLabel={label}
+        data-testid="edition-field"
+      />
     </div>
   );
-}
+};
+
+export default EditionField;

--- a/src/components/title/_fields/edition/edition-field.test.js
+++ b/src/components/title/_fields/edition/edition-field.test.js
@@ -1,0 +1,50 @@
+import { Form } from 'react-final-form';
+import {
+  render,
+  fireEvent,
+} from '@testing-library/react';
+
+import EditionField from './edition-field';
+
+describe('Given EditionField', () => {
+  const renderEditionField = () => render(
+    <Form
+      onSubmit={() => {}}
+      render={() => <EditionField />}
+    />
+  );
+
+  it('should render edition field', () => {
+    const { getByTestId } = renderEditionField();
+
+    expect(getByTestId('edition-field')).toBeDefined();
+  });
+
+  describe('when fill input with more that 250 characters', () => {
+    it('should show validation error', () => {
+      const {
+        getByText,
+        getByTestId,
+      } = renderEditionField();
+
+      fireEvent.change(getByTestId('edition-field'), { target: { value: new Array(251).fill('a').join('') } });
+      fireEvent.blur(getByTestId('edition-field'));
+
+      expect(getByText('ui-eholdings.validate.errors.edition.length')).toBeDefined();
+    });
+  });
+
+  describe('when input value is empty', () => {
+    it('should show validation error', () => {
+      const {
+        getByText,
+        getByTestId,
+      } = renderEditionField();
+
+      fireEvent.change(getByTestId('edition-field'), { target: { value: '  ' } });
+      fireEvent.blur(getByTestId('edition-field'));
+
+      expect(getByText('ui-eholdings.validate.errors.edition.value')).toBeDefined();
+    });
+  });
+});

--- a/src/components/title/_fields/name/title-name-field.js
+++ b/src/components/title/_fields/name/title-name-field.js
@@ -1,5 +1,8 @@
 import { Field } from 'react-final-form';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 
 import { TextField } from '@folio/stripes/components';
 
@@ -17,24 +20,24 @@ function validate(value) {
   return errors;
 }
 
-function TitleNameField() {
+const TitleNameField = () => {
+  const intl = useIntl();
+  const label = intl.formatMessage({ id: 'ui-eholdings.label.name' });
+
   return (
     <div data-test-eholdings-title-name-field>
-      <FormattedMessage id="ui-eholdings.label.name">
-        {(ariaLabel) => (
-          <Field
-            name="name"
-            type="text"
-            component={TextField}
-            label={<FormattedMessage id="ui-eholdings.label.name" />}
-            validate={validate}
-            ariaLabel={ariaLabel}
-            required
-          />
-        )}
-      </FormattedMessage>
+      <Field
+        name="name"
+        type="text"
+        component={TextField}
+        label={label}
+        validate={validate}
+        ariaLabel={label}
+        required
+        data-testid="title-name-field"
+      />
     </div>
   );
-}
+};
 
 export default TitleNameField;

--- a/src/components/title/_fields/name/title-name-field.test.js
+++ b/src/components/title/_fields/name/title-name-field.test.js
@@ -1,0 +1,50 @@
+import { Form } from 'react-final-form';
+import {
+  render,
+  fireEvent,
+} from '@testing-library/react';
+
+import TitleNameField from './title-name-field';
+
+describe('Given TitleNameField', () => {
+  const renderTitleNameField = () => render(
+    <Form
+      onSubmit={() => {}}
+      render={() => <TitleNameField />}
+    />
+  );
+
+  it('should render title name field', () => {
+    const { getByTestId } = renderTitleNameField();
+
+    expect(getByTestId('title-name-field')).toBeDefined();
+  });
+
+  describe('when fill input with more that 400 characters', () => {
+    it('should show validation error', () => {
+      const {
+        getByText,
+        getByTestId,
+      } = renderTitleNameField();
+
+      fireEvent.change(getByTestId('title-name-field'), { target: { value: new Array(401).fill('a').join('') } });
+      fireEvent.blur(getByTestId('title-name-field'));
+
+      expect(getByText('ui-eholdings.validate.errors.customTitle.name.length')).toBeDefined();
+    });
+  });
+
+  describe('when input value is empty', () => {
+    it('should show validation error', () => {
+      const {
+        getByText,
+        getByTestId,
+      } = renderTitleNameField();
+
+      fireEvent.change(getByTestId('title-name-field'), { target: { value: '' } });
+      fireEvent.blur(getByTestId('title-name-field'));
+
+      expect(getByText('ui-eholdings.validate.errors.customTitle.name')).toBeDefined();
+    });
+  });
+});

--- a/src/components/title/_fields/package-select/package-select-field.js
+++ b/src/components/title/_fields/package-select/package-select-field.js
@@ -4,41 +4,49 @@ import {
   FormattedMessage,
   useIntl,
 } from 'react-intl';
+
 import { Selection } from '@folio/stripes/components';
 
 function validate(value) {
   return value ? undefined : <FormattedMessage id="ui-eholdings.validate.errors.packageSelect.required" />;
 }
 
-function PackageSelectField({ options }) {
+const PackageSelectField = ({ options }) => {
   const intl = useIntl();
+  const label = intl.formatMessage({ id: 'ui-eholdings.label.package' });
 
   return (
     <div data-test-eholdings-package-select-field>
       <Field
         name="packageId"
         component={Selection}
-        label={intl.formatMessage({ id: 'ui-eholdings.label.package' })}
+        label={label}
+        ariaLabel={label}
         validate={validate}
         onBlur={null} // preventing validation that is in onBlur
         placeholder={<FormattedMessage id="ui-eholdings.title.chooseAPackage" />}
         dataOptions={options.filter(option => option.label && !option.disabled)}
         required
+        data-testid="package-select-field"
         tether={{
           constraints: [
             {
               to: 'window',
               attachment: 'together',
-            }
-          ]
+            },
+          ],
         }}
       />
     </div>
   );
-}
+};
 
 PackageSelectField.propTypes = {
-  options: PropTypes.array.isRequired
+  options: PropTypes.arrayOf(PropTypes.shape({
+    disabled: PropTypes.bool,
+    key: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+  })).isRequired,
 };
 
 export default PackageSelectField;

--- a/src/components/title/_fields/package-select/package-select-field.test.js
+++ b/src/components/title/_fields/package-select/package-select-field.test.js
@@ -1,0 +1,41 @@
+import { Form } from 'react-final-form';
+import { render } from '@testing-library/react';
+
+import PackageSelectField from './package-select-field';
+
+describe('Given PackageSelectField', () => {
+  const renderPackageSelectField = (options) => render(
+    <Form
+      onSubmit={() => {}}
+      render={() => <PackageSelectField options={options} />}
+    />
+  );
+
+  it('should render package select field', () => {
+    const { getByText } = renderPackageSelectField([{
+      label: 'label1',
+      key: 'key1',
+    }]);
+
+    expect(getByText('ui-eholdings.label.package')).toBeDefined();
+  });
+
+  it('should render package select field options', () => {
+    const { getByText } = renderPackageSelectField([{
+      label: 'label1',
+      key: 'key1',
+    }]);
+
+    expect(getByText('label1')).toBeDefined();
+  });
+
+  it('should not render disabled options', () => {
+    const { queryByText } = renderPackageSelectField([{
+      disabled: true,
+      label: 'label2',
+      key: 'key2',
+    }]);
+
+    expect(queryByText('label2')).toBeNull();
+  });
+});


### PR DESCRIPTION
# UIEH-1051: Jest+RTL > Test CustomUrlFields, DescriptionField, EditionField, TitleNameField, PackageSelectField

## Purpose
- Refactoring
- Add tests for DescriptionField, EditionField, TitleNameField, PackageSelectField
- Tests for `CustomUrlFields` was already done

#### TODOS and Open Questions
- Add validation test for `PackageSelectField` in scope of testing of `TitleCreate` component

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/121489228-908bc800-c9dc-11eb-80da-7dc370bc2df6.png)
![image](https://user-images.githubusercontent.com/55701515/121489290-a00b1100-c9dc-11eb-8359-454d9695c2f9.png)
![image](https://user-images.githubusercontent.com/55701515/121489330-a8fbe280-c9dc-11eb-8013-2216440c1d34.png)
![image](https://user-images.githubusercontent.com/55701515/121489367-b1541d80-c9dc-11eb-95dd-3a62851d4f30.png)
![image](https://user-images.githubusercontent.com/55701515/121489407-badd8580-c9dc-11eb-9945-c18f3051b62f.png)

