### PR TITLE
UIEH-1168: Cannot edit a package-title (aka resource) record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Add tests for PackageCreate component. (UIEH-1072)
 * Jest+RTL > Test SearchFilters. (UIEH-1075)
 * Jest+RTL > Test CustomLabelField. (UIEH-1076)
+* Fix cannot edit a package-title (aka resource) record. (UIEH-1168)
 
 ## [6.1.1] (https://github.com/folio-org/ui-eholdings/tree/v6.1.1) (2021-07-15)
 * Fix: saving the update of coverage settings temporarily shows the old date. (UIEH-1146)

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -83,13 +83,15 @@ const ResourceEditManagedTitle = ({
       ? coverageStatementExistenceStatuses.YES
       : coverageStatementExistenceStatuses.NO;
 
+    const canEditUrl = model.isTitleCustom || model.isPackageCustom;
+
     return {
       isSelected,
       isVisible: !visibilityData.isHidden,
       customCoverages,
       coverageStatement,
       hasCoverageStatement,
-      customUrl: url,
+      customUrl: canEditUrl ? url : undefined,
       customEmbargoPeriod: getEmbargoInitial(customEmbargoPeriod),
       proxyId: (matchingProxy?.id || proxy.id).toLowerCase(),
       accessTypeId: getAccessTypeId(model),


### PR DESCRIPTION
## Description
Don't copy custom url to initial values when a resource is a managed title in a managed package

## Issues
[UIEH-1168](https://issues.folio.org/browse/UIEH-1168)