### PR TITLE
UIEH-1357: Only display tags that have already been added to records …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [8.0.1] (IN PROGRESS)
 
 * Stop infinity loading of package titles when a user edits the package record while they are being added/removed to holdings. (UIEH-1349)
+* Only display tags that have already been added to records as options when the user tries to search for records. (UIEH-1357)
 
 ## [8.0.0] (https://github.com/folio-org/ui-eholdings/tree/v8.0.0) (2023-02-15)
 

--- a/src/components/details-view/details-view.js
+++ b/src/components/details-view/details-view.js
@@ -102,6 +102,13 @@ class DetailsView extends Component {
     this.props.goBack();
   };
 
+  renderAccordionHeader = (props) => (
+    <AccordionListHeader
+      {...props}
+      isLoading={this.props.accordionHeaderLoading}
+    />
+  );
+
   renderFirstMenu = () => {
     const {
       paneTitle,
@@ -142,7 +149,6 @@ class DetailsView extends Component {
       onListToggle,
       ariaRole,
       bodyAriaRole,
-      accordionHeaderLoading,
     } = this.props;
 
     const isListAccordionOpen = sections && sections[listSectionId];
@@ -194,12 +200,7 @@ class DetailsView extends Component {
               data-test-eholdings-details-view-list={type}
             >
               <Accordion
-                header={props => (
-                  <AccordionListHeader
-                    {...props}
-                    isLoading={accordionHeaderLoading}
-                  />
-                )}
+                header={this.renderAccordionHeader}
                 headerProps={{
                   resultsLength,
                   'data-testid': `accordion-toggle-button-${listSectionId}`,

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -75,7 +75,7 @@ class SearchForm extends Component {
       titles: PropTypes.string.isRequired
     }),
     sort: PropTypes.string,
-    tagsModel: PropTypes.object.isRequired,
+    tagsModelOfAlreadyAddedTags: PropTypes.object,
   };
 
   static defaultProps = {
@@ -149,12 +149,12 @@ class SearchForm extends Component {
   };
 
   getSortedDataOptions = () => {
-    const { tagsModel } = this.props;
+    const { tagsModelOfAlreadyAddedTags } = this.props;
 
-    const dataOptions = getTagLabelsArr(tagsModel)
-      .filter(tag => tag.label)
+    const dataOptions = getTagLabelsArr(tagsModelOfAlreadyAddedTags)
+      .filter(tag => tag.value)
       .map(tag => {
-        const tagDisplay = tag.label.toLowerCase();
+        const tagDisplay = tag.value.toLowerCase();
 
         return {
           value: tagDisplay,
@@ -167,7 +167,7 @@ class SearchForm extends Component {
 
   renderTagFilter() {
     const {
-      tagsModel,
+      tagsModelOfAlreadyAddedTags,
       searchByTagsEnabled,
       searchFilter,
       onStandaloneFilterToggle,
@@ -191,7 +191,7 @@ class SearchForm extends Component {
         onToggle={this.toggleSection}
         searchByTagsEnabled={searchByTagsEnabled}
         searchFilter={searchFilter}
-        tagsModel={tagsModel}
+        tagsModel={tagsModelOfAlreadyAddedTags}
       />
     );
   }

--- a/src/components/search-form/search-form.test.js
+++ b/src/components/search-form/search-form.test.js
@@ -27,7 +27,7 @@ const accessTypesStoreData = {
   },
 };
 
-const tagsModel = {
+const tagsModelOfAlreadyAddedTags = {
   resolver: {
     state: {
       tags: {
@@ -38,6 +38,10 @@ const tagsModel = {
         }, {
           attributes: {
             label: 'tag2',
+          },
+        }, {
+          attributes: {
+            value: 'already-added-tag-to-record',
           },
         }],
       },
@@ -63,7 +67,7 @@ const renderSearchForm = (props = {}) => render(
         packages: '/packages',
         titles: '/titles',
       }}
-      tagsModel={tagsModel}
+      tagsModelOfAlreadyAddedTags={tagsModelOfAlreadyAddedTags}
       {...props}
     />
   </Harness>
@@ -115,20 +119,20 @@ describe('Given SearchForm', () => {
       expect(getByTestId('search-submit').disabled).toBeTruthy();
     });
 
-    it('should display tag options', () => {
-      const { getByText } = renderSearchForm({
+    it('should only display tags already added to records in the tag options', () => {
+      const { getByText, queryByText } = renderSearchForm({
         searchByTagsEnabled: true,
       });
 
-      expect(getByText('tag1')).toBeDefined();
-      expect(getByText('tag2')).toBeDefined();
+      expect(getByText('already-added-tag-to-record')).toBeDefined();
+      expect(queryByText('tag-not-added-to-any-record')).not.toBeInTheDocument();
     });
 
     describe('when no tags are provided', () => {
       it('should display an empty message instead of options', () => {
         const { getByText } = renderSearchForm({
           searchByTagsEnabled: true,
-          tagsModel: {
+          tagsModelOfAlreadyAddedTags: {
             resolver: {
               state: {
                 tags: {

--- a/src/components/search-modal/search-modal.js
+++ b/src/components/search-modal/search-modal.js
@@ -1,6 +1,7 @@
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import noop from 'lodash/noop';
 import {
   FormattedMessage,
   injectIntl,
@@ -45,8 +46,13 @@ class SearchModal extends PureComponent {
       searchTypes.TITLES,
     ]).isRequired,
     onFilter: PropTypes.func.isRequired,
+    onToggle: PropTypes.func,
     query: PropTypes.object,
-    tagsModel: PropTypes.object.isRequired,
+    tagsModelOfAlreadyAddedTags: PropTypes.object,
+  };
+
+  static defaultProps = {
+    onToggle: noop,
   };
 
   constructor(props) {
@@ -92,6 +98,8 @@ class SearchModal extends PureComponent {
   }
 
   toggle = () => {
+    this.props.onToggle(!this.state.isModalVisible);
+
     this.setState(({ isModalVisible }) => ({
       isModalVisible: !isModalVisible,
     }));
@@ -172,7 +180,7 @@ class SearchModal extends PureComponent {
   render() {
     const {
       listType,
-      tagsModel,
+      tagsModelOfAlreadyAddedTags,
       accessTypes,
       intl,
     } = this.props;
@@ -233,7 +241,7 @@ class SearchModal extends PureComponent {
             }
           >
             <SearchForm
-              tagsModel={tagsModel}
+              tagsModelOfAlreadyAddedTags={tagsModelOfAlreadyAddedTags}
               searchType={listType}
               searchString={query.q}
               searchFilter={query.filter}

--- a/src/components/search-modal/search-modal.test.js
+++ b/src/components/search-modal/search-modal.test.js
@@ -11,6 +11,7 @@ import {
 import SearchModal from './search-modal';
 
 const mockOnFilter = jest.fn();
+const mockOnToggle = jest.fn();
 
 const accessTypes = {
   errors: [],
@@ -25,7 +26,7 @@ const accessTypes = {
   },
 };
 
-const tagsModel = {
+const tagsModelOfAlreadyAddedTags = {
   isLoading: false,
   request: {
     isResolved: true,
@@ -37,9 +38,14 @@ const tagsModel = {
           'tag-id': {
             attributes: {
               id: 'tag-id',
-              label: 'test-tag',
+              label: 'tag-not-added-to-any-record',
             },
             id: 'tag-id',
+          },
+          'tag-id2': {
+            attributes: {
+              value: 'already-added-tag-to-record',
+            },
           },
         },
       },
@@ -52,7 +58,8 @@ const renderSearchModal = (props = {}) => render(
     accessTypes={accessTypes}
     listType={searchTypes.TITLES}
     onFilter={mockOnFilter}
-    tagsModel={tagsModel}
+    onToggle={mockOnToggle}
+    tagsModelOfAlreadyAddedTags={tagsModelOfAlreadyAddedTags}
     {...props}
   />
 );
@@ -60,6 +67,7 @@ const renderSearchModal = (props = {}) => render(
 describe('Given SearchModal', () => {
   afterEach(() => {
     mockOnFilter.mockClear();
+    mockOnToggle.mockClear();
   });
 
   it('should render SearchModal component', () => {
@@ -117,6 +125,16 @@ describe('Given SearchModal', () => {
     fireEvent.click(getByRole('button', { name: 'ui-eholdings.filter.togglePane' }));
 
     expect(getByRole('button', { name: 'stripes-components.dismissModal' })).toBeDefined();
+  });
+
+  describe('when click the button open the modal', () => {
+    it('should invoke onToggle callback', () => {
+      const { getByRole } = renderSearchModal();
+
+      fireEvent.click(getByRole('button', { name: 'ui-eholdings.filter.togglePane' }));
+
+      expect(mockOnToggle).toHaveBeenCalledWith(true);
+    });
   });
 
   describe('when click on close button', () => {
@@ -227,12 +245,12 @@ describe('Given SearchModal', () => {
       expect(getByRole('searchbox', { name: 'ui-eholdings.search.enterYourSearch' })).toBeDisabled();
 
       fireEvent.click(getByTestId('search-form-tag-filter'));
-      fireEvent.click(getByText('test-tag'));
+      fireEvent.click(getByText('already-added-tag-to-record'));
 
       expect(queryByTestId('search-modal')).toBeNull();
       expect(mockOnFilter).toBeCalledWith({
         filter: {
-          tags: ['test-tag'],
+          tags: ['already-added-tag-to-record'],
           'access-type': undefined,
         },
         q: undefined,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -41,3 +41,4 @@ export * from './packageShowRoute';
 export * from './permissionNames';
 export * from './querySearchListParams';
 export * from './overCount';
+export * from './tagPaths';

--- a/src/constants/tagPaths.js
+++ b/src/constants/tagPaths.js
@@ -1,0 +1,4 @@
+export const tagPaths = {
+  allTags: '/tags?limit=100000',
+  alreadyAddedToRecords: '/eholdings/tags/summary?filter[rectype]=provider&filter[rectype]=package&filter[rectype]=title&filter[rectype]=resource',
+};

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -6,6 +6,7 @@ import {
   filter,
 } from 'rxjs/operators';
 import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 
 import { qs } from '../components/utilities';
 import {
@@ -15,14 +16,15 @@ import {
 import {
   mergeRelationships,
   mergeAttributes,
-  getTagsData,
   getChangedAttributes,
   formatErrors,
+  formatTagsData,
   reduceData,
   getRecord,
   makeRequest,
 } from './helpers';
 import entityTagsActionTypes from './constants/entityTagsActionTypes';
+import { tagPaths } from '../constants/tagPaths';
 import entityTagsReducers from './reducers/entityTagsReducers';
 
 // actions
@@ -154,8 +156,9 @@ const resolve = (request, body, payload = {}, status) => {
   let data;
 
   if (request.resource === 'tags') {
-    data = getTagsData(request, body);
-    meta.totalResults = get(body, 'totalRecords', {});
+    const { data: tagsData, totalRecords } = formatTagsData(request, body);
+    data = tagsData;
+    meta.totalResults = totalRecords;
   } else {
     data = get(body, 'data', payload.data);
     meta = get(body, 'meta', {});
@@ -403,6 +406,47 @@ const handlers = {
 
     if (request.type === 'destroy') {
       next = handlers[actionTypes.UNLOAD](next, action);
+    } else if (request.resource === 'tags' && request.path === tagPaths.alreadyAddedToRecords) {
+      if (isEmpty(records)) {
+        const filteredRecords = Object.values(next.tags.records)
+          .filter(record => record.attributes.label)
+          .reduce((acc, record) => ({
+            ...acc,
+            [record.id]: record,
+          }), {});
+
+        next = {
+          ...next,
+          tags: {
+            ...next.tags,
+            records: filteredRecords,
+          },
+        };
+      } else {
+        next = records.reduce((reducedRecordsSet, record) => {
+          return reduceData(record.type, reducedRecordsSet, (store) => {
+            const recordState = getRecord(store, record.id);
+            // can't rely on id of the tag, as it's different for each request for the same tag.
+            const isUniqueTag = !Object.values(store.records).some(tag => tag.attributes.value === record.attributes.value);
+
+            return {
+              records: {
+                ...store.records,
+                ...(isUniqueTag && {
+                  [record.id]: {
+                    ...recordState,
+                    attributes: mergeAttributes(recordState.attributes, record.attributes),
+                    relationships: mergeRelationships(recordState.relationships, record.relationships),
+                    isSaving: false,
+                    isLoading: false,
+                    isLoaded: true
+                  }
+                }),
+              },
+            };
+          });
+        }, next);
+      }
     } else {
       // then we reduce each record in the set of records
       next = records.reduce((reducedRecordsSet, record) => {

--- a/src/redux/data.test.js
+++ b/src/redux/data.test.js
@@ -1,0 +1,286 @@
+import {
+  actionTypes,
+  reducer,
+} from './data';
+import { tagPaths } from '../constants/tagPaths';
+
+describe('data', () => {
+  describe('reducer', () => {
+    describe('when action type is RESOLVE', () => {
+      describe('and requests resource is "tags"', () => {
+        const prevState = { statuses: {} };
+        const prevRequests = { 1677493534032: {} };
+
+        describe('and request path is /eholdings/tags/summary', () => {
+          const path = tagPaths.alreadyAddedToRecords;
+
+          describe('and there are no tags added to any records', () => {
+            const records = [];
+
+            it('should return data with no tags previously added to any records', () => {
+              const state = {
+                ...prevState,
+                tags: {
+                  requests: {
+                    ...prevRequests,
+                    '1677489946003': {
+                      'timestamp': 1677489946003,
+                      'type': 'query',
+                      'path': path,
+                      'resource': 'tags',
+                      'params': {},
+                      'isPending': true,
+                      'isResolved': false,
+                      'isRejected': false,
+                      'records': [],
+                      'meta': {},
+                      'errors': []
+                    },
+                  },
+                  records: {
+                    '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2': {
+                      'id': '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2',
+                      'isLoading': false,
+                      'isLoaded': true,
+                      'isSaving': false,
+                      'attributes': {
+                        'id': '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2',
+                        'label': 'important',
+                        'metadata': {
+                          'createdDate': '2023-02-26T13:53:54.276+00:00'
+                        }
+                      },
+                      'relationships': {}
+                    },
+                    '3efd2d74-31dc-49ac-8374-ce9f88acef05': {
+                      'id': '3efd2d74-31dc-49ac-8374-ce9f88acef05',
+                      'isLoading': false,
+                      'isLoaded': true,
+                      'isSaving': false,
+                      'attributes': {
+                        'value': 'important'
+                      },
+                      'relationships': {}
+                    },
+                  },
+                },
+              };
+
+              const action = {
+                type: actionTypes.RESOLVE,
+                request: {
+                  resource: 'tags',
+                  path,
+                  timestamp: 1677489946003,
+                  records,
+                  meta: { 'totalResults': 0 },
+                  status: 200,
+                },
+                records,
+              };
+
+              expect(reducer(state, action)).toEqual({
+                ...prevState,
+                tags: {
+                  records: {
+                    '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2': state.tags.records['0d1111ea-39d4-4937-bd58-7d6bd45c0bb2'],
+                  },
+                  requests: {
+                    ...prevRequests,
+                    '1677489946003': {
+                      ...state.tags.requests['1677489946003'],
+                      'isPending': false,
+                      'isResolved': true,
+                      'meta': { totalResults: 0 },
+                      'status': 200,
+                    },
+                  },
+                }
+              });
+            });
+          });
+
+          describe('and there are tags added to any records', () => {
+            it('should return data without duplicate tags', () => {
+              const state = {
+                ...prevState,
+                tags: {
+                  requests: {
+                    ...prevRequests,
+                    '1677489946003': {
+                      'timestamp': 1677489946003,
+                      'type': 'query',
+                      'path': tagPaths.alreadyAddedToRecords,
+                      'resource': 'tags',
+                      'params': {},
+                      'isPending': true,
+                      'isResolved': false,
+                      'isRejected': false,
+                      'records': [],
+                      'meta': {},
+                      'errors': []
+                    },
+                  },
+                  records: {
+                    '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2': {
+                      'id': '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2',
+                      'isLoading': false,
+                      'isLoaded': true,
+                      'isSaving': false,
+                      'attributes': {
+                        'id': '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2',
+                        'label': 'important',
+                        'metadata': {
+                          'createdDate': '2023-02-26T13:53:54.276+00:00'
+                        }
+                      },
+                      'relationships': {}
+                    },
+                    '3efd2d74-31dc-49ac-8374-ce9f88acef05': {
+                      'id': '3efd2d74-31dc-49ac-8374-ce9f88acef05',
+                      'isLoading': false,
+                      'isLoaded': true,
+                      'isSaving': false,
+                      'attributes': {
+                        'value': 'important'
+                      },
+                      'relationships': {}
+                    },
+                  },
+                },
+              };
+
+              const action = {
+                type: actionTypes.RESOLVE,
+                request: {
+                  resource: 'tags',
+                  path: tagPaths.alreadyAddedToRecords,
+                  timestamp: 1677489946003,
+                  records: ['0cba8d99-6942-4661-947e-395a9d748ce2'],
+                  meta: { 'totalResults': 1 },
+                  status: 200,
+                },
+                records: [{
+                  'id': '0cba8d99-6942-4661-947e-395a9d748ce2',
+                  'type': 'tags',
+                  'attributes': {
+                    'value': 'important',
+                  },
+                }],
+              };
+
+              expect(reducer(state, action)).toEqual({
+                ...prevState,
+                tags: {
+                  records: state.tags.records,
+                  requests: {
+                    ...prevRequests,
+                    '1677489946003': {
+                      ...state.tags.requests[1677489946003],
+                      isPending: false,
+                      isResolved: true,
+                      meta: { totalResults: 1 },
+                      records: ['0cba8d99-6942-4661-947e-395a9d748ce2'],
+                      status: 200,
+                    },
+                  },
+                }
+              });
+            });
+          });
+        });
+
+        describe('and request path is /tags', () => {
+          it('should return data without duplicate tags', () => {
+            const state = {
+              ...prevState,
+              tags: {
+                requests: {
+                  ...prevRequests,
+                  '1677489946003': {
+                    'timestamp': 1677489946003,
+                    'type': 'query',
+                    'path': tagPaths.allTags,
+                    'resource': 'tags',
+                    'params': {},
+                    'isPending': true,
+                    'isResolved': false,
+                    'isRejected': false,
+                    'records': [],
+                    'meta': {},
+                    'errors': []
+                  },
+                },
+                records: {
+                  '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2': {
+                    'id': '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2',
+                    'isLoading': false,
+                    'isLoaded': true,
+                    'isSaving': false,
+                    'attributes': {
+                      'id': '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2',
+                      'label': 'important',
+                      'metadata': {
+                        'createdDate': '2023-02-26T13:53:54.276+00:00'
+                      }
+                    },
+                    'relationships': {}
+                  },
+                  '3efd2d74-31dc-49ac-8374-ce9f88acef05': {
+                    'id': '3efd2d74-31dc-49ac-8374-ce9f88acef05',
+                    'isLoading': false,
+                    'isLoaded': true,
+                    'isSaving': false,
+                    'attributes': {
+                      'value': 'important'
+                    },
+                    'relationships': {}
+                  },
+                },
+              },
+            };
+
+            const action = {
+              type: actionTypes.RESOLVE,
+              request: {
+                resource: 'tags',
+                path: tagPaths.allTags,
+                timestamp: 1677489946003,
+                records: ['0d1111ea-39d4-4937-bd58-7d6bd45c0bb2'],
+                meta: { 'totalResults': 1 },
+                status: 200,
+              },
+              records: [{
+                'id': '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2',
+                'type': 'tags',
+                'attributes': {
+                  id: '0d1111ea-39d4-4937-bd58-7d6bd45c0bb2',
+                  label: 'important',
+                  metadata: { 'createdDate': '2023-02-26T13:53:54.276+00:00' },
+                },
+              }],
+            };
+
+            expect(reducer(state, action)).toEqual({
+              ...prevState,
+              tags: {
+                records: state.tags.records,
+                requests: {
+                  ...prevRequests,
+                  '1677489946003': {
+                    ...state.tags.requests[1677489946003],
+                    isPending: false,
+                    isResolved: true,
+                    meta: { totalResults: 1 },
+                    records: ['0d1111ea-39d4-4937-bd58-7d6bd45c0bb2'],
+                    status: 200,
+                  },
+                },
+              }
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/redux/helpers.js
+++ b/src/redux/helpers.js
@@ -1,4 +1,5 @@
 import { foldl, append } from 'funcadelic';
+import { tagPaths } from '../constants/tagPaths';
 
 /**
  * Helper to merge incoming `relationship` information non-
@@ -44,7 +45,7 @@ export function mergeAttributes(existing, incoming) {
  * @param {Object} body - returned body
  * @returns {Object|Array} tags data object or array formatted according to JSON:API
  */
-export const getTagsData = (request, body) => {
+const getTagsData = (request, body) => {
   if (!body.tags) {
     return {
       type: request.resource,
@@ -58,6 +59,39 @@ export const getTagsData = (request, body) => {
     type: request.resource,
     attributes: tag,
   }));
+};
+
+/**
+ * Helper to format tags data retrieved from resolved
+ * request according to JSON:API specification
+ * @param {Object} request - the request state object associated with
+ * the request being resolved
+ * @param {Object} body - returned body
+ * @returns {Object|Array} tags data object or array formatted according to JSON:API
+ */
+
+export const formatTagsData = (request, body) => {
+  if (request.path === tagPaths.alreadyAddedToRecords) {
+    const data = body.data.map((tag) => ({
+      id: tag.id,
+      type: request.resource,
+      attributes: tag.attributes,
+    }));
+
+    return {
+      data,
+      totalRecords: body?.meta?.totalResults || 0,
+    };
+  }
+
+  if (request.path === tagPaths.allTags) {
+    return {
+      data: getTagsData(request, body),
+      totalRecords: body?.totalRecords || 0,
+    };
+  }
+
+  return {};
 };
 
 /**

--- a/src/redux/helpers.test.js
+++ b/src/redux/helpers.test.js
@@ -1,0 +1,92 @@
+import * as helpers from './helpers';
+import { tagPaths } from '../constants/tagPaths';
+
+describe('helpers', () => {
+  describe('formatTagsData', () => {
+    describe('when request is to get tags already added to records', () => {
+      const request = {
+        path: tagPaths.alreadyAddedToRecords,
+        resource: 'tags',
+      };
+
+      const body = {
+        data: [
+          {
+            id: 'fakeId',
+            type: 'tags',
+            attributes: {
+              value: 'tagName',
+            },
+          },
+        ],
+        meta: {
+          totalResults: 1,
+        },
+      };
+
+      it('should return the formatted data', () => {
+        expect(helpers.formatTagsData(request, body)).toEqual({
+          data: [{
+            id: 'fakeId',
+            type: 'tags',
+            attributes: {
+              value: 'tagName',
+            },
+          }],
+          totalRecords: 1,
+        });
+      });
+    });
+
+    describe('when request is to get all tags', () => {
+      const request = {
+        path: tagPaths.allTags,
+        resource: 'tags',
+      };
+
+      describe('when body.tags exists', () => {
+        it('should return formatted data', () => {
+          const body = {
+            tags: [
+              {
+                id: 'fakeId',
+                label: 'tagName',
+              },
+            ],
+            totalRecords: 1,
+          };
+
+          expect(helpers.formatTagsData(request, body)).toEqual({
+            data: [{
+              id: 'fakeId',
+              type: 'tags',
+              attributes: {
+                id: 'fakeId',
+                label: 'tagName',
+              },
+            }],
+            totalRecords: 1,
+          });
+        });
+      });
+
+      describe('when body.tags doesnt exist', () => {
+        it('should return the formatted data', () => {
+          const body = {
+            id: 'fakeId',
+            totalRecords: 1,
+          };
+
+          expect(helpers.formatTagsData(request, body)).toEqual({
+            data: {
+              attributes: body,
+              id: 'fakeId',
+              type: 'tags',
+            },
+            totalRecords: 1,
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/redux/model.js
+++ b/src/redux/model.js
@@ -291,10 +291,13 @@ class BaseModel {
   /**
    * Action creator for querying this specific model's resource
    * @param {Object} [params={}] - query params for the request
+   * @param {String} options.path - the path used to make the request
    */
-  static query(params = {}) {
+  static query(params = {}, options = {}) {
+    const { path } = options;
+
     return query(this.type, params, {
-      path: this.pathFor()
+      path: path || this.pathFor()
     });
   }
 

--- a/src/redux/tag.js
+++ b/src/redux/tag.js
@@ -1,4 +1,5 @@
 import model from './model';
+import { tagPaths } from '../constants/tagPaths';
 
 class Tag {
   id = '';
@@ -14,6 +15,5 @@ class Tag {
 }
 export default model({
   type: 'tags',
-  path: '/tags?limit=100000'
-
+  path: tagPaths.allTags,
 })(Tag);

--- a/src/routes/package-show-route/index.js
+++ b/src/routes/package-show-route/index.js
@@ -16,6 +16,7 @@ import {
 import Tag from '../../redux/tag';
 
 import PackageShowRoute from './package-show-route';
+import { tagPaths } from '../../constants/tagPaths';
 
 export default connect(
   (store, ownProps) => {
@@ -31,6 +32,7 @@ export default connect(
       proxyTypes: resolver.query('proxyTypes'),
       provider: resolver.find('providers', model.providerId),
       tagsModel: resolver.query('tags'),
+      tagsModelOfAlreadyAddedTags: resolver.query('tags', undefined, { path: tagPaths.alreadyAddedToRecords }),
       resolver,
       accessStatusTypes: selectPropFromData(store, 'accessStatusTypes'),
       costPerUse: selectPropFromData(store, 'costPerUse'),
@@ -42,7 +44,7 @@ export default connect(
     getPackageTitles: getPackageTitlesAction,
     clearPackageTitles: clearPackageTitlesAction,
     getProxyTypes: () => ProxyType.query(),
-    getTags: () => Tag.query(),
+    getTags: (params, options) => Tag.query(params, options),
     getProvider: id => Provider.find(id),
     unloadResources: collection => Resource.unload(collection),
     updatePackage: model => Package.save(model),

--- a/src/routes/package-show-route/package-show-route.js
+++ b/src/routes/package-show-route/package-show-route.js
@@ -15,6 +15,7 @@ import {
   PAGE_SIZE,
   FIRST_PAGE,
   INTERVAL_BEFORE_CHECK_FOR_AN_UPDATE,
+  tagPaths,
 } from '../../constants';
 
 import View from '../../components/package/show';
@@ -47,6 +48,7 @@ class PackageShowRoute extends Component {
     proxyTypes: PropTypes.object.isRequired,
     removeUpdateRequests: PropTypes.func.isRequired,
     tagsModel: PropTypes.object.isRequired,
+    tagsModelOfAlreadyAddedTags: PropTypes.object,
     unloadResources: PropTypes.func.isRequired,
     updateFolioTags: PropTypes.func.isRequired,
     updatePackage: PropTypes.func.isRequired,
@@ -318,6 +320,12 @@ class PackageShowRoute extends Component {
     }));
   }
 
+  toggleSearchModal = (isModalVisible) => {
+    if (isModalVisible) {
+      this.props.getTags(undefined, { path: tagPaths.alreadyAddedToRecords });
+    }
+  }
+
   fetchPackageCostPerUse = (filterData) => {
     const {
       getCostPerUse,
@@ -378,6 +386,7 @@ class PackageShowRoute extends Component {
       history,
       model,
       tagsModel,
+      tagsModelOfAlreadyAddedTags,
       provider,
       proxyTypes,
       updateFolioTags,
@@ -433,10 +442,11 @@ class PackageShowRoute extends Component {
           searchModal={
             <SearchModal
               key={queryId}
-              tagsModel={tagsModel}
+              tagsModelOfAlreadyAddedTags={tagsModelOfAlreadyAddedTags}
               listType={listTypes.TITLES}
               query={pkgSearchParams}
               onSearch={this.searchTitles}
+              onToggle={this.toggleSearchModal}
               onFilter={this.searchTitles}
               accessTypes={accessStatusTypes}
             />

--- a/src/routes/package-show-route/package-show-route.test.js
+++ b/src/routes/package-show-route/package-show-route.test.js
@@ -181,6 +181,12 @@ const tagsModel = {
   },
 };
 
+const tagsModelOfAlreadyAddedTags = {
+  request: {
+    isResolved: true,
+  },
+};
+
 const resolver = {
   state: {
     proxyTypes: {
@@ -273,6 +279,7 @@ const getPackageShowRoute = (props = {}) => (
         proxyTypes={proxyTypes}
         provider={provider}
         tagsModel={tagsModel}
+        tagsModelOfAlreadyAddedTags={tagsModelOfAlreadyAddedTags}
         resolver={resolver}
         accessStatusTypes={accessStatusTypes}
         costPerUse={costPerUse}

--- a/src/routes/provider-show-route/index.js
+++ b/src/routes/provider-show-route/index.js
@@ -14,6 +14,7 @@ import {
 } from '../../redux/actions';
 
 import { selectPropFromData } from '../../redux/selectors';
+import { tagPaths } from '../../constants/tagPaths';
 
 export default connect(
   (store, { match }) => {
@@ -25,6 +26,7 @@ export default connect(
       model: resolver.find('providers', match.params.providerId),
       proxyTypes: resolver.query('proxyTypes'),
       tagsModel: resolver.query('tags'),
+      tagsModelOfAlreadyAddedTags: resolver.query('tags', undefined, { path: tagPaths.alreadyAddedToRecords }),
       rootProxy: resolver.find('rootProxies', 'root-proxy'),
       resolver,
       accessTypes: selectPropFromData(store, 'accessStatusTypes'),
@@ -35,7 +37,7 @@ export default connect(
     getProviderPackages: getProviderPackagesAction,
     clearProviderPackages: clearProviderPackagesAction,
     getProxyTypes: () => ProxyType.query(),
-    getTags: () => Tag.query(),
+    getTags: (params, options) => Tag.query(params, options),
     updateFolioTags: (model) => Tag.create(model),
     getRootProxy: () => RootProxy.find('root-proxy'),
     getAccessTypes: getAccessTypesAction,

--- a/src/routes/provider-show-route/provider-show-route.js
+++ b/src/routes/provider-show-route/provider-show-route.js
@@ -15,6 +15,7 @@ import {
   accessTypesReduxStateShape,
   PAGE_SIZE,
   FIRST_PAGE,
+  tagPaths,
 } from '../../constants';
 
 class ProviderShowRoute extends Component {
@@ -43,6 +44,7 @@ class ProviderShowRoute extends Component {
     proxyTypes: PropTypes.object.isRequired,
     rootProxy: PropTypes.object.isRequired,
     tagsModel: PropTypes.object.isRequired,
+    tagsModelOfAlreadyAddedTags: PropTypes.object,
     updateFolioTags: PropTypes.func.isRequired,
   };
 
@@ -146,6 +148,12 @@ class ProviderShowRoute extends Component {
     }));
   };
 
+  toggleSearchModal = (isModalVisible) => {
+    if (isModalVisible) {
+      this.props.getTags(undefined, { path: tagPaths.alreadyAddedToRecords });
+    }
+  }
+
   fetchPackages = (page) => {
     const { pkgSearchParams } = this.state;
     this.searchPackages({ ...pkgSearchParams, page });
@@ -181,6 +189,7 @@ class ProviderShowRoute extends Component {
       proxyTypes,
       rootProxy,
       tagsModel,
+      tagsModelOfAlreadyAddedTags,
       updateFolioTags,
       accessTypes,
       providerPackages,
@@ -204,11 +213,12 @@ class ProviderShowRoute extends Component {
           updateFolioTags={updateFolioTags}
           searchModal={
             <SearchModal
-              tagsModel={tagsModel}
+              tagsModelOfAlreadyAddedTags={tagsModelOfAlreadyAddedTags}
               key={queryId}
               listType={listTypes.PACKAGES}
               query={pkgSearchParams}
               onSearch={this.searchPackages}
+              onToggle={this.toggleSearchModal}
               onFilter={this.searchPackages}
               accessTypes={accessTypes}
             />

--- a/src/routes/provider-show-route/provider-show-route.test.js
+++ b/src/routes/provider-show-route/provider-show-route.test.js
@@ -152,6 +152,12 @@ const tagsModel = {
   },
 };
 
+const tagsModelOfAlreadyAddedTags = {
+  request: {
+    isResolved: true,
+  },
+};
+
 const renderProviderShowRoute = ({ props = {} }) => render(
   <MemoryRouter>
     <Harness>
@@ -161,6 +167,7 @@ const renderProviderShowRoute = ({ props = {} }) => render(
         proxyTypes={proxyTypes}
         rootProxy={rootProxy}
         tagsModel={tagsModel}
+        tagsModelOfAlreadyAddedTags={tagsModelOfAlreadyAddedTags}
         model={model}
         history={mockHistory}
         location={location}

--- a/src/routes/search-route/index.js
+++ b/src/routes/search-route/index.js
@@ -9,6 +9,7 @@ import Title from '../../redux/title';
 import Tag from '../../redux/tag';
 import { getAccessTypes as getAccessTypesAction } from '../../redux/actions';
 import { selectPropFromData } from '../../redux/selectors';
+import { tagPaths } from '../../constants/tagPaths';
 
 export default connect(
   (store) => {
@@ -16,7 +17,7 @@ export default connect(
     const resolver = createResolver(data);
 
     return {
-      tagsModel: resolver.query('tags'),
+      tagsModelOfAlreadyAddedTags: resolver.query('tags', undefined, { path: tagPaths.alreadyAddedToRecords }),
       resolver,
       accessTypes: selectPropFromData(store, 'accessStatusTypes'),
     };
@@ -24,7 +25,7 @@ export default connect(
     searchProviders: params => Provider.query(params),
     searchPackages: params => Package.query(params),
     searchTitles: params => Title.query(params),
-    getTags: () => Tag.query(),
+    getTags: (params, options) => Tag.query(params, options),
     getAccessTypes: getAccessTypesAction,
   }
 )(SearchRoute);

--- a/src/routes/search-route/search-route.js
+++ b/src/routes/search-route/search-route.js
@@ -28,6 +28,7 @@ import {
   accessTypesReduxStateShape,
   PAGE_SIZE,
   FIRST_PAGE,
+  tagPaths,
 } from '../../constants';
 
 class SearchRoute extends Component {
@@ -42,7 +43,7 @@ class SearchRoute extends Component {
     searchPackages: PropTypes.func.isRequired,
     searchProviders: PropTypes.func.isRequired,
     searchTitles: PropTypes.func.isRequired,
-    tagsModel: PropTypes.object.isRequired,
+    tagsModelOfAlreadyAddedTags: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -55,7 +56,7 @@ class SearchRoute extends Component {
     this.queries = {};
     this.path = {};
 
-    props.getTags();
+    props.getTags(undefined, { path: tagPaths.alreadyAddedToRecords });
     props.getAccessTypes();
 
     if (searchType) {
@@ -424,7 +425,7 @@ class SearchRoute extends Component {
   render() {
     const {
       history,
-      tagsModel,
+      tagsModelOfAlreadyAddedTags,
       accessTypes,
     } = this.props;
 
@@ -472,7 +473,7 @@ class SearchRoute extends Component {
                     searchField={searchField}
                     searchByTagsEnabled={searchByTagsEnabled}
                     searchByAccessTypesEnabled={searchByAccessTypesEnabled}
-                    tagsModel={tagsModel}
+                    tagsModelOfAlreadyAddedTags={tagsModelOfAlreadyAddedTags}
                     accessTypesStoreData={accessTypes}
                     searchTypeUrls={this.getSearchTypeUrls()}
                     isLoading={!!params.q && !results.hasLoaded}

--- a/src/routes/search-route/search-route.test.js
+++ b/src/routes/search-route/search-route.test.js
@@ -56,7 +56,7 @@ const match = {
   url: '/eholdings',
 };
 
-const tagsModel = {
+const tagsModelOfAlreadyAddedTags = {
   request: {
     isResolved: true,
   },
@@ -167,7 +167,7 @@ const renderSearchRoute = (props = {}) => render(
         searchPackages={noop}
         searchProviders={noop}
         searchTitles={noop}
-        tagsModel={tagsModel}
+        tagsModelOfAlreadyAddedTags={tagsModelOfAlreadyAddedTags}
         {...props}
       />
     </Harness>
@@ -199,7 +199,12 @@ describe('Given SearchRoute', () => {
       });
     });
 
-    expect(mockGetTags).toHaveBeenCalled();
+    expect(mockGetTags).toHaveBeenCalledWith(
+      undefined,
+      {
+        path: '/eholdings/tags/summary?filter[rectype]=provider&filter[rectype]=package&filter[rectype]=title&filter[rectype]=resource'
+      },
+    );
   });
 
   describe('when search type is providers', () => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Only display tags that have already been added to records as options when the user tries to search for records
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues
[UIEH-1357](https://issues.folio.org/browse/UIEH-1357)

## Screencast





## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
