### PR TITLE
UIEH-1487 "Publication type" column is empty in "Titles" accordion of "Package" record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-eholdings
 
+## [11.2.0] (IN PROGRESS)
+
+* Fix "Publication type" column is empty in "Titles" accordion of "Package" record. (UIEH-1487)
+
 ## [11.1.0] (https://github.com/folio-org/ui-eholdings/tree/v11.1.0) (2026-04-16)
 
 * Replace `moment` usage with `dayjs`. (UIEH-1407)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/eholdings",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "FOLIO UI module for eHoldings",
   "main": "src/index.js",
   "repository": "https://github.com/folio-org/ui-eholdings",

--- a/src/components/package/show/components/PackageTitleList/PackageTitleList.js
+++ b/src/components/package/show/components/PackageTitleList/PackageTitleList.js
@@ -124,7 +124,7 @@ const PackageTitleList = ({
         value: embargoValue,
       });
     },
-    [PACKAGE_TITLES_LIST_COLUMNS.PUBLICATION_TYPE]: item => item.publicationType,
+    [PACKAGE_TITLES_LIST_COLUMNS.PUBLICATION_TYPE]: item => item.attributes.publicationType,
     [PACKAGE_TITLES_LIST_COLUMNS.ACCESS_STATUS_TYPE]: item => item.included.find(included => included.type === 'accessTypes')?.attributes?.name,
     [PACKAGE_TITLES_LIST_COLUMNS.TAGS]: item => {
       const { tagList } = item.attributes.tags;


### PR DESCRIPTION
## Desciption
`publicationType` is located in `attributes` object of a Resource.

## Issues
[UIEH-1487](https://folio-org.atlassian.net/browse/UIEH-1487)