### PR TITLE
ERM-2641: Upgrade to Grails 5 (including Hibernate 5.6.x) for Poppy

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "okapiInterfaces": {
       "eholdings": "3.0",
       "tags": "1.0",
-      "erm": "1.0 2.0 3.0 4.0 5.0"
+      "erm": "1.0 2.0 3.0 4.0 5.0 6.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
build: erm 6.0

Added okapi interface dependency on new erm interface 6.0

refs ERM-2641