### PR TITLE
STRIPES-854 leverage all CPUs in CI

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -84,8 +84,12 @@ jobs:
         run: yarn lint
         continue-on-error: true
 
+      - name: Get number of CPU cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@v1
+
       - name: Run yarn test
-        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS
+        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS --max-workers ${{ steps.cpu-cores.outputs.count }}
 
       - name: Run yarn formatjs-compile
         if : ${{ env.COMPILE_TRANSLATION_FILES == 'true' }}

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -66,8 +66,12 @@ jobs:
         run: yarn lint
         continue-on-error: true
 
+      - name: Get number of CPU cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@v1
+
       - name: Run yarn test
-        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS
+        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS --max-workers ${{ steps.cpu-cores.outputs.count }}
 
       - name: Run yarn formatjs-compile
         if: ${{ env.COMPILE_TRANSLATION_FILES == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix errors appearing when user switch to "User consolidation" pane. (UIEH-1362)
 * Settings > Usage Consolidation naively parses start-month values. (UIEH-1371)
 * Settings: Add `PaneCloseLink` to the `Assigned users` pane. (UIEH-1372)
+* Devops: leverage all available CPUs in CI. (STRIPES-854)
 
 ## [8.0.3] (https://github.com/folio-org/ui-eholdings/tree/v8.0.3) (2023-03-30)
 


### PR DESCRIPTION
Leverage all available CPUs in CI. This is just a config change in the GA workflows; there are no code changes.

Refs [STRIPES-854](https://issues.folio.org/browse/STRIPES-854)