### PR TITLE
UIEH-1140: View/Edit Managed title - Custom Package Record: Custom Package URL field does not display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add tests for ResourceEditManagedTitle component. (UIEH-1096)
 * Avoid .all permissions. (UIEH-1135)
 * Add tests for CoverageDateList component. (UIEH-1056)
+* Fix View/Edit Managed title - Custom Package Record: Custom Package URL field does not display. (UIEH-1140)
 
 ## [6.1.0] (https://github.com/folio-org/ui-eholdings/tree/v6.1.0) (2021-06-04)
 * Add tests coverage for keyboard shortcuts to eholdings. (UIEH-1043)

--- a/src/components/resource/components/edit/resource-settings/edit-resource-settings.js
+++ b/src/components/resource/components/edit/resource-settings/edit-resource-settings.js
@@ -69,7 +69,7 @@ const EditResourceSettings = ({
             <VisibilityField disabled={visibilityMessage} />
             <div>
               {hasInheritedProxy && getAccordionContent()}
-              {resourceIsCustom && <CustomUrlFields />}
+              {model.package.isCustom && <CustomUrlFields />}
               <AccessTypeEditSection accessStatusTypes={accessStatusTypes} />
             </div>
           </>

--- a/src/components/resource/components/edit/resource-settings/edit-resource-settings.test.js
+++ b/src/components/resource/components/edit/resource-settings/edit-resource-settings.test.js
@@ -13,15 +13,18 @@ import ResourceSettings from './edit-resource-settings';
 describe('Given ResourceSettings', () => {
   const onSubmitMock = jest.fn();
   const handleSectionToggleMock = jest.fn();
-  const defaultModel = {
-    package: {
-      proxy: {
-        id: 'proxy-id',
-      },
-      visibilityData: {
-        isHidden: true,
-      },
+  const defaultPackage = {
+    proxy: {
+      id: 'proxy-id',
     },
+    visibilityData: {
+      isHidden: true,
+    },
+    isCustom: true,
+  };
+
+  const defaultModel = {
+    package: defaultPackage,
     update: {
       isPending: false,
     },
@@ -115,6 +118,30 @@ describe('Given ResourceSettings', () => {
       fireEvent.click(getByText('Submit'));
 
       expect(getByText('Submit')).toBeEnabled();
+    });
+  });
+
+  describe('when package is custom', () => {
+    it('should render Custom URL field', () => {
+      const { getByLabelText } = renderResourceSettings();
+
+      expect(getByLabelText('ui-eholdings.customUrl')).toBeDefined();
+    });
+  });
+
+  describe('when package is managed', () => {
+    it('should not render Custom URL field', () => {
+      const { queryByLabelText } = renderResourceSettings({
+        model: {
+          ...defaultModel,
+          package: {
+            ...defaultPackage,
+            isCustom: false,
+          },
+        },
+      });
+
+      expect(queryByLabelText('ui-eholdings.customUrl')).toBeNull();
     });
   });
 });

--- a/src/components/resource/components/resource-settings/resource-settings.js
+++ b/src/components/resource/components/resource-settings/resource-settings.js
@@ -88,7 +88,7 @@ const ResourceSettings = ({
       }
 
       {model.url && (
-        <KeyValue label={model.title.isTitleCustom
+        <KeyValue label={model.package.isCustom
           ? <FormattedMessage id="ui-eholdings.custom" />
           : <FormattedMessage id="ui-eholdings.managed" />}
         >

--- a/src/components/resource/components/resource-settings/resource-settings.test.js
+++ b/src/components/resource/components/resource-settings/resource-settings.test.js
@@ -14,6 +14,17 @@ describe('Given ResourceSettings', () => {
   let component;
   const onToggleMock = jest.fn();
 
+  const defaultPackage = {
+    visibilityData: {
+      reason: '',
+      isHidden: false,
+    },
+    isCustom: true,
+    proxy: {
+      id: 'proxy-id',
+    },
+  };
+
   const defaultModel = {
     visibilityData: {
       reason: '',
@@ -24,15 +35,7 @@ describe('Given ResourceSettings', () => {
     title: {
       isTitleCustom: false,
     },
-    package: {
-      visibilityData: {
-        reason: '',
-        isHidden: false,
-      },
-      proxy: {
-        id: 'proxy-id',
-      },
-    },
+    package: defaultPackage,
   };
 
   const renderResourceSettings = (props = {}) => render(
@@ -96,6 +99,29 @@ describe('Given ResourceSettings', () => {
       expect(component.getByTestId('resource-show-visibility').textContent).toEqual('ui-eholdings.package.visibility.no');
     });
   });
+
+  describe('when package is custom', () => {
+    it('should show custom url', () => {
+      component = renderResourceSettings();
+      expect(component.getByText('ui-eholdings.custom')).toBeDefined();
+    });
+  });
+
+  describe('when package is managed', () => {
+    it('should show managed url', () => {
+      component = renderResourceSettings({
+        model: {
+          ...defaultModel,
+          package: {
+            ...defaultPackage,
+            isCustom: false,
+          },
+        },
+      });
+      expect(component.getByText('ui-eholdings.managed')).toBeDefined();
+    });
+  });
+
 
   it('should render proxy display', () => {
     component = renderResourceSettings();


### PR DESCRIPTION
## Description
Display Managed url of a Resource only when a package is managed

## Issues
[UIEH-1140](https://issues.folio.org/browse/UIEH-1140)