### PR TITLE
UIEH-1266: eHoldings app throws an error when 0 tags comes in the response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [7.2.0] (IN PROGRESS)
 
 * Add tests for useFetchExportTitlesFromPackage hook. (UIEH-1182)
+* Fix eHoldings app throws an error when 0 tags comes in the response. (UIEH-1266)
 
 ## [7.1.2] (https://github.com/folio-org/ui-eholdings/tree/v7.1.2) (2022-03-29)
 

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -146,14 +146,17 @@ class SearchForm extends Component {
 
   getSortedDataOptions = () => {
     const { tagsModel } = this.props;
-    const dataOptions = getTagLabelsArr(tagsModel).map(tag => {
-      const tagDisplay = tag.label.toLowerCase();
 
-      return {
-        value: tagDisplay,
-        label: tagDisplay,
-      };
-    });
+    const dataOptions = getTagLabelsArr(tagsModel)
+      .filter(tag => tag.label)
+      .map(tag => {
+        const tagDisplay = tag.label.toLowerCase();
+
+        return {
+          value: tagDisplay,
+          label: tagDisplay,
+        };
+      });
 
     return sortBy(dataOptions, ['value']);
   }

--- a/src/components/search-form/search-form.test.js
+++ b/src/components/search-form/search-form.test.js
@@ -107,12 +107,45 @@ describe('Given SearchForm', () => {
   });
 
   describe('when search by tags enabled', () => {
-    it('should show field to search select', () => {
+    it('should have search field disabled', () => {
       const { getByTestId } = renderSearchForm({
         searchByTagsEnabled: true,
       });
 
       expect(getByTestId('search-submit').disabled).toBeTruthy();
+    });
+
+    it('should display tag options', () => {
+      const { getByText } = renderSearchForm({
+        searchByTagsEnabled: true,
+      });
+
+      expect(getByText('tag1')).toBeDefined();
+      expect(getByText('tag2')).toBeDefined();
+    });
+
+    describe('when no tags are provided', () => {
+      it('should display an empty message instead of options', () => {
+        const { getByText } = renderSearchForm({
+          searchByTagsEnabled: true,
+          tagsModel: {
+            resolver: {
+              state: {
+                tags: {
+                  records: [{
+                    attributes: {
+                      totalRecords: 0,
+                    },
+                  }],
+                },
+              },
+            },
+            isLoading: false,
+          },
+        });
+
+        expect(getByText('stripes-components.multiSelection.defaultEmptyMessage')).toBeDefined();
+      });
     });
   });
 


### PR DESCRIPTION
## Purpose
Fix eHoldings app throws an error when 0 tags comes in the response.

## Approach
This issue occurred due to the response `{totalRecords: 0}` when there's no tags.

Previously the `map` was applied to the array of the kind `[{totalRecords: 0}]` when there's no tags which led to `tag.label` to be `undefined`.

We couldn't just add a check for an undefined inside `map` because then multiselection filter would just display an empty option.

The solution was to filter out tags that don't have label prior to mapping through an array of tags. In this case the `map` applies to an empty array when there's no tags and the multiselection filter displays a user-friendly empty message.

## Screenshots
![chrome_mTSFMlupAc](https://user-images.githubusercontent.com/84023879/161072057-15e9a187-d401-498a-bab6-8e1b537eb1f0.gif)

## Issues
[UIEH-1266](https://issues.folio.org/browse/UIEH-1266)