### PR TITLE
UIEH-1500 make visibilityData optional (follow-up)

### DIFF
--- a/src/components/resource/components/edit/resource-settings/edit-resource-settings.js
+++ b/src/components/resource/components/edit/resource-settings/edit-resource-settings.js
@@ -39,7 +39,7 @@ const EditResourceSettings = ({
 }) => {
   const renderFields = (resourceIsCustom && resourceSelected) || !resourceIsCustom;
   const hasInheritedProxy = hasIn(model, 'package.proxy.id');
-  const visibilityMessage = model.package.visibilityData.isHidden
+  const visibilityMessage = model.package.visibilityData?.isHidden
     ? <FormattedMessage id="ui-eholdings.resource.visibilityData.isHidden" />
     : model.visibilityData.reason && `(${model.visibilityData.reason})`;
 

--- a/src/components/resource/components/resource-settings/resource-settings.js
+++ b/src/components/resource/components/resource-settings/resource-settings.js
@@ -40,7 +40,7 @@ const ResourceSettings = ({
   accessStatusTypes,
   proxyTypes,
 }) => {
-  const visibilityMessage = model.package.visibilityData.isHidden
+  const visibilityMessage = model.package.visibilityData?.isHidden
     ? <FormattedMessage id="ui-eholdings.resource.visibilityData.isHidden" />
     : model.visibilityData.reason && `(${model.visibilityData.reason})`;
 

--- a/src/components/search-package-list-item/search-package-list-item.js
+++ b/src/components/search-package-list-item/search-package-list-item.js
@@ -84,7 +84,7 @@ const SearchPackageListItem = ({
             </span>
           }
 
-          {item.visibilityData.isHidden && <HiddenLabel />}
+          {item.visibilityData?.isHidden && <HiddenLabel />}
 
           {(showTags && !isEmpty(item.tags.tagList)) && <TagsLabel tagList={item.tags.tagList} />}
         </div>


### PR DESCRIPTION
## Description
`visibilityData` was replaced with `visibility` field. Some components still try to access `visibilityData`, which causes page crashes.
In future PRs we'll update our logic to use `visibility` once the requirements are defined
