### PR TITLE
UIEH-1242 correctly specify list's proptypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add tests for ResourceEditRoute. (UIEH-1190)
 * Fix multiple requests to /resources sent when viewing Titles list on Package Show page. (UIEH-1235)
 * Add tests for PackageShowRoute. (UIEH-1188)
+* Correctly specify proptypes. (UIEH-1242)
 
 ## [7.0.1] (https://github.com/folio-org/ui-eholdings/tree/v7.0.1) (2021-10-19)
 

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -19,7 +19,7 @@ List.propTypes = {
   fullWidth: PropTypes.bool,
 };
 
-List.propTypes = {
+List.defaultProps = {
   className: '',
   fullWidth: false,
 };


### PR DESCRIPTION
This looks like a typo since proptypes were specified twice, and the
second (invalid) settings look like values, not value-types.

Refs [UIEH-1242](https://issues.folio.org/browse/UIEH-1242)
