### PR TITLE
UIEH-1163: Replace loadMoreButton to PrevNextButtons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Add tests for TitleCreate component. (UIEH-1068)
 * Change Resource Settings Display on Edit Resource details record. (UIEH-1161)
 * Support erm 5.0 interface. (UIEH-1154)
+* Change `loadMoreButton` to `PrevNextButtons`. (UIEH-1163)
 
 ## [6.1.1] (https://github.com/folio-org/ui-eholdings/tree/v6.1.1) (2021-07-15)
 * Fix: saving the update of coverage settings temporarily shows the old date. (UIEH-1146)

--- a/src/components/prev-next-buttons/index.js
+++ b/src/components/prev-next-buttons/index.js
@@ -1,0 +1,1 @@
+export { default } from './prev-next-buttons';

--- a/src/components/prev-next-buttons/prev-next-buttons.css
+++ b/src/components/prev-next-buttons/prev-next-buttons.css
@@ -5,7 +5,6 @@
   margin: 0 auto;
   text-align: center;
   border-top: 1px solid #eee;
-
 }
 
 .button-container {

--- a/src/components/prev-next-buttons/prev-next-buttons.css
+++ b/src/components/prev-next-buttons/prev-next-buttons.css
@@ -9,7 +9,7 @@
 
 .button-container {
   display: flex;
-  margin: 1rem auto;
+  margin: 2rem auto 1rem;
   width: 100%;
   max-width: 500px;
   justify-content: space-around;

--- a/src/components/prev-next-buttons/prev-next-buttons.css
+++ b/src/components/prev-next-buttons/prev-next-buttons.css
@@ -1,0 +1,38 @@
+@import '@folio/stripes-components/lib/variables';
+
+.button-wrapper {
+  max-width: calc(var(--container-max-width) - 2rem);
+  margin: 0 auto;
+  text-align: center;
+  border-top: 1px solid #eee;
+
+}
+
+.button-container {
+  display: flex;
+  margin: 1rem auto;
+  width: 100%;
+  max-width: 500px;
+  justify-content: space-around;
+
+  & button[disabled] {
+    background-color: transparent;
+    color: var(--color-text-p2, rgba(0, 0, 0, 0.62));
+
+    &:hover {
+      background-color: var(--color-fill-disabled, rgba(0, 0, 0, 0.15));
+    }
+  }
+}
+
+.prev-next-page-info {
+  font-weight: bold;
+  display: flex;
+  flex-grow: 3;
+  flex-shrink: 0;
+  flex-basis: 45%;
+  align-items: center;
+  justify-content: center;
+  align-content: middle;
+  margin-bottom: 1rem;
+}

--- a/src/components/prev-next-buttons/prev-next-buttons.js
+++ b/src/components/prev-next-buttons/prev-next-buttons.js
@@ -31,6 +31,7 @@ const PrevNextButtons = ({
         <Button
           disabled={page === 1 || isLoading}
           buttonStyle="none"
+          data-testid='previous-button'
           onClick={() => {
             setPage(page - 1);
           }}
@@ -45,6 +46,7 @@ const PrevNextButtons = ({
         <Button
           disabled={disabledNext || isLoading}
           buttonStyle="none"
+          data-testid='next-button'
           onClick={() => {
             setPage(page + 1);
           }}
@@ -59,10 +61,10 @@ const PrevNextButtons = ({
 };
 
 PrevNextButtons.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
   page: PropTypes.number.isRequired,
   setPage: PropTypes.func.isRequired,
   totalResults: PropTypes.number.isRequired,
-  isLoading: PropTypes.bool.isRequired,
 };
 
 export default PrevNextButtons;

--- a/src/components/prev-next-buttons/prev-next-buttons.js
+++ b/src/components/prev-next-buttons/prev-next-buttons.js
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+
+import {
+  Button,
+  Icon,
+} from '@folio/stripes/components';
+
+import { PAGE_SIZE } from '../../constants';
+
+import styles from './prev-next-buttons.css';
+
+const PrevNextButtons = ({
+  page,
+  setPage,
+  totalResults,
+  isLoading,
+}) => {
+  const intl = useIntl();
+
+  const maxItemsLength = page * PAGE_SIZE;
+  const disabledNext = maxItemsLength > totalResults;
+  const dataStartIndex = (page - 1) * PAGE_SIZE + 1;
+  const dataEndIndex = disabledNext
+    ? totalResults
+    : maxItemsLength;
+
+  return (
+    <div className={styles['button-wrapper']}>
+      <div className={styles['button-container']}>
+        <Button
+          disabled={page === 1 || isLoading}
+          buttonStyle="none"
+          onClick={() => {
+            setPage(page - 1);
+          }}
+        >
+          <Icon size="small" icon="caret-left">
+            <span>{intl.formatMessage({ id: 'ui-eholdings.previous' })}</span>
+          </Icon>
+        </Button>
+        <div className={styles['prev-next-page-info']}>
+          <div>{dataStartIndex}</div>&nbsp;-&nbsp;<div>{dataEndIndex}</div>
+        </div>
+        <Button
+          disabled={disabledNext || isLoading}
+          buttonStyle="none"
+          onClick={() => {
+            setPage(page + 1);
+          }}
+        >
+          <Icon size="small" icon="caret-right" iconPosition="end">
+            <span>{intl.formatMessage({ id: 'ui-eholdings.next' })}</span>
+          </Icon>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+PrevNextButtons.propTypes = {
+  page: PropTypes.number.isRequired,
+  setPage: PropTypes.func.isRequired,
+  totalResults: PropTypes.number.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+};
+
+export default PrevNextButtons;

--- a/src/components/prev-next-buttons/prev-next-buttons.js
+++ b/src/components/prev-next-buttons/prev-next-buttons.js
@@ -19,7 +19,7 @@ const PrevNextButtons = ({
   const intl = useIntl();
 
   const maxItemsLength = page * PAGE_SIZE;
-  const disabledNext = maxItemsLength > totalResults;
+  const disabledNext = maxItemsLength >= totalResults;
   const dataStartIndex = (page - 1) * PAGE_SIZE + 1;
   const dataEndIndex = disabledNext
     ? totalResults
@@ -31,13 +31,13 @@ const PrevNextButtons = ({
         <Button
           disabled={page === 1 || isLoading}
           buttonStyle="none"
-          data-testid='previous-button'
+          data-testid="previous-button"
           onClick={() => {
             setPage(page - 1);
           }}
         >
           <Icon size="small" icon="caret-left">
-            <span>{intl.formatMessage({ id: 'ui-eholdings.previous' })}</span>
+            {intl.formatMessage({ id: 'ui-eholdings.previous' })}
           </Icon>
         </Button>
         <div className={styles['prev-next-page-info']}>
@@ -46,13 +46,13 @@ const PrevNextButtons = ({
         <Button
           disabled={disabledNext || isLoading}
           buttonStyle="none"
-          data-testid='next-button'
+          data-testid="next-button"
           onClick={() => {
             setPage(page + 1);
           }}
         >
           <Icon size="small" icon="caret-right" iconPosition="end">
-            <span>{intl.formatMessage({ id: 'ui-eholdings.next' })}</span>
+            {intl.formatMessage({ id: 'ui-eholdings.next' })}
           </Icon>
         </Button>
       </div>

--- a/src/components/prev-next-buttons/prev-next-buttons.test.js
+++ b/src/components/prev-next-buttons/prev-next-buttons.test.js
@@ -18,40 +18,40 @@ describe('Given PrevNextButtons', () => {
   );
 
   it('should render PrevNextButtons', () => {
-    const { getByText } = renderPrevNextButtons();
+    const { getByTestId } = renderPrevNextButtons();
 
-    expect(getByText('ui-eholdings.previous')).toBeDefined();
-    expect(getByText('ui-eholdings.next')).toBeDefined();
+    expect(getByTestId('previous-button')).toBeDefined();
+    expect(getByTestId('next-button')).toBeDefined();
   });
 
   it('should disable previous button', () => {
-    const { getByText } = renderPrevNextButtons();
+    const { getByTestId } = renderPrevNextButtons();
 
-    expect(getByText('ui-eholdings.previous').disabled).toBeTruthy();
-    expect(getByText('ui-eholdings.next').disabled).toBeFalsy();
+    expect(getByTestId('previous-button').disabled).toBeTruthy();
+    expect(getByTestId('next-button').disabled).toBeFalsy();
   });
 
   describe('when click on next button', () => {
     const mockSetPage = jest.fn();
 
     it('should handle setPage', () => {
-      const { getByText } = renderPrevNextButtons({
+      const { getByTestId } = renderPrevNextButtons({
         setPage: mockSetPage,
       });
 
-      fireEvent.click(getByText('ui-eholdings.next'));
+      fireEvent.click(getByTestId('next-button'));
 
       expect(mockSetPage).toHaveBeenCalledWith(2);
     });
 
     it('should disable next button', () => {
-      const { getByText } = renderPrevNextButtons({
+      const { getByTestId } = renderPrevNextButtons({
         setPage: mockSetPage,
       });
 
-      fireEvent.click(getByText('ui-eholdings.next'));
+      fireEvent.click(getByTestId('next-button'));
 
-      expect(getByText('ui-eholdings.next').disabled).toBeTruthy();
+      expect(getByTestId('next-button').disabled).toBeTruthy();
     });
   });
 
@@ -59,24 +59,24 @@ describe('Given PrevNextButtons', () => {
     const mockSetPage = jest.fn();
 
     it('should handle setPage', () => {
-      const { getByText } = renderPrevNextButtons({
+      const { getByTestId } = renderPrevNextButtons({
         page: 2,
         setPage: mockSetPage,
       });
 
-      fireEvent.click(getByText('ui-eholdings.previous'));
+      fireEvent.click(getByTestId('previous-button'));
 
       expect(mockSetPage).toHaveBeenCalledWith(1);
     });
 
-    it('should disable next button', () => {
-      const { getByText } = renderPrevNextButtons({
+    it('should disable previous button', () => {
+      const { getByTestId } = renderPrevNextButtons({
         setPage: mockSetPage,
       });
 
-      fireEvent.click(getByText('ui-eholdings.previous'));
+      fireEvent.click(getByTestId('previous-button'));
 
-      expect(getByText('ui-eholdings.previous').disabled).toBeTruthy();
+      expect(getByTestId('previous-button').disabled).toBeTruthy();
     });
   });
 });

--- a/src/components/prev-next-buttons/prev-next-buttons.test.js
+++ b/src/components/prev-next-buttons/prev-next-buttons.test.js
@@ -43,16 +43,6 @@ describe('Given PrevNextButtons', () => {
 
       expect(mockSetPage).toHaveBeenCalledWith(2);
     });
-
-    it('should disable next button', () => {
-      const { getByTestId } = renderPrevNextButtons({
-        setPage: mockSetPage,
-      });
-
-      fireEvent.click(getByTestId('next-button'));
-
-      expect(getByTestId('next-button').disabled).toBeTruthy();
-    });
   });
 
   describe('when click on previous button', () => {

--- a/src/components/prev-next-buttons/prev-next-buttons.test.js
+++ b/src/components/prev-next-buttons/prev-next-buttons.test.js
@@ -1,0 +1,82 @@
+import {
+  fireEvent,
+  render,
+} from '@testing-library/react';
+import noop from 'lodash/noop';
+
+import PrevNextButtons from './prev-next-buttons';
+
+describe('Given PrevNextButtons', () => {
+  const renderPrevNextButtons = (props) => render(
+    <PrevNextButtons
+      page={1}
+      setPage={noop}
+      totalResults={150}
+      isLoading={false}
+      {...props}
+    />
+  );
+
+  it('should render PrevNextButtons', () => {
+    const { getByText } = renderPrevNextButtons();
+
+    expect(getByText('ui-eholdings.previous')).toBeDefined();
+    expect(getByText('ui-eholdings.next')).toBeDefined();
+  });
+
+  it('should disable previous button', () => {
+    const { getByText } = renderPrevNextButtons();
+
+    expect(getByText('ui-eholdings.previous').disabled).toBeTruthy();
+    expect(getByText('ui-eholdings.next').disabled).toBeFalsy();
+  });
+
+  describe('when click on next button', () => {
+    const mockSetPage = jest.fn();
+
+    it('should handle setPage', () => {
+      const { getByText } = renderPrevNextButtons({
+        setPage: mockSetPage,
+      });
+
+      fireEvent.click(getByText('ui-eholdings.next'));
+
+      expect(mockSetPage).toHaveBeenCalledWith(2);
+    });
+
+    it('should disable next button', () => {
+      const { getByText } = renderPrevNextButtons({
+        setPage: mockSetPage,
+      });
+
+      fireEvent.click(getByText('ui-eholdings.next'));
+
+      expect(getByText('ui-eholdings.next').disabled).toBeTruthy();
+    });
+  });
+
+  describe('when click on previous button', () => {
+    const mockSetPage = jest.fn();
+
+    it('should handle setPage', () => {
+      const { getByText } = renderPrevNextButtons({
+        page: 2,
+        setPage: mockSetPage,
+      });
+
+      fireEvent.click(getByText('ui-eholdings.previous'));
+
+      expect(mockSetPage).toHaveBeenCalledWith(1);
+    });
+
+    it('should disable next button', () => {
+      const { getByText } = renderPrevNextButtons({
+        setPage: mockSetPage,
+      });
+
+      fireEvent.click(getByText('ui-eholdings.previous'));
+
+      expect(getByText('ui-eholdings.previous').disabled).toBeTruthy();
+    });
+  });
+});

--- a/src/components/query-search-list/query-search-list.css
+++ b/src/components/query-search-list/query-search-list.css
@@ -17,10 +17,3 @@
     color: var(--error);
   }
 }
-
-.button-wrapper {
-  max-width: calc(var(--container-max-width) - 2rem);
-  margin: 0 auto;
-  text-align: center;
-  border-top: 1px solid #eee;
-}

--- a/src/components/query-search-list/query-search-list.js
+++ b/src/components/query-search-list/query-search-list.js
@@ -3,16 +3,11 @@ import {
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 import classnames from 'classnames/bind';
 
-import { Button } from '@folio/stripes/components';
-
 import ScrollView from '../scroll-view';
-import {
-  FIRST_PAGE,
-  PAGE_SIZE,
-} from '../../constants';
+import PrevNextButtons from '../prev-next-buttons';
+import { FIRST_PAGE } from '../../constants';
 
 import styles from './query-search-list.css';
 
@@ -35,10 +30,11 @@ const QuerySearchList = ({
   }, [fetch, page]);
 
   const {
-    totalLength,
+    totalResults,
     items,
     hasFailed,
     errors,
+    isLoading,
   } = collection;
   const length = items.length;
 
@@ -54,25 +50,6 @@ const QuerySearchList = ({
     return notFoundMessage;
   }
 
-  const getLoadMoreButton = () => {
-    const isUnloadedPagesPresent = (totalLength !== length) && !(length % PAGE_SIZE);
-
-    if (isUnloadedPagesPresent) {
-      return (
-        <div className={styles['button-wrapper']}>
-          <Button
-            style={{ width: '75%', margin: '1rem auto' }}
-            onClick={() => { setPage(page + 1); }}
-          >
-            <FormattedMessage id="ui-eholdings.loadMore" />
-          </Button>
-        </div>
-      );
-    }
-
-    return null;
-  };
-
   return (
     <ScrollView
       items={items}
@@ -81,7 +58,14 @@ const QuerySearchList = ({
       scrollable={scrollable}
       queryListName={type}
       fullWidth={fullWidth}
-      loadMoreButton={getLoadMoreButton()}
+      prevNextButtons={(
+        <PrevNextButtons
+          isLoading={isLoading}
+          totalResults={totalResults}
+          setPage={setPage}
+          page={page}
+        />
+      )}
     >
       {item => (
         item.isRejected ? (

--- a/src/components/query-search-list/query-search-list.test.js
+++ b/src/components/query-search-list/query-search-list.test.js
@@ -59,55 +59,6 @@ describe('Given QuerySearchList', () => {
     });
   });
 
-  describe('when request returns the collection and total result is more then 100', () => {
-    it('should show load more button', () => {
-      const { getByText } = renderQuerySearchList({
-        collection: {
-          ...collection,
-          totalResults: 150,
-          items: new Array(100).fill({ isRejected: false }),
-        },
-      });
-
-      expect(getByText('ui-eholdings.loadMore')).toBeDefined();
-    });
-
-    describe('when click on load more button', () => {
-      it('should handle fetch', () => {
-        const fetch = jest.fn();
-        const { getByText } = renderQuerySearchList({
-          fetch,
-          collection: {
-            ...collection,
-            totalResults: 150,
-            items: new Array(100).fill({ isRejected: false }),
-          },
-        });
-
-        fireEvent.click(getByText('ui-eholdings.loadMore'));
-
-        expect(fetch).toHaveBeenCalledWith(2);
-      });
-    });
-  });
-
-  describe('when request returns the collection and total result is less then 100', () => {
-    it('should not show load more button', () => {
-      const { queryByText } = renderQuerySearchList({
-        collection: {
-          ...collection,
-          totalResults: 50,
-          items: new Array(50).fill({
-            isRejected: true,
-            error: [{ title: 'error' }],
-          }),
-        },
-      });
-
-      expect(queryByText('ui-eholdings.loadMore')).toBeNull();
-    });
-  });
-
   describe('when request returns the collection and items are not rejected', () => {
     it('should handle renderItem', () => {
       const renderItem = jest.fn();

--- a/src/components/query-search-list/query-search-list.test.js
+++ b/src/components/query-search-list/query-search-list.test.js
@@ -2,7 +2,6 @@ import noop from 'lodash/noop';
 import {
   render,
   cleanup,
-  fireEvent,
 } from '@testing-library/react';
 
 import QuerySearchList from './query-search-list';

--- a/src/components/scroll-view/scroll-view.js
+++ b/src/components/scroll-view/scroll-view.js
@@ -22,7 +22,7 @@ export default class ScrollView extends Component {
       slice: PropTypes.func.isRequired
     }).isRequired,
     length: PropTypes.number,
-    loadMoreButton: PropTypes.node,
+    prevNextButtons: PropTypes.node,
     offset: PropTypes.number,
     onUpdate: PropTypes.func,
     queryListName: PropTypes.string.isRequired,
@@ -33,7 +33,7 @@ export default class ScrollView extends Component {
     offset: 0,
     scrollable: true,
     fullWidth: false,
-    loadMoreButton: null,
+    prevNextButtons: null,
   };
 
   constructor(props) {
@@ -153,7 +153,7 @@ export default class ScrollView extends Component {
       scrollable,
       fullWidth,
       queryListName,
-      loadMoreButton,
+      prevNextButtons,
     } = this.props;
 
     const {
@@ -181,7 +181,7 @@ export default class ScrollView extends Component {
         >
           {this.renderChildren()}
         </List>
-        {loadMoreButton}
+        {prevNextButtons}
       </div>
     );
   }

--- a/src/components/scroll-view/scroll-view.js
+++ b/src/components/scroll-view/scroll-view.js
@@ -22,9 +22,9 @@ export default class ScrollView extends Component {
       slice: PropTypes.func.isRequired
     }).isRequired,
     length: PropTypes.number,
-    prevNextButtons: PropTypes.node,
     offset: PropTypes.number,
     onUpdate: PropTypes.func,
+    prevNextButtons: PropTypes.node,
     queryListName: PropTypes.string.isRequired,
     scrollable: PropTypes.bool,
   };

--- a/src/redux/reducers/packageTitles.js
+++ b/src/redux/reducers/packageTitles.js
@@ -29,7 +29,7 @@ const handlers = {
     isLoading: false,
     hasLoaded: true,
     hasFailed: false,
-    items: [...state.items, ...payload.data],
+    items: [...payload.data],
     totalResults: payload.totalResults,
   }),
   [GET_PACKAGE_TITLES_FAILURE]: (state, action) => ({

--- a/src/redux/reducers/tests/packageTitles.test.js
+++ b/src/redux/reducers/tests/packageTitles.test.js
@@ -38,7 +38,7 @@ describe('packageTitlesReducer', () => {
       ...state,
       hasLoaded: true,
       totalResults: 2,
-      items: [...state.items, ...action.payload.data],
+      items: [...action.payload.data],
     });
   });
 

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -5,6 +5,8 @@
     "startDate": "Start Date",
     "name": "Name",
     "status": "Status",
+    "previous": "Previous",
+    "next": "Next",
     "shortcut.createRecord": "Create a new custom package or title record",
     "shortcut.editRecord": "Edit a record",
     "shortcut.saveRecord": "Save a record",


### PR DESCRIPTION
# UIEH-1163 View Packages Record > List of Titles Accordion | Replace Load More AND Apply Next/Previous Pagination component

## Purpose
- Create `<PrevNextComponent />`
- Add tests
- Update reducer for `packageTitles`

Issue: [UIEH-1163](https://issues.folio.org/browse/UIEH-1163)

## Approach

#### TODOS and Open Questions
After all replacement `<ScrollView />` component should be updated

## Screenshots
![Pb6954D7mJ](https://user-images.githubusercontent.com/55701515/128339018-e640cd94-cc7d-4583-bffb-a3111a82216a.gif)
