### PR TITLE
UIEH-1141: Pagination investigate

### DIFF
--- a/src/components/query-search-list/query-search-list.js
+++ b/src/components/query-search-list/query-search-list.js
@@ -53,10 +53,33 @@ const QuerySearchList = ({
   if (!length) {
     return notFoundMessage;
   }
-
+  /**
+   * main function for paggination
+   * now it's working for prev next buttons
+   * in commented code functionality for load more button
+   * which is already emplemented and working correctly
+   */
   const getLoadMoreButton = () => {
     const isUnloadedPagesPresent = (totalLength !== length) && !(length % PAGE_SIZE);
 
+    return (
+      <>
+        <Button
+          disabled={page === 1} // for first page prev button should be disabled 
+          onClick={() => { setPage(page - 1); }}
+        >
+          prev
+        </Button>
+        {/* place for page counter */}
+        <Button
+          disabled={isUnloadedPagesPresent} // for the last page it should be disabled
+          onClick={() => { setPage(page + 1); }}
+        >
+          next
+        </Button>
+      </>
+    );
+    /*  
     if (isUnloadedPagesPresent) {
       return (
         <div className={styles['button-wrapper']}>
@@ -71,6 +94,7 @@ const QuerySearchList = ({
     }
 
     return null;
+    */
   };
 
   return (

--- a/src/redux/reducers/packageTitles.js
+++ b/src/redux/reducers/packageTitles.js
@@ -29,7 +29,8 @@ const handlers = {
     isLoading: false,
     hasLoaded: true,
     hasFailed: false,
-    items: [...state.items, ...payload.data],
+    // just one change, it is set new collection to state after each *next-prev* click
+    items: [...payload.data],
     totalResults: payload.totalResults,
   }),
   [GET_PACKAGE_TITLES_FAILURE]: (state, action) => ({


### PR DESCRIPTION
# UIEH-1141: Investigate : Change results list scrolling behavior

## Story
[UIEH-1141](https://issues.folio.org/browse/UIEH-1141)

## Description
Throughout this work, it was revealed

### Load more button pagination

This way was implemented for Titles list for package in [UIEH-1004 PR](https://github.com/folio-org/ui-eholdings/pull/1335).
Here a `<QuerySearchList>` component was created for this implementation. For other package / header / provider implementations, developers will need to change `<QueryList>` to `<QuerySearchList>` and add epics to get the collection. The PR for UIEH-1004 can be used as a code base.
The preliminary estimate of each task to change the pagination will be no more than 3-5 SP.
![image](https://user-images.githubusercontent.com/55701515/125771930-c9dcb921-a89a-4c76-a806-b32dde29ba64.png)


### NextPrev buttons pagination ([STCOM-829](https://github.com/folio-org/stripes-components/pull/1554))

It is easier to implement this based on the previous method. It has the same code with minor changes in the reducer and changes the load more button to `next-prev` buttons. How this can be implemented is described in the code for the current PR.
For this way we need one ticket to change `<QuerySearchList>` component with `next-prev` buttons. And estimate it as 2 SP. And other thickets for packages/titles/providers/ lists could be 5 SP.
![vQkUqePTQr](https://user-images.githubusercontent.com/55701515/125770994-d8fa744a-3345-47d7-8557-24ddc5ded919.gif)

### Pagination from [STCOM-827](https://github.com/folio-org/stripes-components/pull/1543)
It is difficult to check because this functionality is not merged. But it has a simple implementation (based on the documentation) and our code already has all the necessary details for its implementation. For this way we need story for implementing `<Pagination>` component for `<QuerySearchList>`. It could be estimate as 5 SP. And other tickets for lists could be 5 SP too.

### Focus functionality
It will be working the similar for all of this ways. But it's difficult functionality and we need the separate story for its implementation.

