### PR TITLE
UIEH-1382 Make package select field container have relative position to fix packages dropdown list not displayed with the label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Remove Bigtest tests. (UIEH-1390)
 * Remove eslint deps that are already listed in eslint-config-stripes. (UIEH-1389)
+* Fix Create custom title > Packages dropdown list does not display with the label. (UIEH-1382)
 
 ## [9.0.1] (IN PROGRESS)
 

--- a/src/components/title/_fields/package-select/package-select-field.css
+++ b/src/components/title/_fields/package-select/package-select-field.css
@@ -1,0 +1,3 @@
+.packageSelectFieldContainer {
+  position: relative;
+}

--- a/src/components/title/_fields/package-select/package-select-field.js
+++ b/src/components/title/_fields/package-select/package-select-field.js
@@ -11,6 +11,8 @@ import {
   Icon,
 } from '@folio/stripes/components';
 
+import css from './package-select-field.css';
+
 function validate(value) {
   return value ? undefined : <FormattedMessage id="ui-eholdings.validate.errors.packageSelect.required" />;
 }
@@ -33,7 +35,10 @@ const PackageSelectField = ({
   };
 
   return (
-    <div data-test-eholdings-package-select-field>
+    <div
+      data-test-eholdings-package-select-field
+      className={css.packageSelectFieldContainer}
+    >
       <Field
         name="packageId"
         component={Selection}


### PR DESCRIPTION
## Description
Make package select field container have relative position to fix packages dropdown list not displayed with the label

## Screenshots
![image](https://github.com/folio-org/ui-eholdings/assets/19309423/6a758b23-5781-4a12-b27b-4930b30cb2b1)


## Issues
[UIEH-1382](https://issues.folio.org/browse/UIEH-1382)