### PR TITLE
UIEH-1215: added missing tags permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,10 @@
           "kb-ebsco.titles.collection.get",
           "kb-ebsco.titles.item.get",
           "tags.collection.get",
-          "tags.item.get"
+          "tags.item.get",
+          "kb-ebsco.package-tags.put",
+          "kb-ebsco.provider-tags.put",
+          "kb-ebsco.resource-tags.put"
         ]
       },
       {


### PR DESCRIPTION
## Description
Some permissions for adding tags were missing from `package.json`

## Issues
[UIEH-1215](https://issues.folio.org/browse/UIEH-1215)