### PR TITLE
MODKBEKBJ-619: Fix 3 GET requests instead of 1 are made when searching Providers/Packages/Titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add tests for PackageCreateRoute. (UIEH-1186)
 * Add tests for PackageEditRoute. (UIEH-1187)
 * Lock `faker` version.
+* Fix 3 GET requests instead of 1 are made when searching Providers/Packages/Titles. (MODKBEKBJ-619)
 
 ## [7.0.1] (https://github.com/folio-org/ui-eholdings/tree/v7.0.1) (2021-10-19)
 

--- a/src/hooks/useImpagination.js
+++ b/src/hooks/useImpagination.js
@@ -1,4 +1,7 @@
-import { useEffect } from 'react';
+import {
+  useEffect,
+  useRef,
+} from 'react';
 
 class Dataset {
   constructor({ pageSize, page }) {
@@ -35,20 +38,22 @@ const useImpagination = ({
   fetch,
   isMainPageSearch,
 }) => {
-  useEffect(() => {
-    if (!isMainPageSearch) {
-      return;
-    }
+  const isInitialMount = useRef([true, true]);
 
-    fetch(page);
+  useEffect(() => {
+    if (isInitialMount.current[0]) {
+      isInitialMount.current[0] = false;
+    } else if (isMainPageSearch) {
+      fetch(page);
+    }
   }, [page]);
 
   useEffect(() => {
-    if (!isMainPageSearch) {
-      return;
+    if (isInitialMount.current[1]) {
+      isInitialMount.current[1] = false;
+    } else if (isMainPageSearch) {
+      fetch(1);
     }
-
-    fetch(1);
   }, [collection.key]);
 
   if (!isMainPageSearch) {


### PR DESCRIPTION
## Purpose
Fix 3 GET requests instead of 1 are made when searching Providers/Packages/Titles.

## Approach
The reason 3 GET requests were made is `useImpagination` custom hook where two `useEffect`s were called not only when values in dependencies array changed but also on mount, which was not needed.

The solution refers to [React docs](https://reactjs.org/docs/hooks-faq.html#can-i-run-an-effect-only-on-updates) where it's suggested to add a mutable ref to check if this is the first mount or not.

## Screenshots
![6S8K4WDThr](https://user-images.githubusercontent.com/84023879/151718711-d562c7e8-a7e9-422b-a27d-bc0ebb816dbd.gif)

## Issues
[MODKBEKBJ-619](https://issues.folio.org/browse/MODKBEKBJ-619)
