### PR TITLE
UIEH-1371 Fix passed month values to Usage Consolidation settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Titles tab: Add a Packages facet. (UIEH-1350)
 * Title detail record: Packages accordion - Honor Packages Facet selection(s). (UIEH-1351)
 * Fix errors appearing when user switch to "User consolidation" pane. (UIEH-1362)
+* Fix errors appearing when user switch to "User consolidation" pane. (UIEH-1362)
+* Settings > Usage Consolidation naively parses start-month values. (UIEH-1371)
 
 ## [8.0.3] (https://github.com/folio-org/ui-eholdings/tree/v8.0.3) (2023-03-30)
 

--- a/src/components/settings/settings-usage-consolidation/settings-usage-consolidation.js
+++ b/src/components/settings/settings-usage-consolidation/settings-usage-consolidation.js
@@ -49,6 +49,7 @@ const propTypes = {
 
 const INVALID_CUSTOMER_KEY_ERROR_MESSAGE = 'Invalid UC Credentials';
 const INVALID_UC_CREDENTIALS = 'Invalid Usage Consolidation Credentials';
+const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
 const SettingsUsageConsolidation = ({
   clearUsageConsolidationErrors,
@@ -131,9 +132,9 @@ const SettingsUsageConsolidation = ({
     return errors;
   };
 
-  const monthDataOptions = moment.months().map(month => ({
-    value: month.toLowerCase().substr(0, 3),
-    label: month,
+  const monthDataOptions = MONTHS.map((month, index) => ({
+    value: month.toLowerCase().substring(0, 3),
+    label: moment.months()[index],
   }));
 
   const parseUsageConsolidationId = value => {


### PR DESCRIPTION
## Description
`moment.months()` returns localized month names. Changed code to use constant months as values instead

## Issues
[UIEH-1371](https://issues.folio.org/browse/UIEH-1371)