### PR TITLE
UIEH-1227: Different date format in eHoldings resource coverage dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Lock `faker` version.
 * Add tests for ProviderEditRoute. (UIEH-1186)
 * Fix 3 GET requests instead of 1 are made when searching Providers/Packages/Titles. (MODKBEKBJ-619)
+* Fix datepicker date format for Custom coverage dates to match current user locale when edit resource. (UIEH-1227)
 
 ## [7.0.1] (https://github.com/folio-org/ui-eholdings/tree/v7.0.1) (2021-10-19)
 

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -21,7 +21,6 @@ import {
   parseDate,
 } from '../../../utilities';
 import {
-  DATE_FORMAT,
   BACKEND_DATE_STANDARD,
   TIME_ZONE,
 } from '../../../../constants';
@@ -79,7 +78,6 @@ class PackageCoverageFields extends Component {
             timeZone={TIME_ZONE}
             render={({ input, meta }) => (
               <Datepicker
-                dateFormat={DATE_FORMAT}
                 parse={parseDate}
                 format={formatDate}
                 backendDateStandard={BACKEND_DATE_STANDARD}
@@ -105,7 +103,6 @@ class PackageCoverageFields extends Component {
             timeZone={TIME_ZONE}
             render={({ input, meta }) => (
               <Datepicker
-                dateFormat={DATE_FORMAT}
                 parse={parseDate}
                 format={formatDate}
                 backendDateStandard={BACKEND_DATE_STANDARD}

--- a/src/components/resource/_fields/resource-coverage-fields/resource-coverage-fields.js
+++ b/src/components/resource/_fields/resource-coverage-fields/resource-coverage-fields.js
@@ -28,7 +28,6 @@ import {
   formatDate,
 } from '../../../utilities';
 import {
-  DATE_FORMAT,
   BACKEND_DATE_STANDARD,
   TIME_ZONE,
 } from '../../../../constants';
@@ -163,7 +162,6 @@ class ResourceCoverageFields extends Component {
             timeZone={TIME_ZONE}
             render={({ input, meta }) => (
               <Datepicker
-                dateFormat={DATE_FORMAT}
                 parse={parseDate}
                 format={formatDate}
                 backendDateStandard={BACKEND_DATE_STANDARD}
@@ -188,7 +186,6 @@ class ResourceCoverageFields extends Component {
             timeZone={TIME_ZONE}
             render={({ input, meta }) => (
               <Datepicker
-                dateFormat={DATE_FORMAT}
                 parse={parseDate}
                 format={formatDate}
                 backendDateStandard={BACKEND_DATE_STANDARD}


### PR DESCRIPTION
## Purpose
Fix datepicker date format for Custom coverage dates to match current user locale when edit resource.

## Approach
The date format was forced to be `MM/DD/YYYY` by passing `DATE_FORMAT` constant with this value to `<Datepicker>` component. Removing this prop allows to format date based on current locale.

## Screenshots

### Date formatting in datepicker for en-US locale:
![image](https://user-images.githubusercontent.com/84023879/152185940-cd271815-04bf-4e4f-9e07-c6a67c5c53e6.png)

### Date formatting in datepicker for en-GB locale:
![image](https://user-images.githubusercontent.com/84023879/152186098-51602a21-e9dd-4f54-8bf0-5719111349e1.png)

## Issues
[UIEH-1227](https://issues.folio.org/browse/UIEH-1227)