### PR TITLE
UIEH-1493 Remove duplicate requests for KB list and Access Types when opening Settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [11.2.0] (IN PROGRESS)
 
 * Fix "Publication type" column is empty in "Titles" accordion of "Package" record. (UIEH-1487)
+* Remove duplicate requests for KB list and Access Types when opening Settings. (UIEH-1493)
 
 ## [11.1.0] (https://github.com/folio-org/ui-eholdings/tree/v11.1.0) (2026-04-16)
 

--- a/src/routes/application-route/application-route.js
+++ b/src/routes/application-route/application-route.js
@@ -36,14 +36,12 @@ class ApplicationRoute extends Component {
     }).isRequired,
   };
 
-  constructor(props) {
-    super(props);
-
-    if (!props.showSettings) {
-      props.getBackendStatus();
+  componentDidMount() {
+    if (!this.props.showSettings) {
+      this.props.getBackendStatus();
     }
 
-    props.getKbCredentials();
+    this.props.getKbCredentials();
   }
 
   render() {

--- a/src/routes/settings-access-status-types-route/settings-access-status-types-route.js
+++ b/src/routes/settings-access-status-types-route/settings-access-status-types-route.js
@@ -42,14 +42,6 @@ const SettingsAccessStatusTypesRoute = ({
     }
   }, [data, getAccessTypes, params.kbId, hasPermToView]);
 
-  useEffect(() => {
-    if (!hasPermToView) {
-      return;
-    }
-
-    getAccessTypes(params.kbId);
-  }, [getAccessTypes, params.kbId, hasPermToView]);
-
   const pageLabel = intl.formatMessage({ id: 'ui-eholdings.label.settings' });
   const recordLabel = intl.formatMessage({ id: 'ui-eholdings.settings.accessStatusTypes' });
 

--- a/src/routes/settings-access-status-types-route/settings-access-status-types-route.test.js
+++ b/src/routes/settings-access-status-types-route/settings-access-status-types-route.test.js
@@ -3,7 +3,6 @@ import { MemoryRouter } from 'react-router-dom';
 import {
   render,
   cleanup,
-  act,
   waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
 

--- a/src/routes/settings-access-status-types-route/settings-access-status-types-route.test.js
+++ b/src/routes/settings-access-status-types-route/settings-access-status-types-route.test.js
@@ -4,6 +4,7 @@ import {
   render,
   cleanup,
   act,
+  waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
 
 import SettingsAccessStatusTypesRoute from './settings-access-status-types-route';
@@ -82,29 +83,38 @@ describe('Given SettingsAccessStatusTypesRoute', () => {
   afterEach(cleanup);
 
   it('should handle getAccessTypes', async () => {
-    await act(async () => {
-      await renderSettingsAccessStatusTypesRoute();
+    await renderSettingsAccessStatusTypesRoute({
+      accessTypes: {
+        items: {
+          data: null,
+        },
+        errors: [],
+      },
     });
 
-    expect(mockGetAccessTypes).toHaveBeenCalledWith(match.params.kbId);
+    await waitFor(() => expect(mockGetAccessTypes).toHaveBeenCalledWith(match.params.kbId));
   });
 
   describe('when kbId changes', () => {
     it('should call getAccessTypes with new kbId', async () => {
-      await act(async () => {
-        const { rerender } = await renderSettingsAccessStatusTypesRoute();
+      const { rerender } = await renderSettingsAccessStatusTypesRoute();
 
-        rerender(getSettingsAccessStatusTypesRoute({
-          match: {
-            ...match,
-            params: {
-              kbId: 'new-test-kb-id',
-            },
+      rerender(getSettingsAccessStatusTypesRoute({
+        match: {
+          ...match,
+          params: {
+            kbId: 'new-test-kb-id',
           },
-        }));
-      });
+        },
+        accessTypes: {
+          items: {
+            data: null,
+          },
+          errors: [],
+        },
+      }));
 
-      expect(mockGetAccessTypes).toHaveBeenCalledWith('new-test-kb-id');
+      await waitFor(() => expect(mockGetAccessTypes).toHaveBeenCalledWith('new-test-kb-id'));
     });
   });
 

--- a/src/routes/settings-route/index.js
+++ b/src/routes/settings-route/index.js
@@ -1,12 +1,9 @@
 import { connect } from 'react-redux';
 import SettingsRoute from './settings-route';
-import { getKbCredentials } from '../../redux/actions';
 import { selectPropFromData } from '../../redux/selectors';
 
 export default connect(
   (store) => ({
     kbCredentials: selectPropFromData(store, 'kbCredentials'),
-  }), {
-    getKbCredentials,
-  }
+  })
 )(SettingsRoute);

--- a/src/routes/settings-route/settings-route.js
+++ b/src/routes/settings-route/settings-route.js
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { useIntl } from 'react-intl';
@@ -11,16 +10,10 @@ import { KbCredentials } from '../../constants';
 
 const SettingsRoute = ({
   children,
-  getKbCredentials,
   kbCredentials,
   location,
 }) => {
   const intl = useIntl();
-
-  useEffect(() => {
-    getKbCredentials();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const sortKbCredentials = () => {
     const kbCredentialsItems = kbCredentials.items;
@@ -44,7 +37,6 @@ const SettingsRoute = ({
 
 SettingsRoute.propTypes = {
   children: PropTypes.node.isRequired,
-  getKbCredentials: PropTypes.func.isRequired,
   kbCredentials: KbCredentials.KbCredentialsReduxStateShape,
   location: ReactRouterPropTypes.location.isRequired,
 };

--- a/src/routes/settings-route/settings-route.test.js
+++ b/src/routes/settings-route/settings-route.test.js
@@ -1,15 +1,9 @@
 import { MemoryRouter } from 'react-router-dom';
 
-import {
-  render,
-  cleanup,
-  act,
-} from '@folio/jest-config-stripes/testing-library/react';
+import { render } from '@folio/jest-config-stripes/testing-library/react';
 
 import SettingsRoute from './settings-route';
 import Harness from '../../../test/jest/helpers/harness';
-
-const mockGetKbCredentials = jest.fn();
 
 const kbCredentials = {
   errors: [],
@@ -70,7 +64,6 @@ const renderSettingsRoute = (props = {}) => render(
   <MemoryRouter>
     <Harness>
       <SettingsRoute
-        getKbCredentials={mockGetKbCredentials}
         kbCredentials={kbCredentials}
         location={location}
         {...props}
@@ -82,12 +75,6 @@ const renderSettingsRoute = (props = {}) => render(
 );
 
 describe('Given SettingsRoute', () => {
-  beforeEach(() => {
-    mockGetKbCredentials.mockClear();
-  });
-
-  afterEach(cleanup);
-
   it('should render children', () => {
     const { getByText } = renderSettingsRoute();
 
@@ -98,13 +85,5 @@ describe('Given SettingsRoute', () => {
     renderSettingsRoute();
 
     expect(document.title).toEqual('ui-eholdings.label.settings - FOLIO');
-  });
-
-  it('should handle getKbCredentials', async () => {
-    await act(async () => {
-      await renderSettingsRoute();
-    });
-
-    expect(mockGetKbCredentials).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description
When opening eHoldings Settings we can see duplicate requests for:
- `/kb-credentials`
- `/access-types`

We can remove a call to `/kb-credentials` from `<SettingsRoute>` because it's also present in `<ApplicationRoute>` child component.
And there are two calls to `/access-types` in `<SettingsAccessStatusTypesRoute>` of which we can remove one.

## Issues
[UIEH-1493](https://folio-org.atlassian.net/browse/UIEH-1493)