### PR TITLE
UIEH-1297 The error message 'Knowledge base not configured' still displayed when user go to 'Settings/eHoldings' link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Remove parameters from POST request for '/eholdings/kb-credentials/{kb-credentials-id}/users'. (UIEH-1237)
 * Remove call to "/groups" api in settings/eholdings/assigned users. (UIEH-1236)
 * Rework-kb-credentials: Remove attributes from user schema. (UIEH-1286)
+* Fix error message "Knowledge base not configured" still displayed when user go to "Settings/eHoldings" link. (UIEH-1297)
 
 ## [7.1.4] (https://github.com/folio-org/ui-eholdings/tree/v7.1.4) (2022-04-08)
 

--- a/src/routes/application-route/application-route.js
+++ b/src/routes/application-route/application-route.js
@@ -80,7 +80,7 @@ class ApplicationRoute extends Component {
       return <FailedBackendErrorScreen />;
     }
 
-    if (status.isLoaded && !status.isConfigurationValid) {
+    if (status.isLoaded && !status.isConfigurationValid && !showSettings) {
       return hasMultipleKbCredentials
         ? <UserNotAssignedToKbErrorScreen />
         : <InvalidBackendErrorScreen />;

--- a/src/routes/application-route/application-route.test.js
+++ b/src/routes/application-route/application-route.test.js
@@ -1,9 +1,6 @@
 import { MemoryRouter } from 'react-router-dom';
 
-import {
-  render,
-  cleanup,
-} from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import ApplicationRoute from './application-route';
 import Harness from '../../../test/jest/helpers/harness';
@@ -62,8 +59,6 @@ describe('Given ApplicationRoute', () => {
     mockGetBackendStatus.mockClear();
     mockGetKbCredentials.mockClear();
   });
-
-  afterEach(cleanup);
 
   describe('when page is not settings', () => {
     it('should call status endpoint', () => {
@@ -209,6 +204,26 @@ describe('Given ApplicationRoute', () => {
             isRejected: true,
             status: 429,
           },
+        },
+        showSettings: true,
+      });
+
+      expect(getByText('Page content')).toBeDefined();
+    });
+  });
+
+  describe('when kb credentials are now configured', () => {
+    it('should render page content', () => {
+      const { getByText } = renderApplicationRoute({
+        status: {
+          ...status,
+          isLoaded: true,
+          isConfigurationValid: false,
+        },
+        kbCredentials: {
+          ...kbCredentials,
+          isLoaded: true,
+          items: [],
         },
         showSettings: true,
       });


### PR DESCRIPTION
## Description
Fix error message 'Knowledge base not configured' still displayed when user go to 'Settings/eHoldings' link.
Should not show configuration-related errors in Settings page

## Screenshots

https://user-images.githubusercontent.com/19309423/174264903-c20c6f7a-d325-4358-a14b-c517fc4afecf.mp4

## Issues
[UIEH-1297](https://issues.folio.org/browse/UIEH-1297)

