### PR TITLE
UIEH-1470 Fix "Undefined" displays in input field of "Packages" facet on "Titles" search pane when facet selection is canceled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [11.1.0] (IN PROGRESS)
 
 * Replace `moment` usage with `dayjs`. (UIEH-1407)
+* Fix "Undefined" displays in input field of "Packages" facet on "Titles" search pane when facet selection is canceled. (UIEH-1470).
 
 ## [11.0.1] (https://github.com/folio-org/ui-eholdings/tree/v11.0.1) (2025-04-16)
 

--- a/src/components/facet-option-formatter/FacetOptionFormatter.js
+++ b/src/components/facet-option-formatter/FacetOptionFormatter.js
@@ -8,7 +8,7 @@ const propTypes = {
 };
 
 const FacetOptionFormatter = ({ option = null, searchTerm = '' }) => {
-  if (!option || !option?.value) {
+  if (!option?.value) {
     return null;
   }
 

--- a/src/components/facet-option-formatter/FacetOptionFormatter.js
+++ b/src/components/facet-option-formatter/FacetOptionFormatter.js
@@ -8,7 +8,7 @@ const propTypes = {
 };
 
 const FacetOptionFormatter = ({ option = null, searchTerm = '' }) => {
-  if (!option) {
+  if (!option || !option?.value) {
     return null;
   }
 

--- a/src/components/facet-option-formatter/FacetOptionFormatter.test.js
+++ b/src/components/facet-option-formatter/FacetOptionFormatter.test.js
@@ -22,4 +22,11 @@ describe('Given FacetOptionFormatter', () => {
     const { container } = renderFacetOptionFormatter({ option: null });
     expect(container).toBeEmptyDOMElement();
   });
+
+  describe('when option.value is empty', () => {
+    it('should render nothing', () => {
+      const { container } = renderFacetOptionFormatter({ option: { value: '' } });
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
 });

--- a/src/components/facet-option-formatter/FacetOptionFormatter.test.js
+++ b/src/components/facet-option-formatter/FacetOptionFormatter.test.js
@@ -4,6 +4,7 @@ import FacetOptionFormatter from './FacetOptionFormatter';
 
 const option = {
   label: 'fakeLabel',
+  value: 'fakeValue',
   totalRecords: 500,
 };
 


### PR DESCRIPTION
## Description
Fix an issue with Packages filter displaying "undefined (undefined)" selected after clearing the filter.
It looks like after refactoring of `<Selection>` component empty option is not just a `null` object, but can be an object with an empty `value` property, so we should also check for this case in our custom `<FacetOptionFormatter>` component.

## Screenshots

https://github.com/user-attachments/assets/8ca94016-1908-4728-b7e4-fdfc7daaabb8



## Issues
[UIEH-1470](https://folio-org.atlassian.net/browse/UIEH-1470)