### PR TITLE
UIEH-1346: Fixed no KB detected error incorrectly popping up on ehold…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Difficulty returning to the eholdings page after adding a new Agreement. (UIEH-1219)
 * Enable react-hooks/exhaustive-deps ESLint rule. (UIEH-1339)
 * Error while accessing undefined properties in eHolidngs Titles list. (UIEH-1344)
+* Fixed no KB detected error incorrectly popping up on eholdings page. (UIEH-1346)
 
 ## [7.3.2] (https://github.com/folio-org/ui-eholdings/tree/v7.3.2) (2022-11-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [7.4.0] (IN PROGRESS)
 * Difficulty returning to the eholdings page after adding a new Agreement. (UIEH-1219)
 * Enable react-hooks/exhaustive-deps ESLint rule. (UIEH-1339)
+* Error while accessing undefined properties in eHolidngs Titles list. (UIEH-1344)
 
 ## [7.3.2] (https://github.com/folio-org/ui-eholdings/tree/v7.3.2) (2022-11-30)
 

--- a/src/components/title-list-item/title-list-item.js
+++ b/src/components/title-list-item/title-list-item.js
@@ -108,9 +108,9 @@ const TitleListItem = ({
           <div className={cx('itemMetadata')}>
             <SelectedLabel isSelected={item.isSelected} />
 
-            {item.visibilityData.isHidden && <HiddenLabel />}
+            {item.visibilityData?.isHidden && <HiddenLabel />}
 
-            {!isEmpty(item.tags.tagList) && <TagsLabel tagList={item.tags.tagList} />}
+            {!isEmpty(item.tags?.tagList) && <TagsLabel tagList={item.tags?.tagList} />}
           </div>
         )}
       </InternalLink>

--- a/src/routes/application-route/application-route.js
+++ b/src/routes/application-route/application-route.js
@@ -22,6 +22,7 @@ class ApplicationRoute extends Component {
         version: PropTypes.string,
       }),
     }),
+    isFinished: PropTypes.bool,
     kbCredentials: KbCredentials.KbCredentialsReduxStateShape.isRequired,
     showSettings: PropTypes.bool,
     status: PropTypes.shape({
@@ -49,6 +50,7 @@ class ApplicationRoute extends Component {
     const {
       status,
       interfaces: { eholdings: version },
+      isFinished,
       showSettings,
       children,
       kbCredentials,
@@ -56,7 +58,7 @@ class ApplicationRoute extends Component {
 
     const hasMultipleKbCredentials = kbCredentials.items?.length > 1;
 
-    if (!version && !status.isLoading && !showSettings) {
+    if (!version && isFinished && !showSettings) {
       return <NoBackendErrorScreen />;
     }
 

--- a/src/routes/application-route/application-route.test.js
+++ b/src/routes/application-route/application-route.test.js
@@ -249,12 +249,13 @@ describe('Given ApplicationRoute', () => {
     });
   });
 
-  describe('when eholdings interface is missing, status is not loading and page is not settings', () => {
+  describe('when eholdings interface is missing, status is finished and page is not settings', () => {
     it('should render no backend error', () => {
       const { getByText } = renderApplicationRoute({
         interfaces: {
           eholdings: null,
         },
+        isFinished: true,
       });
 
       expect(getByText('ui-eholdings.server.errors.noKbDetected')).toBeDefined();

--- a/src/routes/application-route/index.js
+++ b/src/routes/application-route/index.js
@@ -16,6 +16,7 @@ export default connect(
     return {
       status: createResolver(eholdings?.data || {}).find('statuses', 'status'),
       interfaces: discovery?.interfaces || {},
+      isFinished: !!discovery?.isFinished,
       kbCredentials: selectPropFromData(store, 'kbCredentials'),
     };
   }, {


### PR DESCRIPTION
…ings page

## Description
 In application-route.js, version was checked together with status.isLoading flag. status.isLoading refers to a different request and is not synchronized with version. Version is a part of discovery.interfaces.eholdings property.

## Screenshots
![Untitled_ Jan 6, 2023 3_02 PM](https://user-images.githubusercontent.com/101110095/211000197-1c0aa1f9-01cd-4a99-a947-53726318cce1.gif)

## Issues
[UIEH-1346](https://issues.folio.org/browse/UIEH-1346)