### PR TITLE
UIEH-1204: eholdings: Change all detail records headline component size to XL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Add tests for SettingsCustomLabels component. (UIEH-1077)
 * Add tests for DetailsView component. (UIEH-1082)
 * Jest+RTL > Test ScrollView. (UIEH-1085)
+* Change all detail records headline component size to XL. (UIEH-1204)
 
 ## [6.1.1] (https://github.com/folio-org/ui-eholdings/tree/v6.1.1) (2021-07-15)
 * Fix: saving the update of coverage settings temporarily shows the old date. (UIEH-1146)

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -290,7 +290,7 @@ class DetailsView extends Component {
       <>
         <div key="header" className={styles.header}>
           <Headline
-            size="xx-large"
+            size="x-large"
             tag="h2"
             margin="none"
             tabIndex={-1}


### PR DESCRIPTION
## Purpose
Changed all detail records headline component size from XXL to XL in order to eliminate excess whitespace.

Issue: [UIEH-1204](https://issues.folio.org/browse/UIEH-1204)