### PR TITLE
UIEH-1490 Show `createdDate` when `updatedDate` is not available in Access Status Types metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix "Publication type" column is empty in "Titles" accordion of "Package" record. (UIEH-1487)
 * Populate `resourceName` when adding an eHoldings resource to an agreement line via "eHoldings". (ERM-4007)
+* Show `createdDate` when `updatedDate` is not available in Access Status Types metadata. (UIEH-1490)
 
 ## [11.1.1] (https://github.com/folio-org/ui-eholdings/tree/v11.1.1) (2026-05-28)
 

--- a/src/components/settings/settings-access-status-types/settings-access-status-types.js
+++ b/src/components/settings/settings-access-status-types/settings-access-status-types.js
@@ -86,7 +86,7 @@ const SettingsAccessStatusTypes = ({
           <FormattedMessage
             id="ui-eholdings.settings.accessStatusTypes.lastUpdated.data"
             values={{
-              date: <FormattedDate value={data.metadata.updatedDate} />,
+              date: <FormattedDate value={data.metadata.updatedDate || data.metadata.createdDate} />,
               name: `${user?.lastName} ${user?.firstName}`,
             }}
           />


### PR DESCRIPTION
## Description
Show `createdDate` when `updatedDate` is not available in Access Status Types metadata.
`<FormattedDate>` shows the current date when passed value is empty, so not rows which weren't updated for a while would show today's date as last updated.
Now we'll show created date instead, when updated date is empty

## Issues
[UIEH-1490](https://folio-org.atlassian.net/browse/UIEH-1490)