### PR TITLE
UIEH-1496 added validation for double quotes character in custom alt names (follow-up)

### DIFF
--- a/src/components/package/_fields/custom-alternate-names/custom-alternate-names.js
+++ b/src/components/package/_fields/custom-alternate-names/custom-alternate-names.js
@@ -16,12 +16,18 @@ const MAX_CHARACTER_LENGTH = 300;
 const MAX_ALTERNATE_NAMES = 10;
 
 const validate = (value) => {
-  if (value && value.length > MAX_CHARACTER_LENGTH) {
+  if (value?.length > MAX_CHARACTER_LENGTH) {
     return (
       <FormattedMessage
         id="ui-eholdings.validate.errors.customPackage.customAlternateName.length"
         values={{ amount: MAX_CHARACTER_LENGTH }}
       />
+    );
+  }
+
+  if (value?.includes('"')) {
+    return (
+      <FormattedMessage id="ui-eholdings.validate.errors.customPackage.customAlternateName.doubleQuotes" />
     );
   }
 

--- a/src/components/package/_fields/custom-alternate-names/custom-alternate-names.test.js
+++ b/src/components/package/_fields/custom-alternate-names/custom-alternate-names.test.js
@@ -108,6 +108,21 @@ describe('Given CustomAlternateNames', () => {
     });
   });
 
+  describe('when a name contains a double quote character', () => {
+    it('should display the length validation error', () => {
+      const { getByRole, getByText } = renderCustomAlternateNames();
+
+      fireEvent.click(getByRole('button', { name: 'ui-eholdings.label.addCustomAlternateName' }));
+
+      const input = getByRole('textbox', { name: 'ui-eholdings.label.customAlternateName' });
+
+      fireEvent.change(input, { target: { value: '"test"' } });
+      fireEvent.blur(input);
+
+      expect(getByText('ui-eholdings.validate.errors.customPackage.customAlternateName.doubleQuotes')).toBeDefined();
+    });
+  });
+
   describe('when the number of alternate names is 10', () => {
     const clickAddButton = (getByRole, times) => {
       const addButton = getByRole('button', { name: 'ui-eholdings.label.addCustomAlternateName' });

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -503,6 +503,7 @@
     "validate.errors.customPackage.name": "Custom packages must have a name.",
     "validate.errors.customPackage.name.length": "Must not exceed {amount} characters.",
     "validate.errors.customPackage.customAlternateName.length": "{amount} character limit has been exceeded. Please revise the name.",
+    "validate.errors.customPackage.customAlternateName.doubleQuotes": "Double quotes are an invalid character. Please revise the name.",
     "validate.errors.coverageStatement.length": "Statement must be 350 characters or less.",
     "validate.errors.coverageStatement.blank": "Statement field cannot be blank if selected.",
     "validate.errors.customLabels.length": "Value has exceeded {amount} character limit. Please revise your value.",


### PR DESCRIPTION
## Description
Custom Alternate Names should not accept double quotes as a valid character

## Issues
[UIEH-1496](https://folio-org.atlassian.net/browse/UIEH-1496)