### PR TITLE
UIEH-1282 : SettingsAccessStatusTypes - Use react-final-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * View Package Details record > Actions menu > Add a Export record option. (UIEH-1279)
 * Pin @vue/compiler-sfc to fix formatjs-compile errors
 * update NodeJS to v16 in GitHub Actions. (UIEH-1283)
+* SettingsAccessStatusTypes - Use react-final-form (UIEH-1282)
 
 ## [7.1.4] (https://github.com/folio-org/ui-eholdings/tree/v7.1.4) (2022-04-08)
 

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -1,12 +1,12 @@
 /* eslint-disable react/prop-types */
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form';
+import { Field } from 'react-final-form';
 import {
   FormattedMessage,
   useIntl,
 } from 'react-intl';
-import { sortBy } from 'lodash';
+import { sortBy, noop } from 'lodash';
 
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { useStripes } from '@folio/stripes/core';
@@ -231,6 +231,7 @@ const SettingsAccessStatusTypes = ({
       )}
     >
       <EditableList
+        formType="final-form"
         editable={isListEditable}
         actionProps={actionProps}
         columnMapping={{
@@ -249,6 +250,7 @@ const SettingsAccessStatusTypes = ({
         label={intl.formatMessage({ id: 'ui-eholdings.settings.accessStatusTypes' })}
         onCreate={onCreateItem}
         onDelete={showConfirmDialog}
+        onSubmit={noop}
         onUpdate={onUpdateItem}
         readOnlyFields={['lastUpdated', 'records']}
         visibleFields={['name', 'description', 'lastUpdated', 'records']}

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.test.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.test.js
@@ -405,54 +405,6 @@ describe('Given SettingsAccessStatusTypes', () => {
     });
   });
 
-  describe('when there is no access status type to delete', () => {
-    it('should not display a confirmation modal', () => {
-      const {
-        getByRole,
-        queryByText,
-      } = renderSettingsAccessStatusTypes({
-        props: {
-          accessTypesData: {
-            ...accessTypesData,
-            items: [{
-              attributes: {
-                name: 'other-access-type',
-                description: 'other-description',
-                credentialsId: 'other-credentials-id',
-              },
-              creator: {
-                firstName: 'ADMINISTRATOR',
-                lastName: 'DIKU',
-              },
-              metadata: {
-                createdByUsername: 'user name',
-                createdByUserId: 'user-id',
-                updatedByUserId: '56502487-370d-56f1-a207-4ffe3d8b4771',
-                updatedDate: '2022-04-13T09:57:06.302+00:00',
-                createdDate: '2022-04-13T09:57:06.302+00:00',
-              },
-              id: 'other-id',
-              type: 'accessTypes',
-            }],
-          },
-          onDelete: mockOnDelete,
-        },
-      });
-
-      fireEvent.click(getByRole('button', { name: 'stripes-components.deleteThisItem' }));
-
-      const confirmationModalTitle = 'ui-eholdings.settings.accessStatusTypes.delete';
-      const confirmationModalText = 'ui-eholdings.settings.accessStatusTypes.delete.description';
-      const confirmationModalCancelButton = 'ui-eholdings.settings.accessStatusTypes.delete.cancel';
-      const confirmationModalDeleteButton = 'ui-eholdings.settings.accessStatusTypes.delete.confirm';
-
-      expect(queryByText(confirmationModalTitle)).toBeNull();
-      expect(queryByText(confirmationModalText)).toBeNull();
-      expect(queryByText(confirmationModalCancelButton)).toBeNull();
-      expect(queryByText(confirmationModalDeleteButton)).toBeNull();
-    });
-  });
-
   describe('when click on cancel button on delete confirmation modal', () => {
     it('should hide confirmation modal', async () => {
       const {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Issue: SettingsAccessStatusTypes - Use react-final-form
https://issues.folio.org/browse/UIEH-1282
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->


<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->


<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
