### PR TITLE
UIEH-1439: Pass the `AsyncFilter` property to the `Selection` component of packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Return permissions: `kb-ebsco.kb-credentials.uc.item.get`, `kb-ebsco.kb-credentials.item.get`. (UIEH-1434)
 * migrate to shared CI workflows. (UIEH-1429)
 * Rename permissions to match the naming convention. (UIEH-1436)
+* Pass the `asyncFilter` property to the `Selection` component of packages. (UIEH-1439)
 
 ## [9.1.1] (https://github.com/folio-org/ui-eholdings/tree/v9.1.1) (2024-03-24)
 

--- a/src/components/title/_fields/package-select/package-select-field.js
+++ b/src/components/title/_fields/package-select/package-select-field.js
@@ -15,7 +15,7 @@ function validate(value) {
   return value ? undefined : <FormattedMessage id="ui-eholdings.validate.errors.packageSelect.required" />;
 }
 
-const FILTER_DEBOUNCE_MS = 1000;
+const FILTER_DEBOUNCE_MS = 800;
 
 const PackageSelectField = ({
   options,
@@ -47,6 +47,7 @@ const PackageSelectField = ({
         placeholder={intl.formatMessage({ id: 'ui-eholdings.title.chooseAPackage' })}
         dataOptions={options.filter(option => option.label && !option.disabled)}
         required
+        asyncFilter
         onFilter={handleFilter}
         data-testid="package-select-field"
         loading={loadingOptions}

--- a/src/components/title/_fields/package-select/package-select-field.test.js
+++ b/src/components/title/_fields/package-select/package-select-field.test.js
@@ -75,7 +75,7 @@ describe('Given PackageSelectField', () => {
     const input = getAllByLabelText('stripes-components.selection.filterOptionsLabel')[0];
 
     fireEvent.change(input, { target: { value: 'packageName' } });
-    expect(debounce).toHaveBeenCalledWith(mockOnFilter, 1000);
+    expect(debounce).toHaveBeenCalledWith(mockOnFilter, 800);
     expect(mockOnFilter).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Description
The `Selection` component was [rewritten](https://github.com/folio-org/stripes-components/pull/2346) some time ago, this was a breaking change to the eholdings packages implementation, which caused the API to call infinitely. The solution is to pass the `asyncFilter` property, since filtering should call new packages when the filter changes. I Reduced the delay since it was also added to the `Selection` component.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots

https://github.com/user-attachments/assets/971f7772-897b-4176-a031-8e10b036da4b



<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
