### PR TITLE
UIEH-1146: Saving the update of coverage settings temporarily shows the old date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add tests for ResourceEditCustomTitle component. (UIEH-1095)
 * Add tests for TitleShow component. (UIEH-1098)
 * Add tests for AgreementsList component. (UIEH-1055)
+* Fix: saving the update of coverage settings temporarily shows the old date. (UIEH-1146)
 
 ## [6.1.0] (https://github.com/folio-org/ui-eholdings/tree/v6.1.0) (2021-06-04)
 * Add tests coverage for keyboard shortcuts to eholdings. (UIEH-1043)

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -102,7 +102,7 @@ const CustomPackageEdit = ({
   const [allowFormToSubmit, setAllowFormToSubmit] = useStateCallback(false);
   const [packageSelected, setPackageSelected] = useStateCallback(model.isSelected);
   const [formValues, setFormValues] = useStateCallback({});
-  const [initialValues, setInitialValues] = useState({});
+  const [initialValues, setInitialValues] = useState(getInitialValues());
   const [sections, {
     handleSectionToggle,
     toggleAllSections,
@@ -114,20 +114,18 @@ const CustomPackageEdit = ({
   });
   const editFormRef = useRef(null);
 
-  useEffect(() => {
-    setInitialValues(getInitialValues());
-  }, [getInitialValues]);
-
   if (model.isSelected !== initialValues.isSelected) {
     setInitialValues(getInitialValues());
     setPackageSelected(model.isSelected);
   }
 
+  const isProxyTypesLoaded = proxyTypes.request.isResolved && provider.data.isLoaded;
+
   useEffect(() => {
-    if (proxyTypes.request.isResolved && provider.data.isLoaded) {
+    if (isProxyTypesLoaded) {
       setInitialValues(getInitialValues());
     }
-  }, [getInitialValues, proxyTypes.request.isResolved, provider.data.isLoaded]);
+  }, [isProxyTypesLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (model.destroy.errors.length) {
     setShowSelectionModal(false);

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -99,7 +99,7 @@ const ManagedPackageEdit = ({
   const [allowFormToSubmit, setAllowFormToSubmit] = useStateCallback(false);
   const [packageSelected, setPackageSelected] = useStateCallback(model.isSelected);
   const [formValues, setFormValues] = useStateCallback({});
-  const [initialValues, setInitialValues] = useState({});
+  const [initialValues, setInitialValues] = useState(getInitialValues());
   const [sections, {
     handleSectionToggle,
     toggleAllSections,
@@ -110,15 +110,13 @@ const ManagedPackageEdit = ({
   });
   const editFormRef = useRef(null);
 
-  useEffect(() => {
-    setInitialValues(getInitialValues());
-  }, [getInitialValues]);
+  const isProxyTypesLoaded = proxyTypes.request.isResolved && provider.data.isLoaded;
 
   useEffect(() => {
-    if (proxyTypes.request.isResolved && provider.data.isLoaded) {
+    if (isProxyTypesLoaded) {
       setInitialValues(getInitialValues());
     }
-  }, [getInitialValues, proxyTypes.request.isResolved, provider.data.isLoaded]);
+  }, [isProxyTypesLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const providerTokenWasLoaded = !initialValues.providerTokenValue && provider.providerToken.value;
   const selectionStatusChanged = model.isSelected !== initialValues.isSelected;

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -127,7 +127,7 @@ const ResourceEditCustomTitle = ({
     if (proxyTypes.request.isResolved) {
       setInitialValues(getInitialValuesFromModel());
     }
-  }, [proxyTypes.request.isResolved, setInitialValues, getInitialValuesFromModel]);
+  }, [proxyTypes.request.isResolved]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleRemoveResourceFromHoldings = () => {
     setFormValues({

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -121,7 +121,7 @@ const ResourceEditManagedTitle = ({
     if (proxyTypes.request.isResolved) {
       setInitialValues(getInitialValuesFromModel());
     }
-  }, [proxyTypes.request.isResolved, getInitialValuesFromModel]);
+  }, [proxyTypes.request.isResolved]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleToggleResourceHoldings = (isSelected) => {
     handleOnSubmit({


### PR DESCRIPTION
## Description
Saving the update of coverage settings temporarily shows the old date.

This happened because `getInitialValues` function was called after `Save & Close` button was clicked. This function sets form's initial values from existing package `model` object. And because `model` still had old coverage dates - those dates would be set as values to datepicker.
`getInitialValues` function was being called multiple times because of incorrectly set dependencies in `useEffect` hooks - mainly passing functions to dependencies array. When a reference to a function changed that triggered `useEffect`.

## Screenshots
![eHoldings - EBSCO Biotechnology Collection_ India - FOLIO](https://user-images.githubusercontent.com/19309423/125301155-5bec9280-e333-11eb-9125-1c2f906ffc08.gif)

## Issues
[UIEH-1146](https://issues.folio.org/browse/UIEH-1146)