### PR TITLE
UIEH-1333: eHoldings export: Remove "sort" from "titleSearchFilters" export config field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Title Detail Record: Add Alternate title(s) field. (UIEH-1327)
 * Export package/title modal: Include Package level token in list of fields to select. (UIEH-1316)
 * Export package/title modal: Include Provider level token in list of fields to select. (UIEH-1317)
+* eHoldings export: Remove "sort" from "titleSearchFilters" export config field. (UIEH-1333)
 
 ## [7.2.3] (https://github.com/folio-org/ui-eholdings/tree/v7.2.3) (2022-08-29)
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -128,7 +128,7 @@ const PackageShow = ({
   });
 
   const titleSearchFilters = useMemo(() => {
-    const params = transformQueryParams('titles', omit(pkgSearchParams, ['page', 'count']));
+    const params = transformQueryParams('titles', omit(pkgSearchParams, ['page', 'count', 'sort']));
 
     return qs.stringify(params);
   }, [pkgSearchParams]);


### PR DESCRIPTION
## Purpose 
Remove the `sort` parameter from `titleSearchFilters` during export.

## Issues
[UIEH-1333](https://issues.folio.org/browse/UIEH-1333)

## Screencast





https://user-images.githubusercontent.com/77053927/199234578-1774654c-b9f0-4113-a9af-43e8686834a2.mp4








