### PR TITLE
UIEH-1304 Fix Usage Consolidation - does not return 12 months when starting period is not January

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Rework-kb-credentials: Remove attributes from user schema. (UIEH-1286)
 * Fix error message "Knowledge base not configured" still displayed when user go to "Settings/eHoldings" link. (UIEH-1297)
 * Fix Settings > eholdings > Assigned users page does not look right. (UIEH-1296)
+* Fix Usage Consolidation - does not return 12 months when starting period is not January. (UIEH-1304)
 
 ## [7.1.4] (https://github.com/folio-org/ui-eholdings/tree/v7.1.4) (2022-04-08)
 

--- a/src/features/usage-consolidation-accordion/full-text-request-usage-table/full-text-request-usage-table.js
+++ b/src/features/usage-consolidation-accordion/full-text-request-usage-table/full-text-request-usage-table.js
@@ -59,7 +59,7 @@ const FullTextRequestUsageTable = ({
   const fullTextRequestUsageMCLRef = useRef(null);
 
   const indexOfStartMonth = Object.values(monthsNames).indexOf(startMonth);
-  const months = Object.values(monthsNames).slice(indexOfStartMonth);
+  const months = Object.values(monthsNames).slice(indexOfStartMonth).concat(Object.values(monthsNames).slice(0, indexOfStartMonth));
 
   const monthsColumnNames = months.reduce((acc, month) => ({
     ...acc,

--- a/src/features/usage-consolidation-accordion/full-text-request-usage-table/full-text-request-usage-table.test.js
+++ b/src/features/usage-consolidation-accordion/full-text-request-usage-table/full-text-request-usage-table.test.js
@@ -12,7 +12,7 @@ import FullTextRequestUsageTable from './full-text-request-usage-table';
 const usageData = {
   totals: {
     publisher: {
-      counts: [5, 4, 3, 2],
+      counts: [5, 4, 3, 2, 1, null, null, null, null, null, null, null],
       total: 14,
     },
   },
@@ -96,6 +96,19 @@ describe('Given FullTextRequestUsageTable', () => {
       });
 
       expect(getByText('10')).toBeDefined();
+    });
+  });
+
+  describe('when start month is not Jan', () => {
+    it('should display all 12 months starting with start month', () => {
+      const { getByText } = renderFullTextRequestUsageTable();
+
+      const months = ['sep', 'oct', 'nov', 'dec', 'jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug'];
+      const foundMonthsCount = months
+        .map(month => getByText(`ui-eholdings.usageConsolidation.fullTextRequestUsageTable.header.${month}`))
+        .filter(el => !!el);
+
+      expect(foundMonthsCount.length).toEqual(12);
     });
   });
 });


### PR DESCRIPTION
## Description
Fix not all months are displayed in Usage Consolidation.
Issue was caused by slicing months array starting from start month (for example March), but then we need to append months from January to start month at the end

## Screenshots
![image](https://user-images.githubusercontent.com/19309423/175514375-869b017f-a919-4e31-96c9-55fe110173f1.png)

## Issues
[UIEH-1304](https://issues.folio.org/browse/UIEH-1304)