### PR TITLE
UIEH-1315 Clear assigned users redux when leaving Assigned Users page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-eholdings
 
+## [7.3.0] (IN PROGRESS)
+
+* Clear assigned users redux when leaving Assigned Users page. (UIEH-1315)
+
 ## [7.2.0] (https://github.com/folio-org/ui-eholdings/tree/v7.2.0) (2022-07-08)
 
 * Add tests for useFetchExportTitlesFromPackage hook. (UIEH-1182)

--- a/src/redux/actions/kb-credentials-users/clear-kb-credentials-user.js
+++ b/src/redux/actions/kb-credentials-users/clear-kb-credentials-user.js
@@ -1,0 +1,5 @@
+export const CLEAR_KB_CREDENTIALS_USER = 'CLEAR_KB_CREDENTIALS_USER';
+
+export const clearKBCredentialsUser = () => ({
+  type: CLEAR_KB_CREDENTIALS_USER,
+});

--- a/src/redux/actions/kb-credentials-users/index.js
+++ b/src/redux/actions/kb-credentials-users/index.js
@@ -7,3 +7,4 @@ export * from './post-kb-credentials-user-failure';
 export * from './delete-kb-credentials-user';
 export * from './delete-kb-credentials-user-success';
 export * from './delete-kb-credentials-user-failure';
+export * from './clear-kb-credentials-user';

--- a/src/redux/reducers/kb-credentials-users.js
+++ b/src/redux/reducers/kb-credentials-users.js
@@ -8,6 +8,7 @@ import {
   POST_KB_CREDENTIALS_USER,
   POST_KB_CREDENTIALS_USER_SUCCESS,
   POST_KB_CREDENTIALS_USER_FAILURE,
+  CLEAR_KB_CREDENTIALS_USER,
 } from '../actions';
 
 import { formatErrors } from '../helpers';
@@ -72,6 +73,9 @@ const handlers = {
     isLoading: false,
     hasFailed: true,
     errors: formatErrors(action.payload),
+  }),
+  [CLEAR_KB_CREDENTIALS_USER]: () => ({
+    ...initialState,
   }),
 };
 export default function kbCredentialsUsers(state, action) {

--- a/src/redux/reducers/tests/kbCredentialsUsers.test.js
+++ b/src/redux/reducers/tests/kbCredentialsUsers.test.js
@@ -9,6 +9,7 @@ import {
   POST_KB_CREDENTIALS_USER,
   POST_KB_CREDENTIALS_USER_SUCCESS,
   POST_KB_CREDENTIALS_USER_FAILURE,
+  CLEAR_KB_CREDENTIALS_USER,
 } from '../../actions';
 
 const state = {
@@ -138,6 +139,21 @@ describe('kbCredentialsUsersReducer', () => {
       hasFailed: true,
       errors: [{ title: 'error1' }],
     });
+  });
+
+  it('should handle CLEAR_KB_CREDENTIALS_USER action', () => {
+    const action = {
+      type: CLEAR_KB_CREDENTIALS_USER,
+    };
+
+    const changedState = {
+      ...state,
+      isLoading: false,
+      hasLoaded: true,
+      errors: [],
+    };
+
+    expect(kbCredentialsUsersReducer(changedState, action)).toEqual(state);
   });
 
   describe('when handle other action', () => {

--- a/src/routes/settings-assigned-users-route/index.js
+++ b/src/routes/settings-assigned-users-route/index.js
@@ -5,6 +5,7 @@ import {
   getKBCredentialsUsers as getKBCredentialsUsersAction,
   deleteKBCredentialsUser as deleteKBCredentialsUserAction,
   postKBCredentialsUser as postKBCredentialsUserAction,
+  clearKBCredentialsUser as clearKBCredentialsUserAction,
 } from '../../redux/actions';
 
 export default connect(
@@ -16,5 +17,6 @@ export default connect(
     getKBCredentialsUsers: getKBCredentialsUsersAction,
     postKBCredentialsUser: postKBCredentialsUserAction,
     deleteKBCredentialsUser: deleteKBCredentialsUserAction,
+    clearKBCredentialsUser: clearKBCredentialsUserAction,
   }
 )(SettingsAssignedUsersRoute);

--- a/src/routes/settings-assigned-users-route/settings-assigned-users-route.js
+++ b/src/routes/settings-assigned-users-route/settings-assigned-users-route.js
@@ -22,6 +22,7 @@ const ASSIGNED_TO_ANOTHER_CREDENTIALS_BACKEND_ERROR = 'The user is already assig
 
 const propTypes = {
   assignedUsers: KbCredentialsUsers.kbCredentialsUsersReduxStateShape.isRequired,
+  clearKBCredentialsUser: PropTypes.func.isRequired,
   deleteKBCredentialsUser: PropTypes.func.isRequired,
   getKBCredentialsUsers: PropTypes.func.isRequired,
   kbCredentials: KbCredentials.KbCredentialsReduxStateShape,
@@ -33,6 +34,7 @@ const SettingsAssignedUsersRoute = ({
   getKBCredentialsUsers,
   deleteKBCredentialsUser,
   postKBCredentialsUser,
+  clearKBCredentialsUser,
   assignedUsers,
   kbCredentials,
   match: { params: { kbId } },
@@ -53,6 +55,10 @@ const SettingsAssignedUsersRoute = ({
       setAlreadyAssignedMessageDisplayed(true);
     }
   }, [assignedUsers.errors]);
+
+  useEffect(() => {
+    return () => clearKBCredentialsUser();
+  }, []);
 
   const hideAlreadyAssignedMessage = () => {
     setAlreadyAssignedMessageDisplayed(false);


### PR DESCRIPTION
## Description
Fix exception when navigating from and to Assign Users page after failed attempt to assign a user
Issue was caused by redux state that was not being cleared and showed and error, when component's state that stored user data was cleared and attempting to access it threw `reading prop of undefined` error

## Screenshots

https://user-images.githubusercontent.com/19309423/178729034-40b0d205-eae8-41cb-b800-6ce5dd16e637.mp4

## Issues
[UIEH-1315](https://issues.folio.org/browse/UIEH-1315)
