### PR TITLE
UIEH-1269 Save shortcut key does not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [7.2.0] (IN PROGRESS)
 
+* Save shortcut key does not work. (UIEH-1269)
 * Add tests for useFetchExportTitlesFromPackage hook. (UIEH-1182)
 * Replace or remove react-hot-loader. (UIEH-1265)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [7.2.0] (IN PROGRESS)
 
-* Save shortcut key does not work. (UIEH-1269)
 * Add tests for useFetchExportTitlesFromPackage hook. (UIEH-1182)
 * Replace or remove react-hot-loader. (UIEH-1265)
+* Save shortcut key does not work. (UIEH-1269)
 
 ## [7.1.3] (https://github.com/folio-org/ui-eholdings/tree/v7.1.3) (2022-04-06)
 

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -283,7 +283,7 @@ export const combineMCLProps = defaultProps => customProps => {
 };
 
 export const handleSaveKeyFormSubmit = (formRef) => (event) => {
-  const submitEvent = new Event('submit');
+  const submitEvent = new Event('submit', { bubbles: true });
 
   event.preventDefault();
   formRef.dispatchEvent(submitEvent);


### PR DESCRIPTION
added bubbles property into submit event

## Learning
[Bug: Using dispatchEvent 'submit' CustomEvent failure to trigger form onSubmit #20151](https://github.com/facebook/react/issues/20151)