### PR TITLE
UIEH-1449 add more space to custom coverage column (follow-up)

### DIFF
--- a/src/components/package/show/components/PackageTitleList/PackageTitleList.js
+++ b/src/components/package/show/components/PackageTitleList/PackageTitleList.js
@@ -122,9 +122,9 @@ const PackageTitleList = ({
     [COLUMNS.STATUS]: '11%',
     [COLUMNS.TITLE]: '25%',
     [COLUMNS.MANAGED_COVERAGE]: '16%',
-    [COLUMNS.CUSTOM_COVERAGE]: '16%',
+    [COLUMNS.CUSTOM_COVERAGE]: '17%',
     [COLUMNS.MANAGED_EMBARGO]: '17%',
-    [COLUMNS.TAGS]: '13%',
+    [COLUMNS.TAGS]: '12%',
   }), []);
 
   return (


### PR DESCRIPTION
## Description
add more space to custom coverage column so that when there are multiple custom coverage dates they each fit on a single line

## Screenshots
![image](https://github.com/user-attachments/assets/9a9466bc-eb20-4e29-9772-ff8124af8155)

## Issues
[UIEH-1449](https://folio-org.atlassian.net/browse/UIEH-1449)