### PR TITLE
UIEH-1237 Remove parameters from POST request for '/eholdings/kb-cred…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add tests for useFetchExportTitlesFromPackage hook. (UIEH-1182)
 * Replace or remove react-hot-loader. (UIEH-1265)
 * Package Detail Record> Usage & analysis accordion > Apply pagination to Titles list. (UIEH-1259)
+* Remove parameters from POST request for '/eholdings/kb-credentials/{kb-credentials-id}/users'. (UIEH-1237)
 
 ## [7.1.4] (https://github.com/folio-org/ui-eholdings/tree/v7.1.4) (2022-04-08)
 

--- a/src/routes/settings-assigned-users-route/settings-assigned-users-route.js
+++ b/src/routes/settings-assigned-users-route/settings-assigned-users-route.js
@@ -96,31 +96,13 @@ const SettingsAssignedUsersRoute = ({
       }));
   }, [assignedUsers.errors]);
 
-  const getPatronGroupNameById = id => {
-    return userGroups.items.find(userGroup => userGroup.id === id)?.group;
-  };
 
   const getFormattedUserData = user => {
-    const {
-      patronGroup,
-      username,
-      id,
-      personal: {
-        firstName,
-        middleName,
-        lastName,
-      },
-    } = user;
+    const { id } = user;
 
     const attributes = {
-      credentialsId: kbId,
-      patronGroup: getPatronGroupNameById(patronGroup),
-      lastName,
+      credentialsId: kbId
     };
-
-    if (username) attributes.userName = username;
-    if (firstName) attributes.firstName = firstName;
-    if (middleName) attributes.middleName = middleName;
 
     return {
       data: {


### PR DESCRIPTION
## Description
Remove parameters from POST request for '/eholdings/kb-credentials/{kb-credentials-id}/users'.

## Approach
Changed the implementation of (getFormattedUserData) function inside "settings-assigned-users-route.js" which was destructuring user's personal data and was passing to attributes property. Now the attributes property only has credentialsId.

## Issue
[UIEH-1237](https://issues.folio.org/browse/UIEH-1237)