### PR TITLE
UIEH-1169: new permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,7 +330,9 @@
           "ui-eholdings.settings.enabled",
           "kb-ebsco.kb-credentials.uc.item.get",
           "kb-ebsco.currencies.collection.get",
-          "kb-ebsco.uc-credentials.item.get"
+          "kb-ebsco.uc-credentials.item.get",
+          "kb-ebsco.uc-credentials.client-id.get",
+          "kb-ebsco.uc-credentials.client-secret.get"
         ]
       },
       {


### PR DESCRIPTION
Settings (eholdings): View Usage Consolidation API credentials is extended with new permissions to fetch uc-credentials-client-id and uc-credentials-client-secret.

## Issue
The previous PR: https://github.com/folio-org/ui-eholdings/pull/1566
The story: [UIEH-1169](https://issues.folio.org/browse/UIEH-1169)