### PR TITLE
UIEH-1362 Fix  errors appearing when user switch to User Consolidation settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Custom labels | Remove a dashes below labels. (UIEH-1361)
 * Titles tab: Add a Packages facet. (UIEH-1350)
 * Title detail record: Packages accordion - Honor Packages Facet selection(s). (UIEH-1351)
+* Fix errors appearing when user switch to "User consolidation" pane. (UIEH-1362)
 
 ## [8.0.3] (https://github.com/folio-org/ui-eholdings/tree/v8.0.3) (2023-03-30)
 

--- a/src/components/settings/settings-usage-consolidation/settings-usage-consolidation.js
+++ b/src/components/settings/settings-usage-consolidation/settings-usage-consolidation.js
@@ -68,7 +68,7 @@ const SettingsUsageConsolidation = ({
     if (isEqual(usageConsolidationWithoutKey, prevUsageConsolidation)) return;
 
     if (usageConsolidation.hasSaved) {
-      setToasts(t => [...t, {
+      setToasts([{
         id: `settings-uc-${Date.now()}`,
         message: <FormattedMessage id="ui-eholdings.settings.usageConsolidation.saved" />,
         type: 'success',
@@ -76,7 +76,7 @@ const SettingsUsageConsolidation = ({
     }
 
     if (usageConsolidation.isFailed) {
-      setToasts(t => [...t, {
+      setToasts([{
         id: `settings-uc-${Date.now()}`,
         message: <FormattedMessage id="ui-eholdings.settings.usageConsolidation.credentials.systemError" />,
         type: 'error',
@@ -86,11 +86,11 @@ const SettingsUsageConsolidation = ({
 
   useEffect(() => {
     if (ucCredentials.isFailed) {
-      const errorMessageId = ucCredentials.errors[0].title === INVALID_UC_CREDENTIALS
+      const errorMessageId = ucCredentials.errors[0]?.title === INVALID_UC_CREDENTIALS
         ? 'ui-eholdings.settings.usageConsolidation.credentials.validation.invalid'
         : 'ui-eholdings.settings.usageConsolidation.credentials.systemError';
 
-      setToasts(t => [...t, {
+      setToasts([{
         id: `settings-uc-${Date.now()}`,
         message: <FormattedMessage id={errorMessageId} />,
         type: 'error',

--- a/src/redux/reducers/tests/ucCredentials.test.js
+++ b/src/redux/reducers/tests/ucCredentials.test.js
@@ -59,7 +59,6 @@ describe('ucCredentialsReducer', () => {
 
     expect(ucCredentialsReducer(state, action)).toEqual({
       ...state,
-      isFailed: true,
       errors: [{ title: 'error1' }],
     });
   });

--- a/src/redux/reducers/ucCredentials.js
+++ b/src/redux/reducers/ucCredentials.js
@@ -51,7 +51,6 @@ const handlers = {
     return {
       ...state,
       isLoading: false,
-      isFailed: true,
       errors: formatErrors(payload.errors),
     };
   },

--- a/src/redux/reducers/usageConsolidation.js
+++ b/src/redux/reducers/usageConsolidation.js
@@ -57,7 +57,13 @@ const handlers = {
       data: attributes,
     };
   },
-  [GET_USAGE_CONSOLIDATION_FAILURE]: handleError,
+  [GET_USAGE_CONSOLIDATION_FAILURE]: (state, { payload }) => ({
+    ...state,
+    isLoading: false,
+    isLoaded: false,
+    hasSaved: false,
+    errors: formatErrors(payload.errors),
+  }),
   [GET_USAGE_CONSOLIDATION_KEY]: state => ({
     ...state,
     isKeyLoading: true,


### PR DESCRIPTION
## Description
Removed `isFailed` flag when GET uc crendetials fails to use it only when UPDATE fails

## Screenshots

https://user-images.githubusercontent.com/19309423/235140006-cbc14d4f-bbec-4120-b576-21452d82b902.mp4


## Issues
[UIEH-1362](https://issues.folio.org/browse/UIEH-1362)