### PR TITLE
UIEH-1140: Fix missing custom url value in resource edit

### DIFF
--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -72,6 +72,7 @@ const ResourceEditManagedTitle = ({
       customCoverages,
       coverageStatement,
       customEmbargoPeriod,
+      url,
       proxy,
     } = model;
 
@@ -88,6 +89,7 @@ const ResourceEditManagedTitle = ({
       customCoverages,
       coverageStatement,
       hasCoverageStatement,
+      customUrl: url,
       customEmbargoPeriod: getEmbargoInitial(customEmbargoPeriod),
       proxyId: (matchingProxy?.id || proxy.id).toLowerCase(),
       accessTypeId: getAccessTypeId(model),


### PR DESCRIPTION
## Description
Fix missing Custom URL value in field when visiting Resource edit page of managed title

## Issues
[UIEH-1140](https://issues.folio.org/browse/UIEH-1140)