### PR TITLE
UIEH-1463 Package detail record > Titles accordion > Change Publication type radio button filter to single select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Replace `moment` usage with `dayjs`. (UIEH-1407)
 * Show a loading indicator under Package Titles list when package titles are updating. (UIEH-1471)
 * Fix "Undefined" displays in input field of "Packages" facet on "Titles" search pane when facet selection is canceled. (UIEH-1470).
+* Package detail record > Titles accordion > Change Publication type radio button filter to single select. (UIEH-1463)
 
 ## [11.0.1] (https://github.com/folio-org/ui-eholdings/tree/v11.0.1) (2025-04-16)
 

--- a/src/components/search-form/search-form.js
+++ b/src/components/search-form/search-form.js
@@ -26,6 +26,9 @@ import {
   searchTypes,
   accessTypesReduxStateShape,
   searchableIndexes,
+  titleSortFilterConfig,
+  selectionStatusFilterConfig,
+  publicationTypeFilterConfig,
 } from '../../constants';
 import { getTagLabelsArr } from '../utilities';
 import TagFilterAccordion from './components/tags-filter-accordion';
@@ -42,7 +45,16 @@ const validSearchTypes = [
 const searchFiltersComponents = {
   [searchTypes.PACKAGES]: PackageSearchFilters,
   [searchTypes.PROVIDERS]: ProviderSearchFilters,
-  [searchTypes.TITLES]: TitleSearchFilters,
+  [searchTypes.TITLES]: (props = {}) => (
+    <TitleSearchFilters
+      availableFilters={[
+        titleSortFilterConfig,
+        selectionStatusFilterConfig,
+        publicationTypeFilterConfig,
+      ]}
+      {...props}
+    />
+  ),
 };
 
 class SearchForm extends Component {

--- a/src/components/search-section/action-menu/action-menu.js
+++ b/src/components/search-section/action-menu/action-menu.js
@@ -25,14 +25,28 @@ import {
   getTagLabelsArr,
   getTagsList,
 } from '../../utilities';
-import { searchTypes } from '../../../constants';
+import {
+  searchTypes,
+  titleSortFilterConfig,
+  selectionStatusFilterConfig,
+  publicationTypeTitlesListFilterConfig,
+} from '../../../constants';
 
 import styles from './action-menu.css';
 
 const searchFiltersComponents = {
   [searchTypes.PACKAGES]: PackageSearchFilters,
   [searchTypes.PROVIDERS]: ProviderSearchFilters,
-  [searchTypes.TITLES]: TitleSearchFilters,
+  [searchTypes.TITLES]: (props = {}) => (
+    <TitleSearchFilters
+      availableFilters={[
+        titleSortFilterConfig,
+        selectionStatusFilterConfig,
+        publicationTypeTitlesListFilterConfig,
+      ]}
+      {...props}
+    />
+  ),
 };
 
 const propTypes = {

--- a/src/components/title-search-filters.js
+++ b/src/components/title-search-filters.js
@@ -4,11 +4,6 @@ import isEqual from 'lodash/isEqual';
 
 import SearchFilters from './search-form/search-filters';
 import PackagesFilter from './search-form/components/packages-filter';
-import {
-  titleSortFilterConfig,
-  selectionStatusFilterConfig,
-  publicationTypeFilterConfig,
-} from '../constants';
 
 const propTypes = {
   activeFilters: PropTypes.object.isRequired,
@@ -41,17 +36,14 @@ function TitleSearchFilters(props) {
     isPackagesLoading,
     titlesFacets,
     onUpdate,
+    availableFilters,
   } = props;
 
   return (
     <>
       <SearchFilters
         searchType="titles"
-        availableFilters={[
-          titleSortFilterConfig,
-          selectionStatusFilterConfig,
-          publicationTypeFilterConfig,
-        ]}
+        availableFilters={availableFilters}
         {...props}
       />
       <PackagesFilter

--- a/src/constants/filterConfigs.js
+++ b/src/constants/filterConfigs.js
@@ -40,7 +40,13 @@ export const EBSCO_PROVIDER_ID = 19;
 
 export const selectionStatusDefaultFilterOption = selectionStatusFilterOptions.ALL;
 
+export const FILTER_TYPES = {
+  SELECT: 'select',
+  CHECKBOX: 'checkbox',
+};
+
 export const selectionStatusFilterConfig = {
+  type: FILTER_TYPES.CHECKBOX,
   name: 'selected',
   label: <FormattedMessage id="ui-eholdings.label.selectionStatus" />,
   defaultValue: selectionStatusDefaultFilterOption,
@@ -61,6 +67,31 @@ export const selectionStatusFilterConfig = {
 };
 
 export const publicationTypeFilterConfig = {
+  type: FILTER_TYPES.CHECKBOX,
+  name: 'type',
+  label: <FormattedMessage id="ui-eholdings.label.publicationType" />,
+  defaultValue: 'all',
+  options: [
+    { label: <FormattedMessage id="ui-eholdings.filter.all" />, value: 'all' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.audiobook" />, value: 'audiobook' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.book" />, value: 'book' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.book_series" />, value: 'bookseries' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.database" />, value: 'database' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.journal" />, value: 'journal' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.newsletter" />, value: 'newsletter' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.newspaper" />, value: 'newspaper' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.proceedings" />, value: 'proceedings' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.report" />, value: 'report' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.streaming_audio" />, value: 'streamingaudio' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.streaming_video" />, value: 'streamingvideo' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.thesis_dissertation" />, value: 'thesisdissertation' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.website" />, value: 'website' },
+    { label: <FormattedMessage id="ui-eholdings.filter.pubType.unspecified" />, value: 'unspecified' }
+  ]
+};
+
+export const publicationTypeTitlesListFilterConfig = {
+  type: FILTER_TYPES.SELECT,
   name: 'type',
   label: <FormattedMessage id="ui-eholdings.label.publicationType" />,
   defaultValue: 'all',
@@ -84,6 +115,7 @@ export const publicationTypeFilterConfig = {
 };
 
 export const contentTypeFilterConfig = {
+  type: FILTER_TYPES.CHECKBOX,
   name: 'type',
   label: <FormattedMessage id="ui-eholdings.package.contentType" />,
   defaultValue: 'all',

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -423,7 +423,7 @@
     "label.packages": "Packages",
     "label.totalPackages": "Total packages: {count}",
     "label.provider": "Provider",
-    "label.publicationType": "Publication Type",
+    "label.publicationType": "Publication type",
     "label.subjects": "Subjects",
     "label.subject": "Subject",
     "label.peerReviewed": "Peer reviewed",


### PR DESCRIPTION
## Description
Changed Publication type filter on the Package+Title page from a checkbox to single select.
This `<TitleSearchFilters>` component is also used on the Title search page, and we need it to stay a checkbox filter. So we had to extract the configuration of this filter and pass it as `availableFilters` prop.
Updated translations to say "Publication type" instead of "Publication Type".

## Screenshots

https://github.com/user-attachments/assets/ce8f79e0-9f87-4ea6-a8f3-61e930d6879a



## Issues
[UIEH-1463](https://folio-org.atlassian.net/browse/UIEH-1463)