### PR TITLE
UIEH-1212: Refactor '.all' permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Add tests for SettingsKnowledgeBaseRoute component. (UIEH-1196)
 * Add tests for TitleCreateRoute component. (UIEH-1199)
 * Add tests for TitleEditRoute component. (UIEH-1200)
-
+* Refactor '.all' permissions. (UIEH-1212)
 
 ## [7.0.1] (https://github.com/folio-org/ui-eholdings/tree/v7.0.1) (2021-10-19)
 

--- a/package.json
+++ b/package.json
@@ -321,7 +321,10 @@
         "visible": true,
         "subPermissions": [
           "ui-eholdings.settings.enabled",
-          "kb-ebsco.kb-credentials.users.all",
+          "kb-ebsco.kb-credentials.users.collection.get",
+          "kb-ebsco.kb-credentials.users.collection.post",
+          "kb-ebsco.kb-credentials.users.item.put",
+          "kb-ebsco.kb-credentials.users.item.delete",
           "usergroups.collection.get"
         ]
       }


### PR DESCRIPTION
# UIEH-1212 refactor psets away from backend ".all" permissions


## Purpose
Replace `.all` permissions

[UIEH-1212](https://issues.folio.org/browse/UIEH-1212)

