### PR TITLE
UIEH-1222: Add missed permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add tests for SummaryTable component. (UIEH-1180)
 * Add tests for ApplicationRoute component. (UIEH-1184)
 * Add tests for TitlesTable component. (UIEH-1181)
+* Add missing permissions to `package.json`. (UIEH-1222)
 
 ## [7.0.1] (https://github.com/folio-org/ui-eholdings/tree/v7.0.1) (2021-10-19)
 

--- a/package.json
+++ b/package.json
@@ -142,6 +142,8 @@
           "kb-ebsco.providers.collection.get",
           "kb-ebsco.providers.item.get",
           "kb-ebsco.resources.item.get",
+          "kb-ebsco.root-proxy.get",
+          "kb-ebsco.proxy-types.collection.get",
           "kb-ebsco.titles.collection.get",
           "kb-ebsco.titles.item.get",
           "tags.collection.get",
@@ -179,7 +181,10 @@
         "displayName": "Settings (eHoldings): Can create, edit, and view knowledge base credentials",
         "visible": true,
         "subPermissions": [
-          "ui-eholdings.settings.enabled"
+          "ui-eholdings.settings.enabled",
+          "kb-ebsco.kb-credentials.collection.post",
+          "kb-ebsco.kb-credentials.item.get",
+          "kb-ebsco.kb-credentials.item.patch"
         ]
       },
       {
@@ -197,7 +202,9 @@
         "displayName": "Settings (eHoldings): configure root proxy setting",
         "visible": true,
         "subPermissions": [
-          "ui-eholdings.settings.enabled"
+          "ui-eholdings.settings.enabled",
+          "kb-ebsco.kb-credentials.root-proxy.get",
+          "kb-ebsco.kb-credentials.root-proxy.put"
         ]
       },
       {
@@ -218,7 +225,8 @@
           "module.eholdings.enabled",
           "kb-ebsco.packages.item.put",
           "kb-ebsco.resources.item.put",
-          "kb-ebsco.providers.item.put"
+          "kb-ebsco.providers.item.put",
+          "kb-ebsco.titles.item.put"
         ]
       },
       {
@@ -292,7 +300,8 @@
         "displayName": "Settings (eholdings): Can create, edit, view, and delete custom labels",
         "visible": true,
         "subPermissions": [
-          "ui-eholdings.settings.custom-labels.view"
+          "ui-eholdings.settings.custom-labels.view",
+          "kb-ebsco.kb-credentials.custom-labels.collection.put"
         ]
       },
       {
@@ -302,7 +311,8 @@
         "subPermissions": [
           "ui-eholdings.settings.enabled",
           "kb-ebsco.kb-credentials.uc.item.get",
-          "kb-ebsco.currencies.collection.get"
+          "kb-ebsco.currencies.collection.get",
+          "kb-ebsco.uc-credentials.item.get"
         ]
       },
       {
@@ -312,7 +322,8 @@
         "subPermissions": [
           "ui-eholdings.settings.usage-consolidation.view",
           "kb-ebsco.kb-credentials.uc.collection.post",
-          "kb-ebsco.kb-credentials.uc.item.patch"
+          "kb-ebsco.kb-credentials.uc.item.patch",
+          "kb-ebsco.uc-credentials.item.put"
         ]
       },
       {


### PR DESCRIPTION
# UIEH-1222: Permissions "kb-ebsco.root-proxy.get" and "kb-ebsco.proxy-types.collection.get" not available


## Purpose
- Add missing permission

Issue: [UIEH-1222](https://issues.folio.org/browse/UIEH-1222)

## Approach
Checking `mod-kb-ebsco-java` descriptor for correspondence permissions. Permissions which should be discussed:

["kb-ebsco.configuration.get"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L429) - ui does not use `eholdings/configuration` 

["kb-ebsco.configuration.put"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L434) - ui does not use `eholdings/configuration` 

["kb-ebsco.cache.delete"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L444) - ui does not use `eholdings/cache`

["kb-ebsco.resources-bulk.collection.get"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L519) - ui does not use `/eholdings/resources/bulk/fetch`

["kb-ebsco.packages-bulk.collection.get"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L529) - ui does not use `/eholdings/packages/bulk/fetch`

["kb-ebsco.kb-credentials.proxy-types.collection.get"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L568) - does not used. permission for settings view proxy-types is not present.

["kb-ebsco.tags.collection.get"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L593) - ui does not use `/eholdings/tags`

["kb-ebsco.unique.tags.collection.get"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L598) - ui does not use `/eholdings/tags/summary`

["kb-ebsco.kb-credentials.holdings-load-all.post"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L603) - ui does not use `/eholdings/loading/kb-credentials`

["kb-ebsco.kb-credentials.holdings-load.post"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L608) - ui does not use `/eholdings/loading/kb-credentials/{id}`

["kb-ebsco.kb-credentials.holdings-load.status.item.get"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L613) - ui does not use `/eholdings/loading/kb-credentials/{credentialsId}/status`

["kb-ebsco.access-types.item.get"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L638) - ui does not use `/eholdings/access-types/{accessTypeId}`

["kb-ebsco.kb-credentials.item.put"](https://github.com/folio-org/mod-kb-ebsco-java/blob/29280795878c3c38da6077c9e9ff83675aae5192/descriptors/ModuleDescriptor-template.json#L688) - ui does not use `/eholdings/kb-credentials/{credentialsId}` with method PUT

#### TODOS and Open Questions
Discuss with PO and UI team about adding permission for proxy-types.
