### PR TITLE
UIEH-1476 Make "erm" an optional interface in eHoldings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Package detail record > Titles accordion > Change Publication type radio button filter to single select. (UIEH-1463)
 * Package-Title MCL: indicate HLM title visibility (ie Hidden) in status column. (UIEH-1464)
 * Package Details Record: Title List Search within: Make reset action work. (UIEH-1466)
+* Make "erm" an optional interface in eHoldings. (UIEH-1476)
 
 ## [11.0.1] (https://github.com/folio-org/ui-eholdings/tree/v11.0.1) (2025-04-16)
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,9 @@
     ],
     "okapiInterfaces": {
       "eholdings": "4.0",
-      "tags": "1.0",
+      "tags": "1.0"
+    },
+    "optionalOkapiInterfaces": {
       "erm": "1.0 2.0 3.0 4.0 5.0 6.0 7.0"
     },
     "permissionSets": [

--- a/src/components/package/show/package-show.js
+++ b/src/components/package/show/package-show.js
@@ -13,6 +13,7 @@ import omit from 'lodash/omit';
 import {
   useStripes,
   IfPermission,
+  IfInterface,
 } from '@folio/stripes/core';
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
 import { Button } from '@folio/stripes/components';
@@ -338,15 +339,17 @@ const PackageShow = ({
           customCoverage={model.customCoverage}
         />
 
-        <AgreementsAccordion
-          id="packageShowAgreements"
-          stripes={stripes}
-          refId={model.id}
-          refType={entityAuthorityTypes.PACKAGE}
-          isOpen={sections.packageShowAgreements}
-          onToggle={handleSectionToggle}
-          refName={model.name}
-        />
+        <IfInterface name="erm">
+          <AgreementsAccordion
+            id="packageShowAgreements"
+            stripes={stripes}
+            refId={model.id}
+            refType={entityAuthorityTypes.PACKAGE}
+            isOpen={sections.packageShowAgreements}
+            onToggle={handleSectionToggle}
+            refName={model.name}
+          />
+        </IfInterface>
 
         <NotesSmartAccordion
           id="packageShowNotes"

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -8,7 +8,10 @@ import {
   useIntl,
 } from 'react-intl';
 
-import { IfInterface, useStripes } from '@folio/stripes/core';
+import {
+  IfInterface,
+  useStripes,
+} from '@folio/stripes/core';
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
 import {
   Button,

--- a/src/components/resource/resource-show.js
+++ b/src/components/resource/resource-show.js
@@ -8,7 +8,7 @@ import {
   useIntl,
 } from 'react-intl';
 
-import { useStripes } from '@folio/stripes/core';
+import { IfInterface, useStripes } from '@folio/stripes/core';
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
 import {
   Button,
@@ -270,15 +270,17 @@ const ResourceShow = ({
                 userDefinedFields={userDefinedFields}
               />}
 
-            <AgreementsAccordion
-              id="resourceShowAgreements"
-              stripes={stripes}
-              refId={model.id}
-              refType={entityAuthorityTypes.RESOURCE}
-              isOpen={sections.resourceShowAgreements}
-              onToggle={handleSectionToggle}
-              refName={model.title.name}
-            />
+            <IfInterface name="erm">
+              <AgreementsAccordion
+                id="resourceShowAgreements"
+                stripes={stripes}
+                refId={model.id}
+                refType={entityAuthorityTypes.RESOURCE}
+                isOpen={sections.resourceShowAgreements}
+                onToggle={handleSectionToggle}
+                refName={model.title.name}
+              />
+            </IfInterface>
 
             <NotesSmartAccordion
               id="resourceShowNotes"


### PR DESCRIPTION
## Description
Agreements will become a separate application as part of Eureka platform and we need to make erm interface an optional dependency.

In scope of this ticket we need to hide functionality that’s related to Agreements when that interface is missing:
- Package Show page - Agreements accordion
- Package+Title Show page - Agreements accordion

## Issues
[UIEH-1476](https://folio-org.atlassian.net/browse/UIEH-1476)
