### PR TITLE
UIEH-1163: Fix items count per page for PrevNextButtons component

### DIFF
--- a/src/components/prev-next-buttons/prev-next-buttons.js
+++ b/src/components/prev-next-buttons/prev-next-buttons.js
@@ -12,7 +12,7 @@ import styles from './prev-next-buttons.css';
 
 const PrevNextButtons = ({
   page,
-  setPage,
+  fetch,
   totalResults,
   isLoading,
 }) => {
@@ -33,7 +33,7 @@ const PrevNextButtons = ({
           buttonStyle="none"
           data-testid="previous-button"
           onClick={() => {
-            setPage(page - 1);
+            fetch(page - 1);
           }}
         >
           <Icon size="small" icon="caret-left">
@@ -48,7 +48,7 @@ const PrevNextButtons = ({
           buttonStyle="none"
           data-testid="next-button"
           onClick={() => {
-            setPage(page + 1);
+            fetch(page + 1);
           }}
         >
           <Icon size="small" icon="caret-right" iconPosition="end">
@@ -61,9 +61,9 @@ const PrevNextButtons = ({
 };
 
 PrevNextButtons.propTypes = {
+  fetch: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
   page: PropTypes.number.isRequired,
-  setPage: PropTypes.func.isRequired,
   totalResults: PropTypes.number.isRequired,
 };
 

--- a/src/components/prev-next-buttons/prev-next-buttons.test.js
+++ b/src/components/prev-next-buttons/prev-next-buttons.test.js
@@ -6,11 +6,13 @@ import noop from 'lodash/noop';
 
 import PrevNextButtons from './prev-next-buttons';
 
+const mockFetch = jest.fn();
+
 describe('Given PrevNextButtons', () => {
   const renderPrevNextButtons = (props) => render(
     <PrevNextButtons
       page={1}
-      setPage={noop}
+      fetch={noop}
       totalResults={150}
       isLoading={false}
       {...props}
@@ -32,36 +34,32 @@ describe('Given PrevNextButtons', () => {
   });
 
   describe('when click on next button', () => {
-    const mockSetPage = jest.fn();
-
-    it('should handle setPage', () => {
+    it('should handle fetch', () => {
       const { getByTestId } = renderPrevNextButtons({
-        setPage: mockSetPage,
+        fetch: mockFetch,
       });
 
       fireEvent.click(getByTestId('next-button'));
 
-      expect(mockSetPage).toHaveBeenCalledWith(2);
+      expect(mockFetch).toHaveBeenCalledWith(2);
     });
   });
 
   describe('when click on previous button', () => {
-    const mockSetPage = jest.fn();
-
-    it('should handle setPage', () => {
+    it('should handle fetch', () => {
       const { getByTestId } = renderPrevNextButtons({
         page: 2,
-        setPage: mockSetPage,
+        fetch: mockFetch,
       });
 
       fireEvent.click(getByTestId('previous-button'));
 
-      expect(mockSetPage).toHaveBeenCalledWith(1);
+      expect(mockFetch).toHaveBeenCalledWith(1);
     });
 
     it('should disable previous button', () => {
       const { getByTestId } = renderPrevNextButtons({
-        setPage: mockSetPage,
+        fetch: mockFetch,
       });
 
       fireEvent.click(getByTestId('previous-button'));

--- a/src/components/query-search-list/query-search-list.js
+++ b/src/components/query-search-list/query-search-list.js
@@ -24,7 +24,7 @@ const QuerySearchList = ({
 }) => {
   useEffect(() => {
     fetch(FIRST_PAGE);
-  }, [fetch]);
+  }, []);
 
   const {
     totalResults,

--- a/src/components/query-search-list/query-search-list.js
+++ b/src/components/query-search-list/query-search-list.js
@@ -1,6 +1,5 @@
 import {
   useEffect,
-  useState,
 } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames/bind';
@@ -23,11 +22,9 @@ const QuerySearchList = ({
   scrollable,
   type,
 }) => {
-  const [page, setPage] = useState(FIRST_PAGE);
-
   useEffect(() => {
-    fetch(page);
-  }, [fetch, page]);
+    fetch(FIRST_PAGE);
+  }, [fetch]);
 
   const {
     totalResults,
@@ -35,6 +32,7 @@ const QuerySearchList = ({
     hasFailed,
     errors,
     isLoading,
+    page,
   } = collection;
   const length = items.length;
 
@@ -62,7 +60,7 @@ const QuerySearchList = ({
         <PrevNextButtons
           isLoading={isLoading}
           totalResults={totalResults}
-          setPage={setPage}
+          fetch={fetch}
           page={page}
         />
       )}

--- a/src/redux/reducers/packageTitles.js
+++ b/src/redux/reducers/packageTitles.js
@@ -14,11 +14,13 @@ const initialState = {
   items: [],
   errors: [],
   totalResults: 0,
+  page: 1,
 };
 
 const handlers = {
-  [GET_PACKAGE_TITLES]: state => ({
+  [GET_PACKAGE_TITLES]: (state, { payload }) => ({
     ...state,
+    page: payload.params.page,
     isLoading: true,
     hasLoaded: false,
     hasFailed: false,
@@ -43,6 +45,7 @@ const handlers = {
     ...state,
     items: [],
     totalResults: 0,
+    page: 1,
   }),
 };
 

--- a/src/redux/reducers/tests/packageTitles.test.js
+++ b/src/redux/reducers/tests/packageTitles.test.js
@@ -13,15 +13,20 @@ const state = {
   items: [],
   errors: [],
   totalResults: 0,
+  page: 1,
 };
 
 describe('packageTitlesReducer', () => {
   it('should handle GET_PACKAGE_TITLES action', () => {
-    const action = { type: GET_PACKAGE_TITLES };
+    const action = {
+      type: GET_PACKAGE_TITLES,
+      payload: { params: { page: 2 } },
+    };
 
     expect(packageTitlesReducer(state, action)).toEqual({
       ...state,
       isLoading: true,
+      page: 2,
     });
   });
 
@@ -61,6 +66,7 @@ describe('packageTitlesReducer', () => {
     expect(packageTitlesReducer(state, action)).toEqual({
       ...state,
       items: [],
+      page: 1,
     });
   });
 


### PR DESCRIPTION
Fix bug described in the [comment](https://issues.folio.org/browse/UIEH-1163?focusedCommentId=109227&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-109227)

## Approach
Because fetch calls in different places the main propose to keep page value in global state.

## Screenshot
![JoVUtzxqM8](https://user-images.githubusercontent.com/55701515/128850099-327de4e6-041c-4fa8-8436-c47dede84859.gif)
