### PR TITLE
UIEH-1431: Change permission `kb-ebsco.kb-credentials.item.get` to `kb-ebsco.kb-credentials.key.item.get` and `kb-ebsco.kb-credentials.uc.item.get` to `kb-ebsco.kb-credentials.uc.key.item.get`.

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -153,7 +153,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -161,7 +161,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -96,7 +96,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -104,7 +104,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Agreements accordion - Add a tooltip for the `New` and `Add` buttons. (UIEH-1424)
 * eHoldings package-title (resource) view: display Proxied URL. (UIEH-1419)
 * Fix title search is slow with many Packages filter options. (UIEH-1428)
+* Change permission `kb-ebsco.kb-credentials.item.get` to `kb-ebsco.kb-credentials.key.item.get` and `kb-ebsco.kb-credentials.uc.item.get` to `kb-ebsco.kb-credentials.uc.key.item.get`. (UIEH-1431)
 
 ## [9.1.1] (https://github.com/folio-org/ui-eholdings/tree/v9.1.1) (2024-03-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Change history for ui-eholdings
 
-## [9.2.0] (IN PROGRESS)
+## [10.0.0] (IN PROGRESS)
 
 * Agreements accordion - Revise Are you sure you want to unassign agreement? message. (UIEH-1420)
 * Agreements accordion - Add a tooltip for the `New` and `Add` buttons. (UIEH-1424)
 * eHoldings package-title (resource) view: display Proxied URL. (UIEH-1419)
 * Fix title search is slow with many Packages filter options. (UIEH-1428)
-* Change permission `kb-ebsco.kb-credentials.item.get` to `kb-ebsco.kb-credentials.key.item.get` and `kb-ebsco.kb-credentials.uc.item.get` to `kb-ebsco.kb-credentials.uc.key.item.get`. (UIEH-1431)
+* *BREAKING* Upgrade `eholdings` to `4.0`. Change permission `kb-ebsco.kb-credentials.item.get` to `kb-ebsco.kb-credentials.key.item.get` and `kb-ebsco.kb-credentials.uc.item.get` to `kb-ebsco.kb-credentials.uc.key.item.get`. (UIEH-1431)
 
 ## [9.1.1] (https://github.com/folio-org/ui-eholdings/tree/v9.1.1) (2024-03-24)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eholdings",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "description": "FOLIO UI module for eHoldings",
   "main": "src/index.js",
   "repository": "https://github.com/folio-org/ui-eholdings",
@@ -98,7 +98,7 @@
       }
     ],
     "okapiInterfaces": {
-      "eholdings": "3.0",
+      "eholdings": "4.0",
       "tags": "1.0",
       "erm": "1.0 2.0 3.0 4.0 5.0 6.0 7.0"
     },

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
           "settings.eholdings.enabled",
           "module.eholdings.enabled",
           "kb-ebsco.kb-credentials.collection.get",
-          "kb-ebsco.kb-credentials.item.get"
+          "kb-ebsco.kb-credentials.key.item.get"
         ]
       },
       {
@@ -321,7 +321,7 @@
         "visible": true,
         "subPermissions": [
           "ui-eholdings.settings.kb.view",
-          "kb-ebsco.kb-credentials.uc.item.get",
+          "kb-ebsco.kb-credentials.uc.key.item.get",
           "kb-ebsco.currencies.collection.get",
           "kb-ebsco.uc-credentials.item.get",
           "kb-ebsco.uc-credentials.client-id.get",

--- a/src/components/search-form/components/packages-filter-accordion/packages-filter-accordion.test.js
+++ b/src/components/search-form/components/packages-filter-accordion/packages-filter-accordion.test.js
@@ -1,6 +1,8 @@
 import { render, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 import PackagesFilterAccordion from './packages-filter-accordion';
 
+jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
+
 const mockOnUpdate = jest.fn();
 
 const getComponent = (props = {}) => (
@@ -60,6 +62,9 @@ describe('Given PackagesFilterAccordion', () => {
         activeFilters,
       });
 
+      fireEvent.click(getByText('ui-eholdings.packages.filter'));
+      fireEvent.click(getByText('stripes-components.selection.controlLabel'));
+
       fireEvent.click(getByText('option1 (100)'));
 
       expect(mockOnUpdate).toHaveBeenCalledWith({
@@ -81,7 +86,10 @@ describe('Given PackagesFilterAccordion', () => {
         totalRecords: 200,
       }];
 
-      const { container } = renderComponent({ dataOptions });
+      const { container, getByText } = renderComponent({ dataOptions });
+
+      fireEvent.click(getByText('ui-eholdings.packages.filter'));
+      fireEvent.click(getByText('stripes-components.selection.controlLabel'));
 
       const input = container.querySelector('input[type="text"]');
       fireEvent.change(input, { target: { value: '[' } });

--- a/src/components/settings/settings-custom-labels/settings-custom-labels.test.js
+++ b/src/components/settings/settings-custom-labels/settings-custom-labels.test.js
@@ -153,13 +153,14 @@ describe('Given SettingsCustomLabels', () => {
         getByRole,
         getByTestId,
       } = renderSettingsCustomLabels();
-      const name = 'ui-eholdings.settings.customLabels.remove ' +
+      const name =
         'ui-eholdings.settings.customLabels.remove.description ' +
         'ui-eholdings.settings.customLabels.remove.note';
 
       fireEvent.change(getByTestId('customLabel2-display-label'), { target: { value: '' } });
       fireEvent.click(getByRole('button', { name: 'stripes-core.button.save' }));
 
+      expect(getByRole('heading', { name: 'ui-eholdings.settings.customLabels.remove' })).toBeInTheDocument();
       expect(getByRole('dialog', { name })).toBeDefined();
     });
   });

--- a/src/components/title/_fields/package-select/package-select-field.test.js
+++ b/src/components/title/_fields/package-select/package-select-field.test.js
@@ -1,11 +1,14 @@
 import { Form } from 'react-final-form';
+import debounce from 'lodash/debounce';
+
 import {
   fireEvent,
   render,
 } from '@folio/jest-config-stripes/testing-library/react';
 
-import wait from '../../../../../test/jest/helpers/wait';
 import PackageSelectField from './package-select-field';
+
+jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
 
 const mockOnFilter = jest.fn();
 
@@ -43,6 +46,7 @@ describe('Given PackageSelectField', () => {
       }],
     });
 
+    fireEvent.click(getByText('ui-eholdings.title.chooseAPackage'));
     expect(getByText('label1')).toBeDefined();
   });
 
@@ -71,8 +75,7 @@ describe('Given PackageSelectField', () => {
     const input = getAllByLabelText('stripes-components.selection.filterOptionsLabel')[0];
 
     fireEvent.change(input, { target: { value: 'packageName' } });
-    expect(mockOnFilter).not.toHaveBeenCalled();
-    await wait(1100);
+    expect(debounce).toHaveBeenCalledWith(mockOnFilter, 1000);
     expect(mockOnFilter).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Description
BE changes some permissions in [mod-kb-ebsco-java](https://github.com/folio-org/mod-kb-ebsco-java/pull/548), so UI should also make the following changes:
1. `kb-ebsco.kb-credentials.item.get` to `kb-ebsco.kb-credentials.key.item.get`;
2. `kb-ebsco.kb-credentials.uc.item.get` to `kb-ebsco.kb-credentials.uc.key.item.get`.

Hey @zburke - should this permissions change be a breaking UI change if the BE side doesn't change the version?
It will be merged with https://github.com/folio-org/mod-kb-ebsco-java/pull/548.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues
[UIEH-1431](https://folio-org.atlassian.net/browse/UIEH-1431)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
