### PR TITLE
UIEH-1181: Add tests for TitlesTable component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add tests for TitleShowRoute component. (UIEH-1201)
 * Add tests for FullTextRequestUsageTable component. (UIEH-1179)
 * Add tests for SummaryTable component. (UIEH-1180)
+* Add tests for TitlesTable component. (UIEH-1181)
 
 ## [7.0.1] (https://github.com/folio-org/ui-eholdings/tree/v7.0.1) (2021-10-19)
 

--- a/src/constants/costPerUse/costPerUseReduxStateShape.js
+++ b/src/constants/costPerUse/costPerUseReduxStateShape.js
@@ -41,6 +41,9 @@ const CostPerUseReduxStateShape = PropTypes.shape({
   isFailed: PropTypes.bool.isRequired,
   isLoaded: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
+  isPackageTitlesFailed: PropTypes.bool.isRequired,
+  isPackageTitlesLoaded: PropTypes.bool.isRequired,
+  isPackageTitlesLoading: PropTypes.bool.isRequired,
 });
 
 export default {

--- a/src/features/usage-consolidation-accordion/titles-table/titles-table.js
+++ b/src/features/usage-consolidation-accordion/titles-table/titles-table.js
@@ -21,6 +21,8 @@ import { useMultiColumnListSort } from '../../../hooks';
 import {
   costPerUse as costPerUseShape,
   costPerUseTypes,
+  PAGE_SIZE,
+  FIRST_PAGE,
   sortOrders,
 } from '../../../constants';
 
@@ -30,20 +32,17 @@ const propTypes = {
   onSortTitles: PropTypes.func.isRequired,
 };
 
-const PAGE_SIZE = 100;
-const DEFAULT_PAGE = 1;
-
 const TitlesTable = ({
   costPerUseData,
   fetchNextPage,
   onSortTitles,
 }) => {
   const intl = useIntl();
-  const [page, setPage] = useState(DEFAULT_PAGE);
+  const [page, setPage] = useState(FIRST_PAGE);
   const titlesTableMCLRef = useRef(null);
 
   const handleSortChange = (newSortedColumn, newSortOrder) => {
-    setPage(DEFAULT_PAGE);
+    setPage(FIRST_PAGE);
     onSortTitles(newSortedColumn, newSortOrder.name);
   };
 
@@ -90,6 +89,7 @@ const TitlesTable = ({
 
   const onNeedMoreData = () => {
     const nextPage = page + 1;
+
     setPage(nextPage);
     fetchNextPage(nextPage, PAGE_SIZE, sortedColumn, sortOrder.name);
   };

--- a/src/features/usage-consolidation-accordion/titles-table/titles-table.test.js
+++ b/src/features/usage-consolidation-accordion/titles-table/titles-table.test.js
@@ -1,0 +1,220 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+} from '@testing-library/react';
+import Harness from '../../../../test/jest/helpers/harness';
+
+import TitlesTable from './titles-table';
+
+const mockFetchNextPage = jest.fn();
+const mockOnSortTitles = jest.fn();
+
+const defaultResource = {
+  resourceId: 'test-resourceId',
+  attributes: {
+    publicationType: 'test-publication-type',
+    name: 'test-name',
+    percent: 10,
+    cost: 100,
+    usage: 10,
+    costPerUse: 10,
+  },
+};
+
+const getData = (resourceCount = 1, totalResults = 1, resource = defaultResource) => ({
+  packageTitleCostPerUse: {
+    attributes: {
+      resources: new Array(resourceCount).fill(resource),
+      meta: { totalResults },
+      parameters: {
+        currency: 'USD',
+        startMonth: '01/01/2020',
+      },
+      analysis: [{
+        cost: 100,
+        costPerUse: 1,
+        usage: 1,
+      }],
+    },
+    id: 'id',
+    type: 'type',
+  },
+});
+
+const costPerUseData = {
+  data: getData(),
+  errors: [],
+  isFailed: false,
+  isLoaded: true,
+  isLoading: false,
+  isPackageTitlesFailed: false,
+  isPackageTitlesLoaded: true,
+  isPackageTitlesLoading: false,
+};
+
+const renderTitlesTable = (props = {}) => render(
+  <Harness>
+    <TitlesTable
+      costPerUseData={costPerUseData}
+      fetchNextPage={mockFetchNextPage}
+      onSortTitles={mockOnSortTitles}
+      {...props}
+    />
+  </Harness>
+);
+
+describe('Given TitlesTable', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  describe('when package titles for cost per use was not loaded', () => {
+    it('should not render table', () => {
+      const { queryByText } = renderTitlesTable({
+        costPerUseData: {
+          ...costPerUseData,
+          data: {},
+          isPackageTitlesLoaded: false,
+          isPackageTitlesFailed: true,
+        },
+      });
+
+      expect(queryByText('ui-eholdings.usageConsolidation.titles.title')).toBeNull();
+      expect(queryByText('ui-eholdings.usageConsolidation.titles.type')).toBeNull();
+      expect(queryByText('ui-eholdings.usageConsolidation.titles.percentOfUsage')).toBeNull();
+      expect(queryByText('ui-eholdings.usageConsolidation.summary.costPerUse')).toBeNull();
+      expect(queryByText('ui-eholdings.usageConsolidation.titles.cost')).toBeNull();
+      expect(queryByText('ui-eholdings.usageConsolidation.summary.title.usage')).toBeNull();
+    });
+
+    it('should show toast error message', () => {
+      const { getByText } = renderTitlesTable({
+        costPerUseData: {
+          ...costPerUseData,
+          isPackageTitlesFailed: true,
+          errors: ['error'],
+        },
+      });
+
+      expect(getByText('ui-eholdings.usageConsolidation.titles.loadingFailed')).toBeDefined();
+    });
+  });
+
+  describe('when data is loading', () => {
+    it('should show loading message', () => {
+      const { getByText } = renderTitlesTable({
+        costPerUseData: {
+          ...costPerUseData,
+          isPackageTitlesLoaded: false,
+          isPackageTitlesLoading: true,
+          data: {},
+        },
+      });
+
+      expect(getByText('ui-eholdings.usageConsolidation.titles.loading')).toBeDefined();
+    });
+  });
+
+  describe('when table is hidden', () => {
+    it('should not render table', () => {
+      const { queryByText } = renderTitlesTable({
+        costPerUseData: {
+          ...costPerUseData,
+          data: {},
+        },
+      });
+
+      expect(queryByText('ui-eholdings.usageConsolidation.titles.title')).toBeNull();
+      expect(queryByText('ui-eholdings.usageConsolidation.titles.type')).toBeNull();
+      expect(queryByText('ui-eholdings.usageConsolidation.titles.percentOfUsage')).toBeNull();
+      expect(queryByText('ui-eholdings.usageConsolidation.summary.costPerUse')).toBeNull();
+      expect(queryByText('ui-eholdings.usageConsolidation.titles.cost')).toBeNull();
+      expect(queryByText('ui-eholdings.usageConsolidation.summary.title.usage')).toBeNull();
+    });
+  });
+
+  describe('when data loaded succesful', () => {
+    it('should render table', () => {
+      const { getByText } = renderTitlesTable();
+
+      expect(getByText('ui-eholdings.usageConsolidation.titles.title')).toBeDefined();
+      expect(getByText('ui-eholdings.usageConsolidation.titles.type')).toBeDefined();
+      expect(getByText('ui-eholdings.usageConsolidation.titles.percentOfUsage')).toBeDefined();
+      expect(getByText('ui-eholdings.usageConsolidation.summary.costPerUse')).toBeDefined();
+      expect(getByText('ui-eholdings.usageConsolidation.titles.cost')).toBeDefined();
+      expect(getByText('ui-eholdings.usageConsolidation.summary.title.usage')).toBeDefined();
+    });
+
+    describe('and when click on column header', () => {
+      it('should handle onSortTitles', () => {
+        const { getByText } = renderTitlesTable();
+
+        fireEvent.click(getByText('ui-eholdings.usageConsolidation.titles.title'));
+
+        expect(mockOnSortTitles).toHaveBeenCalled();
+      });
+    });
+
+    describe('when percent is 10', () => {
+      it('should show "10 %"', () => {
+        const { getByText } = renderTitlesTable();
+
+        expect(getByText('10 %')).toBeDefined();
+      });
+    });
+
+    describe('when percent is 0.5', () => {
+      it('should show "< 1 %"', () => {
+        const { getByText } = renderTitlesTable(renderTitlesTable({
+          costPerUseData: {
+            ...costPerUseData,
+            data: getData(1, 1, {
+              ...defaultResource,
+              attributes: {
+                ...defaultResource.attributes,
+                percent: 0.5,
+              },
+            }),
+          },
+        }));
+
+        expect(getByText('< 1 %')).toBeDefined();
+      });
+    });
+
+    describe('when percent is 0', () => {
+      it('should show NoValue component', () => {
+        const { getByText } = renderTitlesTable(renderTitlesTable({
+          costPerUseData: {
+            ...costPerUseData,
+            data: getData(1, 1, {
+              ...defaultResource,
+              attributes: {
+                ...defaultResource.attributes,
+                percent: 0,
+              },
+            }),
+          },
+        }));
+
+        expect(getByText('NoValue')).toBeDefined();
+      });
+    });
+
+    describe('when total results more then page size', () => {
+      describe('and click on load more button', () => {
+        const { getByText } = renderTitlesTable({
+          costPerUseData: {
+            ...costPerUseData,
+            data: getData(100, 120),
+          },
+        });
+
+        fireEvent.click(getByText('stripes-components.mcl.loadMore'));
+
+        expect(mockFetchNextPage).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -6,5 +6,5 @@ jest.mock('@folio/stripes/components', () => ({
       <span>{value || children}</span>
     </>
   )),
-  NoValue: jest.fn(({ ariaLabel }) => (<span>{ariaLabel}</span>)),
+  NoValue: jest.fn(({ ariaLabel }) => (<span>{ariaLabel || 'NoValue'}</span>)),
 }));


### PR DESCRIPTION
# UIEH-1181: Add tests for TitlesTable component

## Purpose
- Add tests
- Fix `CostPerUseReduxStateShape`

Issue: [UIEH-1181](https://issues.folio.org/browse/UIEH-1081)

#### TODOS and Open Questions
Should update `CostPerUseShape`. It has different data structure as in `<TitlesTable>`.

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/143504076-bb2c6898-1ecb-4a5c-91f5-bfc2cb201b17.png)
