### PR TITLE
UIEH-1203: Edit Custom Title > Click Save & Close button displays a Are you sure you want to leave pop-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Apply Next/Previous Pagination Component for Titles results. (UIEH-1164)
 * Add tests for SettingsCustomLabels component. (UIEH-1077)
 * Add tests for DetailsView component. (UIEH-1082)
+* Fix apparition of navigation modal after saving changes while editing Custom Title. (UIEH-1203)
 
 ## [6.1.1] (https://github.com/folio-org/ui-eholdings/tree/v6.1.1) (2021-07-15)
 * Fix: saving the update of coverage settings temporarily shows the old date. (UIEH-1146)

--- a/src/components/title/edit/title-edit.js
+++ b/src/components/title/edit/title-edit.js
@@ -129,7 +129,7 @@ export default class TitleEdit extends Component {
                 />
               </form>
 
-              <NavigationModal when={!pristine && !updateRequest.isResolved} />
+              <NavigationModal when={!pristine && !updateRequest.isPending && !updateRequest.isResolved} />
             </>
           )}
         />


### PR DESCRIPTION
## Purpose
Fix apparition of 'Are you sure you want to leave' pop-up after clicked Save & Close button while editing Custom Title.

## Screenshots
![EcFm5skN2E](https://user-images.githubusercontent.com/84023879/130955501-eaaa0dbe-de65-4498-a11f-b6f91b4eefc9.gif)

## Issues
[UIEH-1203](https://issues.folio.org/browse/UIEH-1203)

