### PR TITLE
UIEH-1466 Package Details Record: Title List Search within: Make reset action work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix "Undefined" displays in input field of "Packages" facet on "Titles" search pane when facet selection is canceled. (UIEH-1470).
 * Package detail record > Titles accordion > Change Publication type radio button filter to single select. (UIEH-1463)
 * Package-Title MCL: indicate HLM title visibility (ie Hidden) in status column. (UIEH-1464)
+* Package Details Record: Title List Search within: Make reset action work. (UIEH-1466)
 
 ## [11.0.1] (https://github.com/folio-org/ui-eholdings/tree/v11.0.1) (2025-04-16)
 

--- a/src/components/search-section/search-section.js
+++ b/src/components/search-section/search-section.js
@@ -113,6 +113,7 @@ const SearchSection = ({
       ...cur,
       q: '',
     }));
+    updateFilter('');
   };
 
   const toggleFilter = filterName => () => {

--- a/src/components/search-section/search-section.test.js
+++ b/src/components/search-section/search-section.test.js
@@ -107,6 +107,17 @@ describe('SearchSection', () => {
 
       expect(searchBox.value).toBe('');
     });
+
+    it('should fetch data with empty query', async () => {
+      const { getByRole } = renderSearchSection();
+
+      const searchBox = getByRole('searchbox', { name: 'ui-eholdings.search.enterYourSearch' });
+
+      await userEvent.type(searchBox, 'Title name');
+      await userEvent.click(getByRole('button', { name: 'stripes-components.clearThisField' }));
+
+      expect(mockOnFilter).toHaveBeenCalledWith(expect.objectContaining({ q: undefined }));
+    });
   });
 
   describe('when search by tags filter is enabled', () => {


### PR DESCRIPTION
## Description
Clearing Titles search filter by clicking on the "x" button should fetch all Titles.

## Screenshots

https://github.com/user-attachments/assets/9072ea23-67e7-4337-9b93-a9bf7b656d62



## Issues
[UIEH-1466](https://folio-org.atlassian.net/browse/UIEH-1466)