### PR TITLE
UIEH-1360 Make cancel button show confirmation modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Remove Bigtest tests. (UIEH-1390)
 * Remove eslint deps that are already listed in eslint-config-stripes. (UIEH-1389)
 * Improve HTML page titles for Assigned Users and Usage Consolidation Settings pages. (UIEH-1387)
+* Edit eholdings record (provider/package/title) > Cancel button does not work in same way as other apps Cancel button. (UIEH-1360)
 
 ## [9.0.2] (https://github.com/folio-org/ui-eholdings/tree/v9.0.2) (2023-11-09)
 

--- a/src/components/package/create/package-create.js
+++ b/src/components/package/create/package-create.js
@@ -51,15 +51,18 @@ class PackageCreate extends Component {
 
   createFormRef = createRef();
 
-  getFooter = (pristine, reset) => {
-    const { request } = this.props;
+  getFooter = (pristine) => {
+    const {
+      request,
+      onCancel,
+    } = this.props;
 
     const cancelButton = (
       <Button
         data-test-eholdings-package-create-cancel-button
         buttonStyle="default mega"
         disabled={request.isPending || pristine}
-        onClick={reset}
+        onClick={onCancel}
         marginBottom0
       >
         <FormattedMessage id="stripes-components.cancel" />
@@ -122,7 +125,7 @@ class PackageCreate extends Component {
           decorators={[focusOnErrors]}
           mutators={{ ...arrayMutators }}
           onSubmit={onSubmit}
-          render={({ handleSubmit, pristine, form: { reset } }) => (
+          render={({ handleSubmit, pristine, }) => (
             <div
               data-test-eholdings-package-create
               data-testid="data-test-eholdings-package-create"
@@ -145,7 +148,7 @@ class PackageCreate extends Component {
                     defaultWidth="fill"
                     paneTitle={paneTitle}
                     firstMenu={this.getFirstMenu()}
-                    footer={this.getFooter(pristine, reset)}
+                    footer={this.getFooter(pristine)}
                   >
                     <div className={styles['package-create-form-container']}>
                       <DetailsViewSection

--- a/src/components/package/edit-custom/custom-package-edit.js
+++ b/src/components/package/edit-custom/custom-package-edit.js
@@ -187,11 +187,11 @@ const CustomPackageEdit = ({
     );
   };
 
-  const getFooter = (pristine, reset) => {
+  const getFooter = (pristine) => {
     return (
       <EditPaneFooter
         disabled={model.update.isPending || pristine}
-        reset={reset}
+        onCancel={onCancel}
       />
     );
   };
@@ -206,7 +206,7 @@ const CustomPackageEdit = ({
         decorators={[focusOnErrors]}
         mutators={{ ...arrayMutators }}
         initialValues={initialValues}
-        render={({ handleSubmit, pristine, form: { change, reset } }) => (
+        render={({ handleSubmit, pristine, form: { change } }) => (
           <>
             <Toaster
               toasts={processErrors(model)}
@@ -226,7 +226,7 @@ const CustomPackageEdit = ({
                 sections={sections}
                 ariaRole="tablist"
                 bodyAriaRole="tab"
-                footer={getFooter(pristine, reset)}
+                footer={getFooter(pristine)}
                 bodyContent={(
                   <>
                     <HoldingStatus

--- a/src/components/package/edit-managed/managed-package-edit.js
+++ b/src/components/package/edit-managed/managed-package-edit.js
@@ -215,11 +215,11 @@ const ManagedPackageEdit = ({
     );
   };
 
-  const getFooter = (pristine, reset) => {
+  const getFooter = (pristine) => {
     return (
       <EditPaneFooter
         disabled={model.update.isPending || pristine}
-        reset={reset}
+        onCancel={onCancel}
       />
     );
   };
@@ -237,7 +237,7 @@ const ManagedPackageEdit = ({
         render={({
           handleSubmit,
           pristine,
-          form: { change, reset },
+          form: { change },
         }) => (
           <>
             <Toaster
@@ -257,7 +257,7 @@ const ManagedPackageEdit = ({
                   actionMenu={getActionMenu()}
                   handleExpandAll={toggleAllSections}
                   sections={sections}
-                  footer={getFooter(pristine, reset)}
+                  footer={getFooter(pristine)}
                   bodyContent={(
                     <>
                       <HoldingStatus

--- a/src/components/package/edit/components/edit-pane-footer/edit-pane-footer.js
+++ b/src/components/package/edit/components/edit-pane-footer/edit-pane-footer.js
@@ -8,19 +8,19 @@ import {
 
 const propTypes = {
   disabled: PropTypes.bool.isRequired,
-  reset: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
 };
 
 const EditPaneFooter = ({
   disabled,
-  reset,
+  onCancel,
 }) => {
   const cancelButton = (
     <Button
       data-test-eholdings-package-edit-cancel-button
       buttonStyle="default mega"
       disabled={disabled}
-      onClick={reset}
+      onClick={onCancel}
       marginBottom0
     >
       <FormattedMessage id="stripes-components.cancel" />

--- a/src/components/provider/edit/provider-edit.js
+++ b/src/components/provider/edit/provider-edit.js
@@ -35,15 +35,18 @@ export default class ProviderEdit extends Component {
 
   editFormRef = createRef();
 
-  getFooter = (pristine, reset) => {
-    const { model } = this.props;
+  getFooter = (pristine) => {
+    const {
+      model,
+      onCancel,
+    } = this.props;
 
     const cancelButton = (
       <Button
         data-test-eholdings-provider-edit-cancel-button
         buttonStyle="default mega"
         disabled={model.update.isPending || pristine}
-        onClick={reset}
+        onClick={onCancel}
         marginBottom0
       >
         <FormattedMessage id="stripes-components.cancel" />
@@ -146,7 +149,7 @@ export default class ProviderEdit extends Component {
               proxyId: model.proxy.id?.toLowerCase(),
               providerTokenValue: model.providerToken.value
             }}
-            render={({ handleSubmit, pristine, form: { reset } }) => (
+            render={({ handleSubmit, pristine }) => (
               <>
                 <Toaster
                   toasts={processErrors(model)}
@@ -162,7 +165,7 @@ export default class ProviderEdit extends Component {
                     model={model}
                     key={model.id}
                     paneTitle={model.name}
-                    footer={this.getFooter(pristine, reset)}
+                    footer={this.getFooter(pristine)}
                     bodyContent={this.renderBodyContent()}
                     onCancel={onCancel}
                   />

--- a/src/components/resource/edit-custom-title/resource-edit-custom-title.js
+++ b/src/components/resource/edit-custom-title/resource-edit-custom-title.js
@@ -183,7 +183,7 @@ const ResourceEditCustomTitle = ({
           },
         }}
         initialValues={initialValues}
-        render={({ handleSubmit, pristine, form: { change, reset } }) => (
+        render={({ handleSubmit, pristine, form: { change } }) => (
           <>
             <Toaster
               toasts={processErrors(model)}
@@ -201,7 +201,7 @@ const ResourceEditCustomTitle = ({
                 paneSub={model.package.name}
                 handleExpandAll={handleExpandAll}
                 sections={sections}
-                footer={getFooter(pristine, reset)}
+                footer={getFooter(pristine)}
                 onCancel={onCancel}
                 bodyContent={(
                   <>

--- a/src/components/resource/edit-managed-title/resource-edit-managed-title.js
+++ b/src/components/resource/edit-managed-title/resource-edit-managed-title.js
@@ -179,7 +179,7 @@ const ResourceEditManagedTitle = ({
         }}
         initialValuesEqual={() => true}
         initialValues={initialValues}
-        render={({ handleSubmit, pristine, form: { change, reset } }) => (
+        render={({ handleSubmit, pristine, form: { change } }) => (
           <>
             <Toaster
               toasts={processErrors(model)}
@@ -197,7 +197,7 @@ const ResourceEditManagedTitle = ({
                 paneSub={model.package.name}
                 handleExpandAll={handleExpandAll}
                 sections={sections}
-                footer={getFooter(pristine, reset)}
+                footer={getFooter(pristine)}
                 onCancel={onCancel}
                 bodyContent={(
                   <>

--- a/src/components/resource/resource-edit.js
+++ b/src/components/resource/resource-edit.js
@@ -130,15 +130,18 @@ export default class ResourceEdit extends Component {
     });
   }
 
-  getFooter = (pristine, reset) => {
-    const { model } = this.props;
+  getFooter = (pristine) => {
+    const {
+      model,
+      onCancel,
+    } = this.props;
 
     const cancelButton = (
       <Button
         data-test-eholdings-provider-edit-cancel-button
         buttonStyle="default mega"
         disabled={model.update.isPending || model.destroy.isPending || pristine}
-        onClick={reset}
+        onClick={onCancel}
         marginBottom0
       >
         <FormattedMessage id="stripes-components.cancel" />

--- a/src/components/title/create/title-create.js
+++ b/src/components/title/create/title-create.js
@@ -71,15 +71,18 @@ class TitleCreate extends Component {
     );
   };
 
-  getFooter = (pristine, reset) => {
-    const { request } = this.props;
+  getFooter = (pristine) => {
+    const {
+      request,
+      onCancel,
+    } = this.props;
 
     const cancelButton = (
       <Button
         data-test-eholdings-title-create-cancel-button
         buttonStyle="default mega"
         disabled={request.isPending || pristine}
-        onClick={reset}
+        onClick={onCancel}
         marginBottom0
       >
         <FormattedMessage id="stripes-components.cancel" />
@@ -140,7 +143,7 @@ class TitleCreate extends Component {
             }}
             decorators={[focusOnErrors]}
             mutators={{ ...arrayMutators }}
-            render={({ handleSubmit, pristine, form: { reset } }) => (
+            render={({ handleSubmit, pristine }) => (
               <form
                 ref={this.createFormRef}
                 onSubmit={handleSubmit}
@@ -151,7 +154,7 @@ class TitleCreate extends Component {
                     defaultWidth="fill"
                     paneTitle={paneTitle}
                     firstMenu={this.renderFirstMenu()}
-                    footer={this.getFooter(pristine, reset)}
+                    footer={this.getFooter(pristine)}
                   >
                     <div className={styles['title-create-form-container']}>
                       <DetailsViewSection


### PR DESCRIPTION
## Description
Make cancel button show confirmation modal on Create/Edit pages

## Screenshots

https://github.com/folio-org/ui-eholdings/assets/19309423/ea2542d0-dd0c-4888-a6a5-268c23af19ea

## Issues
[UIEH-1360](https://issues.folio.org/browse/UIEH-1360)