### PR TITLE
test config cleanup

### DIFF
--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,5 +1,6 @@
 jest.mock('@folio/stripes/components', () => ({
   ...jest.requireActual('@folio/stripes/components'),
+  Icon: jest.fn(() => (<span>Icon</span>)),
   KeyValue: jest.fn(({ label, children, value }) => (
     <>
       <span>{label}</span>

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,6 +1,6 @@
 jest.mock('@folio/stripes/components', () => ({
   ...jest.requireActual('@folio/stripes/components'),
-  Icon: jest.fn(() => (<span>Icon</span>)),
+  Icon: jest.fn(({ children }) => (<span>{ children }</span>)),
   KeyValue: jest.fn(({ label, children, value }) => (
     <>
       <span>{label}</span>

--- a/test/jest/__mock__/stripesConfig.mock.js
+++ b/test/jest/__mock__/stripesConfig.mock.js
@@ -1,1 +1,1 @@
-jest.mock('stripes-config', () => ({ modules: [] }), { virtual: true });
+jest.mock('stripes-config', () => ({ modules: [], metadata: {} }), { virtual: true });

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -9,8 +9,17 @@ module.exports = {
   ],
   'plugins': [
     ['@babel/plugin-proposal-decorators', { 'legacy': true }],
+    // when building a platform directly, i.e. outside a workspace,
+    // babel complains loudly and repeatedly that when these modules are enabled:
+    // * @babel/plugin-proposal-class-properties,
+    // * @babel/plugin-proposal-private-methods and
+    // * @babel/plugin-proposal-private-property-in-object
+    // the "loose" option must be the same for all three.
+    // but @babel/preset-env sets it to false for ...private-methods.
+    // overriding it here silences the complaint. STRWEB-12
     ['@babel/plugin-proposal-class-properties', { 'loose': true }],
     ['@babel/plugin-proposal-private-methods', { 'loose': true }],
+    ['@babel/plugin-proposal-private-property-in-object', { 'loose': true }],
     '@babel/plugin-transform-runtime',
   ],
 };


### PR DESCRIPTION
Mitigate a bunch of console noise during tests:

* in stripesComponents, mock `Icon` because it leverages webpack's
  `context` function, which node doesn't know about, leading to a warning
  during tests.
* in stripesConfig, provide `metadata`, which was added to
  stripes-config long, long ago, but after this mock was originally
  written.
* in babel.config.js, configure plugin-proposal-private-property-in-object
  consistently with others to avoid VERY NOISY console warnings.

