### PR TITLE
UIEH-1135: Avoid .all permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * Fix import paths. (UIEH-1133)
 * Add tests for DescriptionField, EditionField, TitleNameField, PackageSelectField components. (UIEH-1051)
 * Usage Consolidation: Unable to handle gracefully handle when user attempts to view titles over 200,000. (UIEH-1136)
-* Add tests for ResourceEditManagedTitle component (UIEH-1096)
+* Add tests for ResourceEditManagedTitle component. (UIEH-1096)
+* Avoid .all permissions. (UIEH-1135)
 
 ## [6.1.0] (https://github.com/folio-org/ui-eholdings/tree/v6.1.0) (2021-06-04)
 * Add tests coverage for keyboard shortcuts to eholdings. (UIEH-1043)

--- a/package.json
+++ b/package.json
@@ -130,8 +130,17 @@
         "displayName": "eHoldings: Can view providers, packages, titles detail records",
         "visible": false,
         "subPermissions": [
-          "kb-ebsco.all",
-          "tags.all"
+          "kb-ebsco.package-resources.collection.get",
+          "kb-ebsco.packages.collection.get",
+          "kb-ebsco.packages.item.get",
+          "kb-ebsco.provider-packages.collection.get",
+          "kb-ebsco.providers.collection.get",
+          "kb-ebsco.providers.item.get",
+          "kb-ebsco.resources.item.get",
+          "kb-ebsco.titles.collection.get",
+          "kb-ebsco.titles.item.get",
+          "tags.collection.get",
+          "tags.item.get"
         ]
       },
       {


### PR DESCRIPTION
# UIEH-1135 permission sets should avoid ".all" permissions

Issue: [UIEH-1135](https://issues.folio.org/browse/UIEH-1135)

Avoid .all permissions. There is a possibility that something will fall off after merge.