### PR TITLE
UIEH-1349: Stop infinity loading of package titles when a user edits the package record while they are being added/removed to holdings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed no KB detected error incorrectly popping up on eholdings page. (UIEH-1346)
 * Bump stripes to 8.0.0 for Orchid/2023-R1. (UIEH-1352)
 * Upgrade react-redux to v8. (UIEH-1353)
+* Stop infinity loading of package titles when a user edits the package record while they are being added/removed to holdings. (UIEH-1349)
 
 ## [7.3.2] (https://github.com/folio-org/ui-eholdings/tree/v7.3.2) (2022-11-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-eholdings
 
+## [8.0.1] (IN PROGRESS)
+
+* Stop infinity loading of package titles when a user edits the package record while they are being added/removed to holdings. (UIEH-1349)
+
 ## [8.0.0] (https://github.com/folio-org/ui-eholdings/tree/v8.0.0) (2023-02-15)
 
 * Enable react-hooks/exhaustive-deps ESLint rule. (UIEH-1339)
@@ -8,7 +12,6 @@
 * Fixed no KB detected error incorrectly popping up on eholdings page. (UIEH-1346)
 * Bump stripes to 8.0.0 for Orchid/2023-R1. (UIEH-1352)
 * Upgrade react-redux to v8. (UIEH-1353)
-* Stop infinity loading of package titles when a user edits the package record while they are being added/removed to holdings. (UIEH-1349)
 
 ## [7.3.2] (https://github.com/folio-org/ui-eholdings/tree/v7.3.2) (2022-11-30)
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -196,6 +196,7 @@ const PackageShow = ({
       <Button
         data-test-eholdings-package-remove-from-holdings-action
         buttonStyle="dropdownItem fullWidth"
+        data-testid={translationId}
         onClick={() => {
           onToggle();
           handleSelectionToggle();

--- a/src/routes/package-show-route/package-show-route.js
+++ b/src/routes/package-show-route/package-show-route.js
@@ -165,7 +165,7 @@ class PackageShowRoute extends Component {
 
   componentWillUnmount() {
     this.props.clearCostPerUseData();
-    window.clearTimeout(this.timeout);
+    clearInterval(this.interval);
   }
 
   /* This method is common between package-show and package-edit routes
@@ -217,6 +217,8 @@ class PackageShowRoute extends Component {
     this.setState(() => {
       return { isTitlesUpdating: true };
     });
+
+    clearInterval(this.interval);
 
     this.interval = window.setInterval(() => {
       const arePackageTitlesUpdated = this.props.packageTitles.items


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Stop infinity loading of package titles when a user fires adding packages to holdings and immediately starts:
- editing the record;
- removing packages from eholdings.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues
[UIEH-1349](https://issues.folio.org/browse/UIEH-1349)

## Screencast


https://user-images.githubusercontent.com/77053927/219599279-1d2b2c05-29be-4a2e-ae38-e37c130cb601.mp4



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
