### PR TITLE
UIEH-1142: The Eholdings app is NOT displayed in the app bar when the "eHoldings: Can view Usage..." permission is applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Avoid .all permissions. (UIEH-1135)
 * Add tests for CoverageDateList component. (UIEH-1056)
 * Fix View/Edit Managed title - Custom Package Record: Custom Package URL field does not display. (UIEH-1140)
+* Fix The Eholdings app is NOT displayed in the app bar when the "eHoldings: Can view Usage..." permission is applied. (UIEH-1142)
 
 ## [6.1.0] (https://github.com/folio-org/ui-eholdings/tree/v6.1.0) (2021-06-04)
 * Add tests coverage for keyboard shortcuts to eholdings. (UIEH-1043)

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
         "displayName": "eHoldings: Can view Usage & analysis data for packages, titles and resources",
         "visible": true,
         "subPermissions": [
+          "module.eholdings.enabled",
           "kb-ebsco.uc.item.get",
           "kb-ebsco.resources-costperuse.item.get",
           "kb-ebsco.titles-costperuse.item.get",


### PR DESCRIPTION
## Description
Add missing `module.eholdings.enabled` subpermission to `ui-eholdings.costperuse.view` to show eHoldings module

## Issues
[UIEH-1142](https://issues.folio.org/browse/UIEH-1142)