### PR TITLE
ERM-4007 Populate `resourceName` when adding an eHoldings resource to an agreement line via "eHoldings"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [11.2.0] (IN PROGRESS)
 
 * Fix "Publication type" column is empty in "Titles" accordion of "Package" record. (UIEH-1487)
+* Populate `resourceName` when adding an eHoldings resource to an agreement line via "eHoldings". (ERM-4007)
 
 ## [11.1.0] (https://github.com/folio-org/ui-eholdings/tree/v11.1.0) (2026-04-16)
 

--- a/src/features/agreements-accordion/agreements-accordion.js
+++ b/src/features/agreements-accordion/agreements-accordion.js
@@ -140,6 +140,7 @@ const AgreementsAccordion = ({
       refId,
       authorityType: refType,
       label: name,
+      resourceName: refName,
     };
 
     attachAgreement(new Agreement(agreementParams));

--- a/src/features/agreements-accordion/model/agreement.js
+++ b/src/features/agreements-accordion/model/agreement.js
@@ -4,11 +4,19 @@ export default class Agreement {
   authority = '';
   reference = '';
   label = '';
+  resourceName = '';
 
-  constructor({ id, refId, authorityType, label }) {
+  constructor({
+    id,
+    refId,
+    authorityType,
+    label,
+    resourceName,
+  }) {
     this.id = id;
     this.reference = refId;
     this.authority = authorityType;
     this.label = label;
+    this.resourceName = resourceName;
   }
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
https://folio-org.atlassian.net/browse/ERM-4007

Populate resourceName when linking an eHoldings resource to an agreement line so that it can be used for search, display

## Screen recordings


https://github.com/user-attachments/assets/e1c68937-5a7f-475a-a05d-d46de98c5c8c

https://github.com/user-attachments/assets/10c00dc4-a48e-4336-bd1e-e00894899b29

