### PR TITLE
MODKBEKBJ-619: Fix unnecessary unmounts in <Application> component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add tests for PackageCreateRoute. (UIEH-1186)
 * Add tests for PackageEditRoute. (UIEH-1187)
 * Lock `faker` version.
+* Fix 3 GET requests instead of 1 are made when searching Providers/Packages/Titles. (MODKBEKBJ-619)
 
 ## [7.0.1] (https://github.com/folio-org/ui-eholdings/tree/v7.0.1) (2021-10-19)
 

--- a/src/components/query-search-list/query-search-list.js
+++ b/src/components/query-search-list/query-search-list.js
@@ -34,7 +34,7 @@ const QuerySearchList = ({
   const listFirstItem = useRef(null);
 
   useEffect(() => {
-    fetch(FIRST_PAGE);
+    fetch(collection.page);
   }, []);
 
   const {

--- a/src/hooks/useImpagination.js
+++ b/src/hooks/useImpagination.js
@@ -1,4 +1,7 @@
-import { useEffect } from 'react';
+import {
+  useEffect,
+  useRef,
+} from 'react';
 
 class Dataset {
   constructor({ pageSize, page }) {
@@ -35,20 +38,22 @@ const useImpagination = ({
   fetch,
   isMainPageSearch,
 }) => {
-  useEffect(() => {
-    if (!isMainPageSearch) {
-      return;
-    }
+  const isInitialMount = useRef([true, true]);
 
-    fetch(page);
+  useEffect(() => {
+    if (isInitialMount.current[0]) {
+      isInitialMount.current[0] = false;
+    } else if (isMainPageSearch) {
+      fetch(page);
+    }
   }, [page]);
 
   useEffect(() => {
-    if (!isMainPageSearch) {
-      return;
+    if (isInitialMount.current[1]) {
+      isInitialMount.current[1] = false;
+    } else if (isMainPageSearch) {
+      fetch(1);
     }
-
-    fetch(1);
   }, [collection.key]);
 
   if (!isMainPageSearch) {

--- a/src/routes/application-route/application-route.js
+++ b/src/routes/application-route/application-route.js
@@ -60,7 +60,10 @@ class ApplicationRoute extends Component {
       return <NoBackendErrorScreen />;
     }
 
-    if (kbCredentials.isLoading && (status.isLoading && !showSettings)) {
+    const isLoadingKbCredentials = kbCredentials.isLoading || (!kbCredentials.hasLoaded && !kbCredentials.hasFailed);
+    const isLoadingStatus = status.isLoading || (!status.isLoaded && !status.request.isRejected);
+
+    if (isLoadingKbCredentials && (isLoadingStatus && !showSettings)) {
       return (
         <Icon
           id="kb-credentials-loading-spinner"


### PR DESCRIPTION
## Description
In addition to fix present in https://github.com/folio-org/ui-eholdings/pull/1492 some duplicated requests are caused by unneeded mounting/mounting of components.
This unmounting can be tracked down to conditional return in `<Application>` component.
`kbCredentials.isLoading` and `status.isLoading` are `false` when first render occurs, even though the data is requested straight away.
This can be fixed by better condition checking.
Additionally, when page is reloaded - user can see empty result message. This is because after reload first page was requested, regardless of offset in url

## Screenshots

https://user-images.githubusercontent.com/19309423/151783051-2412dec2-525a-4dcd-8994-c688c9e19390.mp4


## Issues
[MODKBEKBJ-619](https://issues.folio.org/browse/MODKBEKBJ-619)