### PR TITLE
UIEH-1055: Add tests for AgreementsList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add tests for ResourceEditManagedTitle component. (UIEH-1096)
 * Avoid .all permissions. (UIEH-1135)
 * Add tests for CoverageDateList component. (UIEH-1056)
+* Add tests for AgreementsList component. (UIEH-1055)
 
 ## [6.1.0] (https://github.com/folio-org/ui-eholdings/tree/v6.1.0) (2021-06-04)
 * Add tests coverage for keyboard shortcuts to eholdings. (UIEH-1043)

--- a/src/components/agreements-list/agreements-list.js
+++ b/src/components/agreements-list/agreements-list.js
@@ -27,11 +27,14 @@ const propTypes = {
   agreements: PropTypes.shape({
     isLoading: PropTypes.bool.isRequired,
     isUnassigned: PropTypes.bool.isRequired,
-    items: PropTypes.arrayOf({
+    items: PropTypes.arrayOf(PropTypes.shape({
+      agreementStatus: PropTypes.shape({
+        label: PropTypes.string.isRequired,
+      }).isRequired,
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
       startDate: PropTypes.string.isRequired,
-    }).isRequired,
+    })).isRequired,
   }).isRequired,
   onUnassignAgreement: PropTypes.func.isRequired,
 };

--- a/src/components/agreements-list/agreements-list.test.js
+++ b/src/components/agreements-list/agreements-list.test.js
@@ -1,0 +1,70 @@
+import {
+  fireEvent,
+  render,
+} from '@testing-library/react';
+import noop from 'lodash/noop';
+
+import Harness from '../../../test/jest/helpers/harness';
+import AgreementsList from './agreements-list';
+
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
+  FormattedDate: () => ({ value }) => <span>{value}</span>,
+}));
+
+const agreements = {
+  isLoading: false,
+  isUnassigned: false,
+  items: [{
+    agreementStatus: {
+      label: 'label',
+    },
+    id: 'id',
+    name: 'name',
+    startDate: '2021-07-01',
+  }],
+};
+
+describe('Given AgreementsList', () => {
+  const renderAgreementsList = (props) => render(
+    <Harness>
+      <AgreementsList
+        agreements={agreements}
+        onUnassignAgreement={noop}
+        {...props}
+      />
+    </Harness>
+  );
+
+  describe('when click on trash icon', () => {
+    it('should handle onUnassignAgreement', () => {
+      const mockOnUnassignAgreement = jest.fn();
+      const { items: [{ id, name, agreementStatus }] } = agreements;
+      const deletedAgreement = {
+        id,
+        name,
+        rowIndex: 0,
+        status: agreementStatus.label,
+      };
+
+      const { container } = renderAgreementsList({ onUnassignAgreement: mockOnUnassignAgreement });
+
+      fireEvent.click(container.querySelector('button[icon="trash"]'));
+
+      expect(mockOnUnassignAgreement).toHaveBeenCalledWith(expect.objectContaining(deletedAgreement));
+    });
+  });
+
+  describe('when record is on load', () => {
+    it('should show spinner', () => {
+      const { container } = renderAgreementsList({
+        agreements: {
+          ...agreements,
+          isLoading: true,
+        },
+      });
+
+      expect(container.querySelector('.icon-spinner-ellipsis')).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
### UIEH-1055 Jest+RTL > Test AgreementsList

## Purpose
Add tests for AgreementsList

Issue: [UIEH-1055](https://issues.folio.org/browse/UIEH-1055)

## Learning
If you need to test function with object which it's called, you can use construction `expect.objectContaining()` and set inside object properties. But it doesn't work if parameter is node

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/124264669-722d6e00-db3d-11eb-93ba-a9f0f0d2b8d4.png)

