### PR TITLE
UIEH-1305 refactor away from react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fix error message "Knowledge base not configured" still displayed when user go to "Settings/eHoldings" link. (UIEH-1297)
 * Fix Settings > eholdings > Assigned users page does not look right. (UIEH-1296)
 * Fix Usage Consolidation - does not return 12 months when starting period is not January. (UIEH-1304)
+* refactor away from `react-intl-safe-html`; `react-intl` `v5` subsumes it. Refs UIEH-1305.
 
 ## [7.1.4] (https://github.com/folio-org/ui-eholdings/tree/v7.1.4) (2022-04-08)
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "webpack": "^4.0.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^3.0.0",
     "classnames": "^2.2.5",
     "currency-symbol-map": "^4.0.4",
     "file-saver": "^2.0.5",

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -14,7 +14,6 @@ import {
   useStripes,
   IfPermission,
 } from '@folio/stripes/core';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
 import {
   Button,
@@ -278,7 +277,7 @@ const PackageShow = ({
         cancelButtonLabel={<FormattedMessage id="ui-eholdings.cancel" />}
         confirmButtonLabel={<FormattedMessage id="ui-eholdings.selectPackage.confirmationModal.confirmationButtonText" />}
       >
-        <SafeHTMLMessage id="ui-eholdings.selectPackage.confirmationModal.message" />
+        <FormattedMessage id="ui-eholdings.selectPackage.confirmationModal.message" />
       </SelectionModal>
     );
   };

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -8,7 +8,6 @@ import {
 } from 'react-intl';
 import { sortBy, noop } from 'lodash';
 
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { useStripes } from '@folio/stripes/core';
 import {
   Pane,
@@ -264,7 +263,7 @@ const SettingsAccessStatusTypes = ({
         heading={<FormattedMessage id="ui-eholdings.settings.accessStatusTypes.delete" />}
         ariaLabel={intl.formatMessage({ id: 'ui-eholdings.settings.accessStatusTypes.delete' })}
         message={
-          <SafeHTMLMessage
+          <FormattedMessage
             id="ui-eholdings.settings.accessStatusTypes.delete.description"
             values={{ name: selectedStatusType?.attributes?.name || '' }}
           />

--- a/src/components/settings/settings-assigned-users/settings-assigned-users.js
+++ b/src/components/settings/settings-assigned-users/settings-assigned-users.js
@@ -5,7 +5,6 @@ import {
   useIntl,
 } from 'react-intl';
 
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   IfPermission,
   Pluggable,
@@ -190,7 +189,7 @@ const SettingsAssignedUsers = ({
           </ModalFooter>
         )}
       >
-        <SafeHTMLMessage
+        <FormattedMessage
           id="ui-eholdings.settings.assignedUsers.confirmationModal.prompt"
           values={{
             userName: userToBeUnassigned.name,
@@ -217,7 +216,7 @@ const SettingsAssignedUsers = ({
         </ModalFooter>
       )}
     >
-      <SafeHTMLMessage
+      <FormattedMessage
         id="ui-eholdings.settings.assignedUsers.alreadyAssignedModal.message"
         values={{ userName: getFullName(userToBeAssigned.personal) }}
       />

--- a/src/components/settings/settings-custom-labels/settings-custom-labels.js
+++ b/src/components/settings/settings-custom-labels/settings-custom-labels.js
@@ -13,7 +13,6 @@ import {
   pickBy,
 } from 'lodash';
 
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   Col,
   ConfirmationModal,
@@ -168,12 +167,12 @@ const SettingsCustomLabels = ({
             ariaLabel={intl.formatMessage({ id: 'ui-eholdings.settings.customLabels.remove' })}
             message={
               <>
-                <SafeHTMLMessage
+                <FormattedMessage
                   id="ui-eholdings.settings.customLabels.remove.description"
                   values={{ label: removingLabels }}
                 />
                 <br />
-                <SafeHTMLMessage id="ui-eholdings.settings.customLabels.remove.note" />
+                <FormattedMessage id="ui-eholdings.settings.customLabels.remove.note" />
               </>
             }
             onCancel={closeModal}

--- a/src/components/settings/settings-knowledge-base/settings-knowledge-base.js
+++ b/src/components/settings/settings-knowledge-base/settings-knowledge-base.js
@@ -13,7 +13,6 @@ import {
 import { useHistory } from 'react-router';
 
 import { IfPermission } from '@folio/stripes/core';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   Icon,
   TextField,
@@ -236,7 +235,7 @@ const SettingsKnowledgeBase = ({
         onClose={toggleDeleteConfirmationModal}
         id="delete-kb-confirmation-modal"
       >
-        <SafeHTMLMessage
+        <FormattedMessage
           id="ui-eholdings.settings.kb.delete.warning"
           values={{ kbName: currentKBName }}
         />

--- a/src/components/tags/tags.js
+++ b/src/components/tags/tags.js
@@ -6,7 +6,6 @@ import {
 } from 'lodash';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { MultiSelection } from '@folio/stripes/components';
 
 const propTypes = {
@@ -126,7 +125,7 @@ const Tags = ({
 
     return (
       <div>
-        <SafeHTMLMessage
+        <FormattedMessage
           id="ui-eholdings.tags.addTagFor"
           values={{ filter: filterValue }}
         />

--- a/src/features/agreements-accordion/agreements-accordion.js
+++ b/src/features/agreements-accordion/agreements-accordion.js
@@ -18,7 +18,6 @@ import {
   Modal,
   ModalFooter,
 } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import Toaster from '../../components/toaster';
 
@@ -221,7 +220,7 @@ const AgreementsAccordion = ({
           </ModalFooter>
         )}
       >
-        <SafeHTMLMessage
+        <FormattedMessage
           id="ui-eholdings.agreements.unassignModal.description"
           values={{
             agreementName: currentAgreement.name,


### PR DESCRIPTION
All formatting options provided by `react-intl-safe-html` have been
implemented natively by `react-intl` as of `v5`.

Refs [UIEH-1305](https://issues.folio.org/browse/UIEH-1305)