### PR TITLE
UIEH-1263 [Package Detail Record] The accordion button "Holding statu…

### DIFF
--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -230,6 +230,7 @@ const CustomPackageEdit = ({
                 bodyContent={(
                   <>
                     <HoldingStatus
+                      id="packageHoldingStatus"
                       isOpen={sections.packageHoldingStatus}
                       onToggle={handleSectionToggle}
                       model={model}

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -261,6 +261,7 @@ const ManagedPackageEdit = ({
                   bodyContent={(
                     <>
                       <HoldingStatus
+                        id="packageHoldingStatus"
                         isOpen={sections.packageHoldingStatus}
                         onToggle={handleSectionToggle}
                         model={model}

--- a/src/components/package/show/components/holding-status/holding-status.js
+++ b/src/components/package/show/components/holding-status/holding-status.js
@@ -9,6 +9,7 @@ import {
 import SelectionStatus from '../../../selection-status';
 
 const propTypes = {
+  id: PropTypes.string,
   isOpen: PropTypes.bool.isRequired,
   model: PropTypes.object.isRequired,
   onAddToHoldings: PropTypes.func.isRequired,
@@ -16,6 +17,7 @@ const propTypes = {
 };
 
 const HoldingStatus = ({
+  id,
   isOpen,
   onToggle,
   onAddToHoldings,
@@ -31,7 +33,7 @@ const HoldingStatus = ({
       </Headline>
     )}
     open={isOpen}
-    id="packageHoldingStatus"
+    id={id}
     onToggle={onToggle}
   >
     <SelectionStatus
@@ -42,5 +44,6 @@ const HoldingStatus = ({
 );
 
 HoldingStatus.propTypes = propTypes;
+HoldingStatus.defaultProps = { id: 'packageHoldingStatus' };
 
 export default HoldingStatus;

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -268,6 +268,7 @@ const PackageShow = ({
     return (
       <>
         <HoldingStatus
+          id="packageShowHoldingStatus"
           isOpen={sections.packageShowHoldingStatus}
           onToggle={handleSectionToggle}
           onAddToHoldings={toggleSelectionConfirmationModal}


### PR DESCRIPTION
## Purpose
The issue reason was that an *id* of **HoldingStatus** component did not match to an *id* that was configured in **PackageShow** component to control Accordion show status. So, I think the *id* property of **HoldingStatus** component should be dynamic rather than static, since it was used in different components with different ids which was an actual cause for an issue.

## Approach
**HoldingStatus** component was modified to accept valid *id* property on demand and *packageShowHoldingStatus* value passed as an *id* property into **HoldingStatus** component in **PackageShow**

#### TODOS and Open Questions

* what *id* value should be used for **HoldingStatus** component since it's a static value?