### PR TITLE
UIEH-1389 Remove eslint deps that are already listed in eslint-config-stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [9.1.0] (IN PROGRESS)
 
 * Remove Bigtest tests. (UIEH-1390)
+* Remove eslint deps that are already listed in eslint-config-stripes. (UIEH-1389)
 
 ## [9.0.0] (https://github.com/folio-org/ui-eholdings/tree/v9.0.0) (2023-10-13)
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     }
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.17.0",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/jest-config-stripes": "^2.0.0",
     "@folio/stripes": "^9.0.0",
@@ -32,7 +31,6 @@
     "@folio/stripes-core": "^10.0.0",
     "@formatjs/cli": "^6.1.3",
     "axe-core": "~4.1.4",
-    "eslint": "^7.32.0",
     "eslint-plugin-jest": "^24.1.3",
     "history": "^5.0.0",
     "husky": "^1.3.1",


### PR DESCRIPTION
## Description
Remove eslint deps that are already listed in eslint-config-stripes

## Issues
[UIEH-1389](https://issues.folio.org/browse/UIEH-1389)