### PR TITLE
UIEH-1136: Usage Consolidation: Unable to handle gracefully handle when user attempts to view titles over 200,000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [6.2.0] (IN PROGRESS)
 * Fix import paths. (UIEH-1133)
 * Add tests for DescriptionField, EditionField, TitleNameField, PackageSelectField components. (UIEH-1051)
+* Usage Consolidation: Unable to handle gracefully handle when user attempts to view titles over 200,000. (UIEH-1136)
 
 ## [6.1.0] (https://github.com/folio-org/ui-eholdings/tree/v6.1.0) (2021-06-04)
 * Add tests coverage for keyboard shortcuts to eholdings. (UIEH-1043)

--- a/src/features/usage-consolidation-accordion/full-text-request-usage-table/full-text-request-usage-table.js
+++ b/src/features/usage-consolidation-accordion/full-text-request-usage-table/full-text-request-usage-table.js
@@ -21,7 +21,6 @@ import {
 } from '../../../constants';
 
 import styles from './full-text-request-usage-table.css';
-import { getMCLFirstDataRow } from '../utilities';
 
 const monthsNames = {
   JAN: 'jan',
@@ -79,7 +78,7 @@ const FullTextRequestUsageTable = ({
 
   useEffect(() => {
     if (fullTextRequestUsageMCLRef.current && entityType !== entityTypes.TITLE) {
-      getMCLFirstDataRow(fullTextRequestUsageMCLRef.current).focus();
+      fullTextRequestUsageMCLRef.current.focus();
     }
   }, [fullTextRequestUsageMCLRef, entityType]);
 

--- a/src/features/usage-consolidation-accordion/summary-table/summary-table.js
+++ b/src/features/usage-consolidation-accordion/summary-table/summary-table.js
@@ -17,7 +17,6 @@ import {
   costPerUse as costPerUseShape,
   entityTypes,
 } from '../../../constants';
-import { getMCLFirstDataRow } from '../utilities';
 
 const propTypes = {
   contentData: PropTypes.array,
@@ -60,7 +59,7 @@ const SummaryTable = ({
 
   useEffect(() => {
     if (summaryMCLRef.current && isLoaded) {
-      getMCLFirstDataRow(summaryMCLRef.current).focus();
+      summaryMCLRef.current.focus();
     }
   }, [summaryMCLRef, isLoaded]);
 

--- a/src/features/usage-consolidation-accordion/titles-table/titles-table.js
+++ b/src/features/usage-consolidation-accordion/titles-table/titles-table.js
@@ -23,7 +23,6 @@ import {
   costPerUseTypes,
   sortOrders,
 } from '../../../constants';
-import { getMCLFirstDataRow } from '../utilities';
 
 const propTypes = {
   costPerUseData: costPerUseShape.CostPerUseReduxStateShape.isRequired,
@@ -77,7 +76,7 @@ const TitlesTable = ({
 
   useEffect(() => {
     if (titlesTableMCLRef.current && !isPackageTitlesLoading) {
-      getMCLFirstDataRow(titlesTableMCLRef.current).focus();
+      titlesTableMCLRef.current.focus();
     }
   }, [titlesTableMCLRef, isPackageTitlesLoading]);
 

--- a/src/features/usage-consolidation-accordion/utilities.js
+++ b/src/features/usage-consolidation-accordion/utilities.js
@@ -28,5 +28,3 @@ export const formatValue = (value, callback) => {
 
   return callback ? callback(valueToFixed) : valueToFixed;
 };
-
-export const getMCLFirstDataRow = (MCLRef) => MCLRef.querySelector('div[data-row-inner="0"]');


### PR DESCRIPTION
## Description
An exception was thrown in cases when no titles were loaded because querySelector wasn't able to find a single row element.
Now focusing on the component container.

## Issues
[UIEH-1136](https://issues.folio.org/browse/UIEH-1136)

## Related PRs
https://github.com/folio-org/stripes-components/pull/1579