### PR TITLE
UIEH-1471 Show a loading indicator under Package Titles list when package titles are updating.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [11.1.0] (IN PROGRESS)
 
 * Replace `moment` usage with `dayjs`. (UIEH-1407)
+* Show a loading indicator under Package Titles list when package titles are updating. (UIEH-1471)
 
 ## [11.0.1] (https://github.com/folio-org/ui-eholdings/tree/v11.0.1) (2025-04-16)
 

--- a/src/components/package/show/components/PackageTitleList/PackageTitleList.js
+++ b/src/components/package/show/components/PackageTitleList/PackageTitleList.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import {
+  Icon,
   MCLPagingTypes,
   MultiColumnList,
   TextLink,
@@ -30,6 +31,7 @@ const MAX_HEIGHT = 520;
 const propTypes = {
   count: PropTypes.number.isRequired,
   isLoading: PropTypes.bool,
+  isTitlesUpdating: PropTypes.bool,
   onFetchPackageTitles: PropTypes.func.isRequired,
   page: PropTypes.number.isRequired,
   records: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -43,6 +45,7 @@ const PackageTitleList = ({
   page,
   count,
   onFetchPackageTitles,
+  isTitlesUpdating,
 }) => {
   const intl = useIntl();
 
@@ -129,24 +132,28 @@ const PackageTitleList = ({
 
   return (
     <div className={styles.titlesListContainer}>
-      <MultiColumnList
-        id="package-title-list"
-        maxHeight={MAX_HEIGHT}
-        contentData={records}
-        visibleColumns={Object.values(COLUMNS)}
-        columnMapping={columnMappings}
-        columnWidths={columnWidths}
-        formatter={formatter}
-        isEmptyMessage={intl.formatMessage({ id: 'ui-eholdings.notFound' })}
-        loading={isLoading}
-        totalCount={totalResults}
-        onNeedMoreData={handleMore}
-        pageAmount={count}
-        pagingType={MCLPagingTypes.PREV_NEXT}
-        pagingOffset={count * (page - 1)}
-        getCellClass={formatCellStyles}
-        getHeaderCellClass={formatHeaderCellStyles}
-      />
+      {isTitlesUpdating
+        ? <Icon icon="spinner-ellipsis" width="35px" />
+        : (
+          <MultiColumnList
+            id="package-title-list"
+            maxHeight={MAX_HEIGHT}
+            contentData={records}
+            visibleColumns={Object.values(COLUMNS)}
+            columnMapping={columnMappings}
+            columnWidths={columnWidths}
+            formatter={formatter}
+            isEmptyMessage={intl.formatMessage({ id: 'ui-eholdings.notFound' })}
+            loading={isLoading}
+            totalCount={totalResults}
+            onNeedMoreData={handleMore}
+            pageAmount={count}
+            pagingType={MCLPagingTypes.PREV_NEXT}
+            pagingOffset={count * (page - 1)}
+            getCellClass={formatCellStyles}
+            getHeaderCellClass={formatHeaderCellStyles}
+          />
+        )}
     </div>
   );
 };

--- a/src/components/package/show/components/PackageTitleList/PackageTitleList.test.js
+++ b/src/components/package/show/components/PackageTitleList/PackageTitleList.test.js
@@ -94,6 +94,16 @@ describe('Given PackageTitleList', () => {
     expect(a11yResults.violations.length).toEqual(0);
   });
 
+  describe('when isTitlesUpdating is true', () => {
+    it('should show a loading indicator', async () => {
+      const { container } = renderPackageTitleList({
+        isTitlesUpdating: true,
+      });
+
+      expect(container.querySelector('.icon-spinner-ellipsis')).toBeDefined();
+    });
+  });
+
   it('should display the correct columns', () => {
     const { getByText } = renderPackageTitleList();
 

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -383,7 +383,8 @@ const PackageShow = ({
     return (
       <PackageTitleList
         records={packageTitles.items}
-        isLoading={!isTitlesUpdating && packageTitles.isLoading}
+        isLoading={packageTitles.isLoading}
+        isTitlesUpdating={isTitlesUpdating}
         totalResults={packageTitles.totalResults}
         page={pkgSearchParams.page}
         count={pkgSearchParams.count}


### PR DESCRIPTION
## Description
Before switching to MCL Package Titles list showed a loading indicator when a Package was added/removed from holdings and package-titles records were being updated.
In this PR we're adding that functionality back to current implementation.

## Screenshots

https://github.com/user-attachments/assets/0a1b41a9-3c7a-4fc4-b5ba-799ea68623b4



## Issues
[UIEH-1471](https://folio-org.atlassian.net/browse/UIEH-1471)