### PR TITLE
UIEH-1561: Package display name infotip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add package access filter to package search and provider package search. (UIEH-1526)
 * Create/Edit Custom Package Detail Record: Add a Package display name field. (UIEH-1499)
 * Custom alternate names field and labels updates. (UIEH-1535)
+* Add Package display name field infotip. (UIEH-1561)
 
 ## [11.1.3] (https://github.com/folio-org/ui-eholdings/tree/v11.1.3) (2026-08-12)
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,16 @@
 const path = require('path');
 const config = require('@folio/jest-config-stripes');
 
+const additionalModules = [
+  'keyboardjs',
+].join('|');
+const combinedModules = config.transformIgnorePatterns[0].replace(')', `|${additionalModules})`);
+
 module.exports = {
   ...config,
   setupFiles: [
     ...config.setupFiles,
     path.join(__dirname, './test/jest/setup-tests.js'),
   ],
+  transformIgnorePatterns: [combinedModules],
 };

--- a/src/components/package/_fields/display-name/display-name.js
+++ b/src/components/package/_fields/display-name/display-name.js
@@ -5,7 +5,10 @@ import {
   useIntl,
 } from 'react-intl';
 
-import { TextArea } from '@folio/stripes/components';
+import {
+  InfoPopover,
+  TextArea,
+} from '@folio/stripes/components';
 
 const MAX_CHARACTER_LENGTH = 300;
 
@@ -29,12 +32,15 @@ export const DisplayName = () => {
 
   const labelText = intl.formatMessage({ id: 'ui-eholdings.label.displayName' });
 
-  // later label will contain a Popover component
   const label = useMemo(() => (
     <>
       {labelText}
+      <InfoPopover
+        iconSize="small"
+        content={intl.formatMessage({ id: 'ui-eholdings.label.displayName.infoPopover' })}
+      />
     </>
-  ), [labelText]);
+  ), [labelText, intl]);
 
   return (
     <Field

--- a/src/components/package/_fields/display-name/display-name.test.js
+++ b/src/components/package/_fields/display-name/display-name.test.js
@@ -25,7 +25,7 @@ const renderDisplayName = () => render(
   </Harness>
 );
 
-describe('Given CustomAlternateNames', () => {
+describe('Given DisplayNames', () => {
   describe('when a name exceeds the maximum length', () => {
     it('should display the length validation error', () => {
       const { getByRole, getByText } = renderDisplayName();
@@ -49,6 +49,19 @@ describe('Given CustomAlternateNames', () => {
       fireEvent.blur(input);
 
       expect(queryByText('ui-eholdings.validate.errors.customPackage.displayName.length')).toBeNull();
+    });
+  });
+
+  describe('when rendered', () => {
+    it('infotip is shown when icon clicked', () => {
+      const { getByRole, getByText } = renderDisplayName();
+
+      const infotipButton = getByRole('button');
+      expect(infotipButton).toBeInTheDocument();
+
+      fireEvent.click(infotipButton);
+
+      expect(getByText('ui-eholdings.label.displayName.infoPopover')).toBeInTheDocument();
     });
   });
 });

--- a/translations/ui-eholdings/en.json
+++ b/translations/ui-eholdings/en.json
@@ -437,6 +437,7 @@
     "label.description": "Description",
     "label.name": "Name",
     "label.displayName": "Package display name",
+    "label.displayName.infoPopover": "Customize the name of the package as it appears in Publication Finder, Full Text Finder Link Resolver, and your MARC export records. If there is a value in this field it will overwrite the managed package name in those products, and it will appear in parentheses adjacent to the managed package name in eholdings app search results.",
     "label.addCustomAlternateName": "Add alternate name",
     "label.customAlternateNames": "Custom alternate names",
     "label.customAlternateNames.infoPopover": "Add familiar alternate names to help staff and patrons easily search for and find packages.",


### PR DESCRIPTION
## Purpose

Add an infotip to the "Package display name" field wherever it's used so users can get an in-page explanation of what the field does.

## Approach

Include the `InfoPopover` component in the base field label.

Also addresses the need to transpile `keyboardjs`.

## Refs

https://folio-org.atlassian.net/browse/UIEH-1561

## Screenshots

When creating a package:
<img width="748" height="669" alt="Screenshot 2026-09-08 at 11 58 08" src="https://github.com/user-attachments/assets/3a0cca5e-f2ab-4a33-a603-6d5b4595f396" />

When editing a package:
<img width="748" height="669" alt="Screenshot 2026-09-08 at 11 57 59" src="https://github.com/user-attachments/assets/fad7e054-2061-43b6-8d64-c8ac06fc6c74" />
