### PR TITLE
UIEH-1452 Fix selected titles count not showing, search parameters formatted incorrectly (follow-up)

### DIFF
--- a/src/components/provider/show/components/provider-package-list/provider-package-list.js
+++ b/src/components/provider/show/components/provider-package-list/provider-package-list.js
@@ -90,7 +90,7 @@ const ProviderPackageList = ({
         </TextLink>
       );
     },
-    [PROVIDER_PACKAGES_LIST_COLUMNS.SELECTED_COUNT]: item => item.attributes.selecedCount,
+    [PROVIDER_PACKAGES_LIST_COLUMNS.SELECTED_COUNT]: item => item.attributes.selectedCount,
     [PROVIDER_PACKAGES_LIST_COLUMNS.TITLES_COUNT]: item => item.attributes.titleCount,
     [PROVIDER_PACKAGES_LIST_COLUMNS.CONTENT_TYPE]: item => item.attributes.contentType,
     [PROVIDER_PACKAGES_LIST_COLUMNS.CUSTOM_COVERAGE]: item => {

--- a/src/components/provider/show/components/provider-package-list/provider-package-list.test.js
+++ b/src/components/provider/show/components/provider-package-list/provider-package-list.test.js
@@ -26,7 +26,7 @@ const testProviderPackagesList = [
     attributes: {
       name: 'First Package',
       isSelected: true,
-      selecedCount: 5,
+      selectedCount: 5,
       titleCount: 10,
       contentType: 'Aggregated Full Text',
       customCoverage: {
@@ -47,7 +47,7 @@ const testProviderPackagesList = [
     attributes: {
       name: 'Second Package',
       isSelected: false,
-      selecedCount: 0,
+      selectedCount: 0,
       titleCount: 3,
       contentType: 'Abstract and Index',
       customCoverage: {

--- a/src/hooks/use-provider-packages/use-provider-packages.js
+++ b/src/hooks/use-provider-packages/use-provider-packages.js
@@ -3,13 +3,13 @@ import {
   useState,
 } from 'react';
 import { useQuery } from 'react-query';
-import queryString from 'qs';
 
 import {
   useNamespace,
   useOkapiKy,
 } from '@folio/stripes/core';
 
+import { qs } from '../../components/utilities';
 import {
   FIRST_PAGE,
   PAGE_SIZE,
@@ -41,7 +41,7 @@ export const useProviderPackages = ({ providerId, searchParams }) => {
 
   const { data = {}, isFetching } = useQuery(
     [namespace, paramsWithPageAndCount],
-    () => ky.get(`eholdings/providers/${providerId}/packages?${queryString.stringify(paramsWithPageAndCount)}`).json(),
+    () => ky.get(`eholdings/providers/${providerId}/packages?${qs.stringify(paramsWithPageAndCount)}`).json(),
     { keepPreviousData: true },
   );
 

--- a/src/hooks/use-provider-packages/use-provider-packages.test.js
+++ b/src/hooks/use-provider-packages/use-provider-packages.test.js
@@ -74,6 +74,22 @@ describe('useProviderPackages', () => {
     expect(mockGet).toHaveBeenCalledWith(`eholdings/providers/${providerId}/packages?q=test&page=1&count=100`);
   });
 
+  it('should format repeatable search parameters correctly', async () => {
+    const { result } = renderHook(() => useProviderPackages({
+      providerId,
+      searchParams: {
+        q: 'test',
+        filter: {
+          tags: ['important', 'urgent'],
+        },
+      },
+    }), { wrapper });
+
+    await act(() => !result.current.isLoading);
+
+    expect(mockGet).toHaveBeenCalledWith(`eholdings/providers/${providerId}/packages?q=test&filter[tags]=important&filter[tags]=urgent&page=1&count=100`);
+  });
+
   describe('when fetching the next page', () => {
     it('should make a request with page parameters equal to 2', async () => {
       const { result } = renderHook(() => useProviderPackages({


### PR DESCRIPTION
## Description
Fix 2 issues with Provider Packages list:
1. Selected titles count not showing (typo in attribute name)
2. Tags and access types filters returning 0 results (using queryString to stringify parameters formats them incorrectly. need to use `qs`, which is a wrapper of queryString with additional formatting parameters)

## Issues
[UIEH-1452](https://folio-org.atlassian.net/browse/UIEH-1452)