### PR TITLE
UIEH-1535 Create/Edit Package Detail record: Custom alternate names field updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * View/Edit Package Detail Record: Add a Package Display Name field. (UIEH-1501)
 * Add package access filter to package search and provider package search. (UIEH-1526)
 * Create/Edit Custom Package Detail Record: Add a Package display name field. (UIEH-1499)
+* Custom alternate names field and labels updates. (UIEH-1535)
 
 ## [11.1.3] (https://github.com/folio-org/ui-eholdings/tree/v11.1.3) (2026-08-12)
 

--- a/src/components/package/_fields/custom-alternate-names/custom-alternate-names.js
+++ b/src/components/package/_fields/custom-alternate-names/custom-alternate-names.js
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import {
@@ -8,8 +8,9 @@ import {
 import isEqual from 'lodash/isEqual';
 
 import {
-  TextField,
+  InfoPopover,
   RepeatableField,
+  TextArea,
 } from '@folio/stripes/components';
 
 const MAX_CHARACTER_LENGTH = 300;
@@ -44,13 +45,22 @@ const CustomAlternateNames = () => {
       <Field
         name={`${repeatableFieldName}.altName`}
         type="text"
-        component={TextField}
-        label={fieldLabel}
+        component={TextArea}
         ariaLabel={fieldLabel}
         validate={validate}
       />
     );
   }, [intl]);
+
+  const repeatableFieldLegend = useMemo(() => (
+    <>
+      <FormattedMessage id="ui-eholdings.label.customAlternateName" />
+      <InfoPopover
+        iconSize="small"
+        content={intl.formatMessage({ id: 'ui-eholdings.label.customAlternateNames.infoPopover' })}
+      />
+    </>
+  ), [intl]);
 
   const renderRepeatableField = useCallback(({ fields }) => {
     const addLabel = intl.formatMessage({ id: 'ui-eholdings.label.addCustomAlternateName' });
@@ -65,15 +75,18 @@ const CustomAlternateNames = () => {
 
     return (
       <RepeatableField
+        legend={repeatableFieldLegend}
         addLabel={addLabel}
         fields={fields}
         canAdd={fields.length < MAX_ALTERNATE_NAMES}
         onAdd={addCustomAlternateName}
         onRemove={(index) => fields.remove(index)}
         renderField={renderField}
+        hasMargin={false}
+        hasRemoveButtonMargin={false}
       />
     );
-  }, [intl, renderField]);
+  }, [intl, renderField, repeatableFieldLegend]);
 
   return (
     <FieldArray

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -439,6 +439,7 @@
     "label.displayName": "Package display name",
     "label.addCustomAlternateName": "Add name",
     "label.customAlternateName": "Custom alternate name",
+    "label.customAlternateNames.infoPopover": "Add familiar alternate names to help staff and patrons easily search for and find packages.",
     "label.name.isRequired": "Name *",
     "label.sortOptions": "Sort options",
     "label.selectionStatus": "Selection status",

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -437,7 +437,7 @@
     "label.description": "Description",
     "label.name": "Name",
     "label.displayName": "Package display name",
-    "label.addCustomAlternateName": "Add name",
+    "label.addCustomAlternateName": "Add alternate name",
     "label.customAlternateName": "Custom alternate name",
     "label.customAlternateNames.infoPopover": "Add familiar alternate names to help staff and patrons easily search for and find packages.",
     "label.name.isRequired": "Name *",


### PR DESCRIPTION
## Description
The Custom alternate names field label always displays.
The button label is updated to Add alternate name.
Use the textbox component that supports expanding the field as a user can enter up to 300 characters
Do not repeat the Custom alternate names field label. Display the field label once.
Next to the Custom alternate names label, add the InfoPopover icon

## Screenshots
<img width="1919" height="867" alt="image" src="https://github.com/user-attachments/assets/8667e629-c8e9-4470-bf40-2aa422a76df1" />

## Issues
[UIEH-1535](https://folio-org.atlassian.net/browse/UIEH-1535)