### PR TITLE
UIEH-1383: Fix deleting last date range when creating a new package or editing title.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Remove Bigtest tests. (UIEH-1390)
 * Remove eslint deps that are already listed in eslint-config-stripes. (UIEH-1389)
 * Fix Create custom title > Packages dropdown list does not display with the label. (UIEH-1382)
+* Fix deleting last date range when creating a new package or editing title. (UIEH-1383)
 
 ## [9.0.1] (IN PROGRESS)
 

--- a/src/components/package/_fields/custom-coverage/package-coverage-fields.js
+++ b/src/components/package/_fields/custom-coverage/package-coverage-fields.js
@@ -29,7 +29,7 @@ class PackageCoverageFields extends Component {
   validateDateRange = (values) => {
     const errorArray = [];
 
-    values.forEach(({ beginCoverage, endCoverage }) => {
+    values?.forEach(({ beginCoverage, endCoverage }) => {
       const errors = {};
 
       if (endCoverage && !moment.utc(endCoverage).isAfter(moment.utc(beginCoverage))) {

--- a/src/components/resource/_fields/validate-date-range.js
+++ b/src/components/resource/_fields/validate-date-range.js
@@ -156,7 +156,7 @@ const validateWithinPackageRange = (resourceDateRange, packageDateRange) => {
 const validateDateRange = (values, locale, packageDateRange) => {
   const errors = [];
 
-  values.forEach((dateRange, index) => {
+  values?.forEach((dateRange, index) => {
     const dateRangeErrors =
       validateDateFormat(dateRange, locale)
       || validateStartDateBeforeEndDate(dateRange)

--- a/src/routes/package-create-route/package-create-route.js
+++ b/src/routes/package-create-route/package-create-route.js
@@ -38,7 +38,7 @@ export default class PackageCreateRoute extends Component {
   packageCreateSubmitted = (values) => {
     const attrs = {};
 
-    if (values.customCoverages[0]) {
+    if (values?.customCoverages?.[0]) {
       attrs.customCoverage = {
         beginCoverage: !values.customCoverages[0].beginCoverage ? '' :
           moment.utc(values.customCoverages[0].beginCoverage).format('YYYY-MM-DD'),

--- a/src/routes/package-create-route/package-create-route.test.js
+++ b/src/routes/package-create-route/package-create-route.test.js
@@ -164,4 +164,28 @@ describe('Given PackageCreateRoute', () => {
       expect(mockCreatePackage).toHaveBeenCalled();
     });
   });
+
+  describe('when user adds a name, adds and delete date rage and clicks on Save&close button', () => {
+    it('should call updateResource', () => {
+      const {
+        getByRole,
+        getByText,
+      } = renderPackageCreateRoute();
+
+      const packageNameInput = getByRole('textbox', { name: 'ui-eholdings.label.name' });
+
+      fireEvent.change(packageNameInput, { target: { value: 'New package name' } });
+
+      const addCoverageSettingsButton = getByText('ui-eholdings.package.coverage.addDateRange');
+
+      fireEvent.click(addCoverageSettingsButton);
+
+      const deleteEmbargoBtn = getByRole('button', { name: 'stripes-components.deleteThisItem' });
+      fireEvent.click(deleteEmbargoBtn);
+
+      fireEvent.click(getByRole('button', { name: 'stripes-components.saveAndClose' }));
+
+      expect(mockCreatePackage).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/routes/resource-edit-route/resource-edit-route.test.js
+++ b/src/routes/resource-edit-route/resource-edit-route.test.js
@@ -353,4 +353,22 @@ describe('Given ResourceEditRoute', () => {
       }));
     });
   });
+
+  describe('when user deletes last date range row and clicks on Save&close button', () => {
+    it('should call updateResource', () => {
+      const { getByRole } = renderResourceEditRoute({
+        model: {
+          ...model,
+          isSelected: true,
+        },
+      });
+
+      const deleteItem = getByRole('button', { name: 'stripes-components.deleteThisItem' });
+      fireEvent.click(deleteItem);
+
+      fireEvent.submit(getByRole('button', { name: 'stripes-components.saveAndClose' }));
+
+      expect(mockUpdateResource).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
 Fix deleting last date range when creating a new package or editing title.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues
[UIEH-1383](https://issues.folio.org/browse/UIEH-1383)

## Screencast


https://github.com/folio-org/ui-eholdings/assets/77053927/31d39149-5100-4f07-8ada-4a9bf66a595a




## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
