### PR TITLE
UIEH-1216 Fix store.getState is not a function error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-eholdings
 
+## [7.1.0] (IN PROGRESS)
+
+* Fix store.getState is not a function error. (UIEH-1216)
+
 ## [7.0.0] (https://github.com/folio-org/ui-eholdings/tree/v7.0.0) (2021-10-06)
 
 * Fix import paths. (UIEH-1133)

--- a/src/redux/epics/get-provider-packages.js
+++ b/src/redux/epics/get-provider-packages.js
@@ -12,7 +12,7 @@ import {
   GET_PROVIDER_PACKAGES,
 } from '../actions';
 
-export default ({ providerPackagesApi }) => (action$, store) => {
+export default ({ providerPackagesApi }) => (action$, state) => {
   return action$.pipe(
     filter(action => action.type === GET_PROVIDER_PACKAGES),
     mergeMap(action => {
@@ -24,7 +24,7 @@ export default ({ providerPackagesApi }) => (action$, store) => {
       } = action;
 
       return providerPackagesApi
-        .getCollection(store.getState().okapi, providerId, params)
+        .getCollection(state.value.okapi, providerId, params)
         .pipe(
           map(getProviderPackagesSuccess),
           catchError(errors => of(getProviderPackagesFailure({ errors })))

--- a/src/redux/epics/tests/get-provider-packages.test.js
+++ b/src/redux/epics/tests/get-provider-packages.test.js
@@ -18,14 +18,12 @@ describe('(epic) getProviderPackages', () => {
   });
 
   const state$ = {
-    getState: () => {
-      return {
-        okapi: {
-          url: 'https://folio-snapshot',
-          tenant: 'diku',
-          token: 'token',
-        },
-      };
+    value: {
+      okapi: {
+        url: 'https://folio-snapshot',
+        tenant: 'diku',
+        token: 'token',
+      },
     },
   };
 


### PR DESCRIPTION
## Description
`redux-observable v1.2.0` instead of `store` object passes `state: { value }` as second argument to epics.

## Issues
[UIEH-1216](https://issues.folio.org/browse/UIEH-1216)