### PR TITLE
UIEH-1512 Remove requests with "undefined" UUID are sent when opening eHoldings Knowledge Base credentials settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Populate `resourceName` when adding an eHoldings resource to an agreement line via "eHoldings". (ERM-4007)
 * Update Tags label in "Titles" accordion of "Package" record. (UIEH-1488)
 * Show `createdDate` when `updatedDate` is not available in Access Status Types metadata. (UIEH-1490)
+* Remove requests with "undefined" UUID are sent when opening eHoldings Knowledge Base credentials settings. (UIEH-1512)
 
 ## [11.1.1] (https://github.com/folio-org/ui-eholdings/tree/v11.1.1) (2026-05-28)
 

--- a/src/redux/epics/get-kb-credentials-key.js
+++ b/src/redux/epics/get-kb-credentials-key.js
@@ -16,7 +16,7 @@ export default ({ knowledgeBaseApi }) => (action$, state$) => {
   return action$
     .pipe(
       filter(action => action.type === GET_KB_CREDENTIALS_KEY),
-      mergeMap(({ payload: { credentialsId } }) => {
+      mergeMap(({ payload: credentialsId }) => {
         return knowledgeBaseApi
           .getCredentialsKey(state$.value.okapi, credentialsId)
           .pipe(

--- a/src/routes/settings-knowledge-base-route/settings-knowledge-base-route.js
+++ b/src/routes/settings-knowledge-base-route/settings-knowledge-base-route.js
@@ -2,6 +2,7 @@ import {
   useState,
   useEffect,
   useContext,
+  useCallback,
 } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
@@ -57,9 +58,9 @@ const SettingsKnowledgeBaseRoute = ({
     history.push('/settings/eholdings');
   }
 
-  const getCurrentKBData = () => {
+  const getCurrentKBData = useCallback(() => {
     return kbCredentials.items.find(cred => cred.id === match.params.kbId);
-  };
+  }, [kbCredentials, match.params.kbId]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const getCurrentKBName = () => {
@@ -69,14 +70,13 @@ const SettingsKnowledgeBaseRoute = ({
   const [isCreateMode, setIsCreateMode] = useState(location.pathname === '/settings/eholdings/knowledge-base/new');
   const [currentKBName, setCurrentKBName] = useState(getCurrentKBName());
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const loadCurrentConfigKey = () => {
+  const loadCurrentConfigKey = useCallback(() => {
     const config = getCurrentKBData();
 
     if (config && !config.meta.isKeyLoaded && !kbCredentials.isKeyLoading) {
       getKbCredentialsKey(config.id);
     }
-  };
+  }, [getCurrentKBData, getKbCredentialsKey, kbCredentials.isKeyLoading]);
 
   const getCurrentConfig = () => {
     const {
@@ -123,8 +123,7 @@ const SettingsKnowledgeBaseRoute = ({
   useEffect(() => {
     // eslint-disable-next-line react/no-did-update-set-state
     setIsCreateMode(location.pathname === '/settings/eholdings/knowledge-base/new');
-    loadCurrentConfigKey();
-  }, [location.pathname, loadCurrentConfigKey]);
+  }, [location.pathname]);
 
   useEffect(() => {
     if (kbCredentials.hasLoaded) {

--- a/src/routes/settings-knowledge-base-route/settings-knowledge-base-route.test.js
+++ b/src/routes/settings-knowledge-base-route/settings-knowledge-base-route.test.js
@@ -117,7 +117,12 @@ describe('Given SettingsKnowledgeBaseRoute', () => {
 
   it('should handle getKbCredentialsKey', async () => {
     await act(async () => {
-      await renderSettingsKnowledgeBaseRoute();
+      await renderSettingsKnowledgeBaseRoute({
+        kbCredentials: {
+          ...kbCredentials,
+          hasLoaded: true,
+        }
+      });
     });
 
     expect(mockGetKbCredentialsKey).toHaveBeenCalledWith('kbId');


### PR DESCRIPTION
## Description
Remove requests with "undefined" UUID are sent when opening eHoldings Knowledge Base credentials settings

The root cause is that `getKbCredentialsKey` accepts action payload as a value, but later in the `getKbCredentialsKey` epic it was process as a object with a key.

## Issues
[UIEH-1512](https://folio-org.atlassian.net/browse/UIEH-1512)