### PR TITLE
UIEH-1265: Replace or remove react-hot-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add tests for useFetchExportTitlesFromPackage hook. (UIEH-1182)
 * Fix eHoldings app throws an error when 0 tags comes in the response. (UIEH-1266)
+* Replace or remove react-hot-loader. (UIEH-1265)
 
 ## [7.1.2] (https://github.com/folio-org/ui-eholdings/tree/v7.1.2) (2022-03-29)
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "prop-types": "^15.6.2",
     "react-final-form": "^6.3.0",
     "react-final-form-arrays": "^3.1.0",
-    "react-hot-loader": "^4.3.12",
     "react-router-prop-types": "^1.0.4",
     "redux-actions": "^2.2.1",
     "redux-observable": "^1.2.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import { hot } from 'react-hot-loader';
 import { withConnect } from '@folio/stripes/connect';
 
 import EHoldings from './components/eholdings';

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,4 @@ import { withConnect } from '@folio/stripes/connect';
 
 import EHoldings from './components/eholdings';
 
-export default hot(module)(withConnect(EHoldings));
+export default withConnect(EHoldings);


### PR DESCRIPTION
## Description
Remove react-hot-loader

## Issues
[UIEH-1265](https://issues.folio.org/browse/UIEH-1265)

