### PR TITLE
UIEH-1380 align test babel config with stripes-webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix errors appearing when user switch to "User consolidation" pane. (UIEH-1362)
 * Settings > Usage Consolidation naively parses start-month values. (UIEH-1371)
 * Settings: Add `PaneCloseLink` to the `Assigned users` pane. (UIEH-1372)
+* Align test babel config with stripes-webpack. (UIEH-1380, STRWEB-87)
 
 ## [8.0.3] (https://github.com/folio-org/ui-eholdings/tree/v8.0.3) (2023-03-30)
 

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -17,9 +17,9 @@ module.exports = {
     // the "loose" option must be the same for all three.
     // but @babel/preset-env sets it to false for ...private-methods.
     // overriding it here silences the complaint. STRWEB-12
-    ['@babel/plugin-proposal-class-properties', { 'loose': true }],
-    ['@babel/plugin-proposal-private-methods', { 'loose': true }],
-    ['@babel/plugin-proposal-private-property-in-object', { 'loose': true }],
+    ['@babel/plugin-transform-class-properties', { 'loose': true }],
+    ['@babel/plugin-transform-private-methods', { 'loose': true }],
+    ['@babel/plugin-transform-private-property-in-object', { 'loose': true }],
     '@babel/plugin-transform-runtime',
   ],
 };


### PR DESCRIPTION
Align the babel config with that in `@folio/stripes-webpack` so that all plugins referenced in the config are actually present in the build.

Refs [UIEH-1380](https://issues.folio.org/browse/UIEH-1380), [STRWEB-87](https://issues.folio.org/browse/STRWEB-87)