### PR TITLE
UIEH-1383: Don't display the deleted date range.

### DIFF
--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -209,7 +209,6 @@ const ResourceEditManagedTitle = ({
                       resourceIsCustom={false}
                       resourceSelected={managedResourceSelected}
                       isSelectInFlight={isSelectInFlight}
-                      handleToggleResourceHoldings={handleToggleResourceHoldings}
                     />
 
                     {model.isSelected && (

--- a/src/routes/package-edit-route/package-edit-route.js
+++ b/src/routes/package-edit-route/package-edit-route.js
@@ -124,6 +124,7 @@ class PackageEditRoute extends Component {
 
     model.isSelected = true;
     model.allowKbToAddTitles = true;
+    model.customCoverage = {};
     updatePackage(model);
   };
 

--- a/src/routes/package-edit-route/package-edit-route.test.js
+++ b/src/routes/package-edit-route/package-edit-route.test.js
@@ -322,6 +322,30 @@ describe('Given PackageEditRoute', () => {
     });
   });
 
+  describe('when date range in the "Coverage Settings" section is removed', () => {
+    describe('and user clicks Save&Close button', () => {
+      it('should update package with the empty customCoverage', () => {
+        const { getByRole } = renderPackageEditRoute({
+          model: {
+            ...model,
+            isSelected: true,
+            customCoverage: {
+              beginCoverage: '2023-10-30',
+              endCoverage: '2023-10-31',
+            },
+          },
+        });
+
+        fireEvent.click(getByRole('button', { name: 'stripes-components.deleteThisItem' }));
+        fireEvent.click(getByRole('button', { name: 'stripes-components.saveAndClose' }));
+
+        expect(mockUpdatePackage).toHaveBeenCalledWith(expect.objectContaining({
+          customCoverage: {},
+        }));
+      });
+    });
+  });
+
   describe('when a custom package is deselected', () => {
     it('should call destroyPackage', () => {
       const { getByText } = renderPackageEditRoute();

--- a/src/routes/resource-edit-route/resource-edit-route.js
+++ b/src/routes/resource-edit-route/resource-edit-route.js
@@ -132,6 +132,7 @@ class ResourceEditRoute extends Component {
       }));
     } else if (values.isSelected && !values.customCoverages) {
       updateResource(Object.assign(model, {
+        customCoverages: [],
         isSelected: true,
       }));
     } else {

--- a/src/routes/resource-edit-route/resource-edit-route.test.js
+++ b/src/routes/resource-edit-route/resource-edit-route.test.js
@@ -298,24 +298,6 @@ describe('Given ResourceEditRoute', () => {
     });
   });
 
-  describe('when package is added to holdings', () => {
-    it('should update resource', () => {
-      const { getByText } = renderResourceEditRoute({
-        model: {
-          ...model,
-          isSelected: false,
-        },
-      });
-
-      fireEvent.click(getByText('ui-eholdings.addToHoldings'));
-
-      expect(mockUpdateResource).toHaveBeenCalledWith({
-        ...model,
-        isSelected: true,
-      });
-    });
-  });
-
   describe('when a managed package is deselected', () => {
     it('should handle mockUpdateResource', () => {
       const { getByText } = renderResourceEditRoute({
@@ -369,6 +351,30 @@ describe('Given ResourceEditRoute', () => {
       fireEvent.submit(getByRole('button', { name: 'stripes-components.saveAndClose' }));
 
       expect(mockUpdateResource).toHaveBeenCalled();
+    });
+  });
+
+  describe('when date range in the "Coverage Settings" section is removed', () => {
+    describe('and user clicks Save&Close button', () => {
+      it('should update package with the empty customCoverage', () => {
+        const { getByRole } = renderResourceEditRoute({
+          model: {
+            ...model,
+            isSelected: true,
+            customCoverage: [{
+              beginCoverage: '2023-10-30',
+              endCoverage: '2023-10-31'
+            }],
+          },
+        });
+
+        fireEvent.click(getByRole('button', { name: 'stripes-components.deleteThisItem' }));
+        fireEvent.click(getByRole('button', { name: 'stripes-components.saveAndClose' }));
+
+        expect(mockUpdateResource).toHaveBeenCalledWith(expect.objectContaining({
+          customCoverages: [],
+        }));
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Don't display the deleted date range.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Description
Removed `handleToggleResourceHoldings` because is not possible to have `Add to holdings` button on `resource-edit-managed-title.js` page and deleted the corresponding test for it.

## Issues
[UIEH-1383](https://issues.folio.org/browse/UIEH-1383)

## Screencasts
[packages issue](https://github.com/folio-org/ui-eholdings/assets/77053927/f78386f4-acd7-4204-bb03-231c3fd2d930)
[packages fix](https://github.com/folio-org/ui-eholdings/assets/77053927/8703834f-e3c6-451d-a8b6-54e5f7b81c1a)
[resource issue](https://github.com/folio-org/ui-eholdings/assets/77053927/9fd095d6-3351-4e60-a8c9-3d898acd1d66)
[resource fix](https://github.com/folio-org/ui-eholdings/assets/77053927/d8a3a94a-5436-4e80-9da5-8d269d874f17)















## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
