### PR TITLE
UIEH-1202: Move access status type field to package settings accordion in edit custom package page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Apply Next/Previous Pagination Component for Providers results. (UIEH-1165)
 * Apply Next/Previous Pagination Component for Titles results. (UIEH-1164)
 * Add tests for SettingsCustomLabels component. (UIEH-1077)
+* Move Access status type field to Package Settings accordion in Edit Custom Package page. (UIEH-1202)
 
 ## [6.1.1] (https://github.com/folio-org/ui-eholdings/tree/v6.1.1) (2021-07-15)
 * Fix: saving the update of coverage settings temporarily shows the old date. (UIEH-1146)

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -267,7 +267,6 @@ const CustomPackageEdit = ({
                       getSectionHeader={getSectionHeader}
                       packageSelected={packageSelected}
                       model={model}
-                      accessStatusTypes={accessStatusTypes}
                     />
                     <EditPackageSettings
                       isOpen={sections.packageSettings}
@@ -279,6 +278,7 @@ const CustomPackageEdit = ({
                       proxyTypes={proxyTypes}
                       provider={provider}
                       packageIsCustom
+                      accessStatusTypes={accessStatusTypes}
                     />
 
                     <EditCoverageSettings

--- a/src/components/package/edit/components/edit-package-information/edit-package-information.js
+++ b/src/components/package/edit/components/edit-package-information/edit-package-information.js
@@ -10,10 +10,8 @@ import {
 
 import NameField from '../../../_fields/name';
 import ContentTypeField from '../../../_fields/content-type';
-import AccessTypeEditSection from '../../../../access-type-edit-section';
 
 const propTypes = {
-  accessStatusTypes: PropTypes.object.isRequired,
   getSectionHeader: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
   model: PropTypes.object.isRequired,
@@ -27,7 +25,6 @@ const EditPackageInformation = ({
   onToggle,
   packageSelected,
   model,
-  accessStatusTypes,
 }) => {
   return (
     <Accordion
@@ -55,7 +52,6 @@ const EditPackageInformation = ({
             </div>
           </KeyValue>
         )}
-      <AccessTypeEditSection accessStatusTypes={accessStatusTypes} />
     </Accordion>
   );
 };

--- a/src/components/package/edit/components/edit-package-settings/edit-package-settings.js
+++ b/src/components/package/edit/components/edit-package-settings/edit-package-settings.js
@@ -144,7 +144,7 @@ const EditPackageSettings = ({
     }
 
     const isAccessStatusTypes = accessStatusTypes?.items?.data?.length > 0;
-    console.log(isAccessStatusTypes, accessStatusTypes, packageIsCustom);
+
     const packageSettingsColumnWidth = isAccessStatusTypes
       ? MAX_COLUMN_WIDTH
       : ONE_THIRD_OF_COLUMN_WIDTH;

--- a/src/components/package/edit/components/edit-package-settings/edit-package-settings.js
+++ b/src/components/package/edit/components/edit-package-settings/edit-package-settings.js
@@ -144,7 +144,7 @@ const EditPackageSettings = ({
     }
 
     const isAccessStatusTypes = accessStatusTypes?.items?.data?.length > 0;
-
+    console.log(isAccessStatusTypes, accessStatusTypes, packageIsCustom);
     const packageSettingsColumnWidth = isAccessStatusTypes
       ? MAX_COLUMN_WIDTH
       : ONE_THIRD_OF_COLUMN_WIDTH;
@@ -204,7 +204,7 @@ const EditPackageSettings = ({
                   <Icon icon="spinner-ellipsis" />
                 )
               }
-              {(!packageIsCustom && isAccessStatusTypes) && (
+              {isAccessStatusTypes && (
                 <Col xsOffset={3} xs={dropdownColumnWidth}>
                   <AccessTypeEditSection accessStatusTypes={accessStatusTypes} />
                 </Col>


### PR DESCRIPTION
# UIEH-1202 Edit Custom Package: Move Access status type field under Package Settings

## Purpose
- Remove `AccessStatusType` component to `PackageSettings` accordion

Issue: [UIEH-1202](https://issues.folio.org/browse/UIEH-1202)

### TODO
Tests will be done in a scope of [UIEH-1092](https://issues.folio.org/browse/UIEH-1092)

## Screenshots
![AEBaGULi5T](https://user-images.githubusercontent.com/55701515/131103207-504d4524-090e-4f01-87f3-256ca6914e20.gif)

