### PR TITLE
UIEH-1464 Package-Title MCL: indicate HLM title visibility (ie Hidden) in status column.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Replace `moment` usage with `dayjs`. (UIEH-1407)
 * Show a loading indicator under Package Titles list when package titles are updating. (UIEH-1471)
+* Package-Title MCL: indicate HLM title visibility (ie Hidden) in status column. (UIEH-1464)
 
 ## [11.0.1] (https://github.com/folio-org/ui-eholdings/tree/v11.0.1) (2025-04-16)
 

--- a/src/components/package/show/components/PackageTitleList/PackageTitleList.css
+++ b/src/components/package/show/components/PackageTitleList/PackageTitleList.css
@@ -13,3 +13,10 @@
 .headerCell {
   padding: var(--gutter-static-two-thirds) 0 var(--gutter-static-one-third) var(--gutter-static-two-thirds);
 }
+
+.statusCellWrapper {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}

--- a/src/components/package/show/components/PackageTitleList/PackageTitleList.js
+++ b/src/components/package/show/components/PackageTitleList/PackageTitleList.js
@@ -8,6 +8,7 @@ import {
   MCLPagingTypes,
   MultiColumnList,
   TextLink,
+  Tooltip,
 } from '@folio/stripes/components';
 
 import SelectedLabel from '../../../../selected-label';
@@ -69,7 +70,17 @@ const PackageTitleList = ({
   const formatter = {
     [COLUMNS.STATUS]: item => {
       return (
-        <SelectedLabel isSelected={item.attributes.isSelected} />
+        <div className={styles.statusCellWrapper}>
+          <SelectedLabel isSelected={item.attributes.isSelected} />
+          {item.attributes.visibilityData?.isHidden && (
+            <Tooltip
+              text={intl.formatMessage({ id: 'ui-eholdings.titlesList.hidden' })}
+              id="resource-hidden-tooltip"
+            >
+              {({ ref, ariaIds }) => <Icon icon="eye-closed" ref={ref} aria-labelledby={ariaIds.text} />}
+            </Tooltip>
+          )}
+        </div>
       );
     },
     [COLUMNS.TITLE]: item => {

--- a/src/components/package/show/components/PackageTitleList/PackageTitleList.test.js
+++ b/src/components/package/show/components/PackageTitleList/PackageTitleList.test.js
@@ -34,6 +34,9 @@ const records = [
       tags: {
         tagList: ['testtag'],
       },
+      visibilityData: {
+        isHidden: true,
+      },
     },
   },
   {
@@ -113,6 +116,14 @@ describe('Given PackageTitleList', () => {
     expect(getByText('ui-eholdings.titlesList.customCoverage')).toBeDefined();
     expect(getByText('ui-eholdings.titlesList.managedEmbargo')).toBeDefined();
     expect(getByText('ui-eholdings.titlesList.tags')).toBeDefined();
+  });
+
+  describe('when a resource is hidden', () => {
+    it('should show a "hidden" icon', () => {
+      const { container } = renderPackageTitleList();
+
+      expect(container.querySelector('.icon-eye-closed')).toBeDefined();
+    });
   });
 
   it('should call onFetchPackageTitles when fetching more data', async () => {

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -641,6 +641,7 @@
     "actionMenu.filterBadgeTooltip": "{count} applied {count, plural, one {filter} other {filters}}",
     "titlesList.title": "Title",
     "titlesList.status": "Status",
+    "titlesList.hidden": "Title is set to hide",
     "titlesList.managedCoverage": "Managed coverage",
     "titlesList.customCoverage": "Custom coverage",
     "titlesList.managedEmbargo": "Managed embargo period",


### PR DESCRIPTION
## Description
When a Resource is hidden we should display a "hidden" icon next to the selection status.

## Screenshots
![image](https://github.com/user-attachments/assets/27118db7-bb4e-4f7d-86b1-8a6aed5df900)


## Issues
[UIEH-1464](https://folio-org.atlassian.net/browse/UIEH-1464)